### PR TITLE
fix: Use dynamic future dates in SecretForm tests

### DIFF
--- a/src/components/SecretForm.enhanced.test.tsx
+++ b/src/components/SecretForm.enhanced.test.tsx
@@ -27,6 +27,13 @@ describe("SecretForm", () => {
     submitLabel: "Save",
   };
 
+  // Helper function to generate future dates for testing
+  const getFutureDateString = (daysInFuture = 30): string => {
+    const futureDate = new Date();
+    futureDate.setDate(futureDate.getDate() + daysInFuture);
+    return futureDate.toISOString().split("T")[0]!;
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -194,11 +201,9 @@ describe("SecretForm", () => {
       const dateInput = screen.getByLabelText(/expiration date/i);
 
       // Use a date 30 days in the future to avoid min date validation issues
-      const futureDate = new Date();
-      futureDate.setDate(futureDate.getDate() + 30);
-      const futureDateString = futureDate.toISOString().split("T")[0];
+      const futureDateString = getFutureDateString();
 
-      await userEvent.type(dateInput, futureDateString!);
+      await userEvent.type(dateInput, futureDateString);
 
       expect(dateInput).toHaveValue(futureDateString);
     });
@@ -211,12 +216,10 @@ describe("SecretForm", () => {
       const submitButton = screen.getByRole("button", { name: /save/i });
 
       // Use a date 30 days in the future to avoid min date validation issues
-      const futureDate = new Date();
-      futureDate.setDate(futureDate.getDate() + 30);
-      const futureDateString = futureDate.toISOString().split("T")[0];
+      const futureDateString = getFutureDateString();
 
       await userEvent.type(titleInput, "Test Secret");
-      await userEvent.type(dateInput, futureDateString!);
+      await userEvent.type(dateInput, futureDateString);
       await userEvent.click(submitButton);
 
       await waitFor(() => {
@@ -268,16 +271,14 @@ describe("SecretForm", () => {
       const submitButton = screen.getByRole("button", { name: /save/i });
 
       // Use a date 30 days in the future to avoid min date validation issues
-      const futureDate = new Date();
-      futureDate.setDate(futureDate.getDate() + 30);
-      const futureDateString = futureDate.toISOString().split("T")[0];
+      const futureDateString = getFutureDateString();
 
       // Fill form
       await userEvent.type(titleInput, "Test Secret");
       await userEvent.type(passwordInput, "MyP@ssw0rd!");
       await userEvent.type(tagInput, "work{Enter}");
       await userEvent.type(tagInput, "important{Enter}");
-      await userEvent.type(dateInput, futureDateString!);
+      await userEvent.type(dateInput, futureDateString);
       await userEvent.click(submitButton);
 
       await waitFor(() => {

--- a/src/components/SecretForm.enhanced.test.tsx
+++ b/src/components/SecretForm.enhanced.test.tsx
@@ -193,9 +193,14 @@ describe("SecretForm", () => {
 
       const dateInput = screen.getByLabelText(/expiration date/i);
 
-      await userEvent.type(dateInput, "2025-12-31");
+      // Use a date 30 days in the future to avoid min date validation issues
+      const futureDate = new Date();
+      futureDate.setDate(futureDate.getDate() + 30);
+      const futureDateString = futureDate.toISOString().split("T")[0];
 
-      expect(dateInput).toHaveValue("2025-12-31");
+      await userEvent.type(dateInput, futureDateString!);
+
+      expect(dateInput).toHaveValue(futureDateString);
     });
 
     it("should submit form with expiration date in ISO format", async () => {
@@ -205,15 +210,20 @@ describe("SecretForm", () => {
       const dateInput = screen.getByLabelText(/expiration date/i);
       const submitButton = screen.getByRole("button", { name: /save/i });
 
+      // Use a date 30 days in the future to avoid min date validation issues
+      const futureDate = new Date();
+      futureDate.setDate(futureDate.getDate() + 30);
+      const futureDateString = futureDate.toISOString().split("T")[0];
+
       await userEvent.type(titleInput, "Test Secret");
-      await userEvent.type(dateInput, "2025-12-31");
+      await userEvent.type(dateInput, futureDateString!);
       await userEvent.click(submitButton);
 
       await waitFor(() => {
         expect(mockOnSubmit).toHaveBeenCalledWith(
           expect.objectContaining({
             title: "Test Secret",
-            expires_at: "2025-12-31T23:59:59Z",
+            expires_at: `${futureDateString}T23:59:59Z`,
           })
         );
       });
@@ -257,12 +267,17 @@ describe("SecretForm", () => {
       const dateInput = screen.getByLabelText(/expiration date/i);
       const submitButton = screen.getByRole("button", { name: /save/i });
 
+      // Use a date 30 days in the future to avoid min date validation issues
+      const futureDate = new Date();
+      futureDate.setDate(futureDate.getDate() + 30);
+      const futureDateString = futureDate.toISOString().split("T")[0];
+
       // Fill form
       await userEvent.type(titleInput, "Test Secret");
       await userEvent.type(passwordInput, "MyP@ssw0rd!");
       await userEvent.type(tagInput, "work{Enter}");
       await userEvent.type(tagInput, "important{Enter}");
-      await userEvent.type(dateInput, "2025-12-31");
+      await userEvent.type(dateInput, futureDateString!);
       await userEvent.click(submitButton);
 
       await waitFor(() => {
@@ -273,7 +288,7 @@ describe("SecretForm", () => {
           url: "",
           notes: "",
           tags: ["work", "important"],
-          expires_at: "2025-12-31T23:59:59Z",
+          expires_at: `${futureDateString}T23:59:59Z`,
         });
       });
     });


### PR DESCRIPTION
Fixes test failures in `SecretForm.enhanced.test.tsx` caused by hardcoded dates that became invalid over time.

## Problem

Tests were using hardcoded date `2025-12-31` which is now in the past (today is 2026-01-03). The form's `min` date validation prevented submission, causing:

- ❌ "should submit form with expiration date in ISO format" 
- ❌ "should include all new features in submission"

Both tests failed with: `expected "vi.fn()" to be called with arguments` (0 calls - form never submitted)

## Solution

Replace hardcoded dates with dynamic future dates:

```typescript
// Old: Hardcoded past date
await userEvent.type(dateInput, "2025-12-31");

// New: Dynamic future date (today + 30 days)
const futureDate = new Date();
futureDate.setDate(futureDate.getDate() + 30);
const futureDateString = futureDate.toISOString().split("T")[0];
await userEvent.type(dateInput, futureDateString!);
```

## Changes

- ✅ Updated 3 tests to use dynamic dates
- ✅ Added TypeScript non-null assertions for date strings
- ✅ All 17 tests in SecretForm.enhanced.test.tsx now passing

## Test Results

```bash
✓ src/components/SecretForm.enhanced.test.tsx (17 tests) 5993ms
  ✓ Password Generator (4)
  ✓ Tag Input (6)
  ✓ Expiration Date Picker (4)  # ← Fixed
  ✓ Form Submission (1)          # ← Fixed
  ✓ Accessibility (2)
```

## Related

Part of test suite quality improvements. act() warnings tracked in #407.