### PR TITLE
fix(deps): sync vitest ecosystem to 4.0.13 to resolve Dependabot conflicts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,8 +38,8 @@
         "@typescript-eslint/eslint-plugin": "^8.26.0",
         "@typescript-eslint/parser": "^8.47.0",
         "@vitejs/plugin-react": "^5.1.1",
-        "@vitest/coverage-v8": "^4.0.12",
-        "@vitest/ui": "^4.0.8",
+        "@vitest/coverage-v8": "^4.0.13",
+        "@vitest/ui": "^4.0.13",
         "babel-plugin-macros": "^3.1.0",
         "cross-env": "^10.1.0",
         "dotenv": "^17.2.3",
@@ -55,7 +55,7 @@
         "typescript-eslint": "^8.47.0",
         "vite": "^7.2.4",
         "vite-plugin-pwa": "^1.1.0",
-        "vitest": "^4.0.3",
+        "vitest": "^4.0.13",
         "workbox-window": "^7.4.0"
       },
       "engines": {
@@ -4504,14 +4504,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.12.tgz",
-      "integrity": "sha512-d+w9xAFJJz6jyJRU4BUU7MH409Ush7FWKNkxJU+jASKg6WX33YT0zc+YawMR1JesMWt9QRFQY/uAD3BTn23FaA==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.13.tgz",
+      "integrity": "sha512-w77N6bmtJ3CFnL/YHiYotwW/JI3oDlR3K38WEIqegRfdMSScaYxwYKB/0jSNpOTZzUjQkG8HHEz4sdWQMWpQ5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.0.12",
+        "@vitest/utils": "4.0.13",
         "ast-v8-to-istanbul": "^0.3.8",
         "debug": "^4.4.3",
         "istanbul-lib-coverage": "^3.2.2",
@@ -4526,8 +4526,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.0.12",
-        "vitest": "4.0.12"
+        "@vitest/browser": "4.0.13",
+        "vitest": "4.0.13"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -4536,16 +4536,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.12.tgz",
-      "integrity": "sha512-is+g0w8V3/ZhRNrRizrJNr8PFQKwYmctWlU4qg8zy5r9aIV5w8IxXLlfbbxJCwSpsVl2PXPTm2/zruqTqz3QSg==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.13.tgz",
+      "integrity": "sha512-zYtcnNIBm6yS7Gpr7nFTmq8ncowlMdOJkWLqYvhr/zweY6tFbDkDi8BPPOeHxEtK1rSI69H7Fd4+1sqvEGli6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.12",
-        "@vitest/utils": "4.0.12",
+        "@vitest/spy": "4.0.13",
+        "@vitest/utils": "4.0.13",
         "chai": "^6.2.1",
         "tinyrainbow": "^3.0.3"
       },
@@ -4554,13 +4554,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.12.tgz",
-      "integrity": "sha512-GsmA/tD5Ht3RUFoz41mZsMU1AXch3lhmgbTnoSPTdH231g7S3ytNN1aU0bZDSyxWs8WA7KDyMPD5L4q6V6vj9w==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.13.tgz",
+      "integrity": "sha512-eNCwzrI5djoauklwP1fuslHBjrbR8rqIVbvNlAnkq1OTa6XT+lX68mrtPirNM9TnR69XUPt4puBCx2Wexseylg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.12",
+        "@vitest/spy": "4.0.13",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -4581,9 +4581,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.12.tgz",
-      "integrity": "sha512-R7nMAcnienG17MvRN8TPMJiCG8rrZJblV9mhT7oMFdBXvS0x+QD6S1G4DxFusR2E0QIS73f7DqSR1n87rrmE+g==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.13.tgz",
+      "integrity": "sha512-ooqfze8URWbI2ozOeLDMh8YZxWDpGXoeY3VOgcDnsUxN0jPyPWSUvjPQWqDGCBks+opWlN1E4oP1UYl3C/2EQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4594,13 +4594,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.12.tgz",
-      "integrity": "sha512-hDlCIJWuwlcLumfukPsNfPDOJokTv79hnOlf11V+n7E14rHNPz0Sp/BO6h8sh9qw4/UjZiKyYpVxK2ZNi+3ceQ==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.13.tgz",
+      "integrity": "sha512-9IKlAru58wcVaWy7hz6qWPb2QzJTKt+IOVKjAx5vb5rzEFPTL6H4/R9BMvjZ2ppkxKgTrFONEJFtzvnyEpiT+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.12",
+        "@vitest/utils": "4.0.13",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -4608,13 +4608,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.12.tgz",
-      "integrity": "sha512-2jz9zAuBDUSbnfyixnyOd1S2YDBrZO23rt1bicAb6MA/ya5rHdKFRikPIDpBj/Dwvh6cbImDmudegnDAkHvmRQ==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.13.tgz",
+      "integrity": "sha512-hb7Usvyika1huG6G6l191qu1urNPsq1iFc2hmdzQY3F5/rTgqQnwwplyf8zoYHkpt7H6rw5UfIw6i/3qf9oSxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.12",
+        "@vitest/pretty-format": "4.0.13",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -4623,9 +4623,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.12.tgz",
-      "integrity": "sha512-GZjI9PPhiOYNX8Nsyqdw7JQB+u0BptL5fSnXiottAUBHlcMzgADV58A7SLTXXQwcN1yZ6gfd1DH+2bqjuUlCzw==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.13.tgz",
+      "integrity": "sha512-hSu+m4se0lDV5yVIcNWqjuncrmBgwaXa2utFLIrBkQCQkt+pSwyZTPFQAZiiF/63j8jYa8uAeUZ3RSfcdWaYWw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4633,13 +4633,13 @@
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.0.12.tgz",
-      "integrity": "sha512-RCqeApCnbwd5IFvxk6OeKMXTvzHU/cVqY8HAW0gWk0yAO6wXwQJMKhDfDtk2ss7JCy9u7RNC3kyazwiaDhBA/g==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.0.13.tgz",
+      "integrity": "sha512-MFV6GhTflgBj194+vowTB2iLI5niMZhqiW7/NV7U4AfWbX/IAtsq4zA+gzCLyGzpsQUdJlX26hrQ1vuWShq2BQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.12",
+        "@vitest/utils": "4.0.13",
         "fflate": "^0.8.2",
         "flatted": "^3.3.3",
         "pathe": "^2.0.3",
@@ -4651,17 +4651,17 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.0.12"
+        "vitest": "4.0.13"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.12.tgz",
-      "integrity": "sha512-DVS/TLkLdvGvj1avRy0LSmKfrcI9MNFvNGN6ECjTUHWJdlcgPDOXhjMis5Dh7rBH62nAmSXnkPbE+DZ5YD75Rw==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.13.tgz",
+      "integrity": "sha512-ydozWyQ4LZuu8rLp47xFUWis5VOKMdHjXCWhs1LuJsTNKww+pTHQNK4e0assIB9K80TxFyskENL6vCu3j34EYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.12",
+        "@vitest/pretty-format": "4.0.13",
         "tinyrainbow": "^3.0.3"
       },
       "funding": {
@@ -10898,19 +10898,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.12.tgz",
-      "integrity": "sha512-pmW4GCKQ8t5Ko1jYjC3SqOr7TUKN7uHOHB/XGsAIb69eYu6d1ionGSsb5H9chmPf+WeXt0VE7jTXsB1IvWoNbw==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.13.tgz",
+      "integrity": "sha512-QSD4I0fN6uZQfftryIXuqvqgBxTvJ3ZNkF6RWECd82YGAYAfhcppBLFXzXJHQAAhVFyYEuFTrq6h0hQqjB7jIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.12",
-        "@vitest/mocker": "4.0.12",
-        "@vitest/pretty-format": "4.0.12",
-        "@vitest/runner": "4.0.12",
-        "@vitest/snapshot": "4.0.12",
-        "@vitest/spy": "4.0.12",
-        "@vitest/utils": "4.0.12",
+        "@vitest/expect": "4.0.13",
+        "@vitest/mocker": "4.0.13",
+        "@vitest/pretty-format": "4.0.13",
+        "@vitest/runner": "4.0.13",
+        "@vitest/snapshot": "4.0.13",
+        "@vitest/spy": "4.0.13",
+        "@vitest/utils": "4.0.13",
         "debug": "^4.4.3",
         "es-module-lexer": "^1.7.0",
         "expect-type": "^1.2.2",
@@ -10939,10 +10939,10 @@
         "@opentelemetry/api": "^1.9.0",
         "@types/debug": "^4.1.12",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.12",
-        "@vitest/browser-preview": "4.0.12",
-        "@vitest/browser-webdriverio": "4.0.12",
-        "@vitest/ui": "4.0.12",
+        "@vitest/browser-playwright": "4.0.13",
+        "@vitest/browser-preview": "4.0.13",
+        "@vitest/browser-webdriverio": "4.0.13",
+        "@vitest/ui": "4.0.13",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/package.json
+++ b/package.json
@@ -76,8 +76,8 @@
     "@typescript-eslint/eslint-plugin": "^8.26.0",
     "@typescript-eslint/parser": "^8.47.0",
     "@vitejs/plugin-react": "^5.1.1",
-    "@vitest/coverage-v8": "^4.0.12",
-    "@vitest/ui": "^4.0.8",
+    "@vitest/coverage-v8": "^4.0.13",
+    "@vitest/ui": "^4.0.13",
     "babel-plugin-macros": "^3.1.0",
     "cross-env": "^10.1.0",
     "dotenv": "^17.2.3",
@@ -93,7 +93,7 @@
     "typescript-eslint": "^8.47.0",
     "vite": "^7.2.4",
     "vite-plugin-pwa": "^1.1.0",
-    "vitest": "^4.0.3",
+    "vitest": "^4.0.13",
     "workbox-window": "^7.4.0"
   },
   "engines": {


### PR DESCRIPTION
## Problem

Dependabot PRs #184 and #185 were failing CI with peer dependency conflicts:

```
npm error ERESOLVE could not resolve
npm error While resolving: @vitest/coverage-v8@4.0.12
npm error Found: vitest@4.0.13
npm error Could not resolve dependency:
npm error peer vitest@"4.0.12" from @vitest/coverage-v8@4.0.12
```

This occurred because:
- Main branch had `vitest` at `^4.0.3` (resolves to 4.0.13)
- Dependabot tried to update individual packages (`@vitest/ui` and `@vitest/coverage-v8`) to 4.0.12
- The vitest ecosystem requires all packages to be on the same version

## Solution

Synchronized all vitest-related packages to version 4.0.13:
- `vitest`: `^4.0.3` → `^4.0.13`
- `@vitest/ui`: `^4.0.8` → `^4.0.13`
- `@vitest/coverage-v8`: `^4.0.12` → `^4.0.13`

## Testing

✅ All tests pass locally (364 tests)
✅ ESLint passes
✅ TypeScript check passes
✅ Pre-push hooks pass (formatting, REUSE, domain policy)

## Related Issues

Closes #184
Closes #185