### PR TITLE
fix(auth): revalidate stored sessions on bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Auth bootstrap now revalidates stored sessions before unlocking protected routes** (#503)
+  - added frontend bootstrap revalidation against `GET /v1/me` when a stored session is present and the client is online
+  - protected routes now remain in the loading state until startup revalidation succeeds or fails closed
+  - stale local `auth_user` state is cleared, including sensitive client cleanup, when startup revalidation rejects
+  - offline startup still preserves existing local session state to keep the offline-first flow available
+
 - **Employee API types now use a shared contract source** (#492)
   - added `src/types/api` as the central frontend import path for employee API types
   - removed employee request and response type declarations from `src/services/employeeApi.ts`

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,12 +1,24 @@
 // SPDX-FileCopyrightText: 2025 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, waitFor } from "@testing-library/react";
 import { screen } from "@testing-library/dom";
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
 import App from "./App";
+
+const { mockGetCurrentUser } = vi.hoisted(() => ({
+  mockGetCurrentUser: vi.fn(),
+}));
+
+vi.mock("./services/authApi", async () => {
+  const actual = await vi.importActual("./services/authApi");
+  return {
+    ...actual,
+    getCurrentUser: mockGetCurrentUser,
+  };
+});
 
 // Helper to render with I18n and wait for async updates
 async function renderWithI18n(component: React.ReactElement) {
@@ -18,10 +30,29 @@ async function renderWithI18n(component: React.ReactElement) {
 
 describe("App", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     localStorage.clear();
     window.history.replaceState({}, "", "/login");
     i18n.load("en", {});
     i18n.activate("en");
+    mockGetCurrentUser.mockImplementation(async () => {
+      const storedUser = localStorage.getItem("auth_user");
+
+      return storedUser
+        ? (JSON.parse(storedUser) as {
+            id: number;
+            name: string;
+            email: string;
+            roles?: string[];
+            permissions?: string[];
+            hasOrganizationalScopes?: boolean;
+          })
+        : {
+            id: 1,
+            name: "Fallback User",
+            email: "fallback@example.com",
+          };
+    });
   });
 
   it("renders login page when not authenticated", async () => {

--- a/src/components/ProtectedRoute.test.tsx
+++ b/src/components/ProtectedRoute.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
@@ -10,6 +10,17 @@ import { ProtectedRoute } from "./ProtectedRoute";
 import { AuthProvider } from "../contexts/AuthContext";
 
 const mockNavigate = vi.fn();
+const { mockGetCurrentUser } = vi.hoisted(() => ({
+  mockGetCurrentUser: vi.fn(),
+}));
+
+vi.mock("../services/authApi", async () => {
+  const actual = await vi.importActual("../services/authApi");
+  return {
+    ...actual,
+    getCurrentUser: mockGetCurrentUser,
+  };
+});
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual("react-router-dom");
@@ -60,7 +71,13 @@ describe("ProtectedRoute", () => {
     expect(screen.getByText(/redirected to \/login/i)).toBeInTheDocument();
   });
 
-  it("renders children when authenticated", () => {
+  it("renders children when authenticated", async () => {
+    mockGetCurrentUser.mockResolvedValueOnce({
+      id: 1,
+      name: "Test",
+      email: "test@example.com",
+    });
+
     localStorage.setItem(
       "auth_user",
       JSON.stringify({ id: 1, name: "Test", email: "test@example.com" })
@@ -68,8 +85,47 @@ describe("ProtectedRoute", () => {
 
     renderProtectedRoute();
 
-    expect(screen.getByText("Protected Content")).toBeInTheDocument();
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("Protected Content")).toBeInTheDocument();
+    });
+
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("shows loading instead of protected content while stored auth is revalidated", () => {
+    mockGetCurrentUser.mockReturnValueOnce(new Promise(() => undefined));
+
+    localStorage.setItem(
+      "auth_user",
+      JSON.stringify({ id: 1, name: "Test", email: "test@example.com" })
+    );
+
+    renderProtectedRoute();
+
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    expect(screen.queryByText("Protected Content")).not.toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("redirects to login after stored auth revalidation fails", async () => {
+    mockGetCurrentUser.mockRejectedValueOnce(new Error("Unauthorized"));
+
+    localStorage.setItem(
+      "auth_user",
+      JSON.stringify({ id: 1, name: "Test", email: "test@example.com" })
+    );
+
+    renderProtectedRoute();
+
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/login");
+    });
+
+    expect(screen.getByText(/redirected to \/login/i)).toBeInTheDocument();
   });
 
   it("shows loading state initially", () => {

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -67,10 +67,10 @@ describe("ApplicationLayout", () => {
 
     vi.mocked(authApi.getCurrentUser).mockImplementation(() =>
       createResolvedCurrentUser(
-        (JSON.parse(
+        JSON.parse(
           localStorage.getItem("auth_user") ??
             '{"id":1,"name":"John Doe","email":"john@example.com"}'
-        ) as Awaited<ReturnType<typeof authApi.getCurrentUser>>)
+        ) as Awaited<ReturnType<typeof authApi.getCurrentUser>>
       )
     );
 

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -38,26 +38,6 @@ const renderWithProviders = (
   );
 };
 
-function createResolvedCurrentUser(
-  user: Awaited<ReturnType<typeof authApi.getCurrentUser>>
-): ReturnType<typeof authApi.getCurrentUser> {
-  return {
-    then(
-      onFulfilled: (
-        value: Awaited<ReturnType<typeof authApi.getCurrentUser>>
-      ) => unknown
-    ) {
-      onFulfilled(user);
-
-      return {
-        catch() {
-          return undefined;
-        },
-      };
-    },
-  } as unknown as ReturnType<typeof authApi.getCurrentUser>;
-}
-
 describe("ApplicationLayout", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -65,13 +45,8 @@ describe("ApplicationLayout", () => {
     i18n.load("en", {});
     i18n.activate("en");
 
-    vi.mocked(authApi.getCurrentUser).mockImplementation(() =>
-      createResolvedCurrentUser(
-        JSON.parse(
-          localStorage.getItem("auth_user") ??
-            '{"id":1,"name":"John Doe","email":"john@example.com"}'
-        ) as Awaited<ReturnType<typeof authApi.getCurrentUser>>
-      )
+    vi.mocked(authApi.getCurrentUser).mockImplementation(
+      () => new Promise(() => undefined)
     );
 
     // Set up authenticated user

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -38,12 +38,41 @@ const renderWithProviders = (
   );
 };
 
+function createResolvedCurrentUser(
+  user: Awaited<ReturnType<typeof authApi.getCurrentUser>>
+): ReturnType<typeof authApi.getCurrentUser> {
+  return {
+    then(
+      onFulfilled: (
+        value: Awaited<ReturnType<typeof authApi.getCurrentUser>>
+      ) => unknown
+    ) {
+      onFulfilled(user);
+
+      return {
+        catch() {
+          return undefined;
+        },
+      };
+    },
+  } as unknown as ReturnType<typeof authApi.getCurrentUser>;
+}
+
 describe("ApplicationLayout", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
     i18n.load("en", {});
     i18n.activate("en");
+
+    vi.mocked(authApi.getCurrentUser).mockImplementation(() =>
+      createResolvedCurrentUser(
+        (JSON.parse(
+          localStorage.getItem("auth_user") ??
+            '{"id":1,"name":"John Doe","email":"john@example.com"}'
+        ) as Awaited<ReturnType<typeof authApi.getCurrentUser>>)
+      )
+    );
 
     // Set up authenticated user
     localStorage.setItem(

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -23,6 +23,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     return authStorage.getUser() !== null && isOnline();
   });
   const isClearingSessionRef = useRef(false);
+  const bootstrapRequestVersionRef = useRef(0);
+
+  const invalidateBootstrapRevalidation = useCallback(() => {
+    bootstrapRequestVersionRef.current += 1;
+  }, []);
 
   const clearAuthenticatedState = useCallback(
     (clearSensitiveState: boolean) => {
@@ -30,6 +35,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         return;
       }
 
+      invalidateBootstrapRevalidation();
       isClearingSessionRef.current = true;
       authStorage.clear();
       setUser(null);
@@ -51,14 +57,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           isClearingSessionRef.current = false;
         });
     },
-    []
+    [invalidateBootstrapRevalidation]
   );
 
   const login = useCallback((newUser: User) => {
+    invalidateBootstrapRevalidation();
     authStorage.setUser(newUser);
     setUser(newUser);
     setIsLoading(false);
-  }, []);
+  }, [invalidateBootstrapRevalidation]);
 
   const logout = useCallback(() => {
     clearAuthenticatedState(true);
@@ -104,8 +111,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     return user?.hasOrganizationalScopes ?? false;
   }, [user]);
 
-  // Subscribe to session:expired events
-  // This handles 401 responses from API calls (when online)
+  // Bootstrap: revalidate any stored session on app load/refresh when online.
+  // Uses getCurrentUser() to confirm the session and clear it if invalid.
   useEffect(() => {
     const storedUser = authStorage.getUser();
 
@@ -114,10 +121,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
 
     let isActive = true;
+    const requestVersion = bootstrapRequestVersionRef.current + 1;
+    bootstrapRequestVersionRef.current = requestVersion;
 
     void getCurrentUser()
       .then((currentUser) => {
-        if (!isActive) {
+        if (
+          !isActive ||
+          bootstrapRequestVersionRef.current !== requestVersion
+        ) {
           return;
         }
 
@@ -126,7 +138,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         setIsLoading(false);
       })
       .catch(() => {
-        if (!isActive) {
+        if (
+          !isActive ||
+          bootstrapRequestVersionRef.current !== requestVersion
+        ) {
           return;
         }
 
@@ -138,6 +153,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
   }, [clearAuthenticatedState]);
 
+  // Subscribe to session:expired events.
+  // This handles 401 responses from API calls when online.
   useEffect(() => {
     const unsubscribe = sessionEvents.on("session:expired", () => {
       // Check authStorage instead of user state to avoid adding user as dependency.

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -60,12 +60,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     [invalidateBootstrapRevalidation]
   );
 
-  const login = useCallback((newUser: User) => {
-    invalidateBootstrapRevalidation();
-    authStorage.setUser(newUser);
-    setUser(newUser);
-    setIsLoading(false);
-  }, [invalidateBootstrapRevalidation]);
+  const login = useCallback(
+    (newUser: User) => {
+      invalidateBootstrapRevalidation();
+      authStorage.setUser(newUser);
+      setUser(newUser);
+      setIsLoading(false);
+    },
+    [invalidateBootstrapRevalidation]
+  );
 
   const logout = useCallback(() => {
     clearAuthenticatedState(true);

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -24,32 +24,35 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   });
   const isClearingSessionRef = useRef(false);
 
-  const clearAuthenticatedState = useCallback((clearSensitiveState: boolean) => {
-    if (isClearingSessionRef.current) {
-      return;
-    }
+  const clearAuthenticatedState = useCallback(
+    (clearSensitiveState: boolean) => {
+      if (isClearingSessionRef.current) {
+        return;
+      }
 
-    isClearingSessionRef.current = true;
-    authStorage.clear();
-    setUser(null);
-    setIsLoading(false);
+      isClearingSessionRef.current = true;
+      authStorage.clear();
+      setUser(null);
+      setIsLoading(false);
 
-    if (!clearSensitiveState) {
-      isClearingSessionRef.current = false;
-      return;
-    }
-
-    void clearSensitiveClientState()
-      .catch((error: unknown) => {
-        console.error(
-          "Failed to clear sensitive client state during logout:",
-          error
-        );
-      })
-      .finally(() => {
+      if (!clearSensitiveState) {
         isClearingSessionRef.current = false;
-      });
-  }, []);
+        return;
+      }
+
+      void clearSensitiveClientState()
+        .catch((error: unknown) => {
+          console.error(
+            "Failed to clear sensitive client state during logout:",
+            error
+          );
+        })
+        .finally(() => {
+          isClearingSessionRef.current = false;
+        });
+    },
+    []
+  );
 
   const login = useCallback((newUser: User) => {
     authStorage.setUser(newUser);

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,10 +1,17 @@
 // SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import React, { useState, useEffect, useCallback, useMemo } from "react";
+import React, {
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+  useRef,
+} from "react";
 import { AuthContext, type User } from "./auth-context";
 import { authStorage } from "../services/storage";
-import { sessionEvents } from "../services/sessionEvents";
+import { getCurrentUser } from "../services/authApi";
+import { sessionEvents, isOnline } from "../services/sessionEvents";
 import { clearSensitiveClientState } from "../lib/clientStateCleanup";
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
@@ -12,23 +19,47 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     return authStorage.getUser();
   });
 
-  const [isLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(() => {
+    return authStorage.getUser() !== null && isOnline();
+  });
+  const isClearingSessionRef = useRef(false);
+
+  const clearAuthenticatedState = useCallback((clearSensitiveState: boolean) => {
+    if (isClearingSessionRef.current) {
+      return;
+    }
+
+    isClearingSessionRef.current = true;
+    authStorage.clear();
+    setUser(null);
+    setIsLoading(false);
+
+    if (!clearSensitiveState) {
+      isClearingSessionRef.current = false;
+      return;
+    }
+
+    void clearSensitiveClientState()
+      .catch((error: unknown) => {
+        console.error(
+          "Failed to clear sensitive client state during logout:",
+          error
+        );
+      })
+      .finally(() => {
+        isClearingSessionRef.current = false;
+      });
+  }, []);
 
   const login = useCallback((newUser: User) => {
     authStorage.setUser(newUser);
     setUser(newUser);
+    setIsLoading(false);
   }, []);
 
   const logout = useCallback(() => {
-    authStorage.clear();
-    setUser(null);
-    void clearSensitiveClientState().catch((error: unknown) => {
-      console.error(
-        "Failed to clear sensitive client state during logout:",
-        error
-      );
-    });
-  }, []);
+    clearAuthenticatedState(true);
+  }, [clearAuthenticatedState]);
 
   /**
    * Check if user has a specific role
@@ -73,17 +104,49 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   // Subscribe to session:expired events
   // This handles 401 responses from API calls (when online)
   useEffect(() => {
+    const storedUser = authStorage.getUser();
+
+    if (!storedUser || !isOnline()) {
+      return;
+    }
+
+    let isActive = true;
+
+    void getCurrentUser()
+      .then((currentUser) => {
+        if (!isActive) {
+          return;
+        }
+
+        authStorage.setUser(currentUser);
+        setUser(currentUser);
+        setIsLoading(false);
+      })
+      .catch(() => {
+        if (!isActive) {
+          return;
+        }
+
+        clearAuthenticatedState(true);
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [clearAuthenticatedState]);
+
+  useEffect(() => {
     const unsubscribe = sessionEvents.on("session:expired", () => {
       // Check authStorage instead of user state to avoid adding user as dependency.
       // Adding user would cause re-subscription on every user change, which is unnecessary.
       // authStorage and user state are always in sync via login/logout functions.
       if (authStorage.getUser()) {
-        logout();
+        clearAuthenticatedState(true);
       }
     });
 
     return unsubscribe;
-  }, [logout]);
+  }, [clearAuthenticatedState]);
 
   const value = useMemo(
     () => ({

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -97,6 +97,42 @@ describe("useAuth", () => {
     expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
   });
 
+  it("does not restore auth state when bootstrap revalidation resolves after logout", async () => {
+    const mockUser = { id: 1, name: "Test User", email: "test@example.com" };
+    const revalidatedUser = {
+      ...mockUser,
+      roles: ["Admin"],
+    };
+    const deferred = createDeferredPromise<typeof revalidatedUser>();
+
+    localStorage.setItem("auth_user", JSON.stringify(mockUser));
+    mockGetCurrentUser.mockReturnValueOnce(deferred.promise);
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.isLoading).toBe(true);
+
+    act(() => {
+      result.current.logout();
+    });
+
+    expect(result.current.user).toBeNull();
+    expect(localStorage.getItem("auth_user")).toBeNull();
+
+    await act(async () => {
+      deferred.resolve(revalidatedUser);
+      await Promise.resolve();
+    });
+
+    expect(result.current.user).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(localStorage.getItem("auth_user")).toBeNull();
+    expect(clearSensitiveClientState).toHaveBeenCalledTimes(1);
+  });
+
   it("clears stale stored auth data when revalidation fails", async () => {
     const mockUser = { id: 1, name: "Test User", email: "test@example.com" };
 

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -2,20 +2,50 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, waitFor } from "@testing-library/react";
 import { AuthProvider } from "../contexts/AuthContext";
 import { useAuth } from "./useAuth";
 import { sessionEvents } from "../services/sessionEvents";
 import { clearSensitiveClientState } from "../lib/clientStateCleanup";
 
+const { mockGetCurrentUser } = vi.hoisted(() => ({
+  mockGetCurrentUser: vi.fn(),
+}));
+
+vi.mock("../services/authApi", async () => {
+  const actual = await vi.importActual("../services/authApi");
+  return {
+    ...actual,
+    getCurrentUser: mockGetCurrentUser,
+  };
+});
+
 vi.mock("../lib/clientStateCleanup", () => ({
   clearSensitiveClientState: vi.fn().mockResolvedValue(undefined),
 }));
+
+function createDeferredPromise<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+}
 
 describe("useAuth", () => {
   beforeEach(() => {
     localStorage.clear();
     vi.clearAllMocks();
+    sessionEvents.reset();
+    mockGetCurrentUser.mockResolvedValue({
+      id: 1,
+      name: "Bootstrap User",
+      email: "bootstrap@example.com",
+    });
   });
 
   it("throws error when used outside AuthProvider", () => {
@@ -32,19 +62,82 @@ describe("useAuth", () => {
     expect(result.current.user).toBeNull();
     expect(result.current.isAuthenticated).toBe(false);
     expect(result.current.isLoading).toBe(false);
+    expect(mockGetCurrentUser).not.toHaveBeenCalled();
   });
 
-  it("initializes with user from localStorage", () => {
+  it("revalidates a stored user before completing bootstrap", async () => {
     const mockUser = { id: 1, name: "Test User", email: "test@example.com" };
+    const revalidatedUser = {
+      ...mockUser,
+      roles: ["Admin"],
+    };
+    const deferred = createDeferredPromise<typeof revalidatedUser>();
 
     localStorage.setItem("auth_user", JSON.stringify(mockUser));
+    mockGetCurrentUser.mockReturnValueOnce(deferred.promise);
 
     const { result } = renderHook(() => useAuth(), {
       wrapper: AuthProvider,
     });
 
+    expect(result.current.isLoading).toBe(true);
     expect(result.current.user).toEqual(mockUser);
     expect(result.current.isAuthenticated).toBe(true);
+
+    deferred.resolve(revalidatedUser);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.user).toEqual(revalidatedUser);
+    expect(localStorage.getItem("auth_user")).toBe(
+      JSON.stringify(revalidatedUser)
+    );
+    expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears stale stored auth data when revalidation fails", async () => {
+    const mockUser = { id: 1, name: "Test User", email: "test@example.com" };
+
+    localStorage.setItem("auth_user", JSON.stringify(mockUser));
+    mockGetCurrentUser.mockRejectedValueOnce(new Error("Unauthorized"));
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.user).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(localStorage.getItem("auth_user")).toBeNull();
+    expect(clearSensitiveClientState).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps stored auth when offline without revalidation", () => {
+    const mockUser = { id: 1, name: "Test User", email: "test@example.com" };
+
+    localStorage.setItem("auth_user", JSON.stringify(mockUser));
+
+    const onLineSpy = vi
+      .spyOn(window.navigator, "onLine", "get")
+      .mockReturnValue(false);
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.user).toEqual(mockUser);
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(mockGetCurrentUser).not.toHaveBeenCalled();
+
+    onLineSpy.mockRestore();
   });
 
   it("handles corrupted user data in localStorage", () => {
@@ -74,13 +167,17 @@ describe("useAuth", () => {
     expect(localStorage.getItem("auth_user")).toBe(JSON.stringify(mockUser));
   });
 
-  it("logout clears user", () => {
+  it("logout clears user", async () => {
     const mockUser = { id: 1, name: "Test User", email: "test@example.com" };
 
     localStorage.setItem("auth_user", JSON.stringify(mockUser));
 
     const { result } = renderHook(() => useAuth(), {
       wrapper: AuthProvider,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
     });
 
     act(() => {
@@ -113,12 +210,16 @@ describe("useAuth", () => {
     expect(result.current.isAuthenticated).toBe(false);
   });
 
-  it("logs out when session:expired event is emitted", () => {
+  it("logs out when session:expired event is emitted", async () => {
     const mockUser = { id: 1, name: "Test User", email: "test@example.com" };
     localStorage.setItem("auth_user", JSON.stringify(mockUser));
 
     const { result } = renderHook(() => useAuth(), {
       wrapper: AuthProvider,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
     });
 
     expect(result.current.isAuthenticated).toBe(true);

--- a/src/services/authApi.test.ts
+++ b/src/services/authApi.test.ts
@@ -428,6 +428,15 @@ describe("authApi", () => {
         "Current user fetch failed: 500 Internal Server Error"
       );
     });
+
+    it("wraps network failures in AuthApiError", async () => {
+      mockFetch.mockRejectedValue(new Error("Network down"));
+
+      await expect(getCurrentUser()).rejects.toThrow(
+        "Current user fetch failed: Network down"
+      );
+      await expect(getCurrentUser()).rejects.toBeInstanceOf(AuthApiError);
+    });
   });
 
   describe("AuthApiError", () => {

--- a/src/services/authApi.test.ts
+++ b/src/services/authApi.test.ts
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { login, logout, logoutAll, AuthApiError } from "./authApi";
+import {
+  login,
+  logout,
+  logoutAll,
+  getCurrentUser,
+  AuthApiError,
+} from "./authApi";
 
 const mockFetch = vi.fn();
 
@@ -359,6 +365,68 @@ describe("authApi", () => {
       } as Partial<Response> as Response);
 
       await expect(logoutAll()).rejects.toThrow("Logout all devices failed");
+    });
+  });
+
+  describe("getCurrentUser", () => {
+    it("sends GET request to /v1/me with credentials", async () => {
+      const mockUser = {
+        id: 1,
+        name: "Test User",
+        email: "test@example.com",
+        roles: ["Admin"],
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockUser,
+      } as Response);
+
+      const result = await getCurrentUser();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/v1/me"),
+        expect.objectContaining({
+          method: "GET",
+          credentials: "include",
+        })
+      );
+
+      const currentUserCallArgs = mockFetch.mock.calls[0];
+      expect(currentUserCallArgs).toBeDefined();
+      if (currentUserCallArgs) {
+        const requestInit = currentUserCallArgs[1] as RequestInit;
+        const headers = requestInit.headers as Headers;
+        expect(headers.get("Accept")).toBe("application/json");
+      }
+
+      expect(result).toEqual(mockUser);
+    });
+
+    it("throws AuthApiError on failed current-user fetch", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: async () => ({ message: "Unauthorized" }),
+      } as Response);
+
+      await expect(getCurrentUser()).rejects.toThrow(AuthApiError);
+    });
+
+    it("throws AuthApiError with fallback message on non-JSON response", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        json: async () => {
+          throw new Error("Not JSON");
+        },
+      } as Partial<Response> as Response);
+
+      await expect(getCurrentUser()).rejects.toThrow(
+        "Current user fetch failed: 500 Internal Server Error"
+      );
     });
   });
 

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -123,3 +123,34 @@ export async function logoutAll(): Promise<void> {
     );
   }
 }
+
+/**
+ * Fetch the currently authenticated user for bootstrap revalidation.
+ * @throws {AuthApiError} If the session is invalid or the request fails
+ */
+export async function getCurrentUser(): Promise<LoginResponse["user"]> {
+  const response = await apiFetch(`${getApiBaseUrl()}/v1/me`, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    let error: ApiError | null;
+    try {
+      error = await response.json();
+    } catch {
+      throw new AuthApiError(
+        `Current user fetch failed: ${response.status} ${response.statusText}`
+      );
+    }
+
+    throw new AuthApiError(
+      error?.message || "Current user fetch failed",
+      error?.errors
+    );
+  }
+
+  return response.json();
+}

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -129,12 +129,21 @@ export async function logoutAll(): Promise<void> {
  * @throws {AuthApiError} If the session is invalid or the request fails
  */
 export async function getCurrentUser(): Promise<LoginResponse["user"]> {
-  const response = await apiFetch(`${getApiBaseUrl()}/v1/me`, {
-    method: "GET",
-    headers: {
-      Accept: "application/json",
-    },
-  });
+  let response: Response;
+  try {
+    response = await apiFetch(`${getApiBaseUrl()}/v1/me`, {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+      },
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? `Current user fetch failed: ${error.message}`
+        : "Current user fetch failed";
+    throw new AuthApiError(message);
+  }
 
   if (!response.ok) {
     let error: ApiError | null;


### PR DESCRIPTION
## Summary
- revalidate stored frontend auth state against `GET /v1/me` during online startup
- keep protected routes in loading state until bootstrap revalidation completes
- fail closed by clearing stale local auth state and sensitive client state when revalidation fails
- preserve existing offline-first behavior by skipping startup revalidation while offline

## Validation
- `npx vitest run src/services/authApi.test.ts src/hooks/useAuth.test.ts src/components/ProtectedRoute.test.tsx`
- `npm run typecheck`
- `npm run lint`

Fixes #503