### PR TITLE
fix(ci): make codecov upload non-blocking for dependabot PRs

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -71,4 +71,4 @@ jobs:
           files: ./coverage/lcov.info,./coverage/clover.xml
           flags: frontend
           name: frontend-coverage
-          fail_ci_if_error: true
+          fail_ci_if_error: ${{ github.actor != 'dependabot[bot]' }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -71,4 +71,4 @@ jobs:
           files: ./coverage/lcov.info,./coverage/clover.xml
           flags: frontend
           name: frontend-coverage
-          fail_ci_if_error: ${{ github.actor != 'dependabot[bot]' }}
+          fail_ci_if_error: ${{ !contains(fromJSON('["dependabot[bot]", "renovate[bot]"]'), github.actor) }}


### PR DESCRIPTION
## Problem

All 7 Dependabot PRs (#155-#162) are failing CI with:
```
error - Upload failed: {"message":"Token required because branch is protected"}
```

**Root Cause**: Dependabot PRs don't have access to `CODECOV_TOKEN` secret for security reasons. This causes the Codecov upload step to fail, which in turn fails the entire CI pipeline because `fail_ci_if_error: true`.

**Test Results**: All tests pass (206 passed), only the Codecov upload fails.

## Solution

Set `fail_ci_if_error: ${{ github.actor != 'dependabot[bot]' }}` in the Vitest workflow step.

- ✅ For normal PRs: Codecov upload failures still fail CI (as intended)
- ✅ For Dependabot PRs: Codecov upload failures are non-blocking
- ✅ Tests still run and coverage is attempted for all PRs
- ✅ No security implications (Dependabot already can't access the token)

## Testing

After merging this PR, the 7 blocked Dependabot PRs will be rebased and should pass CI.