### PR TITLE
docs: document intentional singleton persistence in analytics

### DIFF
--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -24,6 +24,15 @@ vi.mock("./db", () => ({
   },
 }));
 
+// NOTE: Singleton persistence across tests is intentional
+// The analytics singleton is created once at module load and persists across all test runs.
+// This mirrors production behavior where event listeners and intervals remain active for
+// the entire app lifetime. Test isolation is maintained through:
+// - vi.clearAllMocks() clears mock call history between tests
+// - Mocked dependencies (db, window.addEventListener, etc.) prevent side effects
+// - Each test operates on the same singleton but with fresh mocks
+// The destroy() method exists for explicit cleanup but is not called in tests to match
+// production behavior where the singleton lives for the app lifetime.
 describe("OfflineAnalytics", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -396,6 +396,13 @@ export function getAnalytics(): OfflineAnalytics {
 // Export singleton instance with safe initialization
 // If initialization fails (e.g., old browser), instance will be null
 // Use getAnalytics() for safe access with error handling
+//
+// NOTE: Singleton persists across tests by design
+// - Event listeners remain active for entire app lifetime in production
+// - Intervals are intentionally not cleaned up between tests
+// - Test isolation is maintained through vi.clearAllMocks() and mocked dependencies
+// - This is intentional behavior for a production singleton pattern
+// - The destroy() method exists for explicit cleanup when needed (e.g., during app teardown)
 let analyticsInstance: OfflineAnalytics | null = null;
 
 try {


### PR DESCRIPTION
Fixes #105 - Document that singleton persistence across tests is intentional behavior