### PR TITLE
refactor(pwa): Remove dismiss option from update banner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,6 +66,7 @@ function App() {
     <AuthProvider>
       <BrowserRouter>
         <div className="flex min-h-screen flex-col">
+          <UpdatePrompt />
           <Routes>
             <Route path="/login" element={<Login />} />
             <Route
@@ -128,7 +129,6 @@ function App() {
           <Footer />
           <OfflineIndicator />
           <SyncStatusIndicator apiBaseUrl={getApiBaseUrl()} />
-          <UpdatePrompt />
         </div>
       </BrowserRouter>
     </AuthProvider>

--- a/src/components/UpdatePrompt.test.tsx
+++ b/src/components/UpdatePrompt.test.tsx
@@ -148,7 +148,7 @@ describe("UpdatePrompt", () => {
     });
   });
 
-  describe("Positioning", () => {
+  describe("Styling", () => {
     beforeEach(() => {
       vi.mocked(useServiceWorkerUpdate).mockReturnValue({
         needRefresh: true,
@@ -157,29 +157,29 @@ describe("UpdatePrompt", () => {
       });
     });
 
-    it("should be fixed at top of screen", () => {
+    it("should render in document flow (not fixed positioned)", () => {
       const { container } = renderWithI18n(<UpdatePrompt />);
       const wrapper = container.firstChild as HTMLElement;
 
-      expect(wrapper).toHaveClass("fixed");
-      expect(wrapper).toHaveClass("top-0");
-      expect(wrapper).toHaveClass("left-0");
-      expect(wrapper).toHaveClass("right-0");
+      // Should NOT have fixed positioning to avoid overlaying content
+      expect(wrapper).not.toHaveClass("fixed");
+      expect(wrapper).not.toHaveClass("absolute");
     });
 
-    it("should have high z-index to overlay other content", () => {
+    it("should have appropriate background styling", () => {
       const { container } = renderWithI18n(<UpdatePrompt />);
       const wrapper = container.firstChild as HTMLElement;
 
-      expect(wrapper).toHaveClass("z-50");
+      expect(wrapper).toHaveClass("bg-blue-600");
+      expect(wrapper).toHaveClass("text-white");
     });
 
-    it("should span full width", () => {
-      const { container } = renderWithI18n(<UpdatePrompt />);
-      const wrapper = container.firstChild as HTMLElement;
+    it("should use Catalyst Button with white color variant", () => {
+      renderWithI18n(<UpdatePrompt />);
 
-      expect(wrapper).toHaveClass("left-0");
-      expect(wrapper).toHaveClass("right-0");
+      // Button should be rendered with proper Catalyst styling
+      const button = screen.getByRole("button", { name: /update/i });
+      expect(button).toBeInTheDocument();
     });
   });
 

--- a/src/components/UpdatePrompt.test.tsx
+++ b/src/components/UpdatePrompt.test.tsx
@@ -14,7 +14,6 @@ vi.mock("../hooks/useServiceWorkerUpdate");
 
 describe("UpdatePrompt", () => {
   const mockUpdateServiceWorker = vi.fn();
-  const mockClose = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -28,7 +27,6 @@ describe("UpdatePrompt", () => {
       needRefresh: false,
       offlineReady: false,
       updateServiceWorker: mockUpdateServiceWorker,
-      close: mockClose,
     });
   });
 
@@ -47,12 +45,32 @@ describe("UpdatePrompt", () => {
         needRefresh: true,
         offlineReady: false,
         updateServiceWorker: mockUpdateServiceWorker,
-        close: mockClose,
       });
 
       renderWithI18n(<UpdatePrompt />);
 
-      expect(screen.getByText("New version available")).toBeInTheDocument();
+      expect(
+        screen.getByText(/A new version of SecPal is available/i)
+      ).toBeInTheDocument();
+    });
+
+    it("should always be visible when update is available (no dismiss option)", () => {
+      vi.mocked(useServiceWorkerUpdate).mockReturnValue({
+        needRefresh: true,
+        offlineReady: false,
+        updateServiceWorker: mockUpdateServiceWorker,
+      });
+
+      renderWithI18n(<UpdatePrompt />);
+
+      // Verify banner is shown
+      expect(
+        screen.getByText(/A new version of SecPal is available/i)
+      ).toBeInTheDocument();
+
+      // Verify no dismiss/later button exists
+      expect(screen.queryByText("Later")).not.toBeInTheDocument();
+      expect(screen.queryByText("Dismiss")).not.toBeInTheDocument();
     });
   });
 
@@ -62,30 +80,24 @@ describe("UpdatePrompt", () => {
         needRefresh: true,
         offlineReady: false,
         updateServiceWorker: mockUpdateServiceWorker,
-        close: mockClose,
       });
     });
 
-    it("should display title", () => {
-      renderWithI18n(<UpdatePrompt />);
-      expect(screen.getByText("New version available")).toBeInTheDocument();
-    });
-
-    it("should display description", () => {
+    it("should display update message", () => {
       renderWithI18n(<UpdatePrompt />);
       expect(
-        screen.getByText(/A new version of SecPal is ready/i)
+        screen.getByText(/A new version of SecPal is available/i)
       ).toBeInTheDocument();
     });
 
-    it("should display Update button", () => {
+    it("should display Update now button", () => {
       renderWithI18n(<UpdatePrompt />);
-      expect(screen.getByText("Update")).toBeInTheDocument();
+      expect(screen.getByText("Update now")).toBeInTheDocument();
     });
 
-    it("should display Later button", () => {
+    it("should not display Later button", () => {
       renderWithI18n(<UpdatePrompt />);
-      expect(screen.getByText("Later")).toBeInTheDocument();
+      expect(screen.queryByText("Later")).not.toBeInTheDocument();
     });
   });
 
@@ -95,38 +107,17 @@ describe("UpdatePrompt", () => {
         needRefresh: true,
         offlineReady: false,
         updateServiceWorker: mockUpdateServiceWorker,
-        close: mockClose,
       });
     });
 
-    it("should call updateServiceWorker when Update button is clicked", async () => {
+    it("should call updateServiceWorker when Update now button is clicked", async () => {
       const user = userEvent.setup();
       renderWithI18n(<UpdatePrompt />);
 
-      const updateButton = screen.getByText("Update");
+      const updateButton = screen.getByText("Update now");
       await user.click(updateButton);
 
       expect(mockUpdateServiceWorker).toHaveBeenCalledTimes(1);
-    });
-
-    it("should call close when Later button is clicked", async () => {
-      const user = userEvent.setup();
-      renderWithI18n(<UpdatePrompt />);
-
-      const laterButton = screen.getByText("Later");
-      await user.click(laterButton);
-
-      expect(mockClose).toHaveBeenCalledTimes(1);
-    });
-
-    it("should not call updateServiceWorker when Later is clicked", async () => {
-      const user = userEvent.setup();
-      renderWithI18n(<UpdatePrompt />);
-
-      const laterButton = screen.getByText("Later");
-      await user.click(laterButton);
-
-      expect(mockUpdateServiceWorker).not.toHaveBeenCalled();
     });
   });
 
@@ -136,7 +127,6 @@ describe("UpdatePrompt", () => {
         needRefresh: true,
         offlineReady: false,
         updateServiceWorker: mockUpdateServiceWorker,
-        close: mockClose,
       });
     });
 
@@ -164,17 +154,17 @@ describe("UpdatePrompt", () => {
         needRefresh: true,
         offlineReady: false,
         updateServiceWorker: mockUpdateServiceWorker,
-        close: mockClose,
       });
     });
 
-    it("should be fixed at bottom-right corner", () => {
+    it("should be fixed at top of screen", () => {
       const { container } = renderWithI18n(<UpdatePrompt />);
       const wrapper = container.firstChild as HTMLElement;
 
       expect(wrapper).toHaveClass("fixed");
-      expect(wrapper).toHaveClass("bottom-4");
-      expect(wrapper).toHaveClass("right-4");
+      expect(wrapper).toHaveClass("top-0");
+      expect(wrapper).toHaveClass("left-0");
+      expect(wrapper).toHaveClass("right-0");
     });
 
     it("should have high z-index to overlay other content", () => {
@@ -184,11 +174,12 @@ describe("UpdatePrompt", () => {
       expect(wrapper).toHaveClass("z-50");
     });
 
-    it("should have max-width constraint", () => {
+    it("should span full width", () => {
       const { container } = renderWithI18n(<UpdatePrompt />);
       const wrapper = container.firstChild as HTMLElement;
 
-      expect(wrapper).toHaveClass("max-w-md");
+      expect(wrapper).toHaveClass("left-0");
+      expect(wrapper).toHaveClass("right-0");
     });
   });
 
@@ -201,22 +192,6 @@ describe("UpdatePrompt", () => {
         needRefresh: true,
         offlineReady: false,
         updateServiceWorker: mockUpdateServiceWorker,
-        close: mockClose,
-      });
-
-      rerender(
-        <I18nProvider i18n={i18n}>
-          <UpdatePrompt />
-        </I18nProvider>
-      );
-      expect(screen.getByText("New version available")).toBeInTheDocument();
-
-      // Change to hidden
-      vi.mocked(useServiceWorkerUpdate).mockReturnValue({
-        needRefresh: false,
-        offlineReady: false,
-        updateServiceWorker: mockUpdateServiceWorker,
-        close: mockClose,
       });
 
       rerender(
@@ -225,7 +200,23 @@ describe("UpdatePrompt", () => {
         </I18nProvider>
       );
       expect(
-        screen.queryByText("New version available")
+        screen.getByText(/A new version of SecPal is available/i)
+      ).toBeInTheDocument();
+
+      // Change to hidden
+      vi.mocked(useServiceWorkerUpdate).mockReturnValue({
+        needRefresh: false,
+        offlineReady: false,
+        updateServiceWorker: mockUpdateServiceWorker,
+      });
+
+      rerender(
+        <I18nProvider i18n={i18n}>
+          <UpdatePrompt />
+        </I18nProvider>
+      );
+      expect(
+        screen.queryByText(/A new version of SecPal is available/i)
       ).not.toBeInTheDocument();
     });
   });

--- a/src/components/UpdatePrompt.tsx
+++ b/src/components/UpdatePrompt.tsx
@@ -13,18 +13,19 @@ import { useServiceWorkerUpdate } from "../hooks/useServiceWorkerUpdate";
  * The banner is always visible when an update is available and cannot be dismissed.
  * Users can click "Update" to reload and use the latest version.
  *
- * The banner is positioned at the top of the screen as a slim, prominent notification
- * that doesn't block user interaction with the rest of the application.
+ * The banner is rendered in the normal document flow (not fixed/absolute) to avoid
+ * overlaying page content. It should be placed at the top of the app layout.
  *
  * @example
  * ```tsx
- * // In App.tsx
+ * // In App.tsx - place as first child in the layout container
  * function App() {
  *   return (
- *     <>
+ *     <div className="flex min-h-screen flex-col">
  *       <UpdatePrompt />
- *       <Router />
- *     </>
+ *       <Header />
+ *       <main>...</main>
+ *     </div>
  *   );
  * }
  * ```
@@ -40,7 +41,7 @@ export function UpdatePrompt() {
 
   return (
     <div
-      className="fixed left-0 right-0 top-0 z-50 bg-blue-600 px-4 py-2 text-white shadow-md dark:bg-blue-700"
+      className="bg-blue-600 px-4 py-2 text-white shadow-md dark:bg-blue-700"
       role="status"
       aria-live="polite"
       aria-atomic="true"
@@ -51,7 +52,8 @@ export function UpdatePrompt() {
         </p>
         <Button
           onClick={updateServiceWorker}
-          className="bg-white! py-1! text-blue-600! hover:bg-blue-50! dark:bg-zinc-100! dark:text-blue-700! dark:hover:bg-zinc-200!"
+          color="white"
+          className="py-1!"
           aria-label={_(msg`Update application now`)}
         >
           <Trans>Update now</Trans>

--- a/src/components/UpdatePrompt.tsx
+++ b/src/components/UpdatePrompt.tsx
@@ -9,12 +9,12 @@ import { useServiceWorkerUpdate } from "../hooks/useServiceWorkerUpdate";
 /**
  * UpdatePrompt Component
  *
- * Displays a notification when a new version of the PWA is available.
- * Users can choose to update immediately or dismiss the prompt.
+ * Displays a non-intrusive banner when a new version of the PWA is available.
+ * The banner is always visible when an update is available and cannot be dismissed.
+ * Users can click "Update" to reload and use the latest version.
  *
- * This component automatically appears when the service worker detects
- * a new version. If dismissed via the "Later" button, it will reappear
- * after 1 hour if the update is still available.
+ * The banner is positioned at the top of the screen as a slim, prominent notification
+ * that doesn't block user interaction with the rest of the application.
  *
  * @example
  * ```tsx
@@ -31,7 +31,7 @@ import { useServiceWorkerUpdate } from "../hooks/useServiceWorkerUpdate";
  */
 export function UpdatePrompt() {
   const { _ } = useLingui();
-  const { needRefresh, updateServiceWorker, close } = useServiceWorkerUpdate();
+  const { needRefresh, updateServiceWorker } = useServiceWorkerUpdate();
 
   // Only render when update is available
   if (!needRefresh) {
@@ -40,39 +40,22 @@ export function UpdatePrompt() {
 
   return (
     <div
-      className="fixed bottom-4 right-4 z-50 max-w-md rounded-lg bg-white p-6 shadow-lg ring-1 ring-zinc-950/10 dark:bg-zinc-900 dark:ring-white/10"
+      className="fixed left-0 right-0 top-0 z-50 bg-blue-600 px-4 py-2 text-white shadow-md dark:bg-blue-700"
       role="status"
       aria-live="polite"
       aria-atomic="true"
     >
-      <div className="space-y-4">
-        <div>
-          <h3 className="text-base font-semibold text-zinc-950 dark:text-white">
-            <Trans>New version available</Trans>
-          </h3>
-          <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
-            <Trans>
-              A new version of SecPal is ready. Click "Update" to reload and use
-              the latest version.
-            </Trans>
-          </p>
-        </div>
-        <div className="flex gap-3">
-          <Button
-            onClick={updateServiceWorker}
-            color="blue"
-            aria-label={_(msg`Update application now`)}
-          >
-            <Trans>Update</Trans>
-          </Button>
-          <Button
-            onClick={close}
-            plain
-            aria-label={_(msg`Dismiss update notification`)}
-          >
-            <Trans>Later</Trans>
-          </Button>
-        </div>
+      <div className="mx-auto flex max-w-7xl items-center justify-center gap-4">
+        <p className="text-sm font-medium">
+          <Trans>A new version of SecPal is available.</Trans>
+        </p>
+        <Button
+          onClick={updateServiceWorker}
+          className="bg-white! py-1! text-blue-600! hover:bg-blue-50! dark:bg-zinc-100! dark:text-blue-700! dark:hover:bg-zinc-200!"
+          aria-label={_(msg`Update application now`)}
+        >
+          <Trans>Update now</Trans>
+        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

The update banner can no longer be dismissed. When an update is available, the banner remains visible until the user clicks "Update now".

## Changes

### Removed
- "Later" button from `UpdatePrompt` component
- `close()` function from `useServiceWorkerUpdate` hook
- Snooze logic (`snoozedUntil` state, `effectiveNeedRefresh`, timeout timers)

### Changed
- Redesigned banner from popup (bottom-right) to slim top bar
- Banner is always visible when update is available
- Simplified hook interface: only `needRefresh`, `offlineReady`, `updateServiceWorker`

## Rationale

There is no practical need to defer updates. If users cannot update immediately, they can simply ignore the non-intrusive banner while working. This:

1. **Simplifies the codebase** - removed ~150 lines of snooze logic
2. **Ensures visibility** - users are always aware of available updates
3. **Non-blocking UX** - slim top bar doesn't interfere with work

## Visual Change

**Before:** Popup dialog at bottom-right with "Update" and "Later" buttons
**After:** Slim blue bar at top with "Update now" button

## Testing

- [x] All existing tests updated and passing
- [x] `npm run lint` - clean
- [x] `npm run typecheck` - clean
- [x] `npm test` - 827 tests passing

## Checklist

- [x] Tests updated
- [x] No TODOs or FIXMEs
- [x] TypeScript strict mode compliant
- [x] Accessibility maintained (`role=status`, `aria-live`)
- [x] i18n maintained
- [x] Dark mode support