### PR TITLE
🔧 Improve pre-push error message for PR size violations

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -206,7 +206,6 @@ else
           echo "💡 Available options:" >&2
           echo "  1. Split PR: Recommended approach" >&2
           echo "  2. Override check: touch .preflight-allow-large-pr" >&2
-          echo "  3. Bypass hook: git push --no-verify (not recommended)" >&2
           echo "" >&2
           echo "Note: Lock files and license files are already excluded" >&2
           echo "      See .preflight-exclude for custom exclusion patterns" >&2

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -183,18 +183,38 @@ else
       echo "Preflight OK · Changed lines: 0 (after exclusions)"
       exit 0
     else
-      # Use --numstat for locale-independent parsing (sum insertions + deletions)
-      CHANGED=$(echo "$DIFF_OUTPUT" | awk '{ins+=$1; del+=$2} END {print ins+del+0}')
-      [ -z "$CHANGED" ] && CHANGED=0
+      # Use --numstat for locale-independent parsing
+      INSERTIONS=$(echo "$DIFF_OUTPUT" | awk '{ins+=$1} END {print ins+0}')
+      DELETIONS=$(echo "$DIFF_OUTPUT" | awk '{del+=$2} END {print del+0}')
+      CHANGED=$((INSERTIONS + DELETIONS))
 
       if [ "$CHANGED" -gt 600 ]; then
         # Check for override file (similar to GitHub label for exceptional cases)
         if [ -f "$ROOT_DIR/.preflight-allow-large-pr" ]; then
           echo "⚠️  Large PR override active ($CHANGED > 600 lines). Remove .preflight-allow-large-pr when done." >&2
         else
-          echo "PR too large ($CHANGED > 600 lines). Please split into smaller slices." >&2
-          echo "Tip: Lock files and license files are already excluded. See .preflight-exclude for details." >&2
-          echo "For exceptional cases, create .preflight-allow-large-pr to override this check." >&2
+          echo "" >&2
+          echo "═══════════════════════════════════════════════════════════════" >&2
+          echo "❌ PRE-PUSH CHECK FAILED: PR TOO LARGE" >&2
+          echo "═══════════════════════════════════════════════════════════════" >&2
+          echo "" >&2
+          echo "Your changes: $CHANGED lines ($INSERTIONS insertions, $DELETIONS deletions)" >&2
+          echo "Maximum allowed: 600 lines per PR" >&2
+          echo "" >&2
+          echo "Action required: Split changes into smaller, focused PRs" >&2
+          echo "" >&2
+          echo "💡 Available options:" >&2
+          echo "  1. Split PR: Recommended approach" >&2
+          echo "  2. Override check: touch .preflight-allow-large-pr" >&2
+          echo "  3. Bypass hook: git push --no-verify (not recommended)" >&2
+          echo "" >&2
+          echo "Note: Lock files and license files are already excluded" >&2
+          echo "      See .preflight-exclude for custom exclusion patterns" >&2
+          echo "" >&2
+          echo "═══════════════════════════════════════════════════════════════" >&2
+          echo "Push aborted. Fix the issue above and try again." >&2
+          echo "═══════════════════════════════════════════════════════════════" >&2
+          echo "" >&2
           exit 2
         fi
       else

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -76,7 +76,45 @@ elif [ -f yarn.lock ] && command -v yarn >/dev/null 2>&1; then
   fi
 fi
 
-# 2) Check PR size locally (against BASE)
+# 2) CHANGELOG validation (for non-docs branches)
+# Branch prefixes that are exempt from CHANGELOG updates (configuration)
+CHANGELOG_EXEMPT_PREFIXES="^(docs|chore|ci|test)/"
+# Minimum lines in [Unreleased] to consider it non-empty
+# Typically: 3 lines = one line each for Added, Changed, Fixed sections
+MIN_CHANGELOG_LINES=3
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [ -f CHANGELOG.md ] && [ "$CURRENT_BRANCH" != "main" ] && [[ ! "$CURRENT_BRANCH" =~ $CHANGELOG_EXEMPT_PREFIXES ]]; then
+  # Check if CHANGELOG has [Unreleased] section
+  if ! grep -q "## \[Unreleased\]" CHANGELOG.md; then
+    echo "❌ CHANGELOG.md missing [Unreleased] section" >&2
+    echo "Tip: Every feature/fix/refactor branch must update CHANGELOG.md" >&2
+    echo "Exempt branches: docs/*, chore/*, ci/*, test/*" >&2
+    exit 1
+  fi
+
+  # Check if there's actual content after [Unreleased] (robust to last/only section)
+  # Find line number of [Unreleased], then extract content up to next heading or EOF
+  UNRELEASED_START=$(grep -n '^## \[Unreleased\]' CHANGELOG.md | cut -d: -f1)
+  if [ -n "$UNRELEASED_START" ]; then
+    # Find next heading after [Unreleased], or use EOF if none found
+    UNRELEASED_END=$(tail -n +"$((UNRELEASED_START + 1))" CHANGELOG.md | grep -n '^## ' | head -1 | cut -d: -f1)
+    if [ -n "$UNRELEASED_END" ]; then
+      # Extract content between [Unreleased] and next heading
+      UNRELEASED_CONTENT=$(sed -n "$((UNRELEASED_START + 1)),$((UNRELEASED_START + UNRELEASED_END - 1))p" CHANGELOG.md | grep -v '^##' | grep -v '^$' | grep -v '^<!--' | grep -v '^-->' | wc -l)
+    else
+      # [Unreleased] is the last section, extract all remaining content
+      UNRELEASED_CONTENT=$(tail -n +"$((UNRELEASED_START + 1))" CHANGELOG.md | grep -v '^##' | grep -v '^$' | grep -v '^<!--' | grep -v '^-->' | wc -l)
+    fi
+
+    if [ "$UNRELEASED_CONTENT" -lt "$MIN_CHANGELOG_LINES" ]; then
+      echo "⚠️  Warning: [Unreleased] section appears empty in CHANGELOG.md" >&2
+      echo "Did you forget to document your changes?" >&2
+    fi
+  fi
+fi
+
+# 3) Check PR size locally (against BASE)
 if ! git rev-parse -q --verify "origin/$BASE" >/dev/null 2>&1; then
   echo "Warning: Cannot verify base branch origin/$BASE - skipping PR size check." >&2
   echo "Tip: Run 'git fetch origin $BASE' to enable PR size checking." >&2


### PR DESCRIPTION
## Problem

Same issue as described in SecPal/api#80 - pre-push hook error messages for PR size violations were unclear.

## Solution

Enhanced error message with clear visual structure (see SecPal/api#81 for example output).

## Changes

- Visual separators for attention
- Exact breakdown (insertions + deletions)
- Numbered bypass options
- Clear "Push aborted" message

Related: SecPal/api#80, SecPal/api#81