### PR TITLE
fix(tests): Add missing @testing-library/dom peer dependency

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,8 +9,8 @@ We follow [Semantic Versioning](https://semver.org/) (SEMVER). Security updates 
 
 | Version | Supported | Notes                                                     |
 | ------- | --------- | --------------------------------------------------------- |
-| 0.x.x   | ✅        | Development phase - all versions receive security updates |
-| < 0.0.1 | ❌        | Not yet released                                          |
+| 0.x.x   | Yes       | Development phase - all versions receive security updates |
+| < 0.0.1 | No        | Not yet released                                          |
 
 **Note:** Once we reach 1.0.0 (stable release), we will support:
 
@@ -147,14 +147,14 @@ SecPal repositories have the following security features enabled:
 
 | Feature                         | Status | Description                            |
 | ------------------------------- | ------ | -------------------------------------- |
-| **Secret Scanning**             | ✅     | Detects leaked credentials             |
-| **Push Protection**             | ✅     | Blocks commits with secrets            |
-| **Dependabot Security Updates** | ✅     | Automated security patches             |
-| **Dependabot Version Updates**  | ✅     | Daily dependency updates (04:00 CET)   |
-| **CodeQL Analysis**             | ✅     | SAST for JavaScript/TypeScript         |
-| **Branch Protection**           | ✅     | Enforced status checks, signed commits |
-| **Security Advisories**         | ✅     | Private vulnerability reporting        |
-| **Two-Factor Authentication**   | ✅     | Required for all maintainers           |
+| **Secret Scanning**             | Yes    | Detects leaked credentials             |
+| **Push Protection**             | Yes    | Blocks commits with secrets            |
+| **Dependabot Security Updates** | Yes    | Automated security patches             |
+| **Dependabot Version Updates**  | Yes    | Daily dependency updates (04:00 CET)   |
+| **CodeQL Analysis**             | Yes    | SAST for JavaScript/TypeScript         |
+| **Branch Protection**           | Yes    | Enforced status checks, signed commits |
+| **Security Advisories**         | Yes    | Private vulnerability reporting        |
+| **Two-Factor Authentication**   | Yes    | Required for all maintainers           |
 
 ## Known Security Limitations
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@lingui/cli": "^5.5.2",
     "@lingui/macro": "^5.5.2",
     "@tailwindcss/vite": "^4.1.17",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
+import { screen } from "@testing-library/dom";
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
 import App from "./App";

--- a/src/components/LanguageSwitcher.test.tsx
+++ b/src/components/LanguageSwitcher.test.tsx
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render } from "@testing-library/react";
+import { screen, fireEvent, waitFor } from "@testing-library/dom";
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
 import { LanguageSwitcher } from "./LanguageSwitcher";

--- a/src/components/NotificationPreferences.test.tsx
+++ b/src/components/NotificationPreferences.test.tsx
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/dom";
 import userEvent from "@testing-library/user-event";
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";

--- a/src/components/StorageQuotaIndicator.test.tsx
+++ b/src/components/StorageQuotaIndicator.test.tsx
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/dom";
 import { StorageQuotaIndicator } from "./StorageQuotaIndicator";
 
 describe("StorageQuotaIndicator", () => {

--- a/src/components/SyncStatusIndicator.test.tsx
+++ b/src/components/SyncStatusIndicator.test.tsx
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/dom";
 import userEvent from "@testing-library/user-event";
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, waitFor, act } from "@testing-library/react";
+import { renderHook, act } from "@testing-library/react";
+import { waitFor } from "@testing-library/dom";
 import { useNotifications } from "./useNotifications";
 
 // Mock Notification API

--- a/src/hooks/useShareTarget.test.ts
+++ b/src/hooks/useShareTarget.test.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, waitFor, act } from "@testing-library/react";
+import { renderHook, act } from "@testing-library/react";
+import { waitFor } from "@testing-library/dom";
 import { useShareTarget } from "./useShareTarget";
 
 describe("useShareTarget", () => {

--- a/src/main.test.tsx
+++ b/src/main.test.tsx
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/dom";
 import { StrictMode } from "react";
 import { AppWithI18n } from "./main";
 


### PR DESCRIPTION
## Problem

Since `@testing-library/react` v16.0.0 (June 2024), `@testing-library/dom` became a **peer dependency** and must be explicitly installed. This was causing TypeScript errors in 8 test files and blocking CI checks for all PRs, including Dependabot auto-merge.

**Error Example:**
```
src/App.test.tsx:5:18 - error TS2305: Module '"@testing-library/react"' has no exported member 'screen'.
```

## Solution

### Testing Library Fix
- ✅ Added `@testing-library/dom@^10.4.1` to devDependencies
- ✅ Updated imports in 8 test files:
  - `screen`, `fireEvent`, `waitFor` now imported from `@testing-library/dom`
  - `render`, `renderHook`, `act` remain from `@testing-library/react`

### SECURITY.md Formatting Fix
- ✅ Fixed MD060 table formatting errors (replaced emojis with text "Yes"/"No" for proper pipe alignment)

## Testing

All 136 tests passing locally:
```
Test Files  12 passed (12)
     Tests  136 passed (136)
  Duration  74.68s
```

## Impact

This fix unblocks:
- ✅ All future PRs (CI TypeScript checks will pass)
- ✅ Dependabot auto-merge workflow
- ✅ Manual test execution (`npm test`, `npm run typecheck`)

## References

- [React Testing Library v16.0.0 Release Notes](https://github.com/testing-library/react-testing-library/releases/tag/v16.0.0)
- Breaking Change: `@testing-library/dom` moved to peer dependency

---

**Related:**  
Fixes blocked Dependabot PRs #126, #128, #129 (Lingui updates)