### PR TITLE
fix(pwa): Replace blocking OfflineIndicator with non-blocking toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **OfflineIndicator no longer blocks app interaction** (#XXX)
+  - Replaced blocking modal dialog (`Alert`) with non-blocking toast banner
+  - Banner auto-minimizes to icon after 5 seconds to reduce obstruction
+  - Users can manually minimize/expand the notification
+  - Resets to expanded state when going offline again (for context)
+  - Added comprehensive test coverage (19 tests)
+  - Improved accessibility with `role="status"`, `aria-live="polite"`
+  - Used `ChevronDownIcon` from HeroIcons instead of inline SVG (DRY)
+
 ### Added
 
 - **Organizational Hierarchy UI Components** (#241, Part of Epic #228)

--- a/src/components/OfflineIndicator.test.tsx
+++ b/src/components/OfflineIndicator.test.tsx
@@ -1,0 +1,279 @@
+// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import { I18nProvider } from "@lingui/react";
+import { i18n } from "@lingui/core";
+import { OfflineIndicator } from "./OfflineIndicator";
+import { useOnlineStatus } from "../hooks/useOnlineStatus";
+
+// Mock useOnlineStatus hook
+vi.mock("../hooks/useOnlineStatus");
+
+describe("OfflineIndicator", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+
+    // Setup i18n with English locale
+    i18n.load("en", {});
+    i18n.activate("en");
+
+    // Default mock: online
+    vi.mocked(useOnlineStatus).mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function renderWithI18n(component: React.ReactElement) {
+    return render(<I18nProvider i18n={i18n}>{component}</I18nProvider>);
+  }
+
+  describe("Visibility", () => {
+    it("should not render when online", () => {
+      vi.mocked(useOnlineStatus).mockReturnValue(true);
+
+      const { container } = renderWithI18n(<OfflineIndicator />);
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("should render when offline", () => {
+      vi.mocked(useOnlineStatus).mockReturnValue(false);
+
+      renderWithI18n(<OfflineIndicator />);
+
+      expect(screen.getByText(/You're offline/i)).toBeInTheDocument();
+    });
+
+    it("should hide when going back online", () => {
+      const mockUseOnlineStatus = vi.mocked(useOnlineStatus);
+      mockUseOnlineStatus.mockReturnValue(false);
+
+      const { rerender } = renderWithI18n(<OfflineIndicator />);
+
+      expect(screen.getByText(/You're offline/i)).toBeInTheDocument();
+
+      // Simulate going online
+      mockUseOnlineStatus.mockReturnValue(true);
+      rerender(
+        <I18nProvider i18n={i18n}>
+          <OfflineIndicator />
+        </I18nProvider>
+      );
+
+      // Component should not render when online
+      expect(screen.queryByText(/You're offline/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Content", () => {
+    beforeEach(() => {
+      vi.mocked(useOnlineStatus).mockReturnValue(false);
+    });
+
+    it("should display offline title", () => {
+      renderWithI18n(<OfflineIndicator />);
+      expect(screen.getByText(/You're offline/i)).toBeInTheDocument();
+    });
+
+    it("should display sync message", () => {
+      renderWithI18n(<OfflineIndicator />);
+      expect(
+        screen.getByText(/Your changes will sync when you're back online/i)
+      ).toBeInTheDocument();
+    });
+
+    it("should display limited features warning", () => {
+      renderWithI18n(<OfflineIndicator />);
+      expect(
+        screen.getByText(/Some features may be limited/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Accessibility", () => {
+    beforeEach(() => {
+      vi.mocked(useOnlineStatus).mockReturnValue(false);
+    });
+
+    it("should have status role for screen readers", () => {
+      renderWithI18n(<OfflineIndicator />);
+
+      const banner = screen.getByRole("status");
+      expect(banner).toBeInTheDocument();
+    });
+
+    it("should have polite aria-live for non-intrusive announcement", () => {
+      renderWithI18n(<OfflineIndicator />);
+
+      const banner = screen.getByRole("status");
+      expect(banner).toHaveAttribute("aria-live", "polite");
+    });
+
+    it("should have aria-atomic for complete announcement", () => {
+      renderWithI18n(<OfflineIndicator />);
+
+      const banner = screen.getByRole("status");
+      expect(banner).toHaveAttribute("aria-atomic", "true");
+    });
+
+    it("should have accessible label on minimized icon button", async () => {
+      vi.mocked(useOnlineStatus).mockReturnValue(false);
+
+      renderWithI18n(<OfflineIndicator />);
+
+      // Wait for auto-minimize
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      const iconButton = screen.getByRole("button");
+      expect(iconButton).toHaveAttribute("aria-label");
+    });
+  });
+
+  describe("Non-blocking behavior", () => {
+    it("should NOT use a modal dialog", () => {
+      vi.mocked(useOnlineStatus).mockReturnValue(false);
+
+      renderWithI18n(<OfflineIndicator />);
+
+      // Should NOT have dialog role (which would block interaction)
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    });
+
+    it("should NOT have a backdrop overlay", () => {
+      vi.mocked(useOnlineStatus).mockReturnValue(false);
+
+      const { container } = renderWithI18n(<OfflineIndicator />);
+
+      // Check that there's no backdrop element
+      const backdropElements = container.querySelectorAll(
+        '[class*="backdrop"], [class*="overlay"]'
+      );
+      expect(backdropElements).toHaveLength(0);
+    });
+
+    it("should be positioned fixed at bottom", () => {
+      vi.mocked(useOnlineStatus).mockReturnValue(false);
+
+      renderWithI18n(<OfflineIndicator />);
+
+      const banner = screen.getByRole("status");
+      expect(banner).toHaveClass("fixed");
+      expect(banner).toHaveClass("bottom-4");
+    });
+  });
+
+  describe("Auto-minimize behavior", () => {
+    beforeEach(() => {
+      vi.mocked(useOnlineStatus).mockReturnValue(false);
+    });
+
+    it("should show expanded banner initially", () => {
+      renderWithI18n(<OfflineIndicator />);
+
+      expect(screen.getByText(/You're offline/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Some features may be limited/i)
+      ).toBeInTheDocument();
+    });
+
+    it("should auto-minimize after 5 seconds", async () => {
+      renderWithI18n(<OfflineIndicator />);
+
+      // Initially expanded
+      expect(screen.getByText(/You're offline/i)).toBeInTheDocument();
+
+      // Advance time by 5 seconds
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      // Should be minimized - only icon button visible
+      expect(screen.queryByText(/You're offline/i)).not.toBeInTheDocument();
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+
+    it("should NOT minimize before 5 seconds", () => {
+      renderWithI18n(<OfflineIndicator />);
+
+      // Advance time by 4.9 seconds
+      act(() => {
+        vi.advanceTimersByTime(4900);
+      });
+
+      // Should still be expanded
+      expect(screen.getByText(/You're offline/i)).toBeInTheDocument();
+    });
+
+    it("should expand when clicking minimized icon", () => {
+      renderWithI18n(<OfflineIndicator />);
+
+      // Wait for auto-minimize
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      // Click the icon button to expand
+      const iconButton = screen.getByRole("button");
+      fireEvent.click(iconButton);
+
+      // Should be expanded again
+      expect(screen.getByText(/You're offline/i)).toBeInTheDocument();
+    });
+
+    it("should allow manual minimize via button", () => {
+      renderWithI18n(<OfflineIndicator />);
+
+      // Find and click minimize button (the chevron button)
+      const minimizeButton = screen.getByRole("button", {
+        name: /minimize/i,
+      });
+      fireEvent.click(minimizeButton);
+
+      // Should be minimized
+      expect(screen.queryByText(/You're offline/i)).not.toBeInTheDocument();
+    });
+
+    it("should reset to expanded state when going online then offline again", async () => {
+      const mockUseOnlineStatus = vi.mocked(useOnlineStatus);
+      mockUseOnlineStatus.mockReturnValue(false);
+
+      const { rerender } = renderWithI18n(<OfflineIndicator />);
+
+      // Wait for auto-minimize
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      // Verify minimized
+      expect(screen.queryByText(/You're offline/i)).not.toBeInTheDocument();
+
+      // Go online
+      mockUseOnlineStatus.mockReturnValue(true);
+      rerender(
+        <I18nProvider i18n={i18n}>
+          <OfflineIndicator />
+        </I18nProvider>
+      );
+
+      // Go offline again
+      mockUseOnlineStatus.mockReturnValue(false);
+      rerender(
+        <I18nProvider i18n={i18n}>
+          <OfflineIndicator />
+        </I18nProvider>
+      );
+
+      // Should be expanded again (reset)
+      expect(screen.getByText(/You're offline/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/OfflineIndicator.tsx
+++ b/src/components/OfflineIndicator.tsx
@@ -1,37 +1,113 @@
 // SPDX-FileCopyrightText: 2025 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { Trans } from "@lingui/macro";
+import { useState, useEffect } from "react";
+import { Trans, msg } from "@lingui/macro";
+import { useLingui } from "@lingui/react";
+import { SignalSlashIcon, ChevronDownIcon } from "@heroicons/react/24/outline";
 import { useOnlineStatus } from "../hooks/useOnlineStatus";
-import { Alert, AlertDescription, AlertTitle } from "./alert";
 
-// No-op function for Alert's required onClose prop
-// Alert dismisses automatically when back online
-const noop = () => {};
+/** Time in milliseconds before the banner auto-minimizes */
+const AUTO_MINIMIZE_DELAY = 5000;
 
 /**
- * Component that displays a banner when the user is offline
+ * Component that displays a non-blocking banner when the user is offline.
+ *
+ * The banner auto-minimizes to a small icon after 5 seconds to avoid
+ * obstructing the user's workflow. Users can click the icon to expand
+ * the full message again.
+ *
+ * @example
+ * ```tsx
+ * // In App.tsx - place outside main content
+ * function App() {
+ *   return (
+ *     <>
+ *       <main>...</main>
+ *       <OfflineIndicator />
+ *     </>
+ *   );
+ * }
+ * ```
  */
 export function OfflineIndicator() {
+  const { _ } = useLingui();
   const isOnline = useOnlineStatus();
+  const [isMinimized, setIsMinimized] = useState(false);
+
+  // Reset to expanded when online status changes to offline
+  const [wasOnline, setWasOnline] = useState(isOnline);
+  if (isOnline !== wasOnline) {
+    setWasOnline(isOnline);
+    if (!isOnline) {
+      // Going offline - reset to expanded state
+      setIsMinimized(false);
+    }
+  }
+
+  // Auto-minimize after delay when offline
+  useEffect(() => {
+    if (isOnline || isMinimized) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setIsMinimized(true);
+    }, AUTO_MINIMIZE_DELAY);
+
+    return () => clearTimeout(timer);
+  }, [isOnline, isMinimized]);
 
   if (isOnline) {
     return null;
   }
 
+  // Minimized state: just the icon button
+  if (isMinimized) {
+    return (
+      <div className="fixed bottom-4 right-4 z-50">
+        <button
+          type="button"
+          onClick={() => setIsMinimized(false)}
+          className="flex h-10 w-10 items-center justify-center rounded-full bg-amber-600 text-white shadow-lg transition-transform hover:scale-110 hover:bg-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:ring-offset-2 dark:bg-amber-700 dark:hover:bg-amber-600"
+          aria-label={_(msg`You're offline. Click for details.`)}
+        >
+          <SignalSlashIcon className="h-5 w-5" aria-hidden="true" />
+        </button>
+      </div>
+    );
+  }
+
+  // Expanded state: full banner
   return (
-    <div className="fixed bottom-4 left-4 right-4 z-50 sm:left-auto sm:right-4 sm:w-96">
-      <Alert open={!isOnline} onClose={noop}>
-        <AlertTitle>
-          <Trans>You're offline</Trans>
-        </AlertTitle>
-        <AlertDescription>
-          <Trans>
-            Some features may be limited. Your changes will sync when you're
-            back online.
-          </Trans>
-        </AlertDescription>
-      </Alert>
+    <div
+      className="fixed bottom-4 left-4 right-4 z-50 sm:left-auto sm:right-4 sm:w-auto sm:max-w-sm"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      <div className="flex items-center gap-3 rounded-lg bg-amber-600 px-4 py-3 text-white shadow-lg dark:bg-amber-700">
+        <SignalSlashIcon className="h-5 w-5 shrink-0" aria-hidden="true" />
+        <div className="flex-1">
+          <p className="text-sm font-semibold">
+            <Trans>You're offline</Trans>
+          </p>
+          <p className="text-xs text-amber-100">
+            <Trans>
+              Some features may be limited. Your changes will sync when you're
+              back online.
+            </Trans>
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setIsMinimized(true)}
+          className="ml-2 rounded p-1 text-amber-200 transition-colors hover:bg-amber-500 hover:text-white focus:outline-none focus:ring-2 focus:ring-amber-400"
+          aria-label={_(msg`Minimize offline notice`)}
+        >
+          <ChevronDownIcon className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The `OfflineIndicator` component previously used a modal `Alert` dialog which blocked all user interaction when offline. This made the app completely unusable during offline periods.

## Changes

- Replace blocking `Alert` modal with non-blocking fixed-position toast banner
- Add auto-minimize behavior (5s delay) to reduce visual obstruction  
- Add manual minimize/expand functionality via buttons
- Reset to expanded state when going offline again (for context)
- Use `ChevronDownIcon` from HeroIcons instead of inline SVG (DRY)
- Add comprehensive test coverage (19 tests)
- Improve accessibility with `role="status"`, `aria-live="polite"`

## Testing

- [x] 19 unit tests covering visibility, content, accessibility, non-blocking behavior, and auto-minimize
- [x] TypeScript strict mode passes
- [x] ESLint passes with zero warnings
- [x] All 1095 frontend tests pass

## Copilot Review - Resolved Comments

### 1. userEvent vs fireEvent (not implemented)
**Reason:** Tests use `vi.useFakeTimers()` for auto-minimize behavior. `userEvent` conflicts with fake timers causing 10s timeouts. `fireEvent` is the correct choice here for fake-timer compatibility. This is a known limitation documented in testing-library.

### 2. useEffect for state sync (not implemented)  
**Reason:** The suggested `useEffect` pattern triggers ESLint error `react-hooks/set-state-in-effect`. The current render-time conditional pattern is the [React-recommended approach](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes) for adjusting state when a prop changes.

## Checklist

- [x] TDD Compliance (tests first)
- [x] DRY Principle (ChevronDownIcon reuse)
- [x] SOLID Principles
- [x] Accessibility (ARIA attributes)
- [x] CHANGELOG updated
- [x] GPG-signed commit
- [x] Preflight passed