### PR TITLE
fix: make action buttons visible on mobile devices

### DIFF
--- a/src/components/CustomerTree.tsx
+++ b/src/components/CustomerTree.tsx
@@ -254,8 +254,8 @@ function CustomerTreeNode({
           </Badge>
         )}
 
-        {/* Actions */}
-        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+        {/* Actions - always visible on mobile, hover-only on desktop */}
+        <div className="flex items-center gap-1 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
           {onViewObjects && objectCount > 0 && (
             <Button
               plain

--- a/src/components/OrganizationalUnitTree.tsx
+++ b/src/components/OrganizationalUnitTree.tsx
@@ -256,8 +256,8 @@ function TreeNode({
         {/* Type Badge */}
         <Badge color={getTypeBadgeColor(unit.type)}>{unit.type}</Badge>
 
-        {/* Actions */}
-        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+        {/* Actions - always visible on mobile, hover-only on desktop */}
+        <div className="flex items-center gap-1 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
           {onEdit && (
             <Button
               plain


### PR DESCRIPTION
## Summary

Fix mobile UX issue where edit and delete action buttons were invisible on touch devices.

## Problem

The action buttons (Edit/Delete) in `OrganizationalUnitTree` and `CustomerTree` components used `opacity-0 group-hover:opacity-100`, which only works with mouse hover. On mobile devices and touch screens, there is no hover event, so the buttons were never visible.

## Solution

Changed the opacity classes to be responsive:
- **Mobile/small screens (`< sm`)**: Buttons are always visible (`opacity-100`)
- **Desktop/larger screens (`≥ sm`)**: Buttons hidden by default, visible on hover (`sm:opacity-0 sm:group-hover:opacity-100`)

```diff
- opacity-0 group-hover:opacity-100
+ opacity-100 sm:opacity-0 sm:group-hover:opacity-100
```

## Changes

- `src/components/OrganizationalUnitTree.tsx` - Action buttons responsive visibility
- `src/components/CustomerTree.tsx` - Action buttons responsive visibility

## Testing

- [x] All 24 existing tests pass
- [x] Linter passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Preflight check passes

## Checklist

- [x] Code follows project conventions
- [x] Self-reviewed the changes
- [x] Tests pass locally
- [x] KISS - Simple CSS class change, no complexity added
- [x] DRY - Applied same fix to both affected components