### PR TITLE
fix: use core workflow to fix startup_failure

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -22,6 +22,6 @@ on:
 jobs:
   project-automation:
     name: Project automation
-    uses: SecPal/.github/.github/workflows/project-automation-v2.yml@main
+    uses: SecPal/.github/.github/workflows/project-automation-core.yml@main
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
## Fix startup_failure

Changes workflow reference from `project-automation-v2.yml` to `project-automation-core.yml`

This fixes the startup_failure issue by using the pure reusable workflow.

Related: SecPal/.github#133, SecPal/api#15