### PR TITLE
fix(build): resolve Vite mixed import warnings and optimize chunking

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@headlessui/react": "^2.2.9",
     "@heroicons/react": "^2.2.0",
+    "@lingui/core": "^5.6.0",
     "@lingui/react": "^5.6.0",
     "clsx": "^2.1.1",
     "dexie": "^4.2.1",

--- a/src/services/secretApi.ts
+++ b/src/services/secretApi.ts
@@ -3,6 +3,8 @@
 
 import { apiConfig } from "../config";
 import { apiFetch } from "./csrf";
+import { deriveFileKey, decryptFile } from "../lib/crypto/encryption";
+import { calculateChecksum } from "../lib/crypto/checksum";
 
 /**
  * Secret API Response Types
@@ -489,15 +491,12 @@ export async function downloadAndDecryptAttachment(
   const ciphertext = encryptedBytes.slice(28); // Rest is ciphertext
 
   // 4. Derive file key (same as encryption)
-  const { deriveFileKey, decryptFile } =
-    await import("../lib/crypto/encryption");
   const fileKey = await deriveFileKey(secretKey, metadata.filename);
 
   // 5. Decrypt file
   const decryptedData = await decryptFile(ciphertext, fileKey, iv, authTag);
 
   // 6. Verify checksum (integrity check)
-  const { calculateChecksum } = await import("../lib/crypto/checksum");
   const actualChecksum = await calculateChecksum(decryptedData);
 
   if (actualChecksum !== metadata.checksum) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -289,6 +289,18 @@ export default defineConfig(({ mode }) => {
         "@": path.resolve(__dirname, "src"),
       },
     },
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            // Vendor chunks for large dependencies
+            "vendor-react": ["react", "react-dom", "react-router-dom"],
+            "vendor-ui": ["@headlessui/react", "@heroicons/react"],
+            "vendor-lingui": ["@lingui/core", "@lingui/react"],
+          },
+        },
+      },
+    },
     server: {
       // Allow DDEV hostnames for local development
       allowedHosts: [".ddev.site"],


### PR DESCRIPTION
## Summary

Resolves Vite build warnings about mixed dynamic/static imports and improves bundle chunking for better Lighthouse performance.

## Problem

The build was producing two types of warnings:

1. **Mixed Import Warning:**
   ```
   /frontend/src/lib/crypto/encryption.ts is dynamically imported by secretApi.ts
   but also statically imported by ShareTarget.tsx, dynamic import will not move
   module into another chunk.
   ```

2. **Large Chunk Warning:**
   ```
   Some chunks are larger than 500 kB after minification.
   ```

## Solution

### 1. Convert Dynamic Imports to Static Imports (`secretApi.ts`)

The crypto modules (`encryption.ts`, `checksum.ts`) were being dynamically imported in `secretApi.ts` but statically imported in `ShareTarget.tsx`. Since static imports always "win" and force the module into the main bundle anyway, the dynamic imports were:
- Not providing any code-splitting benefit
- Causing unnecessary async loading overhead
- Generating confusing build warnings

Changed from:
```typescript
const { deriveFileKey, decryptFile } = await import("../lib/crypto/encryption");
const { calculateChecksum } = await import("../lib/crypto/checksum");
```

To:
```typescript
import { deriveFileKey, decryptFile } from "../lib/crypto/encryption";
import { calculateChecksum } from "../lib/crypto/checksum";
```

### 2. Add Manual Chunk Configuration (`vite.config.ts`)

Added `manualChunks` configuration to split vendor dependencies into separate chunks:

```typescript
build: {
  rollupOptions: {
    output: {
      manualChunks: {
        "vendor-react": ["react", "react-dom", "react-router-dom"],
        "vendor-ui": ["@headlessui/react", "@heroicons/react"],
        "vendor-lingui": ["@lingui/core", "@lingui/react"],
      },
    },
  },
},
```

## Results

### Before
- Mixed import warnings ❌
- Large chunk warnings (>500 kB) ❌

### After
- No build warnings ✅
- Chunk sizes:
  - `index-*.js`: 409 kB (under 500 kB limit)
  - `vendor-react-*.js`: 175 kB
  - `vendor-ui-*.js`: 109 kB
  - `vendor-lingui-*.js`: 8 kB

## Lighthouse Benefits

- **Better Caching:** Vendor chunks (React, UI, Lingui) change rarely, so users benefit from long-term caching
- **Smaller Initial Bundle:** Main chunk reduced to 409 kB
- **No Waterfall Loading:** Static imports load synchronously, avoiding cascading async requests

## Testing

- [x] `npm run build` - Clean build, no warnings
- [x] `npm run lint` - No errors
- [x] `npm run typecheck` - No errors  
- [x] `npm test` - All 1095 tests pass

## Checklist

- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass
- [x] Build succeeds without warnings