### PR TITLE
fix(ui): consistent badge colors between tree and detail view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Inconsistent badge colors between tree and detail view** (#304, Part of Epic #283)
+  - Detail panel now uses type-specific badge colors matching the tree view
+  - Extracted `getTypeBadgeColor()` to `organizationalUnitUtils.ts` (DRY principle)
+  - Added `BadgeColor` type for type-safe color values
+  - Color mapping: blue (holding/company), green (department/division), purple (branch), orange (region), zinc (custom/unknown)
+  - Added unit tests for `getTypeBadgeColor()`
+
 ### Changed
 
 - **Permission-Filtered Organizational Unit Tree View** (#291, Part of Epic SecPal/api#280)

--- a/src/components/OrganizationalUnitTree.tsx
+++ b/src/components/OrganizationalUnitTree.tsx
@@ -13,7 +13,10 @@ import type {
   OrganizationalUnitType,
 } from "../types/organizational";
 import { listOrganizationalUnits } from "../services/organizationalUnitApi";
-import { getTypeLabel } from "../lib/organizationalUnitUtils";
+import {
+  getTypeLabel,
+  getTypeBadgeColor,
+} from "../lib/organizationalUnitUtils";
 
 /**
  * Icon components for tree visualization
@@ -133,25 +136,7 @@ function getUnitIcon(type: OrganizationalUnitType) {
   }
 }
 
-/**
- * Get badge color for organizational unit type
- */
-function getTypeBadgeColor(type: OrganizationalUnitType) {
-  switch (type) {
-    case "holding":
-    case "company":
-      return "blue";
-    case "department":
-    case "division":
-      return "green";
-    case "branch":
-      return "purple";
-    case "region":
-      return "orange";
-    default:
-      return "zinc";
-  }
-}
+// Badge color is now provided by getTypeBadgeColor from organizationalUnitUtils
 
 interface TreeNodeProps {
   unit: OrganizationalUnit;

--- a/src/lib/organizationalUnitUtils.test.ts
+++ b/src/lib/organizationalUnitUtils.test.ts
@@ -3,13 +3,51 @@
 
 import { describe, it, expect, beforeEach } from "vitest";
 import { i18n } from "@lingui/core";
-import { getTypeLabel, getUnitTypeOptions } from "./organizationalUnitUtils";
+import {
+  getTypeLabel,
+  getUnitTypeOptions,
+  getTypeBadgeColor,
+} from "./organizationalUnitUtils";
 
 describe("organizationalUnitUtils", () => {
   beforeEach(() => {
     // Activate i18n for tests with empty messages (uses source strings)
     i18n.load("en", {});
     i18n.activate("en");
+  });
+
+  describe("getTypeBadgeColor", () => {
+    it("returns blue for holding type", () => {
+      expect(getTypeBadgeColor("holding")).toBe("blue");
+    });
+
+    it("returns blue for company type", () => {
+      expect(getTypeBadgeColor("company")).toBe("blue");
+    });
+
+    it("returns green for department type", () => {
+      expect(getTypeBadgeColor("department")).toBe("green");
+    });
+
+    it("returns green for division type", () => {
+      expect(getTypeBadgeColor("division")).toBe("green");
+    });
+
+    it("returns purple for branch type", () => {
+      expect(getTypeBadgeColor("branch")).toBe("purple");
+    });
+
+    it("returns orange for region type", () => {
+      expect(getTypeBadgeColor("region")).toBe("orange");
+    });
+
+    it("returns zinc for custom type", () => {
+      expect(getTypeBadgeColor("custom")).toBe("zinc");
+    });
+
+    it("returns zinc for unknown types", () => {
+      expect(getTypeBadgeColor("unknown-type")).toBe("zinc");
+    });
   });
 
   describe("getTypeLabel", () => {

--- a/src/lib/organizationalUnitUtils.ts
+++ b/src/lib/organizationalUnitUtils.ts
@@ -5,6 +5,44 @@ import { t } from "@lingui/macro";
 import type { OrganizationalUnitType } from "../types/organizational";
 
 /**
+ * Badge color type for organizational unit type badges
+ * Matches the color prop accepted by the Badge component
+ */
+export type BadgeColor = "blue" | "green" | "purple" | "orange" | "zinc";
+
+/**
+ * Get badge color for organizational unit type
+ *
+ * Color mapping:
+ * - blue: holding, company (top-level organizational entities)
+ * - green: department, division (team-based units)
+ * - purple: branch (physical locations)
+ * - orange: region (geographic groupings)
+ * - zinc: custom/unknown types
+ *
+ * @param type - The organizational unit type
+ * @returns Badge color string
+ */
+export function getTypeBadgeColor(
+  type: OrganizationalUnitType | string
+): BadgeColor {
+  switch (type) {
+    case "holding":
+    case "company":
+      return "blue";
+    case "department":
+    case "division":
+      return "green";
+    case "branch":
+      return "purple";
+    case "region":
+      return "orange";
+    default:
+      return "zinc";
+  }
+}
+
+/**
  * Get translated type label for organizational unit type
  *
  * Note: This function must be called at render time, not at module load time,

--- a/src/pages/Organization/OrganizationPage.tsx
+++ b/src/pages/Organization/OrganizationPage.tsx
@@ -9,7 +9,10 @@ import { Button } from "../../components/button";
 import { Badge } from "../../components/badge";
 import { OrganizationalUnitTree } from "../../components/OrganizationalUnitTree";
 import { OrganizationalUnitFormDialog } from "../../components/OrganizationalUnitFormDialog";
-import { getTypeLabel } from "../../lib/organizationalUnitUtils";
+import {
+  getTypeLabel,
+  getTypeBadgeColor,
+} from "../../lib/organizationalUnitUtils";
 import type { OrganizationalUnit } from "../../types";
 
 /**
@@ -169,7 +172,9 @@ export function OrganizationPage() {
             <div className="space-y-4">
               <div className="flex items-start justify-between">
                 <Heading level={3}>{selectedUnit.name}</Heading>
-                <Badge color="blue">{getTypeLabel(selectedUnit.type)}</Badge>
+                <Badge color={getTypeBadgeColor(selectedUnit.type)}>
+                  {getTypeLabel(selectedUnit.type)}
+                </Badge>
               </div>
 
               <dl className="space-y-3 text-sm">


### PR DESCRIPTION
## Summary

Fixes inconsistent badge colors between the OrganizationalUnitTree and the detail panel in OrganizationPage.

**Problem:** The detail panel had a hardcoded `color="blue"` for the type badge, while the tree view used type-specific colors via `getTypeBadgeColor()`.

**Solution:** Extract `getTypeBadgeColor()` to `organizationalUnitUtils.ts` (DRY principle) and use it in both components.

Fixes #304

## Changes

| File | Change |
|------|--------|
| `organizationalUnitUtils.ts` | Added `getTypeBadgeColor()` function and `BadgeColor` type |
| `organizationalUnitUtils.test.ts` | Added 8 unit tests for `getTypeBadgeColor()` |
| `OrganizationalUnitTree.tsx` | Import from utils instead of local function definition |
| `OrganizationPage.tsx` | Import and use `getTypeBadgeColor()` instead of hardcoded `"blue"` |
| `CHANGELOG.md` | Added entry under Fixed section |

## Color Mapping

| Unit Type | Badge Color |
|-----------|-------------|
| `holding`, `company` | 🔵 blue (top-level organizational entities) |
| `department`, `division` | 🟢 green (team-based units) |
| `branch` | 🟣 purple (physical locations) |
| `region` | 🟠 orange (geographic groupings) |
| `custom`, unknown | ⚪ zinc (default) |

## Technical Notes

- **DRY Principle:** Function moved from component-local to shared utils
- **Type Safety:** Added `BadgeColor` type matching Badge component's color prop
- **Backward Compatible:** No API changes, purely visual bugfix

## Quality Gates

- [x] TypeScript: No errors (`tsc --noEmit`)
- [x] ESLint: No warnings
- [x] Prettier: Formatted
- [x] REUSE: License compliant
- [x] Tests: 19 unit tests for organizationalUnitUtils (8 new for getTypeBadgeColor)
- [x] CHANGELOG: Updated

## Screenshots

_N/A - Visual change only affects badge colors in detail panel to match tree view_

## Checklist

- [x] TDD: Tests written for new function
- [x] SOLID: Single responsibility - utils module handles badge colors
- [x] DRY: Eliminated code duplication between components
- [x] KISS: Simple switch statement, no overengineering
- [x] Self-review completed
- [x] One PR = One Topic