### PR TITLE
fix: add labeled event trigger to project automation workflow

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -9,6 +9,7 @@ on:
       - opened
       - reopened
       - closed
+      - labeled
   pull_request:
     types:
       - opened

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Project automation now triggers on label changes (labeled event)
+
 ### Added
 
 - Initial repository setup


### PR DESCRIPTION
Related to SecPal/api#92

## Problem

The project automation workflow was not triggering when labels were added to issues, preventing automatic addition of labeled issues to the GitHub Project board.

## Solution

Add `labeled` event trigger to the workflow:

```yaml
on:
  issues:
    types:
      - labeled  # ✅ ADDED
```

## Impact

- ✅ Issues with priority labels automatically added to project
- ✅ No manual intervention needed
- ✅ Consistent with api repository fix (SecPal/api#95)

See SecPal/api#92 for full context and root cause analysis.