### PR TITLE
feat: Add AGPL v3+ compliant footer with license notice

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { Trans } from "@lingui/macro";
 import { Link } from "./components/link";
+import { Footer } from "./components/Footer";
 import { OfflineIndicator } from "./components/OfflineIndicator";
 import { SyncStatusIndicator } from "./components/SyncStatusIndicator";
 import { AuthProvider } from "./contexts/AuthContext";
@@ -63,7 +64,7 @@ function App() {
   return (
     <AuthProvider>
       <BrowserRouter>
-        <div className="app">
+        <div className="flex min-h-screen flex-col">
           <Routes>
             <Route path="/login" element={<Login />} />
             <Route
@@ -123,9 +124,10 @@ function App() {
               }
             />
           </Routes>
+          <Footer />
+          <OfflineIndicator />
+          <SyncStatusIndicator apiBaseUrl={getApiBaseUrl()} />
         </div>
-        <OfflineIndicator />
-        <SyncStatusIndicator apiBaseUrl={getApiBaseUrl()} />
       </BrowserRouter>
     </AuthProvider>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: 2025 SecPal
+ * SPDX-FileCopyrightText: Tailwind Labs Inc.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { Trans } from "@lingui/macro";
+import { ScaleIcon, CodeBracketIcon } from "@heroicons/react/24/outline";
+import { Text, Strong } from "./text";
+import { Link } from "./link";
+
+export function Footer() {
+  return (
+    <footer className="mt-auto py-4">
+      <div className="mx-auto max-w-6xl px-6 text-center">
+        <Text className="mb-2 text-xs">
+          <Strong>
+            <Trans>Powered by SecPal - a guard's best friend</Trans>
+          </Strong>
+        </Text>
+        <div className="flex items-center justify-center gap-3 text-xs">
+          <Link
+            href="https://www.gnu.org/licenses/agpl-3.0.html"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-zinc-500 hover:text-zinc-950 dark:text-zinc-400 dark:hover:text-white"
+          >
+            <ScaleIcon className="h-4 w-4" aria-hidden="true" />
+            <span>AGPL v3+</span>
+          </Link>
+          <span className="text-zinc-300 dark:text-zinc-600" aria-hidden="true">
+            |
+          </span>
+          <Link
+            href="https://github.com/SecPal"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-zinc-500 hover:text-zinc-950 dark:text-zinc-400 dark:hover:text-white"
+          >
+            <CodeBracketIcon className="h-4 w-4" aria-hidden="true" />
+            <Trans>Source Code</Trans>
+          </Link>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,8 +1,6 @@
-/*
- * SPDX-FileCopyrightText: 2025 SecPal
- * SPDX-FileCopyrightText: Tailwind Labs Inc.
- * SPDX-License-Identifier: AGPL-3.0-or-later
- */
+// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: Tailwind Labs Inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { Trans } from "@lingui/macro";
 import { ScaleIcon, CodeBracketIcon } from "@heroicons/react/24/outline";

--- a/src/components/auth-layout.tsx
+++ b/src/components/auth-layout.tsx
@@ -7,7 +7,7 @@ import type React from "react";
 
 export function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
-    <main className="flex min-h-dvh items-center justify-center p-4 lg:p-8">
+    <main className="flex flex-1 items-center justify-center p-4 lg:p-8">
       <div className="w-full max-w-2xl p-8 lg:rounded-lg lg:bg-white lg:p-12 lg:shadow-xs lg:ring-1 lg:ring-zinc-950/5 dark:lg:bg-zinc-900 dark:lg:ring-white/10">
         {children}
       </div>


### PR DESCRIPTION
## Summary

Adds a global footer component to comply with AGPL v3 or later license requirements (Section 13 - network use).

## Changes

- ✅ **Footer Component** with Catalyst design system
  - Displays "Powered by SecPal - a guard's best friend" tagline
  - Links to AGPL v3+ license (GNU.org)
  - Links to GitHub source code repository
  - Uses Heroicons for visual clarity (ScaleIcon, CodeBracketIcon)
  - Dezent: no border, subtle zinc colors, text-xs size

- ✅ **Layout Optimization**
  - Integrated footer globally in `App.tsx`
  - Fixed `AuthLayout` vertical centering issue
  - Removed unnecessary `.app` wrapper for proper flex layout
  - Login form now properly centered with footer visible

## AGPL Compliance

✅ Complies with **AGPL Section 13** requirements:
- License notice visible to all network users
- Direct access to source code (GitHub link)
- Footer appears on all pages (including login)

## Commercial License Path

For commercial licensing (removing footer), this component can simply be removed from `App.tsx`.

## Related

Part of: License compliance initiative