### PR TITLE
feat: Complete SPA session-based authentication (Epic #208)

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,0 +1,298 @@
+# SPDX-FileCopyrightText: 2025 SecPal Contributors
+# SPDX-License-Identifier: CC0-1.0
+
+name: secpal-frontend
+type: generic
+docroot: dist
+php_version: "8.3"
+webserver_type: nginx-fpm
+xdebug_enabled: false
+additional_hostnames: []
+additional_fqdns: []
+# No database needed for frontend
+omit_containers:
+  - db
+use_dns_when_possible: true
+composer_version: "2"
+disable_settings_management: true
+corepack_enable: true
+nodejs_version: "22"
+web_environment:
+  - VITE_API_URL=https://secpal-api.ddev.site
+# Key features of DDEV's config.yaml:
+
+# name: <projectname> # Name of the project, automatically provides
+#   http://projectname.ddev.site and https://projectname.ddev.site
+# If the name is omitted, the project will take the name of the enclosing directory,
+# which is useful if you want to have a copy of the project side by side with this one.
+
+# type: <projecttype>  # backdrop, cakephp, craftcms, drupal, drupal6, drupal7, drupal8, drupal9, drupal10, drupal11, generic, laravel, magento, magento2, php, shopware6, silverstripe, symfony, typo3, wordpress
+# See https://docs.ddev.com/en/stable/users/quickstart/ for more
+# information on the different project types
+
+# docroot: <relative_path> # Relative path to the directory containing index.php.
+
+# php_version: "8.3"  # PHP version to use, "5.6" through "8.5"
+
+# You can explicitly specify the webimage but this
+# is not recommended, as the images are often closely tied to DDEV's' behavior,
+# so this can break upgrades.
+
+# webimage: <docker_image>
+# It’s unusual to change this option, and we don’t recommend it without Docker experience and a good reason.
+# Typically, this means additions to the existing web image using a .ddev/web-build/Dockerfile.*
+
+# database:
+#   type: <dbtype> # mysql, mariadb, postgres
+#   version: <version> # database version, like "10.11" or "8.0"
+#   MariaDB versions can be 5.5-10.8, 10.11, 11.4, 11.8
+#   MySQL versions can be 5.5-8.0, 8.4
+#   PostgreSQL versions can be 9-18
+
+# router_http_port: <port>  # Port to be used for http (defaults to global configuration, usually 80)
+# router_https_port: <port> # Port for https (defaults to global configuration, usually 443)
+
+# xdebug_enabled: false  # Set to true to enable Xdebug and "ddev start" or "ddev restart"
+# Note that for most people the commands
+# "ddev xdebug" to enable Xdebug and "ddev xdebug off" to disable it work better,
+# as leaving Xdebug enabled all the time is a big performance hit.
+
+# xhgui_http_port: "8143"
+# xhgui_https_port: "8142"
+# The XHGui ports can be changed from the default 8143 and 8142
+# Very rarely used
+
+# host_xhgui_port: "8142"
+# Can be used to change the host binding port of the XHGui
+# application. Rarely used; only when port conflict and
+# bind_all_ports is used (normally with router disabled)
+
+# xhprof_mode: [prepend|xhgui|global]
+# Set to "xhgui" to enable XHGui features
+# "xhgui" will become default in a future major release
+
+# webserver_type: nginx-fpm, apache-fpm, generic
+
+# timezone: Europe/Berlin
+# If timezone is unset, DDEV will attempt to derive it from the host system timezone
+# using the $TZ environment variable or the /etc/localtime symlink.
+# This is the timezone used in the containers and by PHP;
+# it can be set to any valid timezone,
+# see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+# For example Europe/Dublin or MST7MDT
+
+# composer_root: <relative_path>
+# Relative path to the Composer root directory from the project root. This is
+# the directory which contains the composer.json and where all Composer related
+# commands are executed.
+
+# composer_version: "2"
+# You can set it to "" or "2" (default) for Composer v2 or "1" for Composer v1
+# to use the latest major version available at the time your container is built.
+# It is also possible to use each other Composer version channel. This includes:
+#   - 2.2 (latest Composer LTS version)
+#   - stable
+#   - preview
+#   - snapshot
+# Alternatively, an explicit Composer version may be specified, for example "2.2.18".
+# To reinstall Composer after the image was built, run "ddev debug rebuild".
+
+# nodejs_version: "22"
+# change from the default system Node.js version to any other version.
+# See https://docs.ddev.com/en/stable/users/configuration/config/#nodejs_version for more information
+# and https://www.npmjs.com/package/n#specifying-nodejs-versions for the full documentation,
+# Note that using of 'ddev nvm' is discouraged because "nodejs_version" is much easier to use,
+# can specify any version, and is more robust than using 'nvm'.
+
+# corepack_enable: false
+# Change to 'true' to 'corepack enable' and gain access to latest versions of yarn/pnpm
+
+# additional_hostnames:
+#  - somename
+#  - someothername
+# would provide http and https URLs for "somename.ddev.site"
+# and "someothername.ddev.site".
+
+# additional_fqdns:
+#  - example.com
+#  - sub1.example.com
+# would provide http and https URLs for "example.com" and "sub1.example.com"
+# Please take care with this because it can cause great confusion.
+
+# upload_dirs: "custom/upload/dir"
+#
+# upload_dirs:
+#   - custom/upload/dir
+#   - ../private
+#
+# would set the destination paths for ddev import-files to <docroot>/custom/upload/dir
+# When Mutagen is enabled this path is bind-mounted so that all the files
+# in the upload_dirs don't have to be synced into Mutagen.
+
+# disable_upload_dirs_warning: false
+# If true, turns off the normal warning that says
+# "You have Mutagen enabled and your 'php' project type doesn't have upload_dirs set"
+
+# ddev_version_constraint: ""
+# Example:
+# ddev_version_constraint: ">= 1.24.8"
+# This will enforce that the running ddev version is within this constraint.
+# See https://github.com/Masterminds/semver#checking-version-constraints for
+# supported constraint formats
+
+# working_dir:
+#   web: /var/www/html
+#   db: /home
+# would set the default working directory for the web and db services.
+# These values specify the destination directory for ddev ssh and the
+# directory in which commands passed into ddev exec are run.
+
+# omit_containers: [db, ddev-ssh-agent]
+# Currently only these containers are supported. Some containers can also be
+# omitted globally in the ~/.ddev/global_config.yaml. Note that if you omit
+# the "db" container, several standard features of DDEV that access the
+# database container will be unusable. In the global configuration it is also
+# possible to omit ddev-router, but not here.
+
+# performance_mode: "global"
+# DDEV offers performance optimization strategies to improve the filesystem
+# performance depending on your host system. Should be configured globally.
+#
+# If set, will override the global config. Possible values are:
+#   - "global":  uses the value from the global config.
+#   - "none":    disables performance optimization for this project.
+#   - "mutagen": enables Mutagen for this project.
+#   - "nfs":     enables NFS for this project.
+#
+# See https://docs.ddev.com/en/stable/users/install/performance/#nfs
+# See https://docs.ddev.com/en/stable/users/install/performance/#mutagen
+
+# fail_on_hook_fail: False
+# Decide whether 'ddev start' should be interrupted by a failing hook
+
+# host_https_port: "59002"
+# The host port binding for https can be explicitly specified. It is
+# dynamic unless otherwise specified.
+# This is not used by most people, most people use the *router* instead
+# of the localhost port.
+
+# host_webserver_port: "59001"
+# The host port binding for the ddev-webserver can be explicitly specified. It is
+# dynamic unless otherwise specified.
+# This is not used by most people, most people use the *router* instead
+# of the localhost port.
+
+# host_db_port: "59002"
+# The host port binding for the ddev-dbserver can be explicitly specified. It is dynamic
+# unless explicitly specified.
+
+# mailpit_http_port: "8025"
+# mailpit_https_port: "8026"
+# The Mailpit ports can be changed from the default 8025 and 8026
+
+# host_mailpit_port: "8025"
+# The mailpit port is not normally bound on the host at all, instead being routed
+# through ddev-router, but it can be bound directly to localhost if specified here.
+
+# webimage_extra_packages: [php7.4-tidy, php-bcmath]
+# Extra Debian packages that are needed in the webimage can be added here
+
+# dbimage_extra_packages: [telnet,netcat]
+# Extra Debian packages that are needed in the dbimage can be added here
+
+# use_dns_when_possible: true
+# If the host has internet access and the domain configured can
+# successfully be looked up, DNS will be used for hostname resolution
+# instead of editing /etc/hosts
+# Defaults to true
+
+# project_tld: ddev.site
+# The top-level domain used for project URLs
+# The default "ddev.site" allows DNS lookup via a wildcard
+# If you prefer you can change this to "ddev.local" to preserve
+# pre-v1.9 behavior.
+
+# ngrok_args: --basic-auth username:pass1234
+# Provide extra flags to the "ngrok http" command, see
+# https://ngrok.com/docs/agent/config/v3/#agent-configuration or run "ngrok http -h"
+
+# disable_settings_management: false
+# If true, DDEV will not create CMS-specific settings files like
+# Drupal's settings.php/settings.ddev.php or TYPO3's additional.php
+# In this case the user must provide all such settings.
+
+# You can inject environment variables into the web container with:
+# web_environment:
+#     - SOMEENV=somevalue
+#     - SOMEOTHERENV=someothervalue
+
+# no_project_mount: false
+# (Experimental) If true, DDEV will not mount the project into the web container;
+# the user is responsible for mounting it manually or via a script.
+# This is to enable experimentation with alternate file mounting strategies.
+# For advanced users only!
+
+# bind_all_interfaces: false
+# If true, host ports will be bound on all network interfaces,
+# not the localhost interface only. This means that ports
+# will be available on the local network if the host firewall
+# allows it.
+
+# default_container_timeout: 120
+# The default time that DDEV waits for all containers to become ready can be increased from
+# the default 120. This helps in importing huge databases, for example.
+
+#web_extra_exposed_ports:
+#- name: nodejs
+#  container_port: 3000
+#  http_port: 2999
+#  https_port: 3000
+#- name: something
+#  container_port: 4000
+#  https_port: 4000
+#  http_port: 3999
+# Allows a set of extra ports to be exposed via ddev-router
+# Fill in all three fields even if you don’t intend to use the https_port!
+# If you don’t add https_port, then it defaults to 0 and ddev-router will fail to start.
+#
+# The port behavior on the ddev-webserver must be arranged separately, for example
+# using web_extra_daemons.
+# For example, with a web app on port 3000 inside the container, this config would
+# expose that web app on https://<project>.ddev.site:9999 and http://<project>.ddev.site:9998
+# web_extra_exposed_ports:
+#  - name: myapp
+#    container_port: 3000
+#    http_port: 9998
+#    https_port: 9999
+
+#web_extra_daemons:
+#- name: "http-1"
+#  command: "/var/www/html/node_modules/.bin/http-server -p 3000"
+#  directory: /var/www/html
+#- name: "http-2"
+#  command: "/var/www/html/node_modules/.bin/http-server /var/www/html/sub -p 3000"
+#  directory: /var/www/html
+
+# override_config: false
+# By default, config.*.yaml files are *merged* into the configuration
+# But this means that some things can't be overridden
+# For example, if you have 'use_dns_when_possible: true'' you can't override it with a merge
+# and you can't erase existing hooks or all environment variables.
+# However, with "override_config: true" in a particular config.*.yaml file,
+# 'use_dns_when_possible: false' can override the existing values, and
+# hooks:
+#   post-start: []
+# or
+# web_environment: []
+# or
+# additional_hostnames: []
+# can have their intended affect. 'override_config' affects only behavior of the
+# config.*.yaml file it exists in.
+
+# Many DDEV commands can be extended to run tasks before or after the
+# DDEV command is executed, for example "post-start", "post-import-db",
+# "pre-composer", "post-composer"
+# See https://docs.ddev.com/en/stable/users/extend/custom-commands/ for more
+# information on the commands that can be extended and the tasks you can define
+# for them. Example:
+#hooks:

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ node_modules/.cache/
 
 # Storybook
 storybook-static/
+
+# DDEV local development
+/.ddev/*
+!/.ddev/config.yaml

--- a/src/config.ts
+++ b/src/config.ts
@@ -73,19 +73,3 @@ export const appConfig = {
 export function getApiBaseUrl(): string {
   return apiConfig.baseUrl;
 }
-
-/**
- * Get authentication headers for API requests
- * Retrieves stored auth token from localStorage
- *
- * @returns Headers object with Authorization bearer token if available
- */
-export function getAuthHeaders(): HeadersInit {
-  const token = localStorage.getItem("auth_token");
-  if (token) {
-    return {
-      Authorization: `Bearer ${token}`,
-    };
-  }
-  return {};
-}

--- a/src/lib/apiCache.test.ts
+++ b/src/lib/apiCache.test.ts
@@ -367,7 +367,11 @@ describe("API Cache Utilities", () => {
       expect(success).toBe(true);
       expect(mockFetch).toHaveBeenCalledWith("https://api.secpal.dev/guards", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        credentials: "include",
         body: JSON.stringify({ name: "John Doe" }),
       });
 
@@ -403,7 +407,11 @@ describe("API Cache Utilities", () => {
         "https://api.secpal.dev/guards/123",
         {
           method: "PUT",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          },
+          credentials: "include",
           body: JSON.stringify({ name: "Updated Name" }),
         }
       );
@@ -437,7 +445,8 @@ describe("API Cache Utilities", () => {
         "https://api.secpal.dev/guards/123",
         {
           method: "DELETE",
-          headers: {}, // Auth headers (empty when no token in localStorage)
+          headers: { Accept: "application/json" },
+          credentials: "include",
         }
       );
 

--- a/src/lib/apiCache.ts
+++ b/src/lib/apiCache.ts
@@ -3,7 +3,7 @@
 
 import { db } from "./db";
 import type { SyncOperation } from "./db";
-import { apiConfig, getAuthHeaders } from "../config";
+import { apiConfig } from "../config";
 
 /**
  * Cache an API response in IndexedDB
@@ -236,16 +236,16 @@ export async function retrySyncOperation(
 
   try {
     const endpoint = `${apiBaseUrl}/${operation.entity}`;
-    const authHeaders = getAuthHeaders();
     let response: Response;
 
     switch (operation.type) {
       case "create":
         response = await fetch(endpoint, {
           method: "POST",
+          credentials: "include",
           headers: {
             "Content-Type": "application/json",
-            ...authHeaders,
+            Accept: "application/json",
           },
           body: JSON.stringify(operation.data),
         });
@@ -254,9 +254,10 @@ export async function retrySyncOperation(
       case "update":
         response = await fetch(endpoint, {
           method: "PUT",
+          credentials: "include",
           headers: {
             "Content-Type": "application/json",
-            ...authHeaders,
+            Accept: "application/json",
           },
           body: JSON.stringify(operation.data),
         });
@@ -265,7 +266,10 @@ export async function retrySyncOperation(
       case "delete":
         response = await fetch(endpoint, {
           method: "DELETE",
-          headers: authHeaders,
+          credentials: "include",
+          headers: {
+            Accept: "application/json",
+          },
         });
         break;
 

--- a/src/services/secretApi.test.ts
+++ b/src/services/secretApi.test.ts
@@ -725,9 +725,8 @@ describe("Secret API", () => {
       );
 
       // Import encryption functions for test
-      const { deriveFileKey, encryptFile } = await import(
-        "../lib/crypto/encryption"
-      );
+      const { deriveFileKey, encryptFile } =
+        await import("../lib/crypto/encryption");
       const { calculateChecksum } = await import("../lib/crypto/checksum");
 
       const filename = "document.pdf";
@@ -798,9 +797,8 @@ describe("Secret API", () => {
         ["encrypt", "decrypt"]
       );
 
-      const { deriveFileKey, encryptFile } = await import(
-        "../lib/crypto/encryption"
-      );
+      const { deriveFileKey, encryptFile } =
+        await import("../lib/crypto/encryption");
       const { calculateChecksum } = await import("../lib/crypto/checksum");
 
       const filename = "test.txt";
@@ -848,9 +846,8 @@ describe("Secret API", () => {
         ["encrypt", "decrypt"]
       );
 
-      const { deriveFileKey, encryptFile } = await import(
-        "../lib/crypto/encryption"
-      );
+      const { deriveFileKey, encryptFile } =
+        await import("../lib/crypto/encryption");
       const { calculateChecksum } = await import("../lib/crypto/checksum");
 
       const filename = "tampered.txt";
@@ -968,9 +965,8 @@ describe("Secret API", () => {
         ["encrypt", "decrypt"]
       );
 
-      const { deriveFileKey, encryptFile } = await import(
-        "../lib/crypto/encryption"
-      );
+      const { deriveFileKey, encryptFile } =
+        await import("../lib/crypto/encryption");
       const { calculateChecksum } = await import("../lib/crypto/checksum");
 
       const originalFilename = "secret-document.docx";

--- a/src/services/secretApi.ts
+++ b/src/services/secretApi.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { apiConfig, getAuthHeaders } from "../config";
+import { apiConfig } from "../config";
 import { fetchWithCsrf } from "./csrf";
 
 /**
@@ -113,8 +113,8 @@ export async function fetchSecrets(): Promise<Secret[]> {
     method: "GET",
     credentials: "include",
     headers: {
-      ...getAuthHeaders(),
       "Content-Type": "application/json",
+      Accept: "application/json",
     },
   });
 
@@ -151,8 +151,8 @@ export async function getSecretById(secretId: string): Promise<SecretDetail> {
     method: "GET",
     credentials: "include",
     headers: {
-      ...getAuthHeaders(),
       "Content-Type": "application/json",
+      Accept: "application/json",
     },
   });
 
@@ -199,7 +199,7 @@ export async function uploadAttachment(
     `${apiConfig.baseUrl}/v1/secrets/${secretId}/attachments`,
     {
       method: "POST",
-      headers: getAuthHeaders(), // Don't set Content-Type for FormData
+      // Don't set Content-Type for FormData - browser sets it with boundary
       body: formData,
     }
   );
@@ -261,7 +261,7 @@ export async function uploadEncryptedAttachment(
     `${apiConfig.baseUrl}/v1/secrets/${secretId}/attachments`,
     {
       method: "POST",
-      headers: getAuthHeaders(), // Don't set Content-Type for FormData
+      // Don't set Content-Type for FormData - browser sets it with boundary
       body: formData,
     }
   );
@@ -303,8 +303,8 @@ export async function listAttachments(
       method: "GET",
       credentials: "include",
       headers: {
-        ...getAuthHeaders(),
         "Content-Type": "application/json",
+        Accept: "application/json",
       },
     }
   );
@@ -341,7 +341,9 @@ export async function deleteAttachment(attachmentId: string): Promise<void> {
     `${apiConfig.baseUrl}/v1/attachments/${attachmentId}`,
     {
       method: "DELETE",
-      headers: getAuthHeaders(),
+      headers: {
+        Accept: "application/json",
+      },
     }
   );
 
@@ -375,8 +377,8 @@ export async function getSecretMasterKey(secretId: string): Promise<CryptoKey> {
     method: "GET",
     credentials: "include",
     headers: {
-      ...getAuthHeaders(),
       "Content-Type": "application/json",
+      Accept: "application/json",
     },
   });
 
@@ -452,7 +454,9 @@ export async function downloadAndDecryptAttachment(
     {
       method: "GET",
       credentials: "include",
-      headers: getAuthHeaders(),
+      headers: {
+        Accept: "application/json",
+      },
     }
   );
 
@@ -484,9 +488,8 @@ export async function downloadAndDecryptAttachment(
   const ciphertext = encryptedBytes.slice(28); // Rest is ciphertext
 
   // 4. Derive file key (same as encryption)
-  const { deriveFileKey, decryptFile } = await import(
-    "../lib/crypto/encryption"
-  );
+  const { deriveFileKey, decryptFile } =
+    await import("../lib/crypto/encryption");
   const fileKey = await deriveFileKey(secretKey, metadata.filename);
 
   // 5. Decrypt file
@@ -572,8 +575,8 @@ export async function createSecret(
   const response = await fetchWithCsrf(`${apiConfig.baseUrl}/v1/secrets`, {
     method: "POST",
     headers: {
-      ...getAuthHeaders(),
       "Content-Type": "application/json",
+      Accept: "application/json",
     },
     body: JSON.stringify(data),
   });
@@ -619,8 +622,8 @@ export async function updateSecret(
     {
       method: "PATCH",
       headers: {
-        ...getAuthHeaders(),
         "Content-Type": "application/json",
+        Accept: "application/json",
       },
       body: JSON.stringify(data),
     }
@@ -658,7 +661,9 @@ export async function deleteSecret(secretId: string): Promise<void> {
     `${apiConfig.baseUrl}/v1/secrets/${secretId}`,
     {
       method: "DELETE",
-      headers: getAuthHeaders(),
+      headers: {
+        Accept: "application/json",
+      },
     }
   );
 

--- a/src/services/shareApi.ts
+++ b/src/services/shareApi.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { apiConfig, getAuthHeaders } from "../config";
+import { apiConfig } from "../config";
 import { ApiError, type SecretShare } from "./secretApi";
 
 // Re-export ApiError for test convenience
@@ -38,7 +38,7 @@ export async function fetchShares(secretId: string): Promise<SecretShare[]> {
       credentials: "include",
       headers: {
         "Content-Type": "application/json",
-        ...getAuthHeaders(),
+        Accept: "application/json",
       },
     }
   );
@@ -86,7 +86,7 @@ export async function createShare(
       credentials: "include",
       headers: {
         "Content-Type": "application/json",
-        ...getAuthHeaders(),
+        Accept: "application/json",
       },
       body: JSON.stringify(request),
     }
@@ -130,7 +130,7 @@ export async function revokeShare(
       credentials: "include",
       headers: {
         "Content-Type": "application/json",
-        ...getAuthHeaders(),
+        Accept: "application/json",
       },
     }
   );

--- a/tests/integration/auth/cookieAuth.test.ts
+++ b/tests/integration/auth/cookieAuth.test.ts
@@ -60,10 +60,10 @@ describe("Cookie-based Authentication Integration", () => {
         })
       );
 
-      // Verify login request sent credentials
+      // Verify login request sent credentials (SPA uses /v1/auth/login)
       expect(mockFetch).toHaveBeenNthCalledWith(
         2,
-        expect.stringContaining("/v1/auth/token"),
+        expect.stringContaining("/v1/auth/login"),
         expect.objectContaining({
           method: "POST",
           credentials: "include",
@@ -209,9 +209,9 @@ describe("Cookie-based Authentication Integration", () => {
 
       await logout();
 
-      // Verify logout request was sent with credentials
+      // Verify logout request was sent with credentials (SPA uses /v1/auth/session/logout)
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("/v1/auth/logout"),
+        expect.stringContaining("/v1/auth/session/logout"),
         expect.objectContaining({
           method: "POST",
           credentials: "include",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -287,6 +287,10 @@ export default defineConfig(({ mode }) => {
         "@": path.resolve(__dirname, "src"),
       },
     },
+    server: {
+      // Allow DDEV hostnames for local development
+      allowedHosts: [".ddev.site"],
+    },
     test: {
       globals: true,
       environment: "jsdom",


### PR DESCRIPTION
## Summary

Completes the migration from localStorage token storage to httpOnly session cookies for authentication, as required by Epic #208.

## Changes

### Removed (localStorage tokens)
- Removed `getAuthHeaders()` function from `config.ts`
- Removed token storage in `authApi.ts`
- Removed `authToken` from `storage.ts`
- Removed token handling from `secretApi.ts`, `shareApi.ts`, `apiCache.ts`

### Added (SPA session auth)
- Updated login to use `/v1/auth/login` endpoint (session-based)
- Updated logout to use `/v1/auth/session/logout` endpoint
- All API calls now rely on httpOnly cookies (automatic via `credentials: 'include'`)

### Development Setup
- Added DDEV configuration for frontend (`secpal-frontend.ddev.site`)
- Added `server.allowedHosts` for DDEV hostnames in Vite config

## Why

- **Security**: httpOnly cookies cannot be stolen via XSS attacks
- **Simplicity**: Browser handles cookie management automatically
- **Standards**: Follows Laravel Sanctum's recommended SPA authentication pattern

## Dependencies

- Requires API PR #255 (SPA session endpoints)

## Testing

- Manually tested with DDEV:
  - Login via `https://secpal-frontend.ddev.site:5174` ✅
  - API calls work with session cookies ✅
  - Logout clears session ✅

## Related

- Closes #246
- Depends on SecPal/api#255