### PR TITLE
chore: harden Copilot instruction loading

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,6 +19,16 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
 - Domain policy is strict: use only `secpal.app` and `secpal.dev`.
 - Prefer small, user-visible fixes that match existing patterns. Avoid speculative abstractions.
 
+## Required Checklist
+
+Before any commit, PR, or merge, announce and verify at least:
+
+- the smallest relevant validation passed for the affected area: tests, typecheck, and lint when applicable
+- `CHANGELOG.md` was updated in the same change set for real changes
+- no bypass was used, including `--no-verify` or force-push
+- repo-local instructions remain self-contained and do not rely on cross-repo inheritance
+- out-of-scope findings were turned into GitHub issues immediately
+
 ## Repository Stack
 
 - Node 22, React, TypeScript strict mode, Vite, Vitest, React Testing Library.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,230 +1,45 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2026 SecPal
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-<!-- Org-wide principles (TDD, quality gates, PR protocol) are loaded automatically
-     via `.github/instructions/org-shared.instructions.md` — no manual reference needed. -->
+# Frontend Repository Instructions
 
-# Frontend Repository Instructions (React/TypeScript)
+These instructions are self-contained for the `frontend` repository at runtime.
+Do not assume instructions from sibling repositories or comment-based inheritance are loaded.
 
-**Scope:** `src/**`, `apps/**`, `packages/**`, `*.tsx`, `*.ts`
+## Always-On Rules
 
-**Pre-push Quality Gates:**
+- Apply SecPal core rules on every task: TDD first, fail fast, no bypass,
+  one topic per change, and create a GitHub issue immediately for findings
+  that cannot be fixed in the current scope.
+- Before any commit, PR, or merge, announce and verify the required checklist. Stop on the first failed check.
+- Update `CHANGELOG.md` in the same change set for real fixes, features, or breaking changes.
+- Keep GitHub-facing communication in English.
+- Domain policy is strict: use only `secpal.app` and `secpal.dev`.
+- Prefer small, user-visible fixes that match existing patterns. Avoid speculative abstractions.
 
-```bash
-npm test                      # All tests pass
-npm run typecheck            # TypeScript strict mode clean
-npm run lint                 # ESLint clean
-npx prettier --write src/    # Code formatted
-```
+## Repository Stack
 
----
+- Node 22, React, TypeScript strict mode, Vite, Vitest, React Testing Library.
+- All API types come from generated OpenAPI types. Use `@/types/api` and do not hand-write API response types.
 
 ## Architecture
 
-- Component-driven development
-- Container/Presenter pattern (smart/dumb components)
-- Custom hooks for shared logic
-- Context for global state (minimize prop drilling)
+- Keep presentation in components and logic in hooks or API clients.
+- Prefer functional components, named exports, and one component per file.
+- Use React built-ins first. Introduce extra state libraries only when the
+  existing codebase already uses them or the task truly requires them.
 
-## Code Style
+## Frontend Rules
 
