### PR TITLE
refactor: Replace any types with proper TypeScript types in ShareTarget utils

### DIFF
--- a/src/pages/ShareTarget.test.tsx
+++ b/src/pages/ShareTarget.test.tsx
@@ -660,8 +660,10 @@ describe("ShareTarget Component", () => {
 });
 
 describe("handleShareTargetMessage (unit tests)", () => {
-  let loadSharedDataSpy: () => void;
-  let setErrorsSpy: (errors: string[] | ((prev: string[]) => string[])) => void;
+  let loadSharedDataSpy: vi.Mock<() => void>;
+  let setErrorsSpy: vi.Mock<
+    (errors: string[] | ((prev: string[]) => string[])) => void
+  >;
 
   beforeEach(() => {
     sessionStorage.clear();

--- a/src/pages/ShareTarget.test.tsx
+++ b/src/pages/ShareTarget.test.tsx
@@ -660,8 +660,8 @@ describe("ShareTarget Component", () => {
 });
 
 describe("handleShareTargetMessage (unit tests)", () => {
-  let loadSharedDataSpy: ReturnType<typeof vi.fn>;
-  let setErrorsSpy: ReturnType<typeof vi.fn>;
+  let loadSharedDataSpy: () => void;
+  let setErrorsSpy: (errors: string[] | ((prev: string[]) => string[])) => void;
 
   beforeEach(() => {
     sessionStorage.clear();

--- a/src/pages/ShareTarget.test.tsx
+++ b/src/pages/ShareTarget.test.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Mock } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
 import { I18nProvider } from "@lingui/react";
@@ -660,8 +661,8 @@ describe("ShareTarget Component", () => {
 });
 
 describe("handleShareTargetMessage (unit tests)", () => {
-  let loadSharedDataSpy: vi.Mock<() => void>;
-  let setErrorsSpy: vi.Mock<
+  let loadSharedDataSpy: Mock<() => void>;
+  let setErrorsSpy: Mock<
     (errors: string[] | ((prev: string[]) => string[])) => void
   >;
 

--- a/src/pages/ShareTarget.test.tsx
+++ b/src/pages/ShareTarget.test.tsx
@@ -753,7 +753,7 @@ describe("handleShareTargetMessage (unit tests)", () => {
     expect(setErrorsSpy).toHaveBeenCalledOnce();
     const errorUpdater = setErrorsSpy.mock.calls[0]?.[0];
     expect(errorUpdater).toBeDefined();
-    if (errorUpdater) {
+    if (typeof errorUpdater === "function") {
       const newErrors = errorUpdater([]);
       expect(newErrors).toEqual(["File processing failed"]);
     }
@@ -800,7 +800,7 @@ describe("handleShareTargetMessage (unit tests)", () => {
 
     const errorUpdater = setErrorsSpy.mock.calls[0]?.[0];
     expect(errorUpdater).toBeDefined();
-    if (errorUpdater) {
+    if (typeof errorUpdater === "function") {
       const newErrors = errorUpdater([]);
       expect(newErrors).toEqual(["Unknown error"]);
     }

--- a/src/pages/ShareTarget.utils.ts
+++ b/src/pages/ShareTarget.utils.ts
@@ -7,14 +7,14 @@
  *
  * @param event - MessageEvent from Service Worker
  * @param shareId - Current session's share ID (from URL param)
- * @param loadSharedData - Callback to reload shared data after files are received (production: () => void)
- * @param setErrors - Callback to update error state (production: (errors: string[] | ((prev: string[]) => string[])) => void)
+ * @param loadSharedData - Callback to reload shared data after files are received
+ * @param setErrors - Callback to update error state
  */
 export function handleShareTargetMessage(
   event: MessageEvent,
   shareId: string | null,
-  loadSharedData: any, // eslint-disable-line @typescript-eslint/no-explicit-any
-  setErrors: any // eslint-disable-line @typescript-eslint/no-explicit-any
+  loadSharedData: () => void,
+  setErrors: (errors: string[] | ((prev: string[]) => string[])) => void
 ): void {
   if (!event.data) return;
 
@@ -42,8 +42,7 @@ export function handleShareTargetMessage(
 
     // Only add error if shareId matches (or if no shareId provided)
     if (!shareId || !messageShareId || shareId === messageShareId) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      setErrors((prev: any) => [...prev, error]);
+      setErrors((prev) => [...prev, error]);
     }
   }
 }


### PR DESCRIPTION
## Problem

`ShareTarget.utils.ts` uses `any` types for callback parameters, defeating TypeScript's type safety.

## Solution

Replaced `any` types with explicit function signatures:
- `loadSharedData: () => void`
- `setErrors: (errors: string[] | ((prev: string[]) => string[])) => void`

Also removed unnecessary inline type annotation `(prev: any)` in favor of type inference.

## Changes

- ✅ Proper TypeScript types for callbacks
- ✅ Removed eslint-disable comments
- ✅ Removed inline `any` type annotation
- ✅ No behavior changes
- ✅ All tests pass

## Impact

- Better compile-time type checking
- Improved IDE autocomplete
- Easier maintenance
- Addresses Copilot review feedback

Fixes #152