### PR TITLE
fix: add required permissions to project automation workflow

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -22,6 +22,6 @@ on:
 jobs:
   project-automation:
     name: Project automation
-    uses: SecPal/.github/.github/workflows/project-automation-v2.yml@main
+    uses: SecPal/.github/.github/workflows/project-automation-core.yml@main
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -19,6 +19,11 @@ on:
     types:
       - submitted
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   project-automation:
     name: Project automation


### PR DESCRIPTION
## Problem

The project automation workflow was experiencing `startup_failure` with the error:

```
Error calling workflow 'SecPal/.github/.github/workflows/project-automation-core.yml@main'. 
The nested job 'handle-issue' is requesting 'issues: write', but is only allowed 'issues: none'.
```

## Root Cause

**Caller workflows must explicitly grant permissions that reusable workflows request.**

When a workflow calls a reusable workflow using `uses:`, GitHub Actions requires the caller to declare the permissions that the reusable workflow needs.

## Solution

Added `permissions:` block to `project-automation.yml`:

```yaml
permissions:
  contents: read
  issues: write
  pull-requests: write
```

## Pattern Match

This follows the same pattern as other working caller workflows (e.g., `pr-size.yml`).

## Testing

After merge, test by creating an issue to verify the workflow runs successfully.

## Related

- SecPal/.github#136 (same fix for .github repo)
- SecPal/api#17 (same fix for api repo)