### PR TITLE
fix: configure Vitest pool to prevent fork timeout errors

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -178,6 +178,12 @@ export default defineConfig(({ mode }) => {
       globals: true,
       environment: "jsdom",
       setupFiles: "./tests/setup.ts",
+      pool: "forks",
+      poolOptions: {
+        forks: {
+          singleFork: true,
+        },
+      },
       coverage: {
         provider: "v8",
         reporter: ["text", "json", "html"],


### PR DESCRIPTION
## Problem
All Vitest test runs in CI are experiencing "Timeout starting forks runner" errors, causing test failures across multiple Dependabot PRs (#126, #128, #129).

## Solution
Configure Vitest to use explicit fork pool settings:
- `pool: 'forks'` - Use fork pool for test isolation
- `singleFork: true` - Run all tests in a single fork process

## Impact
- ✅ Fixes test timeouts in CI
- ✅ Resolves blocked Dependabot PRs
- ✅ Applies to all future test runs
- ⚠️ Tests run sequentially (may be slightly slower, but stable)

## Testing
- [ ] All existing tests pass without timeout errors
- [ ] CI completes successfully

## Related Issues
- Fixes test failures in #126
- Fixes test failures in #128  
- Fixes test failures in #129