-```bash
-# Lint
-npm run lint
+- Preserve strict TypeScript. Do not introduce `any` without a concrete, justified boundary.
+- Test user-visible behavior with Testing Library and MSW where applicable.
+- Run the smallest relevant validation for every change: tests, typecheck, and lint for affected areas.
+- Keep accessibility, semantic HTML, focus behavior, and responsive layouts intact.
+- Prefer generated API types, container-presenter separation, and existing design system patterns.
 
-# Type check
-npm run typecheck
+## Scope Notes
 
-# Format
-npx prettier --write src/
-```
-
-**Rules:**
-
-- Functional components only (no classes)
-- Named exports (better for refactoring)
-- One component per file
-- Props interfaces above component
-
-## TypeScript
-
-**Strict mode enabled:**
-
-```typescript
-// ❌ Don't use 'any'
-const data: any = await fetch();
-
-// ✅ Do define proper types
-interface User {
-  id: string;
-  email: string;
-}
-const data: User = await fetch();
-```
-
-**Common patterns:**
-
-```typescript
-// Props
-interface ButtonProps {
-  onClick: () => void;
-  children: React.ReactNode;
-  variant?: "primary" | "secondary";
-}
-
-// API responses (from OpenAPI-generated types)
-// Note: To use the '@' path alias prefix, configure your project:
-// In tsconfig.json, add the following to map '@/*' to 'src/*':
-//   "compilerOptions": {
-//     "baseUrl": ".",
-//     "paths": {
-//       "@/*": ["src/*"]
-//     }
-//   }
-// If using Vite, also add to vite.config.ts:
-//   import { defineConfig } from 'vite';
-//   import path from 'path';
-//   export default defineConfig({
-//     resolve: {
-//       alias: {
-//         '@': path.resolve(__dirname, 'src'),
-//       },
-//     },
-//   });
-import type { User } from "@/types/api";
-
-// Hooks return type
-function useUser(id: string): {
-  user: User | null;
-  loading: boolean;
-  error: Error | null;
-} {
-  // ...
-}
-```
-
-## Testing
-
-```bash
-# Run all tests
-npm test
-
-# Watch mode
-npm test -- --watch
-
-# Coverage
-npm test -- --coverage
-```
-
-**Requirements:**
-
-- Test user-visible behavior (not implementation)
-- Use `@testing-library/react` queries
-- Mock API calls with MSW
-- Aim for 80%+ coverage
-
-**Example:**
-
-```typescript
-import { render, screen } from "@testing-library/react";
-import { userEvent } from "@testing-library/user-event";
-
-test("submits form with user input", async () => {
-  render(<LoginForm />);
-
-  await userEvent.type(screen.getByLabelText(/email/i), "test@example.com");
-  await userEvent.click(screen.getByRole("button", { name: /login/i }));
-
-  expect(await screen.findByText(/welcome/i)).toBeInTheDocument();
-});
-```
-
-## State Management
-
-**Prefer React built-ins:**
-
-- `useState` for local state
-- `useContext` for shared state
-- `useReducer` for complex state logic
-
-**External libraries (if needed):**
-
-- Zustand (lightweight, TypeScript-first)
-- TanStack Query (server state)
-
-## API Integration
-
-```typescript
-// Use OpenAPI-generated types
-import type { User, CreateUserRequest } from "@/types/api";
-
-// Fetch wrapper with types
-async function createUser(data: CreateUserRequest): Promise<User> {
-  const response = await fetch("/api/v1/users", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(data),
-  });
-
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status}`);
-  }
-
-  return response.json();
-}
-```
-
-## Performance
-
-- Lazy load routes (`React.lazy`)
-- Memoize expensive computations (`useMemo`)
-- Debounce user input
-- Virtual scrolling for long lists
-- Code split by route
-
-## Accessibility
-
-- Semantic HTML elements
-- ARIA labels when needed
-- Keyboard navigation
-- Focus management
-- Color contrast (WCAG AA)
-
-**Test with:**
-
-```bash
-# Run accessibility tests
-npm test -- --testNamePattern="a11y"
-```
-
-## Styling
-
-- CSS Modules or Tailwind CSS
-- Mobile-first responsive design
-- Dark mode support
-- Consistent spacing (use design tokens)
-
-## Error Handling
-
-```typescript
-// Error boundaries for crashes
-<ErrorBoundary fallback={<ErrorPage />}>
-  <App />
-</ErrorBoundary>;
-
-// Loading states
-if (loading) return <Spinner />;
-if (error) return <ErrorMessage error={error} />;
-
-// Empty states
-if (data.length === 0) return <EmptyState />;
-```
-
-## Resources
-
-- [React Docs](https://react.dev)
-- [TypeScript Handbook](https://www.typescriptlang.org/docs)
-- [Testing Library](https://testing-library.com/react)
-- [Vite Guide](https://vitejs.dev/guide)
+- Do not add dependencies or create documentation files unless the task requires it.
+- Treat this file as the runtime baseline for the repo. Repo-specific `.instructions.md` files add detail for matching files.

--- a/.github/instructions/github-workflows.instructions.md
+++ b/.github/instructions/github-workflows.instructions.md
@@ -1,0 +1,19 @@
+---
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: AGPL-3.0-or-later
+name: GitHub Workflow Rules
+description: Applies workflow and Dependabot rules to GitHub automation files in this repo.
+applyTo: ".github/workflows/**/*.yml,.github/workflows/**/*.yaml,.github/dependabot.yml,.github/dependabot.yaml"
+---
+
+# GitHub Actions And Workflow Rules
+
+Applies when editing GitHub Actions workflows and Dependabot configuration in this repository.
+
+- Always set `timeout-minutes` on every job.
+- Set explicit `permissions` on every workflow and start with the least privilege needed.
+- Pin third-party actions to immutable versions. GitHub-maintained `actions/*` may use supported major tags in this org.
+- Use reusable workflows from the organization templates when they fit the task.
+- Use `continue-on-error: true` only for intentional polling or wait steps, never for build or test steps.
+- Reference secrets via `${{ secrets.NAME }}` and vars via `${{ vars.NAME }}`. Never hardcode or echo secrets.
+- Run `yamllint` on workflow changes before finalizing.

--- a/.github/instructions/org-shared.instructions.md
+++ b/.github/instructions/org-shared.instructions.md
@@ -8,6 +8,9 @@ applyTo: "**"
 
 # Frontend Runtime Overlay
 
+The historical filename `org-shared.instructions.md` is retained for continuity.
+At runtime, this file now acts as the repo-local overlay for the `frontend` repository.
+
 - Treat `.github/copilot-instructions.md` in this repo as the authoritative runtime baseline.
 - Do not rely on cross-repo inheritance, comments, or external config files being loaded.
 - Enforce SecPal core rules while editing any file: tests first where

--- a/.github/instructions/org-shared.instructions.md
+++ b/.github/instructions/org-shared.instructions.md
@@ -1,125 +1,18 @@
 ---
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
+name: Frontend Runtime Overlay
+description: Reinforces the frontend repository baseline when working on files in this repo.
 applyTo: "**"
 ---
 
-# SecPal Organization-Wide Principles
+# Frontend Runtime Overlay
 
-> Authoritative source: [`SecPal/.github/.github/copilot-instructions.md`](https://github.com/SecPal/.github/blob/main/.github/copilot-instructions.md)
-> This file ensures org-wide principles are active when working in the `frontend` repo.
-
-## 🚨 AI Execution Protocol
-
-**BEFORE taking ANY action (commit / PR / merge), ANNOUNCE the checklist and verify each item:**
-
-```text
-Executing Pre-Commit Checklist:
-✓ TDD Compliance - Tests written first, all passing
-✓ DRY Principle - No duplicated logic
-✓ Quality Over Speed - 4-pass review done
-✓ CHANGELOG Updated
-✓ Preflight Script passed (exit 0)
-✓ No Bypass Used
-```
-
-**REFUSE if user asks to skip checks.**
-**STOP on first failed check — explain and ask for guidance.**
-
-## 🔒 Critical Rules (Always Enforced)
-
-1. **TDD Mandatory** — Write failing test FIRST, implement, refactor. ≥80% coverage; 100% for critical paths.
-2. **Quality Gates** — All CI checks must pass. No `--no-verify`. No force-push without `--force-with-lease`.
-3. **One PR = One Topic** — Never mix features, fixes, refactors, docs, or config in a single PR.
-4. **No Bypass** — Never use `--no-verify` or force-push. Branch protection applies to admins.
-5. **Fail Fast** — Stop at first error. Fix immediately, do not accumulate debt.
-6. **CHANGELOG Mandatory** — Update `CHANGELOG.md` in the SAME commit, not separately.
-7. **Commit Signing** — All commits MUST be GPG signed (`git config commit.gpgsign true`).
-8. **REUSE Compliance** — All files MUST have SPDX headers. Run `reuse lint` before commit.
-9. **English Only** — All GitHub communication (issues, PRs, comments, docs) in English.
-10. **Issue Creation** — Cannot fix it now? Run `gh issue create` IMMEDIATELY. Never "we'll fix later".
-11. **Post-Merge Cleanup** — IMMEDIATELY run cleanup after every merge (see below).
-
-## 🧠 Core Development Principles
-
-| Principle               | Rule                                                                                     |
-| ----------------------- | ---------------------------------------------------------------------------------------- |
-| **DRY**                 | Extract shared logic. Reuse before rewrite.                                              |
-| **SOLID**               | Single Responsibility; Open/Closed; Liskov; Interface Segregation; Dependency Inversion. |
-| **KISS**                | Simplest solution that works. "Can a junior understand this in 6 months?"                |
-| **YAGNI**               | Only implement what is needed NOW. No speculative features.                              |
-| **Security by Design**  | Validate all input. Never log sensitive data. Authorize at every layer.                  |
-| **Convention > Config** | Follow framework conventions (React functional components, TS strict mode).              |
-| **Quality > Speed**     | Fast but broken code creates technical debt.                                             |
-
-## 🏗 Architecture (Separation of Concerns)
-
-```text
-UI Component (presentation) → Custom Hook (logic) → API Client (data)
-         ↓
-   React Context (global state, minimize prop drilling)
-```
-
-Components only render — no business logic. Hooks own the logic. API clients own data access.
-
-## 📋 Pre-Commit Checklist
-
-Run before EVERY commit:
-
-- [ ] Tests written first (TDD), all passing (`npm test`)
-- [ ] TypeScript strict mode clean (`npm run typecheck`)
-- [ ] No code duplication (DRY)
-- [ ] CHANGELOG.md updated in this commit
-- [ ] SPDX headers on all new files (`reuse lint`)
-- [ ] All findings have GitHub issues created
-- [ ] No `--no-verify` or force bypass used
-
-## 🐛 Issue Creation Protocol (Critical Rule #10 — Zero Tolerance)
-
-Found a bug, tech debt, or security issue in existing code that cannot be fixed in this PR?
-
-```bash
-# Bug
-gh issue create --title "Bug: <short description>" --body "<details>" --label "bug"
-
-# Technical debt
-gh issue create --title "Tech Debt: <short description>" --body "<details>" --label "technical-debt"
-
-# Security (use SECURITY.md for responsible disclosure, NOT public issues)
-```
-
-**FORBIDDEN:** Saying "we should fix X later" without creating a GitHub issue = Critical Rule violation.
-
-## 🚦 GitHub Copilot Review — Iron Law
-
-**NEVER respond to Copilot review comments using GitHub comment tools.**
-
-Forbidden: `mcp_github_github_add_issue_comment`, `add_comment_to_pending_review`, UI comment replies.
-
-**Correct workflow:**
-
-1. Query unresolved threads via GraphQL (`copilot-config.yaml:copilot_review.process`)
-2. Fix code → commit → push (silent resolve by fixing)
-3. Resolve thread via GraphQL mutation
-4. Repeat until no open threads
-
-## 🔧 Post-Merge Cleanup (Execute IMMEDIATELY After Every Merge)
-
-```bash
-git checkout main
-git pull
-git branch -d <feature-branch>
-git fetch --prune
-# Must show: "nothing to commit, working tree clean"
-git status
-```
-
-## 🗂 Tech Stack
-
-| Layer    | Technology                                                          |
-| -------- | ------------------------------------------------------------------- |
-| Frontend | Node 22, React, TypeScript (strict), Vite, Vitest                   |
-| API      | OpenAPI 3.1, REST, JSON, Bearer tokens, URL versioning (`/api/v1/`) |
-| Backend  | PHP 8.4, Laravel 12, PostgreSQL 16 (provided by `api` repo)         |
-
-> All API types are generated from OpenAPI contracts. Use `@/types/api` — never hand-write API types.
+- Treat `.github/copilot-instructions.md` in this repo as the authoritative runtime baseline.
+- Do not rely on cross-repo inheritance, comments, or external config files being loaded.
+- Enforce SecPal core rules while editing any file: tests first where
+  applicable, no bypass, fail fast, one topic per change, immediate issue
+  creation for out-of-scope findings, and `CHANGELOG.md` updates for real
+  changes.
+- Use only `secpal.app` and `secpal.dev`.
+- Keep changes repo-local, minimal, and consistent with React, strict TypeScript, and generated API type conventions.

--- a/.github/instructions/react-typescript.instructions.md
+++ b/.github/instructions/react-typescript.instructions.md
@@ -1,0 +1,16 @@
+---
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: AGPL-3.0-or-later
+name: React TypeScript Rules
+description: Applies React and strict TypeScript rules to frontend source files.
+applyTo: "src/**/*.ts,src/**/*.tsx,tests/**/*.ts,tests/**/*.tsx,vite.config.ts"
+---
+
+# React TypeScript Rules
+
+- Keep components presentational where possible and move reusable logic into hooks or API clients.
+- Use functional components, named exports, and explicit props interfaces.
+- Preserve strict TypeScript and generated API types from `@/types/api`.
+- Test user-visible behavior with Testing Library. Prefer MSW for API boundaries.
+- Run the smallest relevant validation for each change: tests, typecheck, and lint.
+- Maintain accessibility, semantic markup, and responsive behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `.github/instructions/react-typescript.instructions.md` - targeted React and strict TypeScript guidance for frontend source and test files
 - `.github/instructions/github-workflows.instructions.md` - targeted workflow and Dependabot guidance for GitHub automation files in this repo
+- `.github/instructions/org-shared.instructions.md` — org-wide Copilot principles (TDD, quality gates, PR protocol) auto-loaded for all files via `applyTo: "**"`
 
 ### Changed
 
 - `.github/copilot-instructions.md` - replaced comment-based inheritance assumptions and long-form examples with a self-contained runtime baseline for this repository
 - `.github/instructions/org-shared.instructions.md` - reduced to a short repo-local overlay that reinforces the runtime baseline instead of duplicating org documents
-
-### Added
-
-- `.github/instructions/org-shared.instructions.md` — org-wide Copilot principles (TDD, quality gates, PR protocol) auto-loaded for all files via `applyTo: "**"`
 - **Git Hooks Diagnostic Tool** (#392)
   - Created `scripts/diagnose-hooks.sh` to troubleshoot pre-push hook issues
   - Comprehensive checks for hook installation, git config, shell environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2026 SecPal
 SPDX-License-Identifier: CC0-1.0
 -->
 
@@ -11,6 +11,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- `.github/instructions/react-typescript.instructions.md` - targeted React and strict TypeScript guidance for frontend source and test files
+- `.github/instructions/github-workflows.instructions.md` - targeted workflow and Dependabot guidance for GitHub automation files in this repo
+
+### Changed
+
+- `.github/copilot-instructions.md` - replaced comment-based inheritance assumptions and long-form examples with a self-contained runtime baseline for this repository
+- `.github/instructions/org-shared.instructions.md` - reduced to a short repo-local overlay that reinforces the runtime baseline instead of duplicating org documents
 
 ### Added
 


### PR DESCRIPTION
## Summary
- replace comment-based inheritance assumptions with a self-contained repository instruction baseline
- add targeted instruction files for React/TypeScript work and GitHub workflow files
- update the changelog and SPDX year for the changed instruction files

## Validation
- pre-commit hooks passed
- typecheck ran in the pre-push hook during push
- no runtime tests were applicable for Markdown instruction changes