### PR TITLE
fix: Add missing permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -22,6 +22,11 @@ concurrency:
   group: ${{ github.repository }}-dependabot-auto-merge-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
+# Required permissions for dependabot auto-merge
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   auto-merge:
     uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@v1

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -35,3 +35,6 @@ jobs:
   draft-reminder:
     name: Draft PR Reminder
     uses: SecPal/.github/.github/workflows/draft-pr-reminder.yml@main
+    permissions:
+      issues: write
+      pull-requests: write


### PR DESCRIPTION
## Summary

Fixes permission errors in GitHub Actions workflows that were causing failures in CI/CD pipeline.

## Problem

Two workflows were failing with permission errors:

1. **Dependabot Auto-Merge** - `Invalid workflow file` error because workflow didn't declare required permissions
2. **Draft PR Reminder** - `403 Resource not accessible by integration` when trying to post comments

## Changes

### 1. Dependabot Auto-Merge (`dependabot-auto-merge.yml`)
- ✅ Added explicit `permissions:` block:
  - `contents: write` - Required for auto-merge operations
  - `pull-requests: write` - Required for PR status updates

### 2. Draft PR Reminder Job (`project-automation.yml`)
- ✅ Added job-level `permissions:` for draft-reminder:
  - `issues: write` - Required to post issue comments
  - `pull-requests: write` - Required to post PR comments

## Root Cause

GitHub Actions workflows calling reusable workflows MUST explicitly declare permissions if the reusable workflow requires them, even if the top-level workflow has those permissions.

## Related PRs

- SecPal/api#93 - Same fix for API repository
- SecPal/contracts (TBD) - Same fix needed

## Related Issues

Part of: SecPal/api#90

## Checklist

- [x] Workflow YAML syntax is valid
- [x] Permissions follow least-privilege principle
- [x] Related issue updated
