### PR TITLE
feat(tree): Optimistic UI for all CRUD operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Toggle selection: clicking the same unit again deselects it
   - Improved UX for organizational structure management
 
+### Changed
+
+- **Optimistic UI for organizational unit CRUD operations** (SecPal/api#303, Part of Epic #283)
+  - After creating a unit, it's immediately added to the tree without reload
+  - After updating a unit, changes appear instantly in the tree
+  - After moving/reparenting a unit, the tree structure updates immediately
+  - After deleting a unit, only the affected row is removed from the tree
+  - No full tree reload for any CRUD operation, improving perceived performance and UX
+  - Maintains tree state (expanded/collapsed nodes) after all operations
+  - New `createdUnit` and `updatedUnit` props for optimistic updates from parent
+  - Updated `MoveOrganizationalUnitDialog` to pass new parent ID on success
+  - 6 test cases for optimistic UI behavior (delete, create, update)
+
 ### Fixed
 
 - **Inconsistent badge colors between tree and detail view** (#304, Part of Epic #283)

--- a/src/components/MoveOrganizationalUnitDialog.test.tsx
+++ b/src/components/MoveOrganizationalUnitDialog.test.tsx
@@ -368,7 +368,7 @@ describe("MoveOrganizationalUnitDialog", () => {
         );
       });
 
-      expect(mockOnSuccess).toHaveBeenCalled();
+      expect(mockOnSuccess).toHaveBeenCalledWith("available-1");
       expect(mockOnClose).toHaveBeenCalled();
     });
 
@@ -403,7 +403,7 @@ describe("MoveOrganizationalUnitDialog", () => {
         );
       });
 
-      expect(mockOnSuccess).toHaveBeenCalled();
+      expect(mockOnSuccess).toHaveBeenCalledWith("");
       expect(mockOnClose).toHaveBeenCalled();
     });
 

--- a/src/components/MoveOrganizationalUnitDialog.tsx
+++ b/src/components/MoveOrganizationalUnitDialog.tsx
@@ -31,8 +31,8 @@ export interface MoveOrganizationalUnitDialogProps {
   unit: OrganizationalUnit | null;
   /** Callback when dialog should close */
   onClose: () => void;
-  /** Callback on successful move */
-  onSuccess: () => void;
+  /** Callback on successful move, receives new parent ID (empty string = root) */
+  onSuccess: (newParentId: string) => void;
 }
 
 /**
@@ -160,7 +160,7 @@ export function MoveOrganizationalUnitDialog({
         await attachOrganizationalUnitParent(unit.id, selectedParentId);
       }
 
-      onSuccess();
+      onSuccess(selectedParentId);
       onClose();
     } catch (err) {
       setError(

--- a/src/components/OrganizationalUnitTree.test.tsx
+++ b/src/components/OrganizationalUnitTree.test.tsx
@@ -322,8 +322,8 @@ describe("OrganizationalUnitTree", () => {
         expect(screen.queryByText("North Region")).not.toBeInTheDocument();
       });
 
-      // Selection should be cleared via onSelect(null)
-      // The component itself doesn't manage selection state, so we verify the unit is gone
+      // Note: Selection clearing is handled by the parent component (OrganizationPage)
+      // via onDelete callback. This test verifies the unit is removed from the DOM.
     });
   });
 

--- a/src/components/OrganizationalUnitTree.test.tsx
+++ b/src/components/OrganizationalUnitTree.test.tsx
@@ -354,7 +354,7 @@ describe("OrganizationalUnitTree", () => {
       rerender(
         <I18nProvider i18n={i18n}>
           <OrganizationalUnitTree
-            createdUnit={{ unit: newUnit, parentId: null }}
+            createdUnit={{ unit: newUnit, parentId: null, key: 1 }}
           />
         </I18nProvider>
       );
@@ -387,7 +387,7 @@ describe("OrganizationalUnitTree", () => {
       rerender(
         <I18nProvider i18n={i18n}>
           <OrganizationalUnitTree
-            createdUnit={{ unit: newUnit, parentId: "unit-1" }}
+            createdUnit={{ unit: newUnit, parentId: "unit-1", key: 1 }}
           />
         </I18nProvider>
       );
@@ -403,8 +403,14 @@ describe("OrganizationalUnitTree", () => {
 
   describe("Optimistic Move (Issue #303)", () => {
     it("moves unit to new parent without reloading when move dialog succeeds", async () => {
-      // Mock the move API calls
-      vi.mocked(attachOrganizationalUnitParent).mockResolvedValue(undefined);
+      // Mock the move API calls - returns the moved unit
+      vi.mocked(attachOrganizationalUnitParent).mockResolvedValue({
+        id: "unit-3",
+        type: "region",
+        name: "North Region",
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+      });
 
       const onMove = vi.fn();
       renderWithI18n(<OrganizationalUnitTree onMove={onMove} />);
@@ -515,7 +521,7 @@ describe("OrganizationalUnitTree", () => {
       // Simulate parent passing updated unit
       rerender(
         <I18nProvider i18n={i18n}>
-          <OrganizationalUnitTree updatedUnit={updatedUnit} />
+          <OrganizationalUnitTree updatedUnit={{ unit: updatedUnit, key: 1 }} />
         </I18nProvider>
       );
 
@@ -551,7 +557,7 @@ describe("OrganizationalUnitTree", () => {
 
       rerender(
         <I18nProvider i18n={i18n}>
-          <OrganizationalUnitTree updatedUnit={updatedUnit} />
+          <OrganizationalUnitTree updatedUnit={{ unit: updatedUnit, key: 1 }} />
         </I18nProvider>
       );
 
@@ -583,7 +589,7 @@ describe("OrganizationalUnitTree", () => {
 
       rerender(
         <I18nProvider i18n={i18n}>
-          <OrganizationalUnitTree updatedUnit={updatedUnit} />
+          <OrganizationalUnitTree updatedUnit={{ unit: updatedUnit, key: 1 }} />
         </I18nProvider>
       );
 
@@ -655,7 +661,14 @@ describe("OrganizationalUnitTree", () => {
       };
 
       vi.mocked(listOrganizationalUnits).mockResolvedValue(nestedMockResponse);
-      vi.mocked(attachOrganizationalUnitParent).mockResolvedValue(undefined);
+      // Mock returns the moved unit
+      vi.mocked(attachOrganizationalUnitParent).mockResolvedValue({
+        id: "dept-1",
+        type: "department",
+        name: "Sales Department",
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+      });
 
       const onMove = vi.fn();
       renderWithI18n(<OrganizationalUnitTree onMove={onMove} />);

--- a/src/components/OrganizationalUnitTree.tsx
+++ b/src/components/OrganizationalUnitTree.tsx
@@ -466,7 +466,8 @@ function updateUnitInTree(
   return units.map((unit) => {
     if (unit.id === updatedUnit.id) {
       // Destructure to exclude children from updatedUnit, preserving tree structure
-      const { children: _, ...updates } = updatedUnit;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { children: _unusedChildren, ...updates } = updatedUnit;
       return {
         ...unit,
         ...updates,

--- a/src/components/OrganizationalUnitTree.tsx
+++ b/src/components/OrganizationalUnitTree.tsx
@@ -465,10 +465,12 @@ function updateUnitInTree(
 ): OrganizationalUnit[] {
   return units.map((unit) => {
     if (unit.id === updatedUnit.id) {
+      // Destructure to exclude children from updatedUnit, preserving tree structure
+      const { children: _, ...updates } = updatedUnit;
       return {
         ...unit,
-        ...updatedUnit,
-        children: unit.children, // Preserve children
+        ...updates,
+        children: unit.children, // Preserve existing children
       };
     }
     if (unit.children && unit.children.length > 0) {
@@ -495,13 +497,16 @@ export interface OrganizationalUnitTreeProps {
   /** Callback when create action is triggered (root level) */
   onCreate?: () => void;
   /**
-   * Optimistic UI: Call this to add a newly created unit to the tree
-   * without reloading. Pass the created unit and its parent ID (null for root).
+   * Optimistic UI: When provided, adds the newly created unit to the tree
+   * without reloading. Should contain the created unit and its parent ID (null for root).
+   * The parent component should set this after a successful create operation,
+   * then reset it to null after processing.
    */
   createdUnit?: { unit: OrganizationalUnit; parentId: string | null } | null;
   /**
-   * Optimistic UI: Call this to update a unit in the tree after editing
-   * without reloading.
+   * Optimistic UI: When provided, updates the unit in the tree after editing
+   * without reloading. The parent component should set this after a successful
+   * update operation, then reset it to null after processing.
    */
   updatedUnit?: OrganizationalUnit | null;
   /** Currently selected unit ID */

--- a/src/components/OrganizationalUnitTree.tsx
+++ b/src/components/OrganizationalUnitTree.tsx
@@ -378,6 +378,109 @@ function TreeNode({
   );
 }
 
+/**
+ * Optimistic UI helper: Add a new unit to the tree
+ * @param units - Current tree structure
+ * @param newUnit - Unit to add
+ * @param parentId - Parent ID (null for root units)
+ * @returns Updated tree with new unit inserted
+ */
+function addUnitToTree(
+  units: OrganizationalUnit[],
+  newUnit: OrganizationalUnit,
+  parentId: string | null
+): OrganizationalUnit[] {
+  if (!parentId) {
+    // Add as root unit
+    return [...units, { ...newUnit, children: [] }];
+  }
+
+  // Add as child of parent
+  return units.map((unit) => {
+    if (unit.id === parentId) {
+      return {
+        ...unit,
+        children: [...(unit.children || []), { ...newUnit, children: [] }],
+      };
+    }
+    if (unit.children && unit.children.length > 0) {
+      return {
+        ...unit,
+        children: addUnitToTree(unit.children, newUnit, parentId),
+      };
+    }
+    return unit;
+  });
+}
+
+/**
+ * Optimistic UI helper: Move a unit to a new parent in the tree
+ * @param units - Current tree structure
+ * @param unitId - ID of unit to move
+ * @param newParentId - New parent ID (null for root)
+ * @returns Updated tree with unit moved
+ */
+function moveUnitInTree(
+  units: OrganizationalUnit[],
+  unitId: string,
+  newParentId: string | null
+): OrganizationalUnit[] {
+  // Step 1: Find and extract the unit to move
+  let unitToMove: OrganizationalUnit | null = null;
+
+  const extractUnit = (items: OrganizationalUnit[]): OrganizationalUnit[] => {
+    return items
+      .filter((item) => {
+        if (item.id === unitId) {
+          unitToMove = { ...item };
+          return false;
+        }
+        return true;
+      })
+      .map((item) => ({
+        ...item,
+        children: item.children ? extractUnit(item.children) : undefined,
+      }));
+  };
+
+  const treeWithoutUnit = extractUnit(units);
+
+  if (!unitToMove) {
+    return units; // Unit not found, return unchanged
+  }
+
+  // Step 2: Insert the unit at the new location
+  return addUnitToTree(treeWithoutUnit, unitToMove, newParentId);
+}
+
+/**
+ * Optimistic UI helper: Update a unit's properties in the tree
+ * @param units - Current tree structure
+ * @param updatedUnit - Unit with updated properties
+ * @returns Updated tree with unit modified
+ */
+function updateUnitInTree(
+  units: OrganizationalUnit[],
+  updatedUnit: OrganizationalUnit
+): OrganizationalUnit[] {
+  return units.map((unit) => {
+    if (unit.id === updatedUnit.id) {
+      return {
+        ...unit,
+        ...updatedUnit,
+        children: unit.children, // Preserve children
+      };
+    }
+    if (unit.children && unit.children.length > 0) {
+      return {
+        ...unit,
+        children: updateUnitInTree(unit.children, updatedUnit),
+      };
+    }
+    return unit;
+  });
+}
+
 export interface OrganizationalUnitTreeProps {
   /** Callback when a unit is selected */
   onSelect?: (unit: OrganizationalUnit) => void;
@@ -391,6 +494,16 @@ export interface OrganizationalUnitTreeProps {
   onCreateChild?: (unit: OrganizationalUnit) => void;
   /** Callback when create action is triggered (root level) */
   onCreate?: () => void;
+  /**
+   * Optimistic UI: Call this to add a newly created unit to the tree
+   * without reloading. Pass the created unit and its parent ID (null for root).
+   */
+  createdUnit?: { unit: OrganizationalUnit; parentId: string | null } | null;
+  /**
+   * Optimistic UI: Call this to update a unit in the tree after editing
+   * without reloading.
+   */
+  updatedUnit?: OrganizationalUnit | null;
   /** Currently selected unit ID */
   selectedId?: string | null;
   /** Filter by unit type */
@@ -425,6 +538,8 @@ export function OrganizationalUnitTree({
   onMove,
   onCreateChild,
   onCreate,
+  createdUnit,
+  updatedUnit,
   selectedId,
   typeFilter,
   flatView = false,
@@ -505,17 +620,49 @@ export function OrganizationalUnitTree({
     loadUnits();
   }, [loadUnits]);
 
+  // Optimistic UI: Handle newly created unit from parent component
+  useEffect(() => {
+    if (createdUnit) {
+      setUnits((prevUnits) =>
+        addUnitToTree(prevUnits, createdUnit.unit, createdUnit.parentId)
+      );
+    }
+  }, [createdUnit]);
+
+  // Optimistic UI: Handle updated unit from parent component
+  useEffect(() => {
+    if (updatedUnit) {
+      setUnits((prevUnits) => updateUnitInTree(prevUnits, updatedUnit));
+    }
+  }, [updatedUnit]);
+
   const handleDeleteClick = useCallback((unit: OrganizationalUnit) => {
     setUnitToDelete(unit);
     setDeleteDialogOpen(true);
   }, []);
 
-  const handleDeleteSuccess = useCallback(async () => {
-    await loadUnits();
-    if (unitToDelete) {
-      onDelete?.(unitToDelete);
-    }
-  }, [loadUnits, onDelete, unitToDelete]);
+  const handleDeleteSuccess = useCallback(() => {
+    if (!unitToDelete) return;
+
+    // Optimistic UI update: Remove the deleted unit from local state
+    // This avoids reloading the entire tree (Issue #303)
+    setUnits((prevUnits) => {
+      const removeUnit = (
+        units: OrganizationalUnit[]
+      ): OrganizationalUnit[] => {
+        return units
+          .filter((unit) => unit.id !== unitToDelete.id)
+          .map((unit) => ({
+            ...unit,
+            children: unit.children ? removeUnit(unit.children) : undefined,
+          }));
+      };
+      return removeUnit(prevUnits);
+    });
+
+    // Notify parent component
+    onDelete?.(unitToDelete);
+  }, [onDelete, unitToDelete]);
 
   const handleDeleteDialogClose = useCallback(() => {
     setDeleteDialogOpen(false);
@@ -529,12 +676,25 @@ export function OrganizationalUnitTree({
     setMoveDialogOpen(true);
   }, []);
 
-  const handleMoveSuccess = useCallback(async () => {
-    await loadUnits();
-    if (unitToMove) {
+  const handleMoveSuccess = useCallback(
+    (newParentId: string) => {
+      if (!unitToMove) return;
+
+      // Optimistic UI update: Move the unit in local state
+      // This avoids reloading the entire tree (Issue #303)
+      setUnits((prevUnits) =>
+        moveUnitInTree(
+          prevUnits,
+          unitToMove.id,
+          newParentId === "" ? null : newParentId
+        )
+      );
+
+      // Notify parent component
       onMove?.(unitToMove);
-    }
-  }, [loadUnits, onMove, unitToMove]);
+    },
+    [onMove, unitToMove]
+  );
 
   const handleMoveDialogClose = useCallback(() => {
     setMoveDialogOpen(false);

--- a/src/components/OrganizationalUnitTree.tsx
+++ b/src/components/OrganizationalUnitTree.tsx
@@ -506,17 +506,19 @@ export interface OrganizationalUnitTreeProps {
   onCreate?: () => void;
   /**
    * Optimistic UI: When provided, adds the newly created unit to the tree
-   * without reloading. Should contain the created unit and its parent ID (null for root).
-   * The parent component should set this after a successful create operation,
-   * then reset it to null after processing.
+   * without reloading. Should contain the created unit, its parent ID (null for root),
+   * and a unique key to trigger updates.
    */
-  createdUnit?: { unit: OrganizationalUnit; parentId: string | null } | null;
+  createdUnit?: {
+    unit: OrganizationalUnit;
+    parentId: string | null;
+    key: number;
+  } | null;
   /**
    * Optimistic UI: When provided, updates the unit in the tree after editing
-   * without reloading. The parent component should set this after a successful
-   * update operation, then reset it to null after processing.
+   * without reloading. Should contain the updated unit and a unique key.
    */
-  updatedUnit?: OrganizationalUnit | null;
+  updatedUnit?: { unit: OrganizationalUnit; key: number } | null;
   /** Currently selected unit ID */
   selectedId?: string | null;
   /** Filter by unit type */
@@ -634,20 +636,24 @@ export function OrganizationalUnitTree({
   }, [loadUnits]);
 
   // Optimistic UI: Handle newly created unit from parent component
+  // Uses key property to ensure each create triggers the effect
   useEffect(() => {
     if (createdUnit) {
       setUnits((prevUnits) =>
         addUnitToTree(prevUnits, createdUnit.unit, createdUnit.parentId)
       );
     }
-  }, [createdUnit]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [createdUnit?.key]);
 
   // Optimistic UI: Handle updated unit from parent component
+  // Uses key property to ensure each update triggers the effect
   useEffect(() => {
     if (updatedUnit) {
-      setUnits((prevUnits) => updateUnitInTree(prevUnits, updatedUnit));
+      setUnits((prevUnits) => updateUnitInTree(prevUnits, updatedUnit.unit));
     }
-  }, [updatedUnit]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [updatedUnit?.key]);
 
   const handleDeleteClick = useCallback((unit: OrganizationalUnit) => {
     setUnitToDelete(unit);

--- a/src/pages/Organization/OrganizationPage.tsx
+++ b/src/pages/Organization/OrganizationPage.tsx
@@ -185,6 +185,16 @@ export function OrganizationPage() {
         setSelectedUnit(unit);
       }
 
+      // Reset optimistic state after tree has processed the update
+      // This prevents duplicate additions on re-renders and allows
+      // subsequent operations on the same unit to trigger updates
+      setTimeout(() => {
+        setOptimisticUpdate({
+          createdUnit: null,
+          updatedUnit: null,
+        });
+      }, 0);
+
       // Show success message
       const message =
         dialogMode === "create"


### PR DESCRIPTION
## Summary
Extends optimistic UI from delete-only to all CRUD operations for organizational units.

## Changes
- **Create**: New units appear instantly via `createdUnit` prop
- **Update**: Changes reflect immediately via `updatedUnit` prop  
- **Move**: Tree restructures instantly via `moveUnitInTree` helper
- **Delete**: Units removed without reload (existing)

## Implementation Details
- Added tree manipulation helpers: `addUnitToTree`, `moveUnitInTree`, `updateUnitInTree`
- Added `createdUnit`/`updatedUnit` props to `OrganizationalUnitTree`
- Updated `MoveOrganizationalUnitDialog` to pass `newParentId` on success
- Refactored `OrganizationPage` to use optimistic updates instead of key-based refresh
- Removed `treeRefreshKey` pattern

## Testing
- 6 test cases for optimistic UI behavior
- All 26 OrganizationalUnitTree tests passing

## Benefits
- No full tree reload for any CRUD operation
- Maintains tree expand/collapse state
- Improved perceived performance and UX

Part of Epic #283
Closes SecPal/api#303