### PR TITLE
test: wrap clearSharedData() calls in act() to eliminate RTL warnings

### DIFF
--- a/src/hooks/useShareTarget.test.ts
+++ b/src/hooks/useShareTarget.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor, act } from "@testing-library/react";
 import { useShareTarget } from "./useShareTarget";
 
 describe("useShareTarget", () => {
@@ -154,7 +154,9 @@ describe("useShareTarget", () => {
       });
     });
 
-    result.current.clearSharedData();
+    act(() => {
+      result.current.clearSharedData();
+    });
 
     await waitFor(() => {
       expect(result.current.sharedData).toBeNull();
@@ -177,7 +179,9 @@ describe("useShareTarget", () => {
       expect(result.current.sharedData?.text).toBe("First");
     });
 
-    result.current.clearSharedData();
+    act(() => {
+      result.current.clearSharedData();
+    });
 
     await waitFor(() => {
       expect(result.current.sharedData).toBeNull();


### PR DESCRIPTION
## Problem

Issue #102 - React Testing Library was showing act() warnings for `useShareTarget.test.ts`:

```
Warning: An update to TestComponent inside a test was not wrapped in act(...)
```

These appeared in 2 tests:
- "should clear shared data"
- "should handle multiple share events"

While tests were passing (11/11), the warnings indicated improper handling of async state updates, which could lead to flaky tests or false positives/negatives.

## Root Cause

The `clearSharedData()` function triggers React state updates, but the test calls were not wrapped in `act()`. React Testing Library requires all state-changing operations to be wrapped in `act()` to ensure tests properly wait for updates and render cycles.

## Solution

**Added `act()` import:**
```typescript
import { renderHook, waitFor, act } from "@testing-library/react";
```

**Wrapped state updates in act():**
```typescript
// Before
result.current.clearSharedData();

// After
act(() => {
  result.current.clearSharedData();
});
```

Applied to both affected tests:
1. Line 162: "should clear shared data"
2. Line 185: "should handle multiple share events"

## Testing Evidence

### Before
```
stderr | src/hooks/useShareTarget.test.ts > useShareTarget > should clear shared data
Warning: An update to TestComponent inside a test was not wrapped in act(...)

stderr | src/hooks/useShareTarget.test.ts > useShareTarget > should handle multiple share events
Warning: An update to TestComponent inside a test was not wrapped in act(...)
```

### After
✅ **Zero warnings from useShareTarget.test.ts**
```
✓ src/hooks/useShareTarget.test.ts (11 tests) 189ms
  ✓ useShareTarget (11)
    ✓ should clear shared data 13ms
    ✓ should handle multiple share events 19ms
```

### Quality Gates
- ✅ **Tests**: 136/136 passing (11/11 for useShareTarget.test.ts)
- ✅ **TypeScript**: `tsc --noEmit` - 0 errors
- ✅ **ESLint**: `--max-warnings 0` - 0 warnings
- ✅ **Prettier**: Format check passing
- ✅ **REUSE**: Compliant with version 3.3
- ✅ **Pre-push hooks**: All checks green

## Impact

### Before
- ⚠️ 2 act() warnings in test output
- ⚠️ Potential for flaky tests
- ⚠️ Not following RTL best practices

### After
- ✅ Clean test output (no warnings from this file)
- ✅ Proper synchronization of state updates
- ✅ Follows React Testing Library best practices
- ✅ More reliable test suite

## Implementation Details

The fix uses synchronous `act()` wrapping because `clearSharedData()` is a synchronous state setter. The `waitFor()` after the `act()` block ensures the test properly waits for the state update to complete before making assertions.

Pattern used:
```typescript
act(() => {
  result.current.clearSharedData(); // Synchronous state update
});

await waitFor(() => {
  expect(result.current.sharedData).toBeNull(); // Wait for update
});
```

## References

- [React Testing Library: act()](https://testing-library.com/docs/react-testing-library/api/#act)
- [React docs: act() utility](https://react.dev/reference/react/act)
- [Common mistakes with RTL](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library)

## Notes

**Scope**: This PR only addresses the warnings explicitly mentioned in Issue #102 for `useShareTarget.test.ts`. There are separate act() warnings in `NotificationPreferences.test.tsx` related to HeadlessUI Switch component internals, which will be addressed in a separate issue/PR.

## Self-Review Checklist

- [x] **Functional**: All tests passing (136/136)
- [x] **TypeScript**: `tsc --noEmit` clean
- [x] **ESLint**: No warnings (--max-warnings 0)
- [x] **Prettier**: Format check passing
- [x] **REUSE**: Compliant (106/106 files)
- [x] **Warnings Eliminated**: useShareTarget.test.ts shows zero act() warnings
- [x] **Pre-push**: All hooks green
- [x] **No Regressions**: Test count unchanged (11/11 tests still passing)

## Related Issues

Closes #102

## Changes Summary

- **Files Changed**: 1 (`src/hooks/useShareTarget.test.ts`)
- **Lines Added**: 7 (import + 2x act() wrappers)
- **Lines Removed**: 3 (unwrapped calls)
- **Risk Level**: LOW (test-only change, no production code affected)
- **Breaking Changes**: None