### PR TITLE
feat(ci): migrate to reusable conflict marker workflow

### DIFF
--- a/.github/workflows/check-conflict-markers.yml
+++ b/.github/workflows/check-conflict-markers.yml
@@ -14,14 +14,4 @@ permissions:
 
 jobs:
   check-conflicts:
-    name: Check for Git Conflict Markers
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Run conflict marker check
-        run: |
-          chmod +x scripts/check-conflict-markers.sh
-          ./scripts/check-conflict-markers.sh
+    uses: SecPal/.github/.github/workflows/reusable-check-conflict-markers.yml@main


### PR DESCRIPTION
## Description

Migrates the `frontend` repository to use the new **reusable conflict marker workflow** from the `.github` repository.

## Changes

- ✅ Updated `.github/workflows/check-conflict-markers.yml` to use reusable workflow
- ✅ Removed local workflow implementation (11 lines → 1 line)

## Benefits

- **Consistency**: Uses the same implementation as all other SecPal repos
- **Automatic Updates**: Future improvements are applied automatically
- **Simplified Maintenance**: No need to maintain local copy
- **DRY Principle**: Single source of truth

## Testing

- [x] CI will use reusable workflow after merge

## Related

- Part of SecPal/.github#176
- Implementation: SecPal/.github#195