### PR TITLE
fix: use secrets inherit for cross-repo workflow calls

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -28,5 +28,4 @@ jobs:
   project-automation:
     name: Project automation
     uses: SecPal/.github/.github/workflows/project-automation-core.yml@main
-    secrets:
-      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+    secrets: inherit


### PR DESCRIPTION
## Problem

After adding permissions, the project automation still fails with `Bad credentials` error when called cross-repo.

## Root Cause

Cross-repo workflow calls don't properly receive explicitly passed secrets.

## Solution

Use `secrets: inherit` to ensure all secrets are available to the reusable workflow.

## Related

- SecPal/api#19 (same fix for api repo)