### PR TITLE
test(vitest): harden frontend test isolation

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -19,6 +19,7 @@ async function renderWithI18n(component: React.ReactElement) {
 describe("App", () => {
   beforeEach(() => {
     localStorage.clear();
+    window.history.replaceState({}, "", "/login");
     i18n.load("en", {});
     i18n.activate("en");
   });
@@ -45,6 +46,8 @@ describe("App", () => {
   });
 
   it("protects activity-logs route with permission check", async () => {
+    window.history.replaceState({}, "", "/activity-logs");
+
     // Set authenticated user without activity_log.read permission
     localStorage.setItem(
       "auth_user",
@@ -59,9 +62,11 @@ describe("App", () => {
     // This test verifies that the route structure includes PermissionRoute
     // Actual redirect behavior is tested in PermissionRoute.test.tsx
     await renderWithI18n(<App />);
-    // Should not crash - route configuration is valid
-    expect(
-      screen.getByText(/Your digital guard companion/i)
-    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /Welcome to SecPal/i })
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/src/main.test.tsx
+++ b/src/main.test.tsx
@@ -11,6 +11,7 @@ describe("AppWithI18n Integration", () => {
   beforeEach(() => {
     // Clear localStorage before each test
     localStorage.clear();
+    window.history.replaceState({}, "", "/login");
   });
 
   it("renders the app after loading locale", async () => {
@@ -36,7 +37,7 @@ describe("AppWithI18n Integration", () => {
 
     // Verify app actually rendered - should show login page when not authenticated
     await waitFor(() => {
-      const loginHeading = screen.getByText(/Login/i);
+      const loginHeading = screen.getByRole("heading", { name: /Login/i });
       expect(loginHeading).toBeInTheDocument();
     });
   });
@@ -53,7 +54,7 @@ describe("AppWithI18n Integration", () => {
     });
 
     // Check for English text on Login page
-    expect(screen.getByText(/login/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Login/i })).toBeInTheDocument();
   });
 
   it("does not render blank/black screen on locale load failure", async () => {

--- a/src/pages/Customers/CustomersPage.test.tsx
+++ b/src/pages/Customers/CustomersPage.test.tsx
@@ -85,7 +85,12 @@ describe("CustomersPage", () => {
   });
 
   it("should display loading state initially", () => {
+    vi.mocked(customersApi.listCustomers).mockImplementation(
+      () => new Promise(() => undefined)
+    );
+
     renderWithProviders();
+
     expect(screen.getByText(/loading/i)).toBeInTheDocument();
   });
 

--- a/src/pages/Customers/CustomersPage.test.tsx
+++ b/src/pages/Customers/CustomersPage.test.tsx
@@ -86,7 +86,10 @@ describe("CustomersPage", () => {
 
   it("should display loading state initially", () => {
     vi.mocked(customersApi.listCustomers).mockImplementation(
-      () => new Promise(() => undefined)
+      () =>
+        new Promise<Awaited<ReturnType<typeof customersApi.listCustomers>>>(
+          () => {}
+        )
     );
 
     renderWithProviders();

--- a/src/pages/Sites/SiteCreate.test.tsx
+++ b/src/pages/Sites/SiteCreate.test.tsx
@@ -319,10 +319,18 @@ describe("SiteCreate", () => {
 
   it("displays loading state while loading data", () => {
     vi.mocked(customersApi.listCustomers).mockImplementation(
-      () => new Promise(() => undefined)
+      () =>
+        new Promise<Awaited<ReturnType<typeof customersApi.listCustomers>>>(
+          () => {}
+        )
     );
     vi.mocked(organizationalUnitApi.listOrganizationalUnits).mockImplementation(
-      () => new Promise(() => undefined)
+      () =>
+        new Promise<
+          Awaited<
+            ReturnType<typeof organizationalUnitApi.listOrganizationalUnits>
+          >
+        >(() => {})
     );
 
     renderWithRouter();

--- a/src/pages/Sites/SiteCreate.test.tsx
+++ b/src/pages/Sites/SiteCreate.test.tsx
@@ -318,6 +318,13 @@ describe("SiteCreate", () => {
   });
 
   it("displays loading state while loading data", () => {
+    vi.mocked(customersApi.listCustomers).mockImplementation(
+      () => new Promise(() => undefined)
+    );
+    vi.mocked(organizationalUnitApi.listOrganizationalUnits).mockImplementation(
+      () => new Promise(() => undefined)
+    );
+
     renderWithRouter();
 
     expect(screen.getByText(/loading/i)).toBeInTheDocument();

--- a/src/pages/Sites/SiteEdit.test.tsx
+++ b/src/pages/Sites/SiteEdit.test.tsx
@@ -229,6 +229,16 @@ describe("SiteEdit", () => {
   });
 
   it("displays loading state while fetching data", () => {
+    vi.mocked(customersApi.getSite).mockImplementation(
+      () => new Promise(() => undefined)
+    );
+    vi.mocked(customersApi.listCustomers).mockImplementation(
+      () => new Promise(() => undefined)
+    );
+    vi.mocked(organizationalUnitApi.listOrganizationalUnits).mockImplementation(
+      () => new Promise(() => undefined)
+    );
+
     renderWithRouter();
 
     expect(screen.getByText(/loading/i)).toBeInTheDocument();

--- a/src/pages/Sites/SiteEdit.test.tsx
+++ b/src/pages/Sites/SiteEdit.test.tsx
@@ -230,13 +230,22 @@ describe("SiteEdit", () => {
 
   it("displays loading state while fetching data", () => {
     vi.mocked(customersApi.getSite).mockImplementation(
-      () => new Promise(() => undefined)
+      () =>
+        new Promise<Awaited<ReturnType<typeof customersApi.getSite>>>(() => {})
     );
     vi.mocked(customersApi.listCustomers).mockImplementation(
-      () => new Promise(() => undefined)
+      () =>
+        new Promise<Awaited<ReturnType<typeof customersApi.listCustomers>>>(
+          () => {}
+        )
     );
     vi.mocked(organizationalUnitApi.listOrganizationalUnits).mockImplementation(
-      () => new Promise(() => undefined)
+      () =>
+        new Promise<
+          Awaited<
+            ReturnType<typeof organizationalUnitApi.listOrganizationalUnits>
+          >
+        >(() => {})
     );
 
     renderWithRouter();

--- a/src/pages/Sites/SitesPage.test.tsx
+++ b/src/pages/Sites/SitesPage.test.tsx
@@ -98,7 +98,10 @@ describe("SitesPage", () => {
 
   it("should display loading state initially", () => {
     vi.mocked(customersApi.listSites).mockImplementation(
-      () => new Promise(() => undefined)
+      () =>
+        new Promise<Awaited<ReturnType<typeof customersApi.listSites>>>(
+          () => {}
+        )
     );
 
     renderWithProviders();

--- a/src/pages/Sites/SitesPage.test.tsx
+++ b/src/pages/Sites/SitesPage.test.tsx
@@ -97,7 +97,12 @@ describe("SitesPage", () => {
   });
 
   it("should display loading state initially", () => {
+    vi.mocked(customersApi.listSites).mockImplementation(
+      () => new Promise(() => undefined)
+    );
+
     renderWithProviders();
+
     expect(screen.getByText(/loading/i)).toBeInTheDocument();
   });
 

--- a/src/services/authApi.test.ts
+++ b/src/services/authApi.test.ts
@@ -1,15 +1,15 @@
 // SPDX-FileCopyrightText: 2025 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { login, logout, logoutAll, AuthApiError } from "./authApi";
 
 const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
 
 describe("authApi", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal("fetch", mockFetch);
     // Clear cookies
     document.cookie.split(";").forEach((c) => {
       document.cookie = c
@@ -18,10 +18,6 @@ describe("authApi", () => {
     });
     // Set CSRF token cookie for tests
     document.cookie = "XSRF-TOKEN=test-csrf-token";
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   describe("login", () => {

--- a/src/services/csrf.test.ts
+++ b/src/services/csrf.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   fetchCsrfToken,
   getCsrfTokenFromCookie,
@@ -10,21 +10,17 @@ import {
 } from "./csrf";
 
 const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
 
 describe("csrf", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal("fetch", mockFetch);
     // Clear all cookies before each test
     document.cookie.split(";").forEach((c) => {
       document.cookie = c
         .replace(/^ +/, "")
         .replace(/=.*/, "=;expires=" + new Date().toUTCString() + ";path=/");
     });
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   describe("fetchCsrfToken", () => {

--- a/src/services/healthApi.test.ts
+++ b/src/services/healthApi.test.ts
@@ -5,16 +5,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { checkHealth, HealthCheckError, HealthStatus } from "./healthApi";
 
 const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
 
 describe("healthApi", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal("fetch", mockFetch);
     vi.useFakeTimers();
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
     vi.useRealTimers();
   });
 

--- a/tests/integration/auth/cookieAuth.test.ts
+++ b/tests/integration/auth/cookieAuth.test.ts
@@ -1,25 +1,21 @@
 // SPDX-FileCopyrightText: 2025 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { login, logout } from "../../../src/services/authApi";
 
 const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
 
 describe("Cookie-based Authentication Integration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal("fetch", mockFetch);
     // Clear all cookies before each test
     document.cookie.split(";").forEach((c) => {
       document.cookie = c
         .replace(/^ +/, "")
         .replace(/=.*/, "=;expires=" + new Date().toUTCString() + ";path=/");
     });
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   describe("Login Flow", () => {

--- a/tests/integration/auth/csrfProtection.test.ts
+++ b/tests/integration/auth/csrfProtection.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   fetchWithCsrf,
   fetchCsrfToken,
@@ -9,21 +9,17 @@ import {
 } from "../../../src/services/csrf";
 
 const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
 
 describe("CSRF Protection Integration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal("fetch", mockFetch);
     // Clear all cookies before each test
     document.cookie.split(";").forEach((c) => {
       document.cookie = c
         .replace(/^ +/, "")
         .replace(/=.*/, "=;expires=" + new Date().toUTCString() + ";path=/");
     });
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   describe("CSRF Token Handling", () => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -7,7 +7,7 @@ import { messages as enMessages } from "../src/locales/en/messages";
 import "fake-indexeddb/auto";
 import { mockAnimationsApi } from "jsdom-testing-mocks";
 import { cleanup } from "@testing-library/react";
-import { afterEach } from "vitest";
+import { afterEach, vi } from "vitest";
 
 // Mock the Web Animations API for HeadlessUI components
 // This prevents "Element.prototype.getAnimations" polyfill warnings
@@ -17,11 +17,28 @@ mockAnimationsApi();
 i18n.load("en", enMessages);
 i18n.activate("en");
 
+const originalConfirm = globalThis.confirm;
+const originalAlert = globalThis.alert;
+const originalPrompt = globalThis.prompt;
+const originalLocationHref = window.location.href;
+
 // React 19 act() warning fix: Cleanup after each test to prevent
 // warnings about state updates happening after test completion.
 // This ensures all pending React updates are flushed before test ends.
 afterEach(async () => {
   cleanup();
+
+  // Reset common sources of cross-test leakage.
+  localStorage.clear();
+  sessionStorage.clear();
+  vi.useRealTimers();
+  i18n.load("en", enMessages);
+  i18n.activate("en");
+  globalThis.confirm = originalConfirm;
+  globalThis.alert = originalAlert;
+  globalThis.prompt = originalPrompt;
+  window.history.replaceState({}, "", originalLocationHref);
+
   // Give React a chance to flush any pending updates
   await new Promise((resolve) => setTimeout(resolve, 0));
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -367,6 +367,9 @@ export default defineConfig(({ mode }) => {
       globals: true,
       environment: "jsdom",
       setupFiles: "./tests/setup.ts",
+      clearMocks: true,
+      unstubGlobals: true,
+      unstubEnvs: true,
       testTimeout: 10000, // 10 seconds per test (default is 5s)
       hookTimeout: 10000, // 10 seconds for beforeEach/afterEach hooks
       // Exclude Playwright E2E tests (run separately via npm run test:e2e)


### PR DESCRIPTION
## Summary

Harden frontend test isolation and fix fetch-stub lifecycle issues across bootstrap, service, and integration tests.

## Root cause

After test isolation was tightened, some tests lost their fetch stubs between cases and bootstrap assertions still depended on leaked history or global state.

## Changes

- reset storage, timers, i18n state, history, and dialog globals in `tests/setup.ts`
- enable `clearMocks`, `unstubGlobals`, and `unstubEnvs` in Vitest config
- re-stub `fetch` in `beforeEach` for affected service and auth integration tests
- make `App.test.tsx` and `main.test.tsx` set explicit routes before rendering

## Validation

- `npm test -- --run src/App.test.tsx src/main.test.tsx src/services/authApi.test.ts src/services/csrf.test.ts src/services/healthApi.test.ts tests/integration/auth/cookieAuth.test.ts tests/integration/auth/csrfProtection.test.ts`
