### PR TITLE
feat(auth): implement permission-based navigation

### DIFF
--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -507,4 +507,171 @@ describe("ApplicationLayout", () => {
       expect(avatars.length).toBeGreaterThanOrEqual(2);
     });
   });
+
+  describe("permission-based navigation", () => {
+    it("hides Organization link when user has no organizational scopes", () => {
+      localStorage.setItem(
+        "auth_user",
+        JSON.stringify({
+          id: 1,
+          name: "John Doe",
+          email: "john@example.com",
+          hasOrganizationalScopes: false,
+        })
+      );
+
+      renderWithProviders(
+        <ApplicationLayout>
+          <div>Content</div>
+        </ApplicationLayout>
+      );
+
+      expect(screen.queryByText("Organization")).not.toBeInTheDocument();
+    });
+
+    it("hides Customers link when user has no organizational scopes", () => {
+      localStorage.setItem(
+        "auth_user",
+        JSON.stringify({
+          id: 1,
+          name: "John Doe",
+          email: "john@example.com",
+          hasOrganizationalScopes: false,
+        })
+      );
+
+      renderWithProviders(
+        <ApplicationLayout>
+          <div>Content</div>
+        </ApplicationLayout>
+      );
+
+      expect(screen.queryByText("Customers")).not.toBeInTheDocument();
+    });
+
+    it("hides Guard Books link when user has no organizational scopes", () => {
+      localStorage.setItem(
+        "auth_user",
+        JSON.stringify({
+          id: 1,
+          name: "John Doe",
+          email: "john@example.com",
+          hasOrganizationalScopes: false,
+        })
+      );
+
+      renderWithProviders(
+        <ApplicationLayout>
+          <div>Content</div>
+        </ApplicationLayout>
+      );
+
+      expect(screen.queryByText("Guard Books")).not.toBeInTheDocument();
+    });
+
+    it("shows Organization link when user has organizational scopes", () => {
+      localStorage.setItem(
+        "auth_user",
+        JSON.stringify({
+          id: 1,
+          name: "John Doe",
+          email: "john@example.com",
+          hasOrganizationalScopes: true,
+        })
+      );
+
+      renderWithProviders(
+        <ApplicationLayout>
+          <div>Content</div>
+        </ApplicationLayout>
+      );
+
+      expect(screen.getByText("Organization")).toBeInTheDocument();
+    });
+
+    it("shows Customers link when user has organizational scopes", () => {
+      localStorage.setItem(
+        "auth_user",
+        JSON.stringify({
+          id: 1,
+          name: "John Doe",
+          email: "john@example.com",
+          hasOrganizationalScopes: true,
+        })
+      );
+
+      renderWithProviders(
+        <ApplicationLayout>
+          <div>Content</div>
+        </ApplicationLayout>
+      );
+
+      expect(screen.getByText("Customers")).toBeInTheDocument();
+    });
+
+    it("shows Guard Books link when user has organizational scopes", () => {
+      localStorage.setItem(
+        "auth_user",
+        JSON.stringify({
+          id: 1,
+          name: "John Doe",
+          email: "john@example.com",
+          hasOrganizationalScopes: true,
+        })
+      );
+
+      renderWithProviders(
+        <ApplicationLayout>
+          <div>Content</div>
+        </ApplicationLayout>
+      );
+
+      expect(screen.getByText("Guard Books")).toBeInTheDocument();
+    });
+
+    it("always shows Home, Secrets, and Settings links regardless of scopes", () => {
+      localStorage.setItem(
+        "auth_user",
+        JSON.stringify({
+          id: 1,
+          name: "John Doe",
+          email: "john@example.com",
+          hasOrganizationalScopes: false,
+        })
+      );
+
+      renderWithProviders(
+        <ApplicationLayout>
+          <div>Content</div>
+        </ApplicationLayout>
+      );
+
+      expect(screen.getByText("Home")).toBeInTheDocument();
+      expect(screen.getByText("Secrets")).toBeInTheDocument();
+      expect(screen.getByText("Settings")).toBeInTheDocument();
+    });
+
+    it("treats undefined hasOrganizationalScopes as false", () => {
+      localStorage.setItem(
+        "auth_user",
+        JSON.stringify({
+          id: 1,
+          name: "John Doe",
+          email: "john@example.com",
+          // hasOrganizationalScopes not set
+        })
+      );
+
+      renderWithProviders(
+        <ApplicationLayout>
+          <div>Content</div>
+        </ApplicationLayout>
+      );
+
+      // Should not show organizational menu items
+      expect(screen.queryByText("Organization")).not.toBeInTheDocument();
+      expect(screen.queryByText("Customers")).not.toBeInTheDocument();
+      expect(screen.queryByText("Guard Books")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/application-layout.tsx
+++ b/src/components/application-layout.tsx
@@ -193,9 +193,14 @@ function UserMenuItems({ onLogout }: { onLogout: () => void }) {
 }
 
 export function ApplicationLayout({ children }: { children: React.ReactNode }) {
-  const { user, logout } = useAuth();
+  const { user, logout, hasOrganizationalAccess } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
+
+  // Check if user has access to organizational features
+  const canAccessOrganization = hasOrganizationalAccess();
+  const canAccessCustomers = hasOrganizationalAccess();
+  const canAccessGuardBooks = hasOrganizationalAccess(); // Guard books require organizational context
 
   const handleLogout = async () => {
     // Clear local state FIRST to prevent race conditions
@@ -265,33 +270,39 @@ export function ApplicationLayout({ children }: { children: React.ReactNode }) {
                   <Trans>Secrets</Trans>
                 </SidebarLabel>
               </SidebarItem>
-              <SidebarItem
-                href="/organization"
-                current={isCurrentPath("/organization")}
-              >
-                <BuildingOfficeIcon />
-                <SidebarLabel>
-                  <Trans>Organization</Trans>
-                </SidebarLabel>
-              </SidebarItem>
-              <SidebarItem
-                href="/customers"
-                current={isCurrentPath("/customers")}
-              >
-                <UsersIcon />
-                <SidebarLabel>
-                  <Trans>Customers</Trans>
-                </SidebarLabel>
-              </SidebarItem>
-              <SidebarItem
-                href="/guard-books"
-                current={isCurrentPath("/guard-books")}
-              >
-                <ClipboardDocumentListIcon />
-                <SidebarLabel>
-                  <Trans>Guard Books</Trans>
-                </SidebarLabel>
-              </SidebarItem>
+              {canAccessOrganization && (
+                <SidebarItem
+                  href="/organization"
+                  current={isCurrentPath("/organization")}
+                >
+                  <BuildingOfficeIcon />
+                  <SidebarLabel>
+                    <Trans>Organization</Trans>
+                  </SidebarLabel>
+                </SidebarItem>
+              )}
+              {canAccessCustomers && (
+                <SidebarItem
+                  href="/customers"
+                  current={isCurrentPath("/customers")}
+                >
+                  <UsersIcon />
+                  <SidebarLabel>
+                    <Trans>Customers</Trans>
+                  </SidebarLabel>
+                </SidebarItem>
+              )}
+              {canAccessGuardBooks && (
+                <SidebarItem
+                  href="/guard-books"
+                  current={isCurrentPath("/guard-books")}
+                >
+                  <ClipboardDocumentListIcon />
+                  <SidebarLabel>
+                    <Trans>Guard Books</Trans>
+                  </SidebarLabel>
+                </SidebarItem>
+              )}
             </SidebarSection>
 
             <SidebarSpacer />

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -1,0 +1,355 @@
+// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { AuthProvider } from "./AuthContext";
+import { useAuth } from "../hooks/useAuth";
+
+// Test component for permission checks
+function PermissionTestComponent({
+  role,
+  permission,
+}: {
+  role?: string;
+  permission?: string;
+}) {
+  const auth = useAuth();
+  return (
+    <div>
+      {role && (
+        <span data-testid="hasRole">
+          {auth.hasRole(role) ? "true" : "false"}
+        </span>
+      )}
+      {permission && (
+        <span data-testid="hasPermission">
+          {auth.hasPermission(permission) ? "true" : "false"}
+        </span>
+      )}
+      <span data-testid="hasOrgAccess">
+        {auth.hasOrganizationalAccess() ? "true" : "false"}
+      </span>
+    </div>
+  );
+}
+
+describe("AuthContext", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe("hasRole", () => {
+    it("returns true when user has the specified role", () => {
+      localStorage.setItem(
+        "auth_user",
+        JSON.stringify({
+          id: 1,
+          name: "Test User",
+          email: "test@example.com",
+          roles: ["Admin", "Manager"],
+        })
+      );
+
+      render(
+        <AuthProvider>
+          <PermissionTestComponent role="Admin" />
+        </AuthProvider>
+      );
+
+      expect(screen.getByTestId("hasRole")).toHaveTextContent("true");
+    });
+
+    it("returns false when user does not have the specified role", () => {
+      localStorage.setItem(
+        "auth_user",
+        JSON.stringify({
+          id: 1,
+          name: "Test User",
+          email: "test@example.com",
+          roles: ["Guard"],
+        })
+      );
+
+      render(
+        <AuthProvider>
+          <PermissionTestComponent role="Admin" />
+        </AuthProvider>
+      );
+
+      expect(screen.getByTestId("hasRole")).toHaveTextContent("false");
+    });
+
+    it("returns false when user has no roles", () => {
+      localStorage.setItem(
+        "auth_user",
+        JSON.stringify({
+          id: 1,
+          name: "Test User",
+          email: "test@example.com",
+        })
+      );
+
+      render(
+        <AuthProvider>
+          <PermissionTestComponent role="Admin" />
+        </AuthProvider>
+      );
+
+      expect(screen.getByTestId("hasRole")).toHaveTextContent("false");
+    });
+
+    it("returns false when user is null", () => {
+      render(
+        <AuthProvider>
+          <PermissionTestComponent role="Admin" />
+        </AuthProvider>
+      );
+
+      expect(screen.getByTestId("hasRole")).toHaveTextContent("false");
+    });
+  });
+
+  describe("hasPermission", () => {
+    it("returns true for direct permission match", () => {
+      localStorage.setItem(
+        "auth_user",
+        JSON.stringify({
+          id: 1,
+          name: "Test User",
+          email: "test@example.com",
+          permissions: ["employees.read", "employees.create"],
+        })
+      );
+
+      render(
+        <AuthProvider>
+          <PermissionTestComponent permission="employees.read" />
+        </AuthProvider>
+      );
+
+      expect(screen.getByTestId("hasPermission")).toHaveTextContent("true");
+    });
+
+    it("returns false when permission is not present", () => {
+      localStorage.setItem(
+        "auth_user",
+        JSON.stringify({
+          id: 1,
+          name: "Test User",
+          email: "test@example.com",
+          permissions: ["employees.read"],
+        })
+      );
+
+      render(
+        <AuthProvider>
+          <PermissionTestComponent permission="employees.delete" />
+        </AuthProvider>
+      );
+
+      expect(screen.getByTestId("hasPermission")).toHaveTextContent("false");
+    });
+
+    it("returns true for wildcard permission match", () => {
+      localStorage.setItem(
+        "auth_user",
+        JSON.stringify({
+          id: 1,
+          name: "Test User",
+          email: "test@example.com",
+          permissions: ["employees.*"],
+        })
+      );
+
+      render(
+        <AuthProvider>
+          <PermissionTestComponent permission="employees.delete" />
+        </AuthProvider>
+      );
+
+      expect(screen.getByTestId("hasPermission")).toHaveTextContent("true");
+    });
+
+    it("does not match wildcard across different resources", () => {
+      localStorage.setItem(
+        "auth_user",
+        JSON.stringify({
+          id: 1,
+          name: "Test User",
+          email: "test@example.com",
+          permissions: ["employees.*"],
+        })
+      );
+
+      render(
+        <AuthProvider>
+          <PermissionTestComponent permission="shifts.read" />
+        </AuthProvider>
+      );
+
+      expect(screen.getByTestId("hasPermission")).toHaveTextContent("false");
+    });
+
+    it("returns false when user has no permissions", () => {
+      localStorage.setItem(
+        "auth_user",
+        JSON.stringify({
+          id: 1,
+          name: "Test User",
+          email: "test@example.com",
+        })
+      );
+
+      render(
+        <AuthProvider>
+          <PermissionTestComponent permission="employees.read" />
+        </AuthProvider>
+      );
+
+      expect(screen.getByTestId("hasPermission")).toHaveTextContent("false");
+    });
+
+    it("returns false when user is null", () => {
+      render(
+        <AuthProvider>
+          <PermissionTestComponent permission="employees.read" />
+        </AuthProvider>
+      );
+
+      expect(screen.getByTestId("hasPermission")).toHaveTextContent("false");
+    });
+
+    it("handles permission without dot separator", () => {
+      localStorage.setItem(
+        "auth_user",
+        JSON.stringify({
+          id: 1,
+          name: "Test User",
+          email: "test@example.com",
+          permissions: ["admin"],
+        })
+      );
+
+      render(
+        <AuthProvider>
+          <PermissionTestComponent permission="admin" />
+        </AuthProvider>
+      );
+
+      expect(screen.getByTestId("hasPermission")).toHaveTextContent("true");
+    });
+  });
+
+  describe("hasOrganizationalAccess", () => {
+    it("returns true when hasOrganizationalScopes is true", () => {
+      localStorage.setItem(
+        "auth_user",
+        JSON.stringify({
+          id: 1,
+          name: "Test User",
+          email: "test@example.com",
+          hasOrganizationalScopes: true,
+        })
+      );
+
+      render(
+        <AuthProvider>
+          <PermissionTestComponent />
+        </AuthProvider>
+      );
+
+      expect(screen.getByTestId("hasOrgAccess")).toHaveTextContent("true");
+    });
+
+    it("returns false when hasOrganizationalScopes is false", () => {
+      localStorage.setItem(
+        "auth_user",
+        JSON.stringify({
+          id: 1,
+          name: "Test User",
+          email: "test@example.com",
+          hasOrganizationalScopes: false,
+        })
+      );
+
+      render(
+        <AuthProvider>
+          <PermissionTestComponent />
+        </AuthProvider>
+      );
+
+      expect(screen.getByTestId("hasOrgAccess")).toHaveTextContent("false");
+    });
+
+    it("returns false when hasOrganizationalScopes is undefined", () => {
+      localStorage.setItem(
+        "auth_user",
+        JSON.stringify({
+          id: 1,
+          name: "Test User",
+          email: "test@example.com",
+        })
+      );
+
+      render(
+        <AuthProvider>
+          <PermissionTestComponent />
+        </AuthProvider>
+      );
+
+      expect(screen.getByTestId("hasOrgAccess")).toHaveTextContent("false");
+    });
+
+    it("returns false when user is null", () => {
+      render(
+        <AuthProvider>
+          <PermissionTestComponent />
+        </AuthProvider>
+      );
+
+      expect(screen.getByTestId("hasOrgAccess")).toHaveTextContent("false");
+    });
+  });
+
+  describe("login updates permission state", () => {
+    it("updates hasOrganizationalAccess after login", () => {
+      const LoginComponent = () => {
+        const auth = useAuth();
+        return (
+          <div>
+            <span data-testid="hasOrgAccess">
+              {auth.hasOrganizationalAccess() ? "true" : "false"}
+            </span>
+            <button
+              onClick={() =>
+                auth.login({
+                  id: 1,
+                  name: "Test",
+                  email: "test@test.com",
+                  hasOrganizationalScopes: true,
+                })
+              }
+            >
+              Login
+            </button>
+          </div>
+        );
+      };
+
+      render(
+        <AuthProvider>
+          <LoginComponent />
+        </AuthProvider>
+      );
+
+      expect(screen.getByTestId("hasOrgAccess")).toHaveTextContent("false");
+
+      act(() => {
+        screen.getByText("Login").click();
+      });
+
+      expect(screen.getByTestId("hasOrgAccess")).toHaveTextContent("true");
+    });
+  });
+});

--- a/src/contexts/auth-context.ts
+++ b/src/contexts/auth-context.ts
@@ -7,6 +7,9 @@ export interface User {
   id: number;
   name: string;
   email: string;
+  roles?: string[];
+  permissions?: string[];
+  hasOrganizationalScopes?: boolean;
 }
 
 export interface AuthContextType {
@@ -15,6 +18,18 @@ export interface AuthContextType {
   isLoading: boolean;
   login: (user: User) => void;
   logout: () => void;
+  /**
+   * Check if user has a specific role
+   */
+  hasRole: (role: string) => boolean;
+  /**
+   * Check if user has a specific permission
+   */
+  hasPermission: (permission: string) => boolean;
+  /**
+   * Check if user has any organizational scopes (for org/customer management)
+   */
+  hasOrganizationalAccess: () => boolean;
 }
 
 export const AuthContext = createContext<AuthContextType | undefined>(

--- a/src/contexts/auth-context.ts
+++ b/src/contexts/auth-context.ts
@@ -23,7 +23,8 @@ export interface AuthContextType {
    */
   hasRole: (role: string) => boolean;
   /**
-   * Check if user has a specific permission
+   * Check if user has a specific permission.
+   * Supports wildcard matching (e.g., "employees.*" matches "employees.read").
    */
   hasPermission: (permission: string) => boolean;
   /**


### PR DESCRIPTION
## Summary

Implement permission-based navigation to hide menu items users cannot access.

## Changes

### AuthContext (`auth-context.ts`, `AuthContext.tsx`)

- Extended `User` interface with:
  - `roles?: string[]`
  - `permissions?: string[]`
  - `hasOrganizationalScopes?: boolean`

- Added authorization helpers to `AuthContextType`:
  - `hasRole(role: string): boolean`
  - `hasPermission(permission: string): boolean` (supports wildcards like `employees.*`)
  - `hasOrganizationalAccess(): boolean`

### ApplicationLayout (`application-layout.tsx`)

- Sidebar items conditionally rendered based on `hasOrganizationalAccess()`:
  - **Always visible**: Home, Secrets, Settings
  - **Requires organizational scopes**: Organization, Customers, Guard Books

## Behavior

| User Type | Visible Menu Items |
|-----------|-------------------|
| No org scopes | Home, Secrets, Settings |
| With org scopes | All items |

## Testing

- [x] All 1032 frontend tests pass
- [x] ESLint passes
- [x] TypeScript type check passes

## Dependencies

- **Requires**: SecPal/api#272 (extends `/me` API to return permissions)

## Checklist

- [x] Tests passing
- [x] ESLint passing
- [x] TypeScript check passing
- [x] Conventional commit message