### PR TITLE
feat: exclude lock files and licenses from PR size check

### DIFF
--- a/.preflight-exclude
+++ b/.preflight-exclude
@@ -33,4 +33,4 @@ pnpm-lock.yaml
 
 # License files (boilerplate)
 
-^LICENSES/.\*\.txt$
+^LICENSES/.*\.txt$

--- a/.preflight-exclude
+++ b/.preflight-exclude
@@ -33,4 +33,4 @@ pnpm-lock.yaml
 
 # License files (boilerplate)
 
-^LICENSES/.*\.txt$
+^LICENSES/.\*\.txt$

--- a/.preflight-exclude
+++ b/.preflight-exclude
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 SecPal Contributors
+
+# SPDX-License-Identifier: CC0-1.0
+
+# Preflight PR Size Check - Excluded Files
+
+# ==========================================
+
+# Files matching these patterns are excluded from the 600-line PR size check.
+
+# Each line is a grep-compatible regex pattern.
+
+#
+
+# Why exclude these files?
+
+# - Lock files are auto-generated and can be very large
+
+# - License files are boilerplate and not meaningful code changes
+
+#
+
+# This file should match the exclusions in:
+
+# .github/workflows/reusable-pr-size.yml
+
+# Dependency lock files (auto-generated)
+
+package-lock.json
+composer.lock
+yarn.lock
+pnpm-lock.yaml
+
+# License files (boilerplate)
+
+^LICENSES/.\*\.txt$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,16 @@ This script runs automatically before every `git push` via the pre-push hook.
 - PHP linting and tests (if applicable)
 - Node.js linting and tests (if applicable)
 - OpenAPI validation (if applicable)
-- PR size (< 600 lines recommended)
+- PR size (< 600 lines recommended, excluding lock files and license files)
+
+**Excluded from PR size calculation:**
+
+The following files are automatically excluded from the 600-line limit because they are auto-generated or boilerplate:
+
+- `package-lock.json`, `composer.lock`, `yarn.lock`, `pnpm-lock.yaml` (dependency lock files)
+- `LICENSES/*.txt` (license boilerplate files)
+
+These exclusions are configured in `.preflight-exclude` and match the GitHub CI workflow. You can add project-specific patterns by editing this file.
 
 **Bypassing the PR size check locally:**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,25 @@ This script runs automatically before every `git push` via the pre-push hook.
 - OpenAPI validation (if applicable)
 - PR size (< 600 lines recommended)
 
+**Bypassing the PR size check locally:**
+
+If you need to work on a large PR that is justified (see exceptions below), you can temporarily bypass the 600-line limit:
+
+```bash
+# Create override file to allow large PR
+touch .preflight-allow-large-pr
+
+# Work on your changes
+git add .
+git commit -m "Your changes"
+git push
+
+# Clean up after merge
+rm .preflight-allow-large-pr
+```
+
+⚠️ **Important:** The override file is automatically ignored by git and should only be used for exceptional cases that match the criteria below.
+
 ## How to Contribute
 
 1. **Fork the repository** and create a new branch from `main`.
@@ -153,7 +172,9 @@ Large PRs (> 600 lines) are acceptable for:
 - **Generated code** (e.g., OpenAPI clients, database migrations)
 - **Boilerplate/templates** that cannot be reasonably split
 
-In these cases, add the `large-pr-approved` label to bypass the size check. See [Organization Label Standards](https://github.com/SecPal/.github/blob/main/docs/labels.md) for details.
+**On GitHub:** Add the `large-pr-approved` label to bypass the size check. See [Organization Label Standards](https://github.com/SecPal/.github/blob/main/docs/labels.md) for details.
+
+**Locally:** Create a `.preflight-allow-large-pr` file in the repository root to bypass the preflight check (see "Bypassing the PR size check locally" above).
 
 ## Branch Naming Convention
 

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -86,12 +86,12 @@ else
 
     # Load exclude patterns from .preflight-exclude if it exists
     if [ -f "$ROOT_DIR/.preflight-exclude" ]; then
-      # Extract non-comment, non-empty lines as patterns
+      # Extract non-comment, non-empty lines as grep-compatible regex patterns
       EXCLUDE_PATTERNS=$(grep -vE '^(#|[[:space:]]*$)' "$ROOT_DIR/.preflight-exclude" || true)
 
       if [ -n "$EXCLUDE_PATTERNS" ]; then
-        # Build regex alternation for efficient filtering (escape special regex chars)
-        EXCLUDE_REGEX=$(echo "$EXCLUDE_PATTERNS" | sed 's/[.^$*+?{}()|[\]\\]/\\&/g' | tr '\n' '|' | sed 's/|$//')
+        # Build regex alternation for efficient filtering (patterns are used as-is)
+        EXCLUDE_REGEX=$(echo "$EXCLUDE_PATTERNS" | tr '\n' '|' | sed 's/|$//')
         DIFF_OUTPUT=$(echo "$DIFF_OUTPUT" | grep -vE "$EXCLUDE_REGEX" || true)
       fi
     fi

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -80,20 +80,44 @@ else
   if [ -z "$MERGE_BASE" ]; then
     echo "Warning: Cannot determine merge base with origin/$BASE. Skipping PR size check." >&2
   else
-    # Use --numstat for locale-independent parsing (sum insertions + deletions)
-    CHANGED=$(git diff --numstat "$MERGE_BASE"..HEAD 2>/dev/null | awk '{ins+=$1; del+=$2} END {print ins+del+0}')
-    [ -z "$CHANGED" ] && CHANGED=0
-    if [ "$CHANGED" -gt 600 ]; then
-      # Check for override file (similar to GitHub label for exceptional cases)
-      if [ -f "$ROOT_DIR/.preflight-allow-large-pr" ]; then
-        echo "⚠️  Large PR override active ($CHANGED > 600 lines). Remove .preflight-allow-large-pr when done." >&2
-      else
-        echo "PR too large ($CHANGED > 600 lines). Please split into smaller slices." >&2
-        echo "For exceptional cases, create .preflight-allow-large-pr to override this check." >&2
-        exit 2
+    # Get raw diff output
+    RAW_DIFF_OUTPUT=$(git diff --numstat "$MERGE_BASE"..HEAD 2>/dev/null)
+    DIFF_OUTPUT="$RAW_DIFF_OUTPUT"
+
+    # Load exclude patterns from .preflight-exclude if it exists
+    if [ -f "$ROOT_DIR/.preflight-exclude" ]; then
+      # Extract non-comment, non-empty lines as patterns
+      EXCLUDE_PATTERNS=$(grep -v '^#' "$ROOT_DIR/.preflight-exclude" | grep -v '^[[:space:]]*$' || true)
+
+      if [ -n "$EXCLUDE_PATTERNS" ]; then
+        # Build regex alternation for efficient filtering
+        EXCLUDE_REGEX=$(echo "$EXCLUDE_PATTERNS" | tr '\n' '|' | sed 's/|$//')
+        DIFF_OUTPUT=$(echo "$DIFF_OUTPUT" | grep -vE "$EXCLUDE_REGEX" || true)
       fi
+    fi
+
+    # Check if all files were excluded
+    if [ -n "$RAW_DIFF_OUTPUT" ] && [ -z "$DIFF_OUTPUT" ]; then
+      echo "⚠️  All changed files are excluded (lock files, license files, etc.)"
+      echo "Preflight OK · Changed lines: 0 (after exclusions)"
     else
-      echo "Preflight OK · Changed lines: $CHANGED"
+      # Use --numstat for locale-independent parsing (sum insertions + deletions)
+      CHANGED=$(echo "$DIFF_OUTPUT" | awk '{ins+=$1; del+=$2} END {print ins+del+0}')
+      [ -z "$CHANGED" ] && CHANGED=0
+
+      if [ "$CHANGED" -gt 600 ]; then
+        # Check for override file (similar to GitHub label for exceptional cases)
+        if [ -f "$ROOT_DIR/.preflight-allow-large-pr" ]; then
+          echo "⚠️  Large PR override active ($CHANGED > 600 lines). Remove .preflight-allow-large-pr when done." >&2
+        else
+          echo "PR too large ($CHANGED > 600 lines). Please split into smaller slices." >&2
+          echo "Tip: Lock files and license files are already excluded. See .preflight-exclude for details." >&2
+          echo "For exceptional cases, create .preflight-allow-large-pr to override this check." >&2
+          exit 2
+        fi
+      else
+        echo "Preflight OK · Changed lines: $CHANGED"
+      fi
     fi
   fi
 fi


### PR DESCRIPTION
## Summary
Aligns local preflight PR size check with GitHub CI workflow by automatically excluding lock files and license files from the 600-line limit.

## Problem
Lock files (`package-lock.json`, `composer.lock`, etc.) and license boilerplate files are auto-generated and can be very large. The **GitHub CI workflow already excludes these**, but the **local preflight script did not**, creating an inconsistency.

This meant developers could pass preflight locally but fail CI, or vice versa.

## Solution
- ✅ Add `.preflight-exclude` configuration file with default exclusions
- ✅ Update preflight script to read and apply these exclusions  
- ✅ Exclude: `package-lock.json`, `composer.lock`, `yarn.lock`, `pnpm-lock.yaml`
- ✅ Exclude: `LICENSES/*.txt` files
- ✅ Document exclusions in `CONTRIBUTING.md`
- ✅ Align behavior with `.github/workflows/reusable-pr-size.yml`

## Benefits
1. **Consistency**: Local and CI checks now behave identically
2. **Configurability**: Projects can add custom exclusions to `.preflight-exclude`
3. **Clarity**: Contributors see accurate line counts (excluding noise)
4. **Documentation**: Clear explanation of what's excluded and why

## Configuration File Format
The `.preflight-exclude` file contains grep-compatible regex patterns (one per line):

```
# Comments start with #
package-lock.json
composer.lock
^LICENSES/.*\.txt$
```

## Related
This improves the large PR override feature from #22 by making the baseline calculation more accurate.