### PR TITLE
fix: prevent preflight failure when [Unreleased] is last CHANGELOG section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Pre-push hook no longer fails with exit code 1 when [Unreleased] is the last CHANGELOG section
+
 ### Added
 
 - Initial repository setup

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -105,7 +105,8 @@ if [ -f CHANGELOG.md ] && [ "$CURRENT_BRANCH" != "main" ] && ! echo "$CURRENT_BR
   UNRELEASED_START=$(grep -n '^## \[Unreleased\]' CHANGELOG.md | cut -d: -f1)
   if [ -n "$UNRELEASED_START" ]; then
     # Find next heading after [Unreleased], or use EOF if none found
-    UNRELEASED_END=$(tail -n +"$((UNRELEASED_START + 1))" CHANGELOG.md | grep -n -m 1 '^## ' | cut -d: -f1)
+    # grep returns exit 1 when no match found - this is expected when [Unreleased] is last section
+    UNRELEASED_END=$(tail -n +"$((UNRELEASED_START + 1))" CHANGELOG.md | grep -n -m 1 '^## ' | cut -d: -f1 || true)
     if [ -n "$UNRELEASED_END" ]; then
       # Extract content between [Unreleased] and next heading (using helper function)
       UNRELEASED_CONTENT=$(sed -n "$((UNRELEASED_START + 1)),$((UNRELEASED_START + UNRELEASED_END - 1))p" CHANGELOG.md | filter_changelog_content | wc -l)


### PR DESCRIPTION
Related to SecPal/api#91

## Problem

The pre-push hook consistently failed with **exit code 1** even when all quality checks passed successfully, forcing developers to use `git push --no-verify`.

## Root Cause

The issue was caused by `grep` returning **exit 1** when searching for the next heading after `[Unreleased]` in CHANGELOG.md. When `[Unreleased]` is the **last section** (no subsequent `##` heading), `grep` fails to find a match and returns non-zero.

With `set -euo pipefail` enabled, this non-zero exit code terminated the entire preflight script.

## Solution

Add `|| true` to the grep command:

```bash
UNRELEASED_END=$(tail -n +"$((UNRELEASED_START + 1))" CHANGELOG.md | grep -n -m 1 '^## ' | cut -d: -f1 || true)
```

## Impact

- ✅ Developers can now push without `--no-verify` when checks pass
- ✅ Pre-push hook works as intended
- ✅ Consistent with api repository fix (SecPal/api#94)

See SecPal/api#91 for full context and root cause analysis.