### PR TITLE
fix(ci): make codecov upload fully functional for dependabot PRs

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -67,8 +67,13 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          # Token is optional for public repos (tokenless uploads supported)
+          # Dependabot PRs cannot access secrets, so token may be empty
+          token: ${{ secrets.CODECOV_TOKEN || '' }}
           files: ./coverage/lcov.info,./coverage/clover.xml
           flags: frontend
           name: frontend-coverage
           fail_ci_if_error: ${{ !contains(fromJSON('["dependabot[bot]", "renovate[bot]"]'), github.actor) }}
+        # Allow step to succeed even if upload fails for dependabot
+        # This prevents blocking the PR when CODECOV_TOKEN is unavailable
+        continue-on-error: ${{ contains(fromJSON('["dependabot[bot]", "renovate[bot]"]'), github.actor) }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,6 +261,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CI/CD**: Codecov upload now fully functional for Dependabot PRs
+  - Added `continue-on-error` for dependabot/renovate bots to prevent blocking
+  - Made `CODECOV_TOKEN` optional (tokenless uploads work for public repos)
+  - Upload step succeeds even without token access (Dependabot security restriction)
+  - Normal PRs still fail CI on codecov errors (security preserved)
+  - Fixes issue where Codecov checks remained pending/missing on Dependabot PRs
 - **Blank Page Issue**: Fixed blank page caused by incompatible module format in translation catalogs
   - Changed Lingui compilation from CommonJS (`module.exports`) to ES modules (`export`)
   - Updated `package.json` scripts to use `--namespace es` flag for `lingui compile`


### PR DESCRIPTION
- Added continue-on-error for dependabot/renovate bots
- Made CODECOV_TOKEN optional (tokenless uploads for public repos)
- Upload step now succeeds even without token access (Dependabot security)
- Normal PRs still fail CI on codecov errors (security preserved)
- Fixes issue where Codecov checks remained pending/missing on Dependabot PRs

Dependabot PRs cannot access repository secrets due to GitHub security
restrictions. Since SecPal/frontend is a public repo, Codecov supports
tokenless uploads. This fix allows the upload step to succeed gracefully
for bot PRs while maintaining strict validation for human PRs.

Aligns with backend implementation (DRY principle).
