### PR TITLE
feat: permission-filtered organizational unit tree view

### DIFF
--- a/src/components/OrganizationalUnitTree.test.tsx
+++ b/src/components/OrganizationalUnitTree.test.tsx
@@ -8,7 +8,7 @@ import { i18n } from "@lingui/core";
 import { OrganizationalUnitTree } from "./OrganizationalUnitTree";
 import type {
   OrganizationalUnit,
-  PaginatedResponse,
+  OrganizationalUnitPaginatedResponse,
 } from "../types/organizational";
 
 // Mock the API module
@@ -60,9 +60,15 @@ describe("OrganizationalUnitTree", () => {
     },
   ];
 
-  const mockResponse: PaginatedResponse<OrganizationalUnit> = {
+  const mockResponse: OrganizationalUnitPaginatedResponse = {
     data: mockUnits,
-    meta: { current_page: 1, last_page: 1, per_page: 100, total: 3 },
+    meta: {
+      current_page: 1,
+      last_page: 1,
+      per_page: 100,
+      total: 3,
+      root_unit_ids: ["unit-1", "unit-3"],
+    },
   };
 
   beforeEach(() => {
@@ -95,7 +101,13 @@ describe("OrganizationalUnitTree", () => {
   it("renders empty state when no units", async () => {
     vi.mocked(listOrganizationalUnits).mockResolvedValue({
       data: [],
-      meta: { current_page: 1, last_page: 1, per_page: 100, total: 0 },
+      meta: {
+        current_page: 1,
+        last_page: 1,
+        per_page: 100,
+        total: 0,
+        root_unit_ids: [],
+      },
     });
 
     renderWithI18n(<OrganizationalUnitTree />);
@@ -147,7 +159,13 @@ describe("OrganizationalUnitTree", () => {
   it("shows create button in empty state", async () => {
     vi.mocked(listOrganizationalUnits).mockResolvedValue({
       data: [],
-      meta: { current_page: 1, last_page: 1, per_page: 100, total: 0 },
+      meta: {
+        current_page: 1,
+        last_page: 1,
+        per_page: 100,
+        total: 0,
+        root_unit_ids: [],
+      },
     });
 
     const onCreate = vi.fn();
@@ -216,5 +234,227 @@ describe("OrganizationalUnitTree", () => {
 
     const treeItems = screen.getAllByRole("treeitem");
     expect(treeItems.length).toBeGreaterThan(0);
+  });
+
+  it("displays 'My Organization' as default heading", async () => {
+    renderWithI18n(<OrganizationalUnitTree />);
+
+    await waitFor(() => {
+      expect(screen.getByText("My Organization")).toBeInTheDocument();
+    });
+  });
+
+  it("allows custom title via prop", async () => {
+    renderWithI18n(<OrganizationalUnitTree title="Custom Title" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Custom Title")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("OrganizationalUnitTree - Permission Filtered", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses root_unit_ids to determine tree roots", async () => {
+    // Scenario: User only has access to a region and its branches
+    // The region's parent (company) is NOT accessible
+    const regionUnit: OrganizationalUnit = {
+      id: "region-1",
+      type: "region",
+      name: "Berlin-Brandenburg",
+      parent: {
+        id: "company-1", // Parent exists but not in accessible units
+        type: "company",
+        name: "ProSec Nord GmbH",
+        created_at: "",
+        updated_at: "",
+      },
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+    };
+
+    const branchUnit: OrganizationalUnit = {
+      id: "branch-1",
+      type: "branch",
+      name: "Niederlassung Berlin",
+      parent: {
+        id: "region-1",
+        type: "region",
+        name: "Berlin-Brandenburg",
+        created_at: "",
+        updated_at: "",
+      },
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+    };
+
+    vi.mocked(listOrganizationalUnits).mockResolvedValue({
+      data: [regionUnit, branchUnit],
+      meta: {
+        current_page: 1,
+        last_page: 1,
+        per_page: 100,
+        total: 2,
+        root_unit_ids: ["region-1"], // Region is root because parent is inaccessible
+      },
+    });
+
+    renderWithI18n(<OrganizationalUnitTree />);
+
+    await waitFor(() => {
+      // Region should be displayed as root
+      expect(screen.getByText("Berlin-Brandenburg")).toBeInTheDocument();
+      // Branch should be displayed as child
+      expect(screen.getByText("Niederlassung Berlin")).toBeInTheDocument();
+    });
+
+    // Verify tree structure - region should be at level 0 (root)
+    const treeItems = screen.getAllByRole("treeitem");
+    expect(treeItems).toHaveLength(2);
+  });
+
+  it("branch manager sees only their single branch", async () => {
+    const singleBranch: OrganizationalUnit = {
+      id: "branch-berlin",
+      type: "branch",
+      name: "Niederlassung Berlin",
+      parent: {
+        id: "region-1", // Parent not accessible
+        type: "region",
+        name: "Berlin-Brandenburg",
+        created_at: "",
+        updated_at: "",
+      },
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+    };
+
+    vi.mocked(listOrganizationalUnits).mockResolvedValue({
+      data: [singleBranch],
+      meta: {
+        current_page: 1,
+        last_page: 1,
+        per_page: 100,
+        total: 1,
+        root_unit_ids: ["branch-berlin"],
+      },
+    });
+
+    renderWithI18n(<OrganizationalUnitTree />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Niederlassung Berlin")).toBeInTheDocument();
+    });
+
+    // Only one tree item should be visible
+    const treeItems = screen.getAllByRole("treeitem");
+    expect(treeItems).toHaveLength(1);
+  });
+
+  it("regional manager sees region with expandable children", async () => {
+    const regionUnit: OrganizationalUnit = {
+      id: "region-1",
+      type: "region",
+      name: "Region Berlin-Brandenburg",
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+    };
+
+    const branch1: OrganizationalUnit = {
+      id: "branch-1",
+      type: "branch",
+      name: "Niederlassung Berlin",
+      parent: {
+        id: "region-1",
+        type: "region",
+        name: "Region Berlin-Brandenburg",
+        created_at: "",
+        updated_at: "",
+      },
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+    };
+
+    const branch2: OrganizationalUnit = {
+      id: "branch-2",
+      type: "branch",
+      name: "Niederlassung Potsdam",
+      parent: {
+        id: "region-1",
+        type: "region",
+        name: "Region Berlin-Brandenburg",
+        created_at: "",
+        updated_at: "",
+      },
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+    };
+
+    vi.mocked(listOrganizationalUnits).mockResolvedValue({
+      data: [regionUnit, branch1, branch2],
+      meta: {
+        current_page: 1,
+        last_page: 1,
+        per_page: 100,
+        total: 3,
+        root_unit_ids: ["region-1"],
+      },
+    });
+
+    renderWithI18n(<OrganizationalUnitTree />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Region Berlin-Brandenburg")).toBeInTheDocument();
+      expect(screen.getByText("Niederlassung Berlin")).toBeInTheDocument();
+      expect(screen.getByText("Niederlassung Potsdam")).toBeInTheDocument();
+    });
+
+    // Three tree items: 1 region + 2 branches
+    const treeItems = screen.getAllByRole("treeitem");
+    expect(treeItems).toHaveLength(3);
+  });
+
+  it("handles user with multiple scopes (multiple roots)", async () => {
+    // User has access to two separate regions
+    const region1: OrganizationalUnit = {
+      id: "region-1",
+      type: "region",
+      name: "Region Berlin",
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+    };
+
+    const region2: OrganizationalUnit = {
+      id: "region-2",
+      type: "region",
+      name: "Region Hamburg",
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+    };
+
+    vi.mocked(listOrganizationalUnits).mockResolvedValue({
+      data: [region1, region2],
+      meta: {
+        current_page: 1,
+        last_page: 1,
+        per_page: 100,
+        total: 2,
+        root_unit_ids: ["region-1", "region-2"], // Both regions are roots
+      },
+    });
+
+    renderWithI18n(<OrganizationalUnitTree />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Region Berlin")).toBeInTheDocument();
+      expect(screen.getByText("Region Hamburg")).toBeInTheDocument();
+    });
+
+    // Both regions should be at root level
+    const treeItems = screen.getAllByRole("treeitem");
+    expect(treeItems).toHaveLength(2);
   });
 });

--- a/src/components/OrganizationalUnitTree.tsx
+++ b/src/components/OrganizationalUnitTree.tsx
@@ -342,18 +342,24 @@ export interface OrganizationalUnitTreeProps {
   flatView?: boolean;
   /** CSS class name */
   className?: string;
+  /** Custom title for the tree view (defaults to i18n "My Organization") */
+  title?: string;
 }
 
 /**
  * Tree view component for displaying organizational hierarchy
  *
  * Features:
+ * - Permission-filtered view: Users only see units they have access to
+ * - Root units determined by API's `root_unit_ids` metadata
  * - Hierarchical tree view with expand/collapse
  * - Icons for different unit types
  * - Selection support
  * - Edit/Delete actions
  * - Loading and error states
  * - Empty state
+ *
+ * @see ADR-007: Organizational Structure Hierarchy
  */
 export function OrganizationalUnitTree({
   onSelect,
@@ -364,6 +370,7 @@ export function OrganizationalUnitTree({
   typeFilter,
   flatView = false,
   className = "",
+  title,
 }: OrganizationalUnitTreeProps) {
   const [units, setUnits] = useState<OrganizationalUnit[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -374,7 +381,7 @@ export function OrganizationalUnitTree({
     setError(null);
 
     try {
-      // Load all units - the API returns hierarchical data when include=children is supported
+      // Load accessible units - API returns permission-filtered results with root_unit_ids
       const response = await listOrganizationalUnits({
         type: typeFilter,
         per_page: 100,
@@ -383,34 +390,43 @@ export function OrganizationalUnitTree({
       if (flatView) {
         setUnits(response.data);
       } else {
-        // Build tree from flat list
+        // Build tree using root_unit_ids from API response
         const buildTree = (
-          items: OrganizationalUnit[]
+          items: OrganizationalUnit[],
+          rootUnitIds: string[]
         ): OrganizationalUnit[] => {
           const itemMap = new Map<string, OrganizationalUnit>();
-          const rootItems: OrganizationalUnit[] = [];
 
-          // First pass: create map
+          // First pass: create map with empty children arrays
           items.forEach((item) => {
             itemMap.set(item.id, { ...item, children: [] });
           });
 
-          // Second pass: build tree
+          // Second pass: build tree structure
+          const rootItems: OrganizationalUnit[] = [];
           items.forEach((item) => {
             const node = itemMap.get(item.id)!;
             if (item.parent?.id && itemMap.has(item.parent.id)) {
+              // Has accessible parent - add as child
               const parent = itemMap.get(item.parent.id)!;
               parent.children = parent.children || [];
               parent.children.push(node);
-            } else {
+            } else if (rootUnitIds.includes(item.id)) {
+              // No accessible parent and is a designated root - add to root items
+              rootItems.push(node);
+            } else if (!item.parent?.id) {
+              // No parent at all (true root) - add to root items
               rootItems.push(node);
             }
+            // Units with inaccessible parents that aren't in rootUnitIds are ignored
           });
 
           return rootItems;
         };
 
-        setUnits(buildTree(response.data));
+        // Use root_unit_ids from API response (defaults to empty array for safety)
+        const rootUnitIds = response.meta.root_unit_ids || [];
+        setUnits(buildTree(response.data, rootUnitIds));
       }
     } catch (err) {
       setError(
@@ -499,9 +515,7 @@ export function OrganizationalUnitTree({
   return (
     <div className={className}>
       <div className="flex items-center justify-between mb-4">
-        <Heading level={3}>
-          <Trans>Organizational Structure</Trans>
-        </Heading>
+        <Heading level={3}>{title || <Trans>My Organization</Trans>}</Heading>
         {onCreate && (
           <Button onClick={onCreate}>
             <Trans>Add Unit</Trans>

--- a/src/components/OrganizationalUnitTree.tsx
+++ b/src/components/OrganizationalUnitTree.tsx
@@ -412,13 +412,10 @@ export function OrganizationalUnitTree({
               parent.children = parent.children || [];
               parent.children.push(node);
             } else if (rootUnitIds.includes(item.id)) {
-              // No accessible parent and is a designated root - add to root items
-              rootItems.push(node);
-            } else if (!item.parent?.id) {
-              // No parent at all (true root) - add to root items
+              // Either no parent (true root) or parent inaccessible (designated root)
               rootItems.push(node);
             }
-            // Units with inaccessible parents that aren't in rootUnitIds are ignored
+            // Units with parents that aren't accessible and aren't in rootUnitIds are ignored
           });
 
           return rootItems;

--- a/src/pages/Organization/OrganizationPage.test.tsx
+++ b/src/pages/Organization/OrganizationPage.test.tsx
@@ -49,7 +49,13 @@ describe("OrganizationPage", () => {
     vi.clearAllMocks();
     vi.mocked(organizationalUnitApi.listOrganizationalUnits).mockResolvedValue({
       data: mockUnits,
-      meta: { current_page: 1, last_page: 1, per_page: 100, total: 2 },
+      meta: {
+        current_page: 1,
+        last_page: 1,
+        per_page: 100,
+        total: 2,
+        root_unit_ids: ["unit-1"],
+      },
     });
   });
 

--- a/src/services/organizationalUnitApi.ts
+++ b/src/services/organizationalUnitApi.ts
@@ -8,7 +8,7 @@ import type {
   CreateOrganizationalUnitRequest,
   UpdateOrganizationalUnitRequest,
   OrganizationalUnitFilters,
-  PaginatedResponse,
+  OrganizationalUnitPaginatedResponse,
   UserOrganizationalScope,
 } from "../types/organizational";
 import { ApiError } from "./secretApi";
@@ -19,15 +19,23 @@ import { ApiError } from "./secretApi";
  * Provides CRUD operations and hierarchy management for internal
  * organizational units (holdings, companies, regions, branches, etc.).
  *
+ * The list endpoint returns permission-filtered results based on the
+ * user's organizational scopes (Need-to-Know principle). The response
+ * includes `root_unit_ids` for building tree views.
+ *
  * @see ADR-007: Organizational Structure Hierarchy
  */
 
 /**
  * List organizational units with optional filters
+ *
+ * Returns ONLY units the authenticated user has access to (Need-to-Know principle).
+ * The response includes `root_unit_ids` in metadata for building permission-filtered
+ * tree views where the user's highest accessible units are displayed as roots.
  */
 export async function listOrganizationalUnits(
   filters?: OrganizationalUnitFilters
-): Promise<PaginatedResponse<OrganizationalUnit>> {
+): Promise<OrganizationalUnitPaginatedResponse> {
   const params = new URLSearchParams();
 
   if (filters?.type) {

--- a/src/types/organizational.ts
+++ b/src/types/organizational.ts
@@ -245,6 +245,27 @@ export interface PaginationMeta {
 }
 
 /**
+ * Extended pagination metadata for organizational units
+ * Includes root_unit_ids for permission-filtered tree views
+ */
+export interface OrganizationalUnitPaginationMeta extends PaginationMeta {
+  /**
+   * IDs of units that should be displayed as tree roots.
+   * These are the user's highest accessible units (units without accessible parents).
+   * Used to build permission-filtered tree views.
+   */
+  root_unit_ids: string[];
+}
+
+/**
+ * Paginated response specifically for organizational units
+ */
+export interface OrganizationalUnitPaginatedResponse {
+  data: OrganizationalUnit[];
+  meta: OrganizationalUnitPaginationMeta;
+}
+
+/**
  * Create organizational unit request
  */
 export interface CreateOrganizationalUnitRequest {


### PR DESCRIPTION
## Summary

Implements a permission-filtered tree view for organizational units that respects the Need-to-Know principle. Users now only see organizational units they have access to, with their highest accessible units displayed as tree roots.

## Changes

### New Types (`src/types/organizational.ts`)
- `OrganizationalUnitPaginationMeta` - extends `PaginationMeta` with `root_unit_ids` field
- `OrganizationalUnitPaginatedResponse` - specialized response type for organizational units

### API Service (`src/services/organizationalUnitApi.ts`)
- Updated `listOrganizationalUnits()` return type to use `OrganizationalUnitPaginatedResponse`
- Added JSDoc documentation about Need-to-Know principle and permission filtering

### Component (`src/components/OrganizationalUnitTree.tsx`)
- Refactored `buildTree()` function to use `root_unit_ids` from API response instead of inferring roots from missing parents
- Changed header from "Organizational Structure" to "My Organization" (more user-centric)
- Added `title` prop for customization when needed
- Updated JSDoc with ADR-007 reference and permission-filtering documentation

### Tests (`src/components/OrganizationalUnitTree.test.tsx`)
- Updated all mock responses to include `root_unit_ids`
- Added new test suite "Permission Filtered" with 6 new test cases:
  - ✅ Uses `root_unit_ids` to determine tree roots
  - ✅ Branch manager sees only their single branch
  - ✅ Regional manager sees region with expandable children
  - ✅ Handles user with multiple scopes (multiple roots)
  - ✅ Displays "My Organization" as default heading
  - ✅ Allows custom title via prop

### Test Fix (`src/pages/Organization/OrganizationPage.test.tsx`)
- Added `root_unit_ids` to existing mock to match new type requirements

## How It Works

1. **API returns filtered data**: The API (Issue #279, already completed) returns only organizational units the user has access to, along with `root_unit_ids` in the response metadata
2. **Frontend uses metadata**: Instead of inferring roots from missing parent references, the frontend now uses the explicit `root_unit_ids` to determine which units to display at the root level
3. **Correct tree structure**: Units with inaccessible parents (not in the response) are properly placed at their designated root level based on `root_unit_ids`

## Example Scenarios

| User Role | Sees | Tree Roots |
|-----------|------|------------|
| Global Admin | All units | `["holding-1"]` |
| Regional Manager | Region + its branches | `["region-berlin"]` |
| Branch Manager | Single branch only | `["branch-123"]` |
| Multi-Scope User | Two separate regions | `["region-1", "region-2"]` |

## Related

- Fixes #291
- Part of Epic #280 (Organizational Structure MVP)
- Depends on API #279 (completed 2025-01-04)
- Implements [ADR-007: Organizational Structure Hierarchy](https://github.com/SecPal/.github/blob/main/docs/adr/20251126-organizational-structure-hierarchy.md)

## Checklist

- [x] Types updated with new interfaces
- [x] API service return type updated
- [x] Component logic refactored for permission filtering
- [x] Header changed to "My Organization"
- [x] Tests passing (18/18 in component + 1 page test fixed)
- [x] TypeScript compiles without errors
- [x] ESLint passes
- [x] Prettier formatting valid
- [x] REUSE compliance verified