### PR TITLE
fix(auth): extend LoginResponse type to include authorization data

### DIFF
--- a/src/services/authApi.test.ts
+++ b/src/services/authApi.test.ts
@@ -84,6 +84,38 @@ describe("authApi", () => {
       expect(result).toEqual(mockResponse);
     });
 
+    it("returns user with authorization data when provided", async () => {
+      const mockResponse = {
+        user: {
+          id: 1,
+          name: "Test User",
+          email: "test@example.com",
+          roles: ["Admin"],
+          permissions: ["users.read", "secrets.*"],
+          hasOrganizationalScopes: true,
+        },
+      };
+
+      // Mock CSRF token fetch
+      mockFetch.mockResolvedValueOnce({ ok: true } as Response);
+
+      // Mock login request
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockResponse,
+      } as Response);
+
+      const result = await login({
+        email: "test@example.com",
+        password: "password123",
+      });
+
+      expect(result.user.roles).toEqual(["Admin"]);
+      expect(result.user.permissions).toEqual(["users.read", "secrets.*"]);
+      expect(result.user.hasOrganizationalScopes).toBe(true);
+    });
+
     it("sends login request with email and password only (no device_name for SPA)", async () => {
       const mockResponse = {
         user: { id: 1, name: "Test", email: "test@example.com" },

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -15,6 +15,9 @@ interface LoginResponse {
     id: number;
     name: string;
     email: string;
+    roles?: string[];
+    permissions?: string[];
+    hasOrganizationalScopes?: boolean;
   };
 }
 


### PR DESCRIPTION
## Summary

Update the `LoginResponse` TypeScript interface to include optional `roles`, `permissions`, and `hasOrganizationalScopes` fields that the API now returns.

## Changes

Extended the `LoginResponse` interface in `authApi.ts`:
```typescript
interface LoginResponse {
  user: {
    id: number;
    name: string;
    email: string;
    roles?: string[];              // NEW
    permissions?: string[];        // NEW
    hasOrganizationalScopes?: boolean;  // NEW
  };
}
```

## Why Optional?

The fields are marked as optional (`?`) for backwards compatibility. If for any reason the API response doesn't include them (e.g., during transition), the existing code will still work - it will just default to `false` for `hasOrganizationalScopes`.

## Testing

- [x] All tests pass (1056 tests)
- [x] TypeScript check passes
- [x] ESLint passes

## Related

- Companion PR in API: SecPal/api#273
- Fixes navigation menu visibility issue introduced after #272 was merged