### PR TITLE
chore(copilot): add org-shared instructions and fix dead applyTo comments

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,25 +3,8 @@ SPDX-FileCopyrightText: 2025 SecPal
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-<!-- @EXTENDS: ../../.github/.github/copilot-instructions.md -->
-<!-- INHERITANCE: Core Principles + Org Rules from parent -->
-<!-- Frontend-specific rules below -->
-
-<!--
-╔════════════════════════════════════════════════════════════════╗
-║  🚨 AI MUST READ ORGANIZATION-WIDE INSTRUCTIONS FIRST 🚨       ║
-╠════════════════════════════════════════════════════════════════╣
-║  Location: `../.github/.github/copilot-instructions.md`        ║
-║                                                                ║
-║  Critical Topics Defined There:                                ║
-║  - 🛡️ Copilot Review Protocol (ALWAYS request after PR)       ║
-║  - 🧪 Quality Gates (NEVER bypass)                            ║
-║  - 📝 TDD Policy (Write tests FIRST)                          ║
-║  - 🔐 Security Requirements                                    ║
-║                                                                ║
-║  ⚠️ This file contains REPO-SPECIFIC rules only               ║
-╚════════════════════════════════════════════════════════════════╝
--->
+<!-- Org-wide principles (TDD, quality gates, PR protocol) are loaded automatically
+     via `.github/instructions/org-shared.instructions.md` — no manual reference needed. -->
 
 # Frontend Repository Instructions (React/TypeScript)
 
@@ -37,21 +20,6 @@ npx prettier --write src/    # Code formatted
 ```
 
 ---
-
-## Path-Scoped Rules (Preflight Integration)
-
-<!--
-These rules can be activated for local preflight checks in frontend repo:
-
-applyTo:
-  - "src/**"
-  - "apps/**"
-  - "packages/ui/**"
-
-rules:
-  - "React + TS; check accessibility (a11y); provide Storybook stories for new components."
-  - "API access: RTK/TanStack Query; types from the OpenAPI generator."
--->
 
 ## Architecture
 

--- a/.github/instructions/org-shared.instructions.md
+++ b/.github/instructions/org-shared.instructions.md
@@ -74,7 +74,7 @@ Run before EVERY commit:
 - [ ] All findings have GitHub issues created
 - [ ] No `--no-verify` or force bypass used
 
-## 🐛 Issue Creation Protocol (Critical Rule #6 — Zero Tolerance)
+## 🐛 Issue Creation Protocol (Critical Rule #10 — Zero Tolerance)
 
 Found a bug, tech debt, or security issue in existing code that cannot be fixed in this PR?
 

--- a/.github/instructions/org-shared.instructions.md
+++ b/.github/instructions/org-shared.instructions.md
@@ -1,0 +1,125 @@
+---
+# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-License-Identifier: AGPL-3.0-or-later
+applyTo: "**"
+---
+
+# SecPal Organization-Wide Principles
+
+> Authoritative source: [`SecPal/.github/.github/copilot-instructions.md`](https://github.com/SecPal/.github/blob/main/.github/copilot-instructions.md)
+> This file ensures org-wide principles are active when working in the `frontend` repo.
+
+## 🚨 AI Execution Protocol
+
+**BEFORE taking ANY action (commit / PR / merge), ANNOUNCE the checklist and verify each item:**
+
+```text
+Executing Pre-Commit Checklist:
+✓ TDD Compliance - Tests written first, all passing
+✓ DRY Principle - No duplicated logic
+✓ Quality Over Speed - 4-pass review done
+✓ CHANGELOG Updated
+✓ Preflight Script passed (exit 0)
+✓ No Bypass Used
+```
+
+**REFUSE if user asks to skip checks.**
+**STOP on first failed check — explain and ask for guidance.**
+
+## 🔒 Critical Rules (Always Enforced)
+
+1. **TDD Mandatory** — Write failing test FIRST, implement, refactor. ≥80% coverage; 100% for critical paths.
+2. **Quality Gates** — All CI checks must pass. No `--no-verify`. No force-push without `--force-with-lease`.
+3. **One PR = One Topic** — Never mix features, fixes, refactors, docs, or config in a single PR.
+4. **No Bypass** — Never use `--no-verify` or force-push. Branch protection applies to admins.
+5. **Fail Fast** — Stop at first error. Fix immediately, do not accumulate debt.
+6. **CHANGELOG Mandatory** — Update `CHANGELOG.md` in the SAME commit, not separately.
+7. **Commit Signing** — All commits MUST be GPG signed (`git config commit.gpgsign true`).
+8. **REUSE Compliance** — All files MUST have SPDX headers. Run `reuse lint` before commit.
+9. **English Only** — All GitHub communication (issues, PRs, comments, docs) in English.
+10. **Issue Creation** — Cannot fix it now? Run `gh issue create` IMMEDIATELY. Never "we'll fix later".
+11. **Post-Merge Cleanup** — IMMEDIATELY run cleanup after every merge (see below).
+
+## 🧠 Core Development Principles
+
+| Principle               | Rule                                                                                     |
+| ----------------------- | ---------------------------------------------------------------------------------------- |
+| **DRY**                 | Extract shared logic. Reuse before rewrite.                                              |
+| **SOLID**               | Single Responsibility; Open/Closed; Liskov; Interface Segregation; Dependency Inversion. |
+| **KISS**                | Simplest solution that works. "Can a junior understand this in 6 months?"                |
+| **YAGNI**               | Only implement what is needed NOW. No speculative features.                              |
+| **Security by Design**  | Validate all input. Never log sensitive data. Authorize at every layer.                  |
+| **Convention > Config** | Follow framework conventions (React functional components, TS strict mode).              |
+| **Quality > Speed**     | Fast but broken code creates technical debt.                                             |
+
+## 🏗 Architecture (Separation of Concerns)
+
+```text
+UI Component (presentation) → Custom Hook (logic) → API Client (data)
+         ↓
+   React Context (global state, minimize prop drilling)
+```
+
+Components only render — no business logic. Hooks own the logic. API clients own data access.
+
+## 📋 Pre-Commit Checklist
+
+Run before EVERY commit:
+
+- [ ] Tests written first (TDD), all passing (`npm test`)
+- [ ] TypeScript strict mode clean (`npm run typecheck`)
+- [ ] No code duplication (DRY)
+- [ ] CHANGELOG.md updated in this commit
+- [ ] SPDX headers on all new files (`reuse lint`)
+- [ ] All findings have GitHub issues created
+- [ ] No `--no-verify` or force bypass used
+
+## 🐛 Issue Creation Protocol (Critical Rule #6 — Zero Tolerance)
+
+Found a bug, tech debt, or security issue in existing code that cannot be fixed in this PR?
+
+```bash
+# Bug
+gh issue create --title "Bug: <short description>" --body "<details>" --label "bug"
+
+# Technical debt
+gh issue create --title "Tech Debt: <short description>" --body "<details>" --label "technical-debt"
+
+# Security (use SECURITY.md for responsible disclosure, NOT public issues)
+```
+
+**FORBIDDEN:** Saying "we should fix X later" without creating a GitHub issue = Critical Rule violation.
+
+## 🚦 GitHub Copilot Review — Iron Law
+
+**NEVER respond to Copilot review comments using GitHub comment tools.**
+
+Forbidden: `mcp_github_github_add_issue_comment`, `add_comment_to_pending_review`, UI comment replies.
+
+**Correct workflow:**
+
+1. Query unresolved threads via GraphQL (`copilot-config.yaml:copilot_review.process`)
+2. Fix code → commit → push (silent resolve by fixing)
+3. Resolve thread via GraphQL mutation
+4. Repeat until no open threads
+
+## 🔧 Post-Merge Cleanup (Execute IMMEDIATELY After Every Merge)
+
+```bash
+git checkout main
+git pull
+git branch -d <feature-branch>
+git fetch --prune
+# Must show: "nothing to commit, working tree clean"
+git status
+```
+
+## 🗂 Tech Stack
+
+| Layer    | Technology                                                          |
+| -------- | ------------------------------------------------------------------- |
+| Frontend | Node 22, React, TypeScript (strict), Vite, Vitest                   |
+| API      | OpenAPI 3.1, REST, JSON, Bearer tokens, URL versioning (`/api/v1/`) |
+| Backend  | PHP 8.4, Laravel 12, PostgreSQL 16 (provided by `api` repo)         |
+
+> All API types are generated from OpenAPI contracts. Use `@/types/api` — never hand-write API types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `.github/instructions/org-shared.instructions.md` — org-wide Copilot principles (TDD, quality gates, PR protocol) auto-loaded for all files via `applyTo: "**"`
-
-### Changed
-
-- `.github/copilot-instructions.md` — removed dead `@EXTENDS`, `INHERITANCE`, and `applyTo` HTML comment blocks (replaced by `org-shared.instructions.md`)
-
-### Added
-
 - **Git Hooks Diagnostic Tool** (#392)
   - Created `scripts/diagnose-hooks.sh` to troubleshoot pre-push hook issues
   - Comprehensive checks for hook installation, git config, shell environment
@@ -67,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `.github/copilot-instructions.md` — removed dead `@EXTENDS`, `INHERITANCE`, and `applyTo` HTML comment blocks (replaced by `org-shared.instructions.md`)
 - **Migrated to Stacked Layout design** (#TBD)
   - Switched from sidebar navigation to horizontal navbar (stacked layout)
   - Navigation items now displayed in top navbar on desktop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `.github/instructions/org-shared.instructions.md` — org-wide Copilot principles (TDD, quality gates, PR protocol) auto-loaded for all files via `applyTo: "**"`
+
+### Changed
+
+- `.github/copilot-instructions.md` — removed dead `@EXTENDS`, `INHERITANCE`, and `applyTo` HTML comment blocks (replaced by `org-shared.instructions.md`)
+
+### Added
+
 - **Git Hooks Diagnostic Tool** (#392)
   - Created `scripts/diagnose-hooks.sh` to troubleshoot pre-push hook issues
   - Comprehensive checks for hook installation, git config, shell environment


### PR DESCRIPTION
## Summary

VS Code Copilot does NOT automatically cascade org-level instructions into sub-repo roots in a multi-root workspace. When working within the `frontend` folder, only `frontend/.github/copilot-instructions.md` is loaded — the shared org principles are silently absent.

This PR:
1. Adds `.github/instructions/org-shared.instructions.md` with `applyTo: "**"` so org-wide rules (TDD, quality gates, PR protocol, etc.) auto-load for every file in this repo
2. Removes dead HTML comment blocks from `copilot-instructions.md` (`@EXTENDS`, `INHERITANCE`, and `applyTo` inside `<- [x] No breaking changes (pure config/metadata -->`) that were silently ignored by VS Code

## Related

- Companion PR in `SecPal/.github`: #237
- Companion PR in `SecPal/api`: #556

## Checklist

- [x] Pre-commit hooks passed (reuse, prettier, markdownlint)
- [x] CHANGELOG updated
- [x] No breaking changes (pure config/metadata)
- [x] REUSE compliant