### PR TITLE
fix: remove /api/ prefix from all API paths

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,7 @@
  */
 export const apiConfig = {
   /**
-   * Base URL for API requests
+   * Base URL for API requests (without /api prefix - backend routes are at /v1/*)
    * Can be overridden via VITE_API_URL environment variable
    *
    * Examples:
@@ -21,6 +21,9 @@ export const apiConfig = {
    * - Demo/Testing: https://api.secpal.dev
    * - Production: https://api.secpal.app
    * - Customer On-Premise: https://api.customer.example.com
+   *
+   * Note: The backend uses apiPrefix: '' in Laravel's bootstrap/app.php,
+   * so routes are accessible at /v1/secrets NOT /api/v1/secrets
    */
   baseUrl:
     import.meta.env.VITE_API_URL ||

--- a/src/hooks/useCache.test.ts
+++ b/src/hooks/useCache.test.ts
@@ -133,15 +133,12 @@ describe("useCache", () => {
 
       let cached;
       await act(async () => {
-        cached = await result.current.isCached(
-          "/api/v1/secrets",
-          "api-secrets"
-        );
+        cached = await result.current.isCached("/v1/secrets", "api-secrets");
       });
 
       expect(cached).toBe(true);
       expect(mockCaches.open).toHaveBeenCalledWith("api-secrets");
-      expect(mockCache.match).toHaveBeenCalledWith("/api/v1/secrets");
+      expect(mockCache.match).toHaveBeenCalledWith("/v1/secrets");
     });
 
     it("should check if URL is cached in any cache", async () => {
@@ -151,11 +148,11 @@ describe("useCache", () => {
 
       let cached;
       await act(async () => {
-        cached = await result.current.isCached("/api/v1/secrets");
+        cached = await result.current.isCached("/v1/secrets");
       });
 
       expect(cached).toBe(true);
-      expect(mockCaches.match).toHaveBeenCalledWith("/api/v1/secrets");
+      expect(mockCaches.match).toHaveBeenCalledWith("/v1/secrets");
     });
 
     it("should return false if URL not cached", async () => {
@@ -165,7 +162,7 @@ describe("useCache", () => {
 
       let cached;
       await act(async () => {
-        cached = await result.current.isCached("/api/v1/secrets");
+        cached = await result.current.isCached("/v1/secrets");
       });
 
       expect(cached).toBe(false);

--- a/src/hooks/usePrefetch.ts
+++ b/src/hooks/usePrefetch.ts
@@ -16,11 +16,11 @@ import { useCallback, useRef } from "react";
  *
  * // Prefetch when browser is idle
  * useEffect(() => {
- *   prefetchOnIdle('/api/v1/secrets');
+ *   prefetchOnIdle('/v1/secrets');
  * }, []);
  *
  * // Prefetch when user hovers over link
- * <Link to="/secrets/123" {...prefetchOnHover('/api/v1/secrets/123')}>
+ * <Link to="/secrets/123" {...prefetchOnHover('/v1/secrets/123')}>
  *   View Secret
  * </Link>
  * ```

--- a/src/lib/apiCache.test.ts
+++ b/src/lib/apiCache.test.ts
@@ -24,7 +24,7 @@ describe("API Cache Utilities", () => {
 
   describe("cacheApiResponse", () => {
     it("should cache API response with TTL", async () => {
-      const url = "/api/v1/guards";
+      const url = "/v1/guards";
       const data = [{ id: "1", name: "Test Guard" }];
 
       await cacheApiResponse(url, data);
@@ -38,7 +38,7 @@ describe("API Cache Utilities", () => {
     });
 
     it("should set expiration to 24 hours by default", async () => {
-      const url = "/api/v1/test";
+      const url = "/v1/test";
       const data = { test: true };
       const beforeCache = Date.now();
 
@@ -53,7 +53,7 @@ describe("API Cache Utilities", () => {
     });
 
     it("should allow custom TTL", async () => {
-      const url = "/api/v1/custom-ttl";
+      const url = "/v1/custom-ttl";
       const data = { test: true };
       const customTtl = 60 * 60 * 1000; // 1 hour
       const beforeCache = Date.now();
@@ -70,7 +70,7 @@ describe("API Cache Utilities", () => {
 
   describe("getCachedResponse", () => {
     it("should retrieve valid cached response", async () => {
-      const url = "/api/v1/guards";
+      const url = "/v1/guards";
       const data = [{ id: "1", name: "Cached" }];
 
       await cacheApiResponse(url, data);
@@ -80,7 +80,7 @@ describe("API Cache Utilities", () => {
     });
 
     it("should return null for expired cache", async () => {
-      const url = "/api/v1/expired";
+      const url = "/v1/expired";
       const data = { test: true };
 
       // Cache with negative TTL (already expired)
@@ -96,7 +96,7 @@ describe("API Cache Utilities", () => {
     });
 
     it("should return null for non-existent cache", async () => {
-      const retrieved = await getCachedResponse("/api/v1/nonexistent");
+      const retrieved = await getCachedResponse("/v1/nonexistent");
       expect(retrieved).toBeNull();
     });
   });

--- a/src/lib/apiCache.ts
+++ b/src/lib/apiCache.ts
@@ -14,9 +14,9 @@ import { apiConfig, getAuthHeaders } from "../config";
  *
  * @example
  * ```ts
- * const response = await fetch('/api/v1/guards');
+ * const response = await fetch('/v1/guards');
  * const guards = await response.json();
- * await cacheApiResponse('/api/v1/guards', guards);
+ * await cacheApiResponse('/v1/guards', guards);
  * ```
  */
 export async function cacheApiResponse(
@@ -41,7 +41,7 @@ export async function cacheApiResponse(
  *
  * @example
  * ```ts
- * const cachedGuards = await getCachedResponse('/api/v1/guards');
+ * const cachedGuards = await getCachedResponse('/v1/guards');
  * if (cachedGuards) {
  *   // Use cached data
  * } else {

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -176,7 +176,7 @@ describe("IndexedDB Database", () => {
   describe("API Cache Table", () => {
     it("should cache API response", async () => {
       const cacheEntry: ApiCacheEntry = {
-        url: "/api/v1/guards",
+        url: "/v1/guards",
         data: [{ id: "1", name: "Cached Guard" }],
         cachedAt: new Date(),
         expiresAt: new Date(Date.now() + 86400000), // 24h
@@ -184,7 +184,7 @@ describe("IndexedDB Database", () => {
 
       await db.apiCache.put(cacheEntry);
 
-      const retrieved = await db.apiCache.get("/api/v1/guards");
+      const retrieved = await db.apiCache.get("/v1/guards");
       expect(retrieved).toBeDefined();
       expect(retrieved?.data).toEqual([{ id: "1", name: "Cached Guard" }]);
     });

--- a/src/services/secretApi.create.test.ts
+++ b/src/services/secretApi.create.test.ts
@@ -51,7 +51,7 @@ describe("secretApi - createSecret", () => {
 
     expect(result).toEqual(mockSecret);
     expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining("/api/v1/secrets"),
+      expect.stringContaining("/v1/secrets"),
       expect.objectContaining({
         method: "POST",
         credentials: "include",
@@ -170,7 +170,7 @@ describe("secretApi - updateSecret", () => {
 
     expect(result).toEqual(mockSecret);
     expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining("/api/v1/secrets/secret-123"),
+      expect.stringContaining("/v1/secrets/secret-123"),
       expect.objectContaining({
         method: "PATCH",
         credentials: "include",

--- a/src/services/secretApi.test.ts
+++ b/src/services/secretApi.test.ts
@@ -45,7 +45,7 @@ describe("Secret API", () => {
 
       expect(secrets).toEqual(mockSecrets);
       expect(mockFetch).toHaveBeenCalledWith(
-        `${apiConfig.baseUrl}/api/v1/secrets`,
+        `${apiConfig.baseUrl}/v1/secrets`,
         expect.objectContaining({
           method: "GET",
           headers: expect.objectContaining({
@@ -127,7 +127,7 @@ describe("Secret API", () => {
 
       expect(result).toEqual(mockSecret);
       expect(mockFetch).toHaveBeenCalledWith(
-        `${apiConfig.baseUrl}/api/v1/secrets/secret-1`,
+        `${apiConfig.baseUrl}/v1/secrets/secret-1`,
         expect.objectContaining({
           method: "GET",
           headers: expect.objectContaining({
@@ -194,7 +194,7 @@ describe("Secret API", () => {
 
       expect(result).toEqual(mockAttachment);
       expect(mockFetch).toHaveBeenCalledWith(
-        `${apiConfig.baseUrl}/api/v1/secrets/secret-1/attachments`,
+        `${apiConfig.baseUrl}/v1/secrets/secret-1/attachments`,
         expect.objectContaining({
           method: "POST",
           body: expect.any(FormData),
@@ -251,7 +251,7 @@ describe("Secret API", () => {
 
       expect(attachments).toEqual(mockAttachments);
       expect(mockFetch).toHaveBeenCalledWith(
-        `${apiConfig.baseUrl}/api/v1/secrets/secret-1/attachments`,
+        `${apiConfig.baseUrl}/v1/secrets/secret-1/attachments`,
         expect.objectContaining({
           method: "GET",
         })
@@ -277,7 +277,7 @@ describe("Secret API", () => {
 
       await expect(deleteAttachment("att-1")).resolves.toBeUndefined();
       expect(mockFetch).toHaveBeenCalledWith(
-        `${apiConfig.baseUrl}/api/v1/attachments/att-1`,
+        `${apiConfig.baseUrl}/v1/attachments/att-1`,
         expect.objectContaining({
           method: "DELETE",
         })
@@ -396,7 +396,7 @@ describe("Secret API", () => {
       expect(masterKey.usages).toContain("decrypt");
 
       expect(mockFetch).toHaveBeenCalledWith(
-        `${apiConfig.baseUrl}/api/v1/secrets/secret-123`,
+        `${apiConfig.baseUrl}/v1/secrets/secret-123`,
         expect.objectContaining({
           method: "GET",
           headers: expect.objectContaining({
@@ -558,7 +558,7 @@ describe("Secret API", () => {
 
       expect(result).toEqual(mockAttachment);
       expect(mockFetch).toHaveBeenCalledWith(
-        `${apiConfig.baseUrl}/api/v1/secrets/secret-123/attachments`,
+        `${apiConfig.baseUrl}/v1/secrets/secret-123/attachments`,
         expect.objectContaining({
           method: "POST",
           body: expect.any(FormData),
@@ -782,7 +782,7 @@ describe("Secret API", () => {
 
       // Verify API call
       expect(mockFetch).toHaveBeenCalledWith(
-        `${apiConfig.baseUrl}/api/v1/attachments/attachment-123/download`,
+        `${apiConfig.baseUrl}/v1/attachments/attachment-123/download`,
         expect.objectContaining({
           method: "GET",
           credentials: "include",

--- a/src/services/secretApi.ts
+++ b/src/services/secretApi.ts
@@ -109,7 +109,7 @@ export class ApiError extends Error {
  * ```
  */
 export async function fetchSecrets(): Promise<Secret[]> {
-  const response = await fetch(`${apiConfig.baseUrl}/api/v1/secrets`, {
+  const response = await fetch(`${apiConfig.baseUrl}/v1/secrets`, {
     method: "GET",
     credentials: "include",
     headers: {
@@ -147,17 +147,14 @@ export async function getSecretById(secretId: string): Promise<SecretDetail> {
     throw new Error("secretId is required");
   }
 
-  const response = await fetch(
-    `${apiConfig.baseUrl}/api/v1/secrets/${secretId}`,
-    {
-      method: "GET",
-      credentials: "include",
-      headers: {
-        ...getAuthHeaders(),
-        "Content-Type": "application/json",
-      },
-    }
-  );
+  const response = await fetch(`${apiConfig.baseUrl}/v1/secrets/${secretId}`, {
+    method: "GET",
+    credentials: "include",
+    headers: {
+      ...getAuthHeaders(),
+      "Content-Type": "application/json",
+    },
+  });
 
   if (!response.ok) {
     const error: ApiErrorResponse = await response
@@ -199,7 +196,7 @@ export async function uploadAttachment(
   formData.append("file", file);
 
   const response = await fetchWithCsrf(
-    `${apiConfig.baseUrl}/api/v1/secrets/${secretId}/attachments`,
+    `${apiConfig.baseUrl}/v1/secrets/${secretId}/attachments`,
     {
       method: "POST",
       headers: getAuthHeaders(), // Don't set Content-Type for FormData
@@ -261,7 +258,7 @@ export async function uploadEncryptedAttachment(
   formData.append("metadata", JSON.stringify(metadata));
 
   const response = await fetchWithCsrf(
-    `${apiConfig.baseUrl}/api/v1/secrets/${secretId}/attachments`,
+    `${apiConfig.baseUrl}/v1/secrets/${secretId}/attachments`,
     {
       method: "POST",
       headers: getAuthHeaders(), // Don't set Content-Type for FormData
@@ -301,7 +298,7 @@ export async function listAttachments(
   }
 
   const response = await fetch(
-    `${apiConfig.baseUrl}/api/v1/secrets/${secretId}/attachments`,
+    `${apiConfig.baseUrl}/v1/secrets/${secretId}/attachments`,
     {
       method: "GET",
       credentials: "include",
@@ -341,7 +338,7 @@ export async function deleteAttachment(attachmentId: string): Promise<void> {
   }
 
   const response = await fetchWithCsrf(
-    `${apiConfig.baseUrl}/api/v1/attachments/${attachmentId}`,
+    `${apiConfig.baseUrl}/v1/attachments/${attachmentId}`,
     {
       method: "DELETE",
       headers: getAuthHeaders(),
@@ -374,17 +371,14 @@ export async function getSecretMasterKey(secretId: string): Promise<CryptoKey> {
     throw new Error("secretId is required");
   }
 
-  const response = await fetch(
-    `${apiConfig.baseUrl}/api/v1/secrets/${secretId}`,
-    {
-      method: "GET",
-      credentials: "include",
-      headers: {
-        ...getAuthHeaders(),
-        "Content-Type": "application/json",
-      },
-    }
-  );
+  const response = await fetch(`${apiConfig.baseUrl}/v1/secrets/${secretId}`, {
+    method: "GET",
+    credentials: "include",
+    headers: {
+      ...getAuthHeaders(),
+      "Content-Type": "application/json",
+    },
+  });
 
   if (!response.ok) {
     const error: ApiErrorResponse = await response
@@ -454,7 +448,7 @@ export async function downloadAndDecryptAttachment(
 
   // 1. Download encrypted blob + metadata from backend
   const response = await fetch(
-    `${apiConfig.baseUrl}/api/v1/attachments/${attachmentId}/download`,
+    `${apiConfig.baseUrl}/v1/attachments/${attachmentId}/download`,
     {
       method: "GET",
       credentials: "include",
@@ -575,7 +569,7 @@ export async function createSecret(
     throw new Error("title is required");
   }
 
-  const response = await fetchWithCsrf(`${apiConfig.baseUrl}/api/v1/secrets`, {
+  const response = await fetchWithCsrf(`${apiConfig.baseUrl}/v1/secrets`, {
     method: "POST",
     headers: {
       ...getAuthHeaders(),
@@ -621,7 +615,7 @@ export async function updateSecret(
   }
 
   const response = await fetchWithCsrf(
-    `${apiConfig.baseUrl}/api/v1/secrets/${secretId}`,
+    `${apiConfig.baseUrl}/v1/secrets/${secretId}`,
     {
       method: "PATCH",
       headers: {

--- a/src/services/shareApi.test.ts
+++ b/src/services/shareApi.test.ts
@@ -41,7 +41,7 @@ describe("shareApi", () => {
 
       expect(shares).toEqual(mockShares);
       expect(mockFetch).toHaveBeenCalledWith(
-        `${apiConfig.baseUrl}/api/v1/secrets/secret-1/shares`,
+        `${apiConfig.baseUrl}/v1/secrets/secret-1/shares`,
         expect.objectContaining({
           method: "GET",
           headers: expect.objectContaining({
@@ -114,7 +114,7 @@ describe("shareApi", () => {
 
       expect(share).toEqual(mockShare);
       expect(mockFetch).toHaveBeenCalledWith(
-        `${apiConfig.baseUrl}/api/v1/secrets/secret-1/shares`,
+        `${apiConfig.baseUrl}/v1/secrets/secret-1/shares`,
         expect.objectContaining({
           method: "POST",
           headers: expect.objectContaining({
@@ -213,7 +213,7 @@ describe("shareApi", () => {
       await expect(revokeShare("secret-1", "share-1")).resolves.toBeUndefined();
 
       expect(mockFetch).toHaveBeenCalledWith(
-        `${apiConfig.baseUrl}/api/v1/secrets/secret-1/shares/share-1`,
+        `${apiConfig.baseUrl}/v1/secrets/secret-1/shares/share-1`,
         expect.objectContaining({
           method: "DELETE",
           headers: expect.objectContaining({

--- a/src/services/shareApi.ts
+++ b/src/services/shareApi.ts
@@ -32,7 +32,7 @@ export interface CreateShareRequest {
  */
 export async function fetchShares(secretId: string): Promise<SecretShare[]> {
   const response = await fetch(
-    `${apiConfig.baseUrl}/api/v1/secrets/${secretId}/shares`,
+    `${apiConfig.baseUrl}/v1/secrets/${secretId}/shares`,
     {
       method: "GET",
       credentials: "include",
@@ -80,7 +80,7 @@ export async function createShare(
   request: CreateShareRequest
 ): Promise<SecretShare> {
   const response = await fetch(
-    `${apiConfig.baseUrl}/api/v1/secrets/${secretId}/shares`,
+    `${apiConfig.baseUrl}/v1/secrets/${secretId}/shares`,
     {
       method: "POST",
       credentials: "include",
@@ -124,7 +124,7 @@ export async function revokeShare(
   shareId: string
 ): Promise<void> {
   const response = await fetch(
-    `${apiConfig.baseUrl}/api/v1/secrets/${secretId}/shares/${shareId}`,
+    `${apiConfig.baseUrl}/v1/secrets/${secretId}/shares/${shareId}`,
     {
       method: "DELETE",
       credentials: "include",

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -38,7 +38,7 @@ precacheAndRoute(self.__WB_MANIFEST);
 // Cache API requests with NetworkFirst strategy
 registerRoute(
   ({ url }) =>
-    url.origin === self.location.origin && url.pathname.startsWith("/api/"),
+    url.origin === self.location.origin && url.pathname.startsWith("/v1/"),
   new NetworkFirst({
     cacheName: "api-cache",
     networkTimeoutSeconds: 10,
@@ -427,7 +427,7 @@ async function syncFileQueue(): Promise<void> {
  *
  * WORKFLOW:
  * 1. Query fileQueue for files with uploadState='encrypted'
- * 2. For each file, call /api/v1/secrets/{secretId}/attachments
+ * 2. For each file, call /v1/secrets/{secretId}/attachments
  * 3. Update uploadState: 'encrypted' → 'uploading' → 'completed'/'failed'
  * 4. Notify clients of progress and results
  */
@@ -512,7 +512,7 @@ async function syncEncryptedUploads(): Promise<void> {
 
         // POST to backend
         const response = await fetch(
-          `${self.location.origin}/api/v1/secrets/${fileEntry.secretId}/attachments`,
+          `${self.location.origin}/v1/secrets/${fileEntry.secretId}/attachments`,
           {
             method: "POST",
             credentials: "include", // Include cookies for authentication


### PR DESCRIPTION
## Problem

Backend uses `apiPrefix: ''` in `bootstrap/app.php`, meaning API routes are accessible at `/v1/*` directly, **NOT** at `/api/v1/*`.

Frontend was incorrectly building URLs like `https://api.secpal.app/api/v1/secrets` with redundant `/api/` prefix.

## Solution

Removed `/api/` prefix from all API calls:
- ✅ **secretApi.ts**: 10 endpoints fixed (`/api/v1/secrets` → `/v1/secrets`)
- ✅ **shareApi.ts**: 3 endpoints fixed
- ✅ **sw.ts**: All cache patterns fixed (`/api/v1/*` → `/v1/*`)
- ✅ **config.ts**: Updated documentation to clarify baseUrl should NOT include `/api`
- ✅ **All tests**: Updated expectations (57 assertions)

## Backend Reference

```php
// api/bootstrap/app.php
return Application::configure(basePath: dirname(__DIR__))
    ->withRouting(
        api: __DIR__.'/../routes/api.php',
        apiPrefix: '', // ← Routes at /v1/* directly
```

## Testing

All existing tests pass with updated paths.