### PR TITLE
test(organization): isolate organization and employee tests

### DIFF
--- a/src/pages/Employees/EmployeeList.test.tsx
+++ b/src/pages/Employees/EmployeeList.test.tsx
@@ -8,6 +8,7 @@ import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
 import { EmployeeList } from "./EmployeeList";
 import * as employeeApi from "../../services/employeeApi";
+import * as organizationalUnitApi from "../../services/organizationalUnitApi";
 import type {
   Employee,
   EmployeeListResponse,
@@ -15,6 +16,7 @@ import type {
 
 // Mock the employee API
 vi.mock("../../services/employeeApi");
+vi.mock("../../services/organizationalUnitApi");
 
 // Helper to render with providers
 const renderWithProviders = () => {
@@ -86,6 +88,37 @@ describe("EmployeeList", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(employeeApi.fetchEmployees).mockResolvedValue(mockResponse);
+    vi.mocked(organizationalUnitApi.listOrganizationalUnits).mockResolvedValue({
+      data: [
+        {
+          id: "unit-1",
+          name: "Engineering",
+          type: "department",
+          description: null,
+          parent: null,
+          children: [],
+          created_at: "2025-01-01T00:00:00Z",
+          updated_at: "2025-01-01T00:00:00Z",
+        },
+        {
+          id: "unit-2",
+          name: "Design",
+          type: "department",
+          description: null,
+          parent: null,
+          children: [],
+          created_at: "2025-01-01T00:00:00Z",
+          updated_at: "2025-01-01T00:00:00Z",
+        },
+      ],
+      meta: {
+        current_page: 1,
+        last_page: 1,
+        per_page: 100,
+        total: 2,
+        root_unit_ids: [],
+      },
+    });
   });
 
   it("should render employee list with table", async () => {

--- a/src/pages/Organization/OrganizationPage.test.tsx
+++ b/src/pages/Organization/OrganizationPage.test.tsx
@@ -9,6 +9,7 @@ import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
 import { OrganizationPage } from "./OrganizationPage";
 import * as organizationalUnitApi from "../../services/organizationalUnitApi";
+import * as organizationalUnitsHook from "../../hooks/useOrganizationalUnitsWithOffline";
 import type { OrganizationalUnit } from "../../types/organizational";
 
 // Mock the API
@@ -17,6 +18,10 @@ vi.mock("../../services/organizationalUnitApi", () => ({
   createOrganizationalUnit: vi.fn(),
   updateOrganizationalUnit: vi.fn(),
   deleteOrganizationalUnit: vi.fn(),
+}));
+
+vi.mock("../../hooks/useOrganizationalUnitsWithOffline", () => ({
+  useOrganizationalUnitsWithOffline: vi.fn(),
 }));
 
 // Helper to render with providers
@@ -50,6 +55,20 @@ describe("OrganizationPage", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    i18n.load("en", {});
+    i18n.activate("en");
+    vi.mocked(
+      organizationalUnitsHook.useOrganizationalUnitsWithOffline
+    ).mockReturnValue({
+      units: mockUnits,
+      loading: false,
+      error: null,
+      isOffline: false,
+      isStale: false,
+      rootUnitIds: ["unit-1"],
+      lastSynced: null,
+      refresh: vi.fn(),
+    });
     vi.mocked(organizationalUnitApi.listOrganizationalUnits).mockResolvedValue({
       data: mockUnits,
       meta: {
@@ -99,11 +118,8 @@ describe("OrganizationPage", () => {
   it("renders the OrganizationalUnitTree component", async () => {
     renderWithProviders(<OrganizationPage />);
 
-    // Wait for tree to load
     await waitFor(() => {
-      expect(
-        organizationalUnitApi.listOrganizationalUnits
-      ).toHaveBeenCalledWith({ per_page: 100 });
+      expect(screen.getByText("SecPal Holding")).toBeInTheDocument();
     });
   });
 

--- a/src/pages/Organization/OrganizationPage.test.tsx
+++ b/src/pages/Organization/OrganizationPage.test.tsx
@@ -55,7 +55,6 @@ describe("OrganizationPage", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    i18n.load("en", {});
     i18n.activate("en");
     vi.mocked(
       organizationalUnitsHook.useOrganizationalUnitsWithOffline
@@ -65,7 +64,7 @@ describe("OrganizationPage", () => {
       error: null,
       isOffline: false,
       isStale: false,
-      rootUnitIds: ["unit-1"],
+      rootUnitIds: ["unit-1", "unit-2"],
       lastSynced: null,
       refresh: vi.fn(),
     });
@@ -76,7 +75,7 @@ describe("OrganizationPage", () => {
         last_page: 1,
         per_page: 100,
         total: 2,
-        root_unit_ids: ["unit-1"],
+        root_unit_ids: ["unit-1", "unit-2"],
       },
     });
   });


### PR DESCRIPTION
## Summary

Make organization and employee list tests deterministic by fully controlling organizational-unit data dependencies.

## Root cause

The full suite could reach unintended loading paths because organizational-unit state was not mocked consistently across these tests.

## Changes

- mock `useOrganizationalUnitsWithOffline` with deterministic values in `OrganizationPage.test.tsx`
- seed stable root unit ids and locale state for organization tests
- mock `organizationalUnitApi.listOrganizationalUnits` in `EmployeeList.test.tsx`

## Validation

- `npm test -- --run src/pages/Organization/OrganizationPage.test.tsx src/pages/Employees/EmployeeList.test.tsx`
