### PR TITLE
docs: fix workflow badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ SPDX-License-Identifier: CC0-1.0
 
 # SecPal Frontend
 
-[![REUSE Compliance](https://github.com/SecPal/frontend/actions/workflows/reuse.yml/badge.svg)](https://github.com/SecPal/frontend/actions/workflows/reuse.yml)
-[![License Check](https://github.com/SecPal/frontend/actions/workflows/license-compatibility.yml/badge.svg)](https://github.com/SecPal/frontend/actions/workflows/license-compatibility.yml)
 [![Quality Gates](https://github.com/SecPal/frontend/actions/workflows/quality.yml/badge.svg)](https://github.com/SecPal/frontend/actions/workflows/quality.yml)
+[![CodeQL](https://github.com/SecPal/frontend/actions/workflows/codeql.yml/badge.svg)](https://github.com/SecPal/frontend/actions/workflows/codeql.yml)
+[![PR Size](https://github.com/SecPal/frontend/actions/workflows/pr-size.yml/badge.svg)](https://github.com/SecPal/frontend/actions/workflows/pr-size.yml)
+[![License](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](LICENSE)
 
 React/TypeScript frontend for the SecPal platform.
 


### PR DESCRIPTION
## 📝 Fix README Badges

This PR fixes broken workflow badges in the README that pointed to non-existent workflow files.

### 🐛 Problem

The README had badges for workflows that don't exist:
- ❌ `reuse.yml` (doesn't exist in this repo)
- ❌ `license-compatibility.yml` (doesn't exist in this repo)

### ✅ Solution

Updated badges to reflect **actual** workflows:
- ✅ `quality.yml` - Main quality gates workflow
- ✅ `codeql.yml` - Security scanning
- ✅ `pr-size.yml` - PR size labeling
- ✅ Static AGPL v3 license badge

### 📋 Changes

**Before:**
```markdown
[![REUSE Compliance](reuse.yml badge)]
[![License Check](license-compatibility.yml badge)]
[![Quality Gates](quality.yml badge)]
```

**After:**
```markdown
[![Quality Gates](quality.yml badge)]
[![CodeQL](codeql.yml badge)]
[![PR Size](pr-size.yml badge)]
[![License](static AGPL badge)]
```

### ✅ Verification

All badges now point to:
- Existing workflow files in `.github/workflows/`
- OR static shields.io badges (for license)

---

Small documentation fix! 📚