### PR TITLE
chore: remove outdated TODO comments for closed issues

### DIFF
--- a/src/lib/cacheMonitor.ts
+++ b/src/lib/cacheMonitor.ts
@@ -138,15 +138,9 @@ export class CacheMonitor {
       console.log("[CacheMonitor] Metrics:", metrics);
     }
 
-    // TODO: Send to analytics service when implemented (Issue #167)
-    // analytics.track({
-    //   type: 'performance',
-    //   data: {
-    //     metric: 'cache_hit_ratio',
-    //     value: metrics.hitRatio * 100,
-    //     unit: 'percent',
-    //   },
-    // });
+    // Note: Analytics is local-only by design (privacy-first architecture).
+    // Cache metrics are logged to console in dev mode only.
+    // See Issue #167 for privacy-first design rationale.
   }
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -136,9 +136,6 @@ export default defineConfig(({ mode }) => {
               title: "title",
               text: "text",
               url: "url",
-              // Note: File handling is configured here but not yet fully implemented
-              // in useShareTarget hook. The hook currently uses GET parameters only.
-              // Full POST + file support tracked in Issue #101
               files: [
                 {
                   name: "files",


### PR DESCRIPTION
## Summary

Remove outdated TODO comments that reference closed issues.

## Changes

### `vite.config.ts`
- Removed stale comment referencing Issue #101 (closed)
- POST + file support for Share Target API is **fully implemented**

### `src/lib/cacheMonitor.ts`
- Updated comment for Issue #167 (closed)
- Analytics is **local-only by design** (privacy-first architecture)
- No server upload is intentional, not a missing feature

## Context

During investigation of Epic #64 (PWA Infrastructure), discovered that Phase 3 is 100% complete but documentation was outdated. These comments incorrectly suggested features were incomplete.

## Testing

- ✅ All 1057 tests passing
- ✅ Preflight checks passed
- ✅ No functional changes

## Related

- Closes outdated references to #101, #167
- Part of Epic #64 documentation cleanup