### PR TITLE
chore(deps): enhance dependabot with daily GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,32 +1,47 @@
 # SPDX-FileCopyrightText: 2025 SecPal
 # SPDX-License-Identifier: CC0-1.0
 
+# Dependabot configuration for SecPal Frontend (React/TypeScript/Vite)
+# Automatically creates PRs for ALL dependency updates (including Major versions)
+# Security updates are prioritized and checked daily in early morning hours
 version: 2
 updates:
+  # npm - JavaScript/TypeScript dependencies
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
       time: "04:00"
       timezone: "Europe/Berlin"
+    versioning-strategy: "increase"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
     open-pull-requests-limit: 10
-    reviewers:
-      - "SecPal/maintainers"
     labels:
       - "dependencies"
       - "dependabot"
+    rebase-strategy: "auto"
+    target-branch: "main"
+    pull-request-branch-name:
+      separator: "-"
 
+  # GitHub Actions - Workflow dependencies
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "04:00"
       timezone: "Europe/Berlin"
-    open-pull-requests-limit: 5
-    reviewers:
-      - "SecPal/maintainers"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    open-pull-requests-limit: 10
     labels:
       - "dependencies"
       - "dependabot"
       - "github-actions"
+    rebase-strategy: "auto"
+    target-branch: "main"
+    pull-request-branch-name:
+      separator: "-"


### PR DESCRIPTION
## 📋 Changes

This PR enhances the existing Dependabot configuration to match best practices from the `.github` repository.

### ✅ What's Enhanced

**Critical Change:**
- ⚠️ **GitHub Actions schedule changed from weekly to daily** (security updates!)

**Improvements:**
- **Versioning Strategy:** Added `increase` for npm (accepts all version updates)
- **Commit Messages:** Added conventional commit format with `chore(scope)` prefix
- **Auto-Rebase:** Added automatic rebase strategy
- **Open PRs Limit:** Increased from 5 to 10 for GitHub Actions
- **Target Branch:** Explicitly set to `main`
- **PR Branch Naming:** Added separator configuration
- **Comments:** Added detailed ecosystem descriptions
- **Reviewers:** Removed (not supported in Dependabot v2)

### 📊 Before vs After

**Before:**
- Daily npm updates
- **Weekly** GitHub Actions updates (Monday only)
- Basic labels
- Reviewers field (deprecated)

**After:**
- **Daily** npm updates with versioning-strategy
- **Daily** GitHub Actions updates (improved security!)
- Conventional commit messages
- Auto-rebase enabled
- 10 open PRs allowed
- Compliant with Dependabot v2 spec

---

**Auto-merge:** ✅ Will be merged automatically after checks pass