### PR TITLE
fix(deps): sync vitest versions to 4.0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@typescript-eslint/parser": "^8.47.0",
     "@vitejs/plugin-react": "^5.1.1",
     "@vitest/coverage-v8": "^4.0.14",
-    "@vitest/ui": "^4.0.13",
+    "@vitest/ui": "^4.0.14",
     "babel-plugin-macros": "^3.1.0",
     "cross-env": "^10.1.0",
     "dotenv": "^17.2.3",
@@ -94,7 +94,7 @@
     "vite": "^7.2.4",
     "vite-plugin-pwa": "^1.1.0",
     "vite-plugin-static-copy": "^3.1.4",
-    "vitest": "^4.0.13",
+    "vitest": "^4.0.14",
     "workbox-window": "^7.4.0"
   },
   "engines": {


### PR DESCRIPTION
## Summary

Resolves peer dependency conflict from Dependabot PRs #231, #232, #233.

## Changes

All vitest-related packages synchronized to 4.0.14:
- `vitest`: 4.0.13 → 4.0.14
- `@vitest/ui`: 4.0.13 → 4.0.14
- `@vitest/coverage-v8`: 4.0.14 (already up-to-date)

## Root Cause

Dependabot created separate PRs to update vitest packages incrementally, but `@vitest/ui@4.0.14` requires `vitest@4.0.14` as a peer dependency. This caused `npm ci` failures in CI:

```
npm error While resolving: @vitest/ui@4.0.14
npm error Found: vitest@4.0.13
npm error Could not resolve dependency:
npm error peer vitest@"4.0.14" from @vitest/ui@4.0.14
```

## Testing

- ✅ `npm install` completes successfully
- ✅ Preflight checks pass (lint, typecheck, REUSE, domain policy)
- ⏳ CI will validate all tests

## Related Issues

- Fixes CI failures in #231 (vitest update)
- Fixes CI failures in #232 (@vitest/coverage-v8 update)
- Fixes CI failures in #233 (@vitest/ui update)