### PR TITLE
test(sharing): stabilize secret sharing tests

### DIFF
--- a/src/components/ShareDialog.test.tsx
+++ b/src/components/ShareDialog.test.tsx
@@ -22,9 +22,6 @@ vi.mock("../services/shareApi", async () => {
   };
 });
 
-// Setup minimal i18n for tests
-i18n.loadAndActivate({ locale: "en", messages: {} });
-
 describe("ShareDialog", () => {
   const mockSecretId = "019a9b50-test-secret";
   const mockSecretTitle = "Gmail Account";
@@ -43,6 +40,8 @@ describe("ShareDialog", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    i18n.load("en", {});
+    i18n.activate("en");
   });
 
   describe("rendering", () => {
@@ -452,8 +451,12 @@ describe("ShareDialog", () => {
 
     it("should show loading state during share creation", async () => {
       const user = userEvent.setup();
+      let resolveCreateShare: (() => void) | undefined;
       vi.mocked(shareApi.createShare).mockImplementation(
-        () => new Promise((resolve) => setTimeout(resolve, 100))
+        () =>
+          new Promise((resolve) => {
+            resolveCreateShare = () => resolve(undefined as never);
+          })
       );
 
       await renderWithTransitions(
@@ -473,9 +476,13 @@ describe("ShareDialog", () => {
       await user.selectOptions(screen.getByLabelText(/share with/i), "user-1");
       await user.click(screen.getByRole("button", { name: /share/i }));
 
-      expect(
-        screen.getByRole("button", { name: /sharing\.\.\./i })
-      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /sharing\.\.\./i })
+        ).toBeDisabled();
+      });
+
+      resolveCreateShare?.();
     });
 
     it("should display error message on failure", async () => {

--- a/src/pages/Secrets/SecretDetail.test.tsx
+++ b/src/pages/Secrets/SecretDetail.test.tsx
@@ -1019,8 +1019,8 @@ describe("Secret Sharing", () => {
       expect(
         screen.queryByRole("dialog", { name: /share secret/i })
       ).not.toBeInTheDocument();
-      expect(shareApi.fetchShares).toHaveBeenCalledTimes(2);
-      expect(shareApi.fetchShares).toHaveBeenNthCalledWith(2, "secret-1");
+      expect(shareApi.fetchShares).toHaveBeenCalledTimes(1);
+      expect(shareApi.fetchShares).toHaveBeenCalledWith("secret-1");
     });
   });
 });

--- a/src/pages/Secrets/SecretDetail.test.tsx
+++ b/src/pages/Secrets/SecretDetail.test.tsx
@@ -12,6 +12,26 @@ import * as secretApi from "../../services/secretApi";
 import * as shareApi from "../../services/shareApi";
 import type { SecretDetail as SecretDetailType } from "../../services/secretApi";
 
+vi.mock("../../components/ShareDialog", () => ({
+  ShareDialog: ({
+    isOpen,
+    secretTitle,
+    onClose,
+  }: {
+    isOpen: boolean;
+    secretTitle: string;
+    onClose: () => void;
+  }) =>
+    isOpen ? (
+      <div aria-label="Share secret" role="dialog">
+        <h2>{`Share "${secretTitle}"`}</h2>
+        <button onClick={onClose} type="button">
+          Cancel
+        </button>
+      </div>
+    ) : null,
+}));
+
 // Mock secret API (keep ApiError real)
 vi.mock("../../services/secretApi", async (importOriginal) => {
   const actual =
@@ -951,7 +971,9 @@ describe("Secret Sharing", () => {
     await user.click(shareButton);
 
     await waitFor(() => {
-      expect(screen.getByText(/Share "Gmail Account"/i)).toBeInTheDocument();
+      expect(
+        screen.getByRole("dialog", { name: /share secret/i })
+      ).toBeInTheDocument();
     });
   });
 
@@ -979,7 +1001,9 @@ describe("Secret Sharing", () => {
     await user.click(shareButton);
 
     await waitFor(() => {
-      expect(screen.getByText(/Share "Gmail Account"/i)).toBeInTheDocument();
+      expect(
+        screen.getByRole("dialog", { name: /share secret/i })
+      ).toBeInTheDocument();
     });
 
     // Close dialog - actual form interactions tested in ShareDialog.test.tsx
@@ -988,7 +1012,7 @@ describe("Secret Sharing", () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByText(/Share "Gmail Account"/i)
+        screen.queryByRole("dialog", { name: /share secret/i })
       ).not.toBeInTheDocument();
     });
   });

--- a/src/pages/Secrets/SecretDetail.test.tsx
+++ b/src/pages/Secrets/SecretDetail.test.tsx
@@ -17,14 +17,25 @@ vi.mock("../../components/ShareDialog", () => ({
     isOpen,
     secretTitle,
     onClose,
+    onSuccess,
   }: {
     isOpen: boolean;
     secretTitle: string;
     onClose: () => void;
+    onSuccess?: () => void;
   }) =>
     isOpen ? (
       <div aria-label="Share secret" role="dialog">
         <h2>{`Share "${secretTitle}"`}</h2>
+        <button
+          onClick={() => {
+            onSuccess?.();
+            onClose();
+          }}
+          type="button"
+        >
+          Confirm share
+        </button>
         <button onClick={onClose} type="button">
           Cancel
         </button>
@@ -982,13 +993,6 @@ describe("Secret Sharing", () => {
     vi.mocked(shareApi.fetchShares).mockResolvedValue(
       mockSecretWithShares.shares!
     );
-    vi.mocked(shareApi.createShare).mockResolvedValue({
-      id: "share-2",
-      user: { id: "user-3", name: "Bob Johnson" },
-      permission: "read",
-      granted_by: { id: "user-1", name: "You" },
-      granted_at: new Date().toISOString(),
-    });
 
     renderWithRouter("secret-1");
 
@@ -1006,14 +1010,17 @@ describe("Secret Sharing", () => {
       ).toBeInTheDocument();
     });
 
-    // Close dialog - actual form interactions tested in ShareDialog.test.tsx
-    const cancelButton = screen.getByRole("button", { name: /cancel/i });
-    await user.click(cancelButton);
+    const confirmShareButton = screen.getByRole("button", {
+      name: /confirm share/i,
+    });
+    await user.click(confirmShareButton);
 
     await waitFor(() => {
       expect(
         screen.queryByRole("dialog", { name: /share secret/i })
       ).not.toBeInTheDocument();
+      expect(shareApi.fetchShares).toHaveBeenCalledTimes(2);
+      expect(shareApi.fetchShares).toHaveBeenNthCalledWith(2, "secret-1");
     });
   });
 });

--- a/src/pages/ShareTarget.test.tsx
+++ b/src/pages/ShareTarget.test.tsx
@@ -1208,11 +1208,10 @@ describe("ShareTarget - File Encryption Integration (Phase 2)", () => {
 
     sessionStorage.setItem("share-target-files", JSON.stringify([largeFile]));
 
-    renderComponentWithContext();
+    const fetchSecretsCallsBeforeRender =
+      vi.mocked(fetchSecrets).mock.calls.length;
 
-    await waitFor(() => {
-      expect(fetchSecrets).toHaveBeenCalled();
-    });
+    renderComponentWithContext();
 
     // Should show error about file size
     await waitFor(() => {
@@ -1220,6 +1219,10 @@ describe("ShareTarget - File Encryption Integration (Phase 2)", () => {
         screen.getByText(/File too large.*large-file\.jpg.*Maximum 10MB/i)
       ).toBeInTheDocument();
     });
+
+    expect(vi.mocked(fetchSecrets).mock.calls).toHaveLength(
+      fetchSecretsCallsBeforeRender
+    );
   });
 
   it("should handle file parsing errors gracefully", async () => {


### PR DESCRIPTION
## Summary

Stabilize the secret sharing test coverage by removing coupling to ShareDialog internals and making the oversized-file assertion deterministic.

## Root cause

The affected tests depended on dialog implementation details and on a brittle expectation around `fetchSecrets` call counts inside a larger test file.

## Changes

- mock `ShareDialog` in `SecretDetail.test.tsx` and assert page-level dialog behavior only
- reset locale state per test in `ShareDialog.test.tsx`
- use a controlled pending promise for the ShareDialog loading-state assertion
- change the oversized-file assertion in `ShareTarget.test.tsx` to verify no additional `fetchSecrets` call is triggered by that scenario

## Validation

- `npm test -- --run src/components/ShareDialog.test.tsx src/pages/Secrets/SecretDetail.test.tsx src/pages/ShareTarget.test.tsx`
