### PR TITLE
feat: add Vite proxy for local DDEV development

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -17,19 +17,22 @@ export const apiConfig = {
    * Can be overridden via VITE_API_URL environment variable
    *
    * Examples:
-   * - Development: http://localhost:8000
+   * - Development with DDEV: (empty string, Vite proxy handles routing)
+   * - Development without proxy: http://localhost:8000
    * - Demo/Testing: https://api.secpal.dev
    * - Production: https://api.secpal.app
    * - Customer On-Premise: https://api.customer.example.com
    *
    * Note: The backend uses apiPrefix: '' in Laravel's bootstrap/app.php,
    * so routes are accessible at /v1/secrets NOT /api/v1/secrets
+   *
+   * Local Development:
+   * When VITE_API_URL is not set, we use empty string for same-origin requests.
+   * Vite's proxy (see vite.config.ts) forwards /v1/* and /sanctum/* to DDEV.
    */
   baseUrl:
     import.meta.env.VITE_API_URL ||
-    (import.meta.env.MODE === "production"
-      ? "https://api.secpal.app"
-      : "http://localhost:8000"),
+    (import.meta.env.MODE === "production" ? "https://api.secpal.app" : ""),
 
   /**
    * API timeout in milliseconds

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -290,6 +290,33 @@ export default defineConfig(({ mode }) => {
     server: {
       // Allow DDEV hostnames for local development
       allowedHosts: [".ddev.site"],
+      // Proxy API requests to DDEV backend to avoid CORS issues in local development
+      // This allows frontend on localhost:5173 to communicate with backend on secpal-api.ddev.site
+      // without cross-origin restrictions.
+      // Only active when VITE_API_URL is not explicitly set.
+      proxy: !env.VITE_API_URL
+        ? {
+            "/v1": {
+              target: "https://secpal-api.ddev.site",
+              changeOrigin: true,
+              secure: false, // Accept self-signed DDEV certificates
+              // Add headers to help Sanctum recognize the request origin
+              headers: {
+                Origin: "http://localhost:5173",
+                Referer: "http://localhost:5173/",
+              },
+            },
+            "/sanctum": {
+              target: "https://secpal-api.ddev.site",
+              changeOrigin: true,
+              secure: false,
+              headers: {
+                Origin: "http://localhost:5173",
+                Referer: "http://localhost:5173/",
+              },
+            },
+          }
+        : undefined,
     },
     test: {
       globals: true,


### PR DESCRIPTION
## Summary

Adds Vite proxy configuration for seamless local development with DDEV backend.

## Problem

When running the frontend locally on `localhost:5173` and the API on `secpal-api.ddev.site`, cookie-based authentication doesn't work due to cross-origin restrictions. Cookies with `domain=.ddev.site` won't be sent to `localhost`.

## Solution

Configure Vite's dev server to proxy API requests:
- `/v1/*` → `https://secpal-api.ddev.site`
- `/sanctum/*` → `https://secpal-api.ddev.site`

This makes all API requests same-origin from the browser's perspective, allowing cookies to work correctly.

## Changes

- **vite.config.ts**: Add proxy configuration with proper headers for Sanctum recognition
- **src/config.ts**: Use empty `baseUrl` in dev mode (Vite proxy handles routing)

## Usage

1. Start DDEV: `cd api && ddev start`
2. Start frontend: `cd frontend && npm run dev`
3. Open `http://localhost:5173` - API requests are automatically proxied

## Notes

- Proxy is only active when `VITE_API_URL` is not explicitly set
- Production builds are not affected (uses `https://api.secpal.app`)
- If you need to use a different backend, set `VITE_API_URL` in `.env.local`