### PR TITLE
fix: improve validation error display for employee creation

### DIFF
--- a/src/pages/Employees/EmployeeCreate.test.tsx
+++ b/src/pages/Employees/EmployeeCreate.test.tsx
@@ -330,6 +330,7 @@ describe("EmployeeCreate", () => {
         last_page: 1,
         per_page: 100,
         total: mockOrganizationalUnits.length,
+        root_unit_ids: ["unit-1", "unit-2"],
       },
     });
     vi.mocked(employeeApi.createEmployee).mockRejectedValue(

--- a/src/pages/Employees/EmployeeCreate.test.tsx
+++ b/src/pages/Employees/EmployeeCreate.test.tsx
@@ -321,4 +321,70 @@ describe("EmployeeCreate", () => {
     fireEvent.change(contractTypeSelect, { target: { value: "part_time" } });
     expect(contractTypeSelect).toHaveValue("part_time");
   });
+
+  it("should clear error message when user changes input", async () => {
+    vi.mocked(organizationalUnitApi.listOrganizationalUnits).mockResolvedValue({
+      data: mockOrganizationalUnits,
+      meta: {
+        current_page: 1,
+        last_page: 1,
+        per_page: 100,
+        total: mockOrganizationalUnits.length,
+      },
+    });
+    vi.mocked(employeeApi.createEmployee).mockRejectedValue(
+      new Error("Validation error: email already exists")
+    );
+
+    renderWithProviders(<EmployeeCreate />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Main Office")).toBeInTheDocument();
+    });
+
+    // Fill form and trigger error
+    fireEvent.change(screen.getByLabelText(/first name/i), {
+      target: { value: "John" },
+    });
+    fireEvent.change(screen.getByLabelText(/last name/i), {
+      target: { value: "Doe" },
+    });
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "duplicate@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText(/date of birth/i), {
+      target: { value: "1990-01-01" },
+    });
+    fireEvent.change(screen.getByLabelText(/position/i), {
+      target: { value: "Developer" },
+    });
+    fireEvent.change(screen.getByLabelText(/contract start date/i), {
+      target: { value: "2025-01-01" },
+    });
+    fireEvent.change(screen.getByLabelText(/organizational unit/i), {
+      target: { value: "unit-1" },
+    });
+
+    // Submit form to trigger error
+    fireEvent.click(screen.getByRole("button", { name: /create employee/i }));
+
+    // Verify error is displayed
+    await waitFor(() => {
+      expect(
+        screen.getByText(/validation error: email already exists/i)
+      ).toBeInTheDocument();
+    });
+
+    // Change any input field
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "new@example.com" },
+    });
+
+    // Verify error is cleared
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/validation error: email already exists/i)
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/pages/Employees/EmployeeCreate.test.tsx
+++ b/src/pages/Employees/EmployeeCreate.test.tsx
@@ -218,9 +218,6 @@ describe("EmployeeCreate", () => {
     fireEvent.click(screen.getByRole("button", { name: /create employee/i }));
 
     await waitFor(() => {
-      expect(
-        screen.getByRole("heading", { name: /error/i })
-      ).toBeInTheDocument();
       expect(screen.getByText(/server error/i)).toBeInTheDocument();
     });
 

--- a/src/pages/Employees/EmployeeCreate.tsx
+++ b/src/pages/Employees/EmployeeCreate.tsx
@@ -302,7 +302,11 @@ export function EmployeeCreate() {
           </Fieldset>
 
           {error && (
-            <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-center dark:border-red-800 dark:bg-red-900/20">
+            <div
+              className="rounded-lg border border-red-200 bg-red-50 p-4 text-center dark:border-red-800 dark:bg-red-900/20"
+              role="alert"
+              aria-live="assertive"
+            >
               <Text className="text-red-800 dark:text-red-400">{error}</Text>
             </div>
           )}

--- a/src/pages/Employees/EmployeeCreate.tsx
+++ b/src/pages/Employees/EmployeeCreate.tsx
@@ -80,6 +80,8 @@ export function EmployeeCreate() {
       }
 
       setError(errorMessage);
+      // Scroll to top to show error message
+      window.scrollTo({ top: 0, behavior: "smooth" });
     } finally {
       setLoading(false);
     }
@@ -306,6 +308,12 @@ export function EmployeeCreate() {
               </div>
             </FieldGroup>
           </Fieldset>
+
+          {error && (
+            <div className="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-900 dark:bg-red-900/20">
+              <Text className="text-red-700 dark:text-red-500">{error}</Text>
+            </div>
+          )}
 
           <div className="flex justify-end gap-3">
             <Button

--- a/src/pages/Employees/EmployeeCreate.tsx
+++ b/src/pages/Employees/EmployeeCreate.tsx
@@ -298,7 +298,9 @@ export function EmployeeCreate() {
           </Fieldset>
 
           {error && (
-            <Text className="text-red-600 dark:text-red-500">{error}</Text>
+            <div className="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">
+              <Text className="text-red-800 dark:text-red-400">{error}</Text>
+            </div>
           )}
 
           <div className="flex justify-end gap-3">

--- a/src/pages/Employees/EmployeeCreate.tsx
+++ b/src/pages/Employees/EmployeeCreate.tsx
@@ -87,6 +87,10 @@ export function EmployeeCreate() {
 
   function handleChange(field: keyof EmployeeFormData, value: string) {
     setFormData((prev) => ({ ...prev, [field]: value }));
+    // Clear error when user starts editing
+    if (error) {
+      setError(null);
+    }
   }
 
   return (
@@ -298,7 +302,7 @@ export function EmployeeCreate() {
           </Fieldset>
 
           {error && (
-            <div className="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">
+            <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-center dark:border-red-800 dark:bg-red-900/20">
               <Text className="text-red-800 dark:text-red-400">{error}</Text>
             </div>
           )}

--- a/src/pages/Employees/EmployeeCreate.tsx
+++ b/src/pages/Employees/EmployeeCreate.tsx
@@ -12,13 +12,13 @@ import { listOrganizationalUnits } from "../../services/organizationalUnitApi";
 import type { OrganizationalUnit } from "../../types/organizational";
 import { Heading } from "../../components/heading";
 import { Button } from "../../components/button";
-import { Text } from "../../components/text";
 import {
   Fieldset,
   Legend,
   FieldGroup,
   Field,
   Label,
+  ErrorMessage,
 } from "../../components/fieldset";
 import { Input } from "../../components/input";
 import { Select } from "../../components/select";
@@ -80,8 +80,6 @@ export function EmployeeCreate() {
       }
 
       setError(errorMessage);
-      // Scroll to top to show error message
-      window.scrollTo({ top: 0, behavior: "smooth" });
     } finally {
       setLoading(false);
     }
@@ -103,16 +101,6 @@ export function EmployeeCreate() {
         <Heading className="mb-6">
           <Trans>Create New Employee</Trans>
         </Heading>
-
-        {error && (
-          <div className="mb-6 rounded-lg border border-red-200 bg-red-50 p-6 text-center dark:border-red-900 dark:bg-red-900/20">
-            <div className="mb-2 text-4xl">⚠️</div>
-            <Heading level={3} className="text-red-900 dark:text-red-400">
-              <Trans>Error</Trans>
-            </Heading>
-            <Text className="mt-2 text-red-700 dark:text-red-500">{error}</Text>
-          </div>
-        )}
 
         <form onSubmit={handleSubmit} className="space-y-8">
           {/* Personal Information */}
@@ -309,11 +297,7 @@ export function EmployeeCreate() {
             </FieldGroup>
           </Fieldset>
 
-          {error && (
-            <div className="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-900 dark:bg-red-900/20">
-              <Text className="text-red-700 dark:text-red-500">{error}</Text>
-            </div>
-          )}
+          {error && <ErrorMessage>{error}</ErrorMessage>}
 
           <div className="flex justify-end gap-3">
             <Button

--- a/src/pages/Employees/EmployeeCreate.tsx
+++ b/src/pages/Employees/EmployeeCreate.tsx
@@ -12,13 +12,13 @@ import { listOrganizationalUnits } from "../../services/organizationalUnitApi";
 import type { OrganizationalUnit } from "../../types/organizational";
 import { Heading } from "../../components/heading";
 import { Button } from "../../components/button";
+import { Text } from "../../components/text";
 import {
   Fieldset,
   Legend,
   FieldGroup,
   Field,
   Label,
-  ErrorMessage,
 } from "../../components/fieldset";
 import { Input } from "../../components/input";
 import { Select } from "../../components/select";
@@ -297,7 +297,9 @@ export function EmployeeCreate() {
             </FieldGroup>
           </Fieldset>
 
-          {error && <ErrorMessage>{error}</ErrorMessage>}
+          {error && (
+            <Text className="text-red-600 dark:text-red-500">{error}</Text>
+          )}
 
           <div className="flex justify-end gap-3">
             <Button

--- a/src/services/ApiError.ts
+++ b/src/services/ApiError.ts
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * Custom error class for API-related errors
+ */
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+    public readonly response?: Response
+  ) {
+    super(message);
+    this.name = "ApiError";
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ApiError);
+    }
+  }
+
+  /**
+   * Check if this is a validation error (422)
+   */
+  isValidationError(): boolean {
+    return this.statusCode === 422;
+  }
+
+  /**
+   * Check if this is a not found error (404)
+   */
+  isNotFoundError(): boolean {
+    return this.statusCode === 404;
+  }
+
+  /**
+   * Check if this is an authentication error (401)
+   */
+  isAuthenticationError(): boolean {
+    return this.statusCode === 401;
+  }
+
+  /**
+   * Check if this is an authorization error (403)
+   */
+  isAuthorizationError(): boolean {
+    return this.statusCode === 403;
+  }
+
+  /**
+   * Check if this is a server error (5xx)
+   */
+  isServerError(): boolean {
+    return this.statusCode ? this.statusCode >= 500 : false;
+  }
+}

--- a/src/services/employeeApi.ts
+++ b/src/services/employeeApi.ts
@@ -177,7 +177,7 @@ export async function createEmployee(
           const fieldName = field.replace(/_/g, " ");
           return `${fieldName}: ${Array.isArray(messages) ? messages.join(", ") : messages}`;
         })
-        .join("\n");
+        .join("; ");
       throw new Error(errorMessages || error.message || "Validation failed");
     }
 

--- a/src/services/employeeApi.ts
+++ b/src/services/employeeApi.ts
@@ -3,6 +3,7 @@
 
 import { apiConfig } from "../config";
 import { apiFetch } from "./csrf";
+import { ApiError } from "./ApiError";
 
 /**
  * Employee status types
@@ -76,6 +77,14 @@ export interface EmployeeFormData {
 }
 
 /**
+ * Laravel validation error response structure
+ */
+export interface ValidationErrorResponse {
+  message: string;
+  errors: Record<string, string[]>;
+}
+
+/**
  * Employee list filters
  */
 export interface EmployeeFilters {
@@ -110,7 +119,11 @@ export async function fetchEmployees(
     const error = await response
       .json()
       .catch(() => ({ message: response.statusText }));
-    throw new Error(error.message || "Failed to fetch employees");
+    throw new ApiError(
+      error.message || "Failed to fetch employees",
+      response.status,
+      response
+    );
   }
 
   const data = await response.json().catch(() => ({
@@ -118,7 +131,7 @@ export async function fetchEmployees(
     meta: { current_page: 1, last_page: 1, per_page: 15, total: 0 },
   }));
   if (!data.data) {
-    throw new Error("Failed to parse employees list response");
+    throw new ApiError("Failed to parse employees list response");
   }
   return data;
 }
@@ -136,12 +149,16 @@ export async function fetchEmployee(id: string): Promise<Employee> {
     const error = await response
       .json()
       .catch(() => ({ message: response.statusText }));
-    throw new Error(error.message || "Failed to fetch employee");
+    throw new ApiError(
+      error.message || "Failed to fetch employee",
+      response.status,
+      response
+    );
   }
 
   const data = await response.json().catch(() => ({ data: null }));
   if (!data.data) {
-    throw new Error("Failed to parse employee response");
+    throw new ApiError("Failed to parse employee response");
   }
   return data.data;
 }
@@ -164,24 +181,34 @@ export async function createEmployee(
 
   if (!response.ok) {
     // Try to parse validation errors (422) or other JSON errors
-    const error = await response.json().catch(() => ({
-      message: response.statusText,
-      errors: {},
-    }));
+    const error: Partial<ValidationErrorResponse> = await response
+      .json()
+      .catch(() => ({
+        message: response.statusText,
+        errors: {},
+      }));
 
     // Handle Laravel validation errors (422)
     if (response.status === 422 && error.errors) {
       // Format validation errors for display
       const errorMessages = Object.entries(error.errors)
-        .map(([field, messages]) => {
+        .map(([field, messages]: [string, string[]]) => {
           const fieldName = field.replace(/_/g, " ");
           return `${fieldName}: ${Array.isArray(messages) ? messages.join(", ") : messages}`;
         })
         .join("; ");
-      throw new Error(errorMessages || error.message || "Validation failed");
+      throw new ApiError(
+        errorMessages || error.message || "Validation failed",
+        response.status,
+        response
+      );
     }
 
-    throw new Error(error.message || "Failed to create employee");
+    throw new ApiError(
+      error.message || "Failed to create employee",
+      response.status,
+      response
+    );
   }
 
   const data = await response.json().catch((err) => {
@@ -197,8 +224,10 @@ export async function createEmployee(
   });
 
   if (!data.data) {
-    throw new Error(
-      `API returned status ${response.status} but response has no 'data' field. Check console for details.`
+    throw new ApiError(
+      `API returned status ${response.status} but response has no 'data' field. Check console for details.`,
+      response.status,
+      response
     );
   }
   return data.data;
@@ -224,12 +253,16 @@ export async function updateEmployee(
     const error = await response
       .json()
       .catch(() => ({ message: response.statusText }));
-    throw new Error(error.message || "Failed to update employee");
+    throw new ApiError(
+      error.message || "Failed to update employee",
+      response.status,
+      response
+    );
   }
 
   const data = await response.json().catch(() => ({ data: null }));
   if (!data.data) {
-    throw new Error("Failed to parse employee response");
+    throw new ApiError("Failed to parse employee response");
   }
   return data.data;
 }
@@ -247,7 +280,11 @@ export async function deleteEmployee(id: string): Promise<void> {
     const error = await response
       .json()
       .catch(() => ({ message: response.statusText }));
-    throw new Error(error.message || "Failed to delete employee");
+    throw new ApiError(
+      error.message || "Failed to delete employee",
+      response.status,
+      response
+    );
   }
 }
 
@@ -264,12 +301,16 @@ export async function activateEmployee(id: string): Promise<Employee> {
     const error = await response
       .json()
       .catch(() => ({ message: response.statusText }));
-    throw new Error(error.message || "Failed to activate employee");
+    throw new ApiError(
+      error.message || "Failed to activate employee",
+      response.status,
+      response
+    );
   }
 
   const data = await response.json().catch(() => ({ data: null }));
   if (!data.data) {
-    throw new Error("Failed to parse employee response");
+    throw new ApiError("Failed to parse employee response");
   }
   return data.data;
 }
@@ -287,12 +328,16 @@ export async function terminateEmployee(id: string): Promise<Employee> {
     const error = await response
       .json()
       .catch(() => ({ message: response.statusText }));
-    throw new Error(error.message || "Failed to terminate employee");
+    throw new ApiError(
+      error.message || "Failed to terminate employee",
+      response.status,
+      response
+    );
   }
 
   const data = await response.json().catch(() => ({ data: null }));
   if (!data.data) {
-    throw new Error("Failed to parse employee response");
+    throw new ApiError("Failed to parse employee response");
   }
   return data.data;
 }


### PR DESCRIPTION
## Problem

When validation errors occurred (e.g., duplicate email), the error message was displayed at the top of the form, but the user was at the bottom near the submit button and couldn't see the error.

**Additionally:** API validation errors (422) were not properly formatted for display.

## Solution

### 1. Improved Error Handling
`employeeApi.ts`:
- Detect and format Laravel 422 validation errors
- Display multiple validation errors clearly  
- Explicit `Accept: application/json` header (additional safety)
- **NEW:** Add `ValidationErrorResponse` interface for type safety
- **NEW:** Refactor to use `ApiError` class for consistent error handling

### 2. Better UX on Errors
`EmployeeCreate.tsx`:
- Error message displayed near submit button (where user's attention is)
- Clear, accessible error display with ARIA attributes
- Error automatically clears when user changes any input
- Compact error display (red border, background, centered text)

## Example

**Before:**
```
Failed to create employee
```

**After:**
```
email: The email has already been taken; position: The position field is required
```

## Testing

### Manual
1. Create employee with email "test@example.com"
2. Try to create second employee with same email
3. **Expected Result:** 
   - Error message visible near submit button
   - Properly formatted validation errors (field: message)
   - Error clears when input changes

### Automated
- ✅ ESLint: No errors
- ✅ TypeScript: Compiles without errors
- ✅ All tests pass (10/10)
- ✅ New test: Error clearing on input change

## Related PR
- Backend: SecPal/api#374

## Checklist
- [x] Code follows project style
- [x] ESLint passes
- [x] TypeScript compiles
- [x] Tested manually
- [x] No breaking changes
- [x] Tests added for new functionality