### PR TITLE
♿ Add autocomplete attributes to customer forms

### DIFF
--- a/src/pages/Customers/CustomerCreate.tsx
+++ b/src/pages/Customers/CustomerCreate.tsx
@@ -125,6 +125,7 @@ export default function CustomerCreate() {
               name="name"
               type="text"
               required
+              autoComplete="organization"
               value={formData.name}
               onChange={(e) => updateField("name", e.target.value)}
             />
@@ -145,6 +146,7 @@ export default function CustomerCreate() {
                 name="street"
                 type="text"
                 required
+                autoComplete="street-address"
                 value={formData.billing_address.street}
                 onChange={(e) => updateAddress("street", e.target.value)}
               />
@@ -159,6 +161,7 @@ export default function CustomerCreate() {
                   name="postal_code"
                   type="text"
                   required
+                  autoComplete="postal-code"
                   value={formData.billing_address.postal_code}
                   onChange={(e) => updateAddress("postal_code", e.target.value)}
                 />
@@ -172,6 +175,7 @@ export default function CustomerCreate() {
                   name="city"
                   type="text"
                   required
+                  autoComplete="address-level2"
                   value={formData.billing_address.city}
                   onChange={(e) => updateAddress("city", e.target.value)}
                 />
@@ -188,6 +192,7 @@ export default function CustomerCreate() {
                 required
                 maxLength={2}
                 placeholder="DE"
+                autoComplete="country"
                 value={formData.billing_address.country}
                 onChange={(e) =>
                   updateAddress("country", e.target.value.toUpperCase())
@@ -210,6 +215,7 @@ export default function CustomerCreate() {
               <Input
                 name="contact_name"
                 type="text"
+                autoComplete="name"
                 value={formData.contact?.name || ""}
                 onChange={(e) => updateContact("name", e.target.value)}
               />
@@ -222,6 +228,7 @@ export default function CustomerCreate() {
               <Input
                 name="contact_email"
                 type="email"
+                autoComplete="email"
                 value={formData.contact?.email || ""}
                 onChange={(e) => updateContact("email", e.target.value)}
               />
@@ -234,6 +241,7 @@ export default function CustomerCreate() {
               <Input
                 name="contact_phone"
                 type="tel"
+                autoComplete="tel"
                 value={formData.contact?.phone || ""}
                 onChange={(e) => updateContact("phone", e.target.value)}
               />

--- a/src/pages/Customers/CustomerEdit.tsx
+++ b/src/pages/Customers/CustomerEdit.tsx
@@ -144,6 +144,7 @@ export default function CustomerEdit() {
               name="name"
               type="text"
               required
+              autoComplete="organization"
               value={formData.name || ""}
               onChange={(e) => updateField("name", e.target.value)}
             />
@@ -164,6 +165,7 @@ export default function CustomerEdit() {
                 name="street"
                 type="text"
                 required
+                autoComplete="street-address"
                 value={formData.billing_address?.street || ""}
                 onChange={(e) => updateAddress("street", e.target.value)}
               />
@@ -178,6 +180,7 @@ export default function CustomerEdit() {
                   name="postal_code"
                   type="text"
                   required
+                  autoComplete="postal-code"
                   value={formData.billing_address?.postal_code || ""}
                   onChange={(e) => updateAddress("postal_code", e.target.value)}
                 />
@@ -191,6 +194,7 @@ export default function CustomerEdit() {
                   name="city"
                   type="text"
                   required
+                  autoComplete="address-level2"
                   value={formData.billing_address?.city || ""}
                   onChange={(e) => updateAddress("city", e.target.value)}
                 />
@@ -207,6 +211,7 @@ export default function CustomerEdit() {
                 required
                 maxLength={2}
                 placeholder="DE"
+                autoComplete="country"
                 value={formData.billing_address?.country || ""}
                 onChange={(e) =>
                   updateAddress("country", e.target.value.toUpperCase())
@@ -229,6 +234,7 @@ export default function CustomerEdit() {
               <Input
                 name="contact_name"
                 type="text"
+                autoComplete="name"
                 value={formData.contact?.name || ""}
                 onChange={(e) => updateContact("name", e.target.value)}
               />
@@ -241,6 +247,7 @@ export default function CustomerEdit() {
               <Input
                 name="contact_email"
                 type="email"
+                autoComplete="email"
                 value={formData.contact?.email || ""}
                 onChange={(e) => updateContact("email", e.target.value)}
               />
@@ -253,6 +260,7 @@ export default function CustomerEdit() {
               <Input
                 name="contact_phone"
                 type="tel"
+                autoComplete="tel"
                 value={formData.contact?.phone || ""}
                 onChange={(e) => updateContact("phone", e.target.value)}
               />


### PR DESCRIPTION
## Summary

Add `autocomplete` attributes to all form fields in customer create and edit forms to improve browser autofill support and accessibility.

## Changes

### CustomerCreate.tsx
- Customer name: `autoComplete="organization"`
- Street: `autoComplete="street-address"`
- Postal code: `autoComplete="postal-code"`
- City: `autoComplete="address-level2"`
- Country: `autoComplete="country"`
- Contact name: `autoComplete="name"`
- Contact email: `autoComplete="email"`
- Contact phone: `autoComplete="tel"`

### CustomerEdit.tsx
- Same autocomplete attributes added to all form fields

## Problem

Browser DevTools reported accessibility warnings:
- "An element doesn't have an autocomplete attribute" (3 resources)
- This prevented proper browser autofill functionality

## Testing

- ✅ Build succeeds without errors
- ✅ Forms now support browser autofill
- ✅ Accessibility warnings resolved

## Related

Part of Epic #210 - Customer & Site Management
