### PR TITLE
fix: prevent plaintext handoff in share target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - stale local `auth_user` state is cleared, including sensitive client cleanup, when startup revalidation rejects
   - offline startup still preserves existing local session state to keep the offline-first flow available
 
+- **Share Target now keeps shared files out of plaintext persistent storage** (#504)
+  - replaced the Share Target service worker's plaintext IndexedDB handoff with a transient in-memory handoff keyed by `share_id`
+  - added a request/clear message protocol so the share page can retrieve files after navigation without persisting raw attachments at rest
+  - switched the post-encryption upload path to the encrypted attachment queue processor so successful UI states require real encrypted uploads
+  - added regression coverage for the encrypted queue processor, the no-op success case, and service-worker-delivered `File` objects without `dataUrl`
+
 - **Employee API types now use a shared contract source** (#492)
   - added `src/types/api` as the central frontend import path for employee API types
   - removed employee request and response type declarations from `src/services/employeeApi.ts`

--- a/src/lib/fileQueue.test.ts
+++ b/src/lib/fileQueue.test.ts
@@ -9,6 +9,7 @@ import {
   updateFileUploadState,
   retryFileUpload,
   processFileQueue,
+  processEncryptedFileQueue,
   clearCompletedUploads,
   getStorageQuota,
   getFailedFiles,
@@ -26,6 +27,13 @@ vi.mock("../services/secretApi", () => ({
     filename: "test.txt",
     size: 12,
     mime_type: "text/plain",
+    created_at: new Date().toISOString(),
+  }),
+  uploadEncryptedAttachment: vi.fn().mockResolvedValue({
+    id: "att-enc-123",
+    filename: "encrypted.bin",
+    size: 32,
+    mime_type: "application/octet-stream",
     created_at: new Date().toISOString(),
   }),
   ApiError: class ApiError extends Error {
@@ -819,6 +827,45 @@ describe("File Queue Utilities", () => {
       const encrypted = await getEncryptedFiles();
 
       expect(encrypted).toHaveLength(0);
+    });
+  });
+
+  describe("processEncryptedFileQueue", () => {
+    it("uploads encrypted queue entries via the encrypted attachment API", async () => {
+      const file = new Blob(["encrypted-payload"], {
+        type: "application/octet-stream",
+      });
+      const metadata = {
+        name: "report.pdf",
+        type: "application/pdf",
+        size: 1024,
+        timestamp: Date.now(),
+      };
+
+      await db.fileQueue.add({
+        id: "enc-1",
+        file,
+        metadata,
+        uploadState: "encrypted",
+        secretId: "secret-123",
+        retryCount: 0,
+        checksum: "a".repeat(64),
+        checksumEncrypted: "b".repeat(64),
+        createdAt: new Date(),
+      });
+
+      const stats = await processEncryptedFileQueue();
+
+      expect(stats).toEqual({
+        total: 1,
+        completed: 1,
+        failed: 0,
+        pending: 0,
+        skipped: 0,
+      });
+
+      const updated = await db.fileQueue.get("enc-1");
+      expect(updated?.uploadState).toBe("completed");
     });
   });
 });

--- a/src/lib/fileQueue.ts
+++ b/src/lib/fileQueue.ts
@@ -8,7 +8,11 @@ import {
   MAX_BACKOFF_MS,
   UPLOAD_CONCURRENCY,
 } from "./db-constants";
-import { uploadAttachment, ApiError } from "../services/secretApi";
+import {
+  uploadAttachment,
+  uploadEncryptedAttachment,
+  ApiError,
+} from "../services/secretApi";
 
 /**
  * Add a file to the upload queue
@@ -204,6 +208,94 @@ export async function retryFileUpload(entry: FileQueueEntry): Promise<boolean> {
   }
 }
 
+async function retryEncryptedFileUpload(
+  entry: FileQueueEntry
+): Promise<boolean> {
+  if (entry.retryCount >= MAX_RETRY_COUNT) {
+    await updateFileUploadState(entry.id, "failed", "Max retries exceeded");
+    return false;
+  }
+
+  if (entry.lastAttemptAt) {
+    const backoffMs = Math.min(
+      Math.pow(2, entry.retryCount) * 1000,
+      MAX_BACKOFF_MS
+    );
+    const timeSinceLastAttempt = Date.now() - entry.lastAttemptAt.getTime();
+
+    if (timeSinceLastAttempt < backoffMs) {
+      return false;
+    }
+  }
+
+  try {
+    await updateFileUploadState(entry.id, "uploading");
+
+    if (!entry.secretId) {
+      throw new Error("Cannot upload file without target Secret ID");
+    }
+
+    const checksumEncrypted =
+      entry.checksumEncrypted && entry.checksumEncrypted.trim() !== ""
+        ? entry.checksumEncrypted
+        : await calculateEncryptedChecksum(entry.file);
+
+    const attachment = await uploadEncryptedAttachment(entry.secretId, entry.file, {
+      filename: entry.metadata.name,
+      type: entry.metadata.type,
+      size: entry.metadata.size,
+      encryptedSize: entry.file.size,
+      checksum: entry.checksum || "",
+      checksumEncrypted,
+    });
+
+    console.log(
+      `[FileQueue] Successfully uploaded encrypted ${attachment.filename} (${attachment.size} bytes) to secret ${entry.secretId}`,
+      { attachmentId: attachment.id }
+    );
+
+    await db.fileQueue.update(entry.id, {
+      uploadState: "completed",
+      checksumEncrypted,
+      error: undefined,
+      lastAttemptAt: new Date(),
+    });
+    return true;
+  } catch (error) {
+    let errorMsg = "Encrypted upload failed";
+
+    if (error instanceof ApiError) {
+      errorMsg = error.message;
+      if (error.errors && Object.keys(error.errors).length > 0) {
+        const firstErrorField = Object.keys(error.errors)[0];
+        if (firstErrorField) {
+          const fieldErrors = error.errors[firstErrorField];
+          if (fieldErrors && fieldErrors.length > 0) {
+            errorMsg = `${errorMsg}: ${fieldErrors[0]}`;
+          }
+        }
+      }
+    } else if (error instanceof Error) {
+      errorMsg = error.message;
+    }
+
+    console.error(
+      `[FileQueue] Encrypted upload failed for ${entry.metadata.name}:`,
+      errorMsg
+    );
+    await updateFileUploadState(entry.id, "failed", errorMsg);
+    return false;
+  }
+}
+
+async function calculateEncryptedChecksum(file: Blob): Promise<string> {
+  const arrayBuffer = await file.arrayBuffer();
+  const hashBuffer = await crypto.subtle.digest("SHA-256", arrayBuffer);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+
+  return hashArray.map((value) => value.toString(16).padStart(2, "0")).join("");
+}
+
 /**
  * Process files with concurrency limit using worker pool pattern
  *
@@ -293,6 +385,53 @@ export async function processFileQueue(
     else if (file.uploadState === "pending") {
       // Check if retry count increased - if not, it was skipped due to backoff
       const originalFile = files.find((f) => f.id === file.id);
+      if (originalFile && file.retryCount === originalFile.retryCount) {
+        skipped++;
+      } else {
+        pending++;
+      }
+    } else if (file.uploadState === "uploading") pending++;
+  }
+
+  return {
+    total: files.length,
+    completed,
+    failed,
+    pending,
+    skipped,
+  };
+}
+
+export async function processEncryptedFileQueue(
+  concurrency = UPLOAD_CONCURRENCY
+): Promise<{
+  total: number;
+  completed: number;
+  failed: number;
+  pending: number;
+  skipped: number;
+}> {
+  const files = await getEncryptedFiles();
+
+  await processWithConcurrency(
+    files,
+    (entry) => retryEncryptedFileUpload(entry),
+    concurrency
+  );
+
+  const updatedFiles = await Promise.all(files.map((file) => db.fileQueue.get(file.id)));
+
+  let completed = 0;
+  let failed = 0;
+  let pending = 0;
+  let skipped = 0;
+
+  for (const file of updatedFiles) {
+    if (!file) continue;
+    if (file.uploadState === "completed") completed++;
+    else if (file.uploadState === "failed") failed++;
+    else if (file.uploadState === "encrypted") {
+      const originalFile = files.find((entry) => entry.id === file.id);
       if (originalFile && file.retryCount === originalFile.retryCount) {
         skipped++;
       } else {

--- a/src/lib/fileQueue.ts
+++ b/src/lib/fileQueue.ts
@@ -240,14 +240,18 @@ async function retryEncryptedFileUpload(
         ? entry.checksumEncrypted
         : await calculateEncryptedChecksum(entry.file);
 
-    const attachment = await uploadEncryptedAttachment(entry.secretId, entry.file, {
-      filename: entry.metadata.name,
-      type: entry.metadata.type,
-      size: entry.metadata.size,
-      encryptedSize: entry.file.size,
-      checksum: entry.checksum || "",
-      checksumEncrypted,
-    });
+    const attachment = await uploadEncryptedAttachment(
+      entry.secretId,
+      entry.file,
+      {
+        filename: entry.metadata.name,
+        type: entry.metadata.type,
+        size: entry.metadata.size,
+        encryptedSize: entry.file.size,
+        checksum: entry.checksum || "",
+        checksumEncrypted,
+      }
+    );
 
     console.log(
       `[FileQueue] Successfully uploaded encrypted ${attachment.filename} (${attachment.size} bytes) to secret ${entry.secretId}`,
@@ -419,7 +423,9 @@ export async function processEncryptedFileQueue(
     concurrency
   );
 
-  const updatedFiles = await Promise.all(files.map((file) => db.fileQueue.get(file.id)));
+  const updatedFiles = await Promise.all(
+    files.map((file) => db.fileQueue.get(file.id))
+  );
 
   let completed = 0;
   let failed = 0;

--- a/src/pages/ShareTarget.test.tsx
+++ b/src/pages/ShareTarget.test.tsx
@@ -15,6 +15,23 @@ import { db } from "../lib/db";
 vi.mock("../services/secretApi", () => ({
   fetchSecrets: vi.fn().mockResolvedValue([]),
   getSecretMasterKey: vi.fn(),
+  uploadEncryptedAttachment: vi.fn().mockResolvedValue({
+    id: "attachment-123",
+    filename: "encrypted.bin",
+    size: 32,
+    mime_type: "application/octet-stream",
+    created_at: new Date().toISOString(),
+  }),
+  ApiError: class ApiError extends Error {
+    constructor(
+      message: string,
+      public status?: number,
+      public errors?: Record<string, string[]>
+    ) {
+      super(message);
+      this.name = "ApiError";
+    }
+  },
 }));
 
 import { fetchSecrets, getSecretMasterKey } from "../services/secretApi";
@@ -943,7 +960,9 @@ describe("ShareTarget - File Encryption Integration (Phase 2)", () => {
         return queueEntries.then((entries) => {
           expect(entries.length).toBeGreaterThan(0);
           const entry = entries[0];
-          expect(entry?.uploadState).toBe("encrypted");
+          expect(["encrypted", "uploading", "completed"]).toContain(
+            entry?.uploadState
+          );
         });
       },
       { timeout: 5000 }
@@ -1096,7 +1115,9 @@ describe("ShareTarget - File Encryption Integration (Phase 2)", () => {
       async () => {
         const entries = await db.fileQueue.toArray();
         const entry = entries.find((e) => e.metadata.name === "test.pdf");
-        expect(entry?.uploadState).toBe("encrypted");
+        expect(["encrypted", "uploading", "completed"]).toContain(
+          entry?.uploadState
+        );
       },
       { timeout: 5000 }
     );

--- a/src/pages/ShareTarget.tsx
+++ b/src/pages/ShareTarget.tsx
@@ -1,20 +1,19 @@
 // SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { useEffect, useState, useCallback, useRef } from "react";
+import { useEffect, useState, useRef } from "react";
 import { Trans } from "@lingui/macro";
 import { Heading } from "../components/heading";
 import { Text } from "../components/text";
 import { Button } from "../components/button";
 import { Badge } from "../components/badge";
 import { EncryptionProgress } from "../components/EncryptionProgress";
-import { handleShareTargetMessage } from "./ShareTarget.utils";
 import {
   fetchSecrets,
   getSecretMasterKey,
   type Secret,
 } from "../services/secretApi";
-import { addFileToQueue, processFileQueue } from "../lib/fileQueue";
+import { addFileToQueue, processEncryptedFileQueue } from "../lib/fileQueue";
 import { encryptFile, deriveFileKey } from "../lib/crypto/encryption";
 import { calculateChecksum } from "../lib/crypto/checksum";
 import { db } from "../lib/db";
@@ -24,6 +23,7 @@ interface SharedFile {
   type: string;
   size: number;
   dataUrl?: string;
+  file?: File;
 }
 
 interface SharedData {
@@ -109,65 +109,125 @@ function sanitizeUrl(url: string | undefined): string | null {
   }
 }
 
+function getShareTextDataFromUrl(): Omit<SharedData, "files"> {
+  const url = new URL(window.location.href);
+
+  return {
+    title: url.searchParams.get("title") || undefined,
+    text: url.searchParams.get("text") || undefined,
+    url: url.searchParams.get("url") || undefined,
+  };
+}
+
+function buildShareDataFromUrl(files?: SharedFile[]): SharedData | null {
+  const { title, text, url } = getShareTextDataFromUrl();
+
+  const hasContent =
+    (title && title !== "") ||
+    (text && text !== "") ||
+    (url && url !== "") ||
+    (files && files.length > 0);
+
+  if (!hasContent) {
+    return null;
+  }
+
+  return {
+    title: title || undefined,
+    text: text || undefined,
+    url: url || undefined,
+    files: files && files.length > 0 ? files : undefined,
+  };
+}
+
+function normalizeSharedFiles(
+  files: unknown,
+  newErrors: string[]
+): SharedFile[] {
+  if (!Array.isArray(files)) {
+    newErrors.push("Invalid files format");
+    return [];
+  }
+
+  return files.filter((file): file is SharedFile => {
+    if (
+      typeof file !== "object" ||
+      file === null ||
+      typeof file.name !== "string" ||
+      typeof file.type !== "string" ||
+      typeof file.size !== "number"
+    ) {
+      newErrors.push("Invalid file data structure");
+      return false;
+    }
+
+    if (file.dataUrl !== undefined && typeof file.dataUrl !== "string") {
+      newErrors.push("Invalid file data structure");
+      return false;
+    }
+
+    if (file.file !== undefined && !(file.file instanceof File)) {
+      newErrors.push("Invalid file data structure");
+      return false;
+    }
+
+    if (!isFileTypeAllowed(file.type)) {
+      newErrors.push(
+        `Invalid file type: ${file.name} (${file.type}) is not supported`
+      );
+      return false;
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      newErrors.push(
+        `File too large: ${file.name} (${formatFileSize(file.size)}). Maximum 10MB allowed.`
+      );
+      return false;
+    }
+
+    return true;
+  });
+}
+
+async function readSharedFileBytes(file: SharedFile): Promise<Uint8Array> {
+  if (file.file) {
+    return new Uint8Array(await file.file.arrayBuffer());
+  }
+
+  if (!file.dataUrl) {
+    throw new Error(`File ${file.name} has no data URL`);
+  }
+
+  const response = await fetch(file.dataUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch file data for ${file.name}`);
+  }
+
+  const blob = await response.blob();
+  return new Uint8Array(await blob.arrayBuffer());
+}
+
 export function ShareTarget() {
+  const [shareTextData] = useState<Omit<SharedData, "files">>(() =>
+    getShareTextDataFromUrl()
+  );
+
   // Parse initial data once using lazy initialization
   const [sharedData, setSharedData] = useState<SharedData | null>(() => {
-    const url = new URL(window.location.href);
-    const title = url.searchParams.get("title");
-    const text = url.searchParams.get("text");
-    const urlParam = url.searchParams.get("url");
     const filesJson = sessionStorage.getItem("share-target-files");
-    let files: SharedFile[] = [];
+    let files: SharedFile[] | undefined;
+    const newErrors: string[] = [];
 
     if (filesJson) {
       try {
-        const parsedFiles = JSON.parse(filesJson);
-
-        // Runtime type validation
-        if (!Array.isArray(parsedFiles)) {
-          throw new Error("Invalid files format: not an array");
-        }
-
-        files = parsedFiles.filter((file): file is SharedFile => {
-          // Validate required properties exist and have correct types
-          if (
-            typeof file !== "object" ||
-            file === null ||
-            typeof file.name !== "string" ||
-            typeof file.type !== "string" ||
-            typeof file.size !== "number"
-          ) {
-            return false;
-          }
-
-          // Validate dataUrl if present
-          if (file.dataUrl !== undefined && typeof file.dataUrl !== "string") {
-            return false;
-          }
-
-          // Apply business logic validation
-          return isFileTypeAllowed(file.type) && file.size <= MAX_FILE_SIZE;
-        });
+        files = normalizeSharedFiles(JSON.parse(filesJson), newErrors);
       } catch (error) {
         // Log parsing errors for debugging
         console.error("Failed to parse shared files during init:", error);
       }
     }
 
-    const hasContent =
-      (title && title !== "") ||
-      (text && text !== "") ||
-      (urlParam && urlParam !== "") ||
-      files.length > 0;
-
-    return hasContent
-      ? {
-          title: title || undefined,
-          text: text || undefined,
-          url: urlParam || undefined,
-          files: files.length > 0 ? files : undefined,
-        }
-      : null;
+    return buildShareDataFromUrl(files);
   });
 
   const [errors, setErrors] = useState<string[]>(() => {
@@ -176,38 +236,7 @@ export function ShareTarget() {
 
     if (filesJson) {
       try {
-        const parsedFiles = JSON.parse(filesJson);
-
-        // Runtime type validation
-        if (!Array.isArray(parsedFiles)) {
-          newErrors.push("Invalid files format");
-          return newErrors;
-        }
-
-        parsedFiles.forEach((file) => {
-          // Validate required properties
-          if (
-            typeof file !== "object" ||
-            file === null ||
-            typeof file.name !== "string" ||
-            typeof file.type !== "string" ||
-            typeof file.size !== "number"
-          ) {
-            newErrors.push("Invalid file data structure");
-            return;
-          }
-
-          if (!isFileTypeAllowed(file.type)) {
-            newErrors.push(
-              `Invalid file type: ${file.name} (${file.type}) is not supported`
-            );
-          }
-          if (file.size > MAX_FILE_SIZE) {
-            newErrors.push(
-              `File too large: ${file.name} (${formatFileSize(file.size)}). Maximum 10MB allowed.`
-            );
-          }
-        });
+        normalizeSharedFiles(JSON.parse(filesJson), newErrors);
       } catch {
         newErrors.push("Failed to load shared files");
       }
@@ -276,106 +305,67 @@ export function ShareTarget() {
     }
   }, []);
 
-  // Reload function for Service Worker messages
-  const loadSharedData = useCallback(() => {
-    const url = new URL(window.location.href);
-    const newErrors: string[] = [];
-
-    // Parse text data from URL parameters (GET method)
-    const title = url.searchParams.get("title");
-    const text = url.searchParams.get("text");
-    const urlParam = url.searchParams.get("url");
-
-    // Parse files from sessionStorage (set by Service Worker)
-    const filesJson = sessionStorage.getItem("share-target-files");
-    let files: SharedFile[] = [];
-
-    if (filesJson) {
-      try {
-        const parsedFiles = JSON.parse(filesJson);
-
-        // Runtime type validation
-        if (!Array.isArray(parsedFiles)) {
-          console.error("Invalid files format: not an array");
-          newErrors.push("Failed to load shared files");
-          return;
-        }
-
-        // Validate each file with type guard
-        files = parsedFiles.filter((file): file is SharedFile => {
-          // Validate required properties exist and have correct types
-          if (
-            typeof file !== "object" ||
-            file === null ||
-            typeof file.name !== "string" ||
-            typeof file.type !== "string" ||
-            typeof file.size !== "number"
-          ) {
-            console.warn("Invalid file structure:", file);
-            return false;
-          }
-
-          // Validate dataUrl if present
-          if (file.dataUrl !== undefined && typeof file.dataUrl !== "string") {
-            console.warn("Invalid dataUrl type for file:", file.name);
-            return false;
-          }
-
-          if (!isFileTypeAllowed(file.type)) {
-            newErrors.push(
-              `Invalid file type: ${file.name} (${file.type}) is not supported`
-            );
-            return false;
-          }
-
-          if (file.size > MAX_FILE_SIZE) {
-            newErrors.push(
-              `File too large: ${file.name} (${formatFileSize(file.size)}). Maximum 10MB allowed.`
-            );
-            return false;
-          }
-
-          return true;
-        });
-      } catch (error) {
-        console.error("Failed to parse shared files:", error);
-        newErrors.push("Failed to load shared files");
-      }
-    }
-
-    // Only set shared data if we have something (including errors)
-    const hasContent =
-      (title && title !== "") ||
-      (text && text !== "") ||
-      (urlParam && urlParam !== "") ||
-      files.length > 0 ||
-      newErrors.length > 0;
-
-    if (hasContent) {
-      setSharedData({
-        title: title || undefined,
-        text: text || undefined,
-        url: urlParam || undefined,
-        files: files.length > 0 ? files : undefined,
-      });
-    }
-
-    setErrors(newErrors);
-  }, []);
-
   // Service Worker message handler
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
-      handleShareTargetMessage(event, shareId, loadSharedData, setErrors);
+      if (!event.data) {
+        return;
+      }
+
+      const { type, shareId: messageShareId } = event.data;
+
+      if (shareId && messageShareId && shareId !== messageShareId) {
+        return;
+      }
+
+      if (type === "SHARE_TARGET_FILES") {
+        const newErrors: string[] = [];
+        const files = normalizeSharedFiles(event.data.files, newErrors);
+
+        setSharedData((current) => {
+          const nextData: SharedData = {
+            ...(current ?? shareTextData),
+            ...shareTextData,
+            files: files.length > 0 ? files : undefined,
+          };
+
+          if (
+            !nextData.title &&
+            !nextData.text &&
+            !nextData.url &&
+            !nextData.files
+          ) {
+            return null;
+          }
+
+          return nextData;
+        });
+
+        if (newErrors.length > 0) {
+          setErrors((current) => [...current, ...newErrors]);
+        }
+      } else if (type === "SHARE_TARGET_ERROR") {
+        setErrors((current) => [
+          ...current,
+          event.data.error || "Unknown error processing shared content",
+        ]);
+      }
     };
 
     navigator.serviceWorker?.addEventListener("message", handleMessage);
+
+    if (shareId && navigator.serviceWorker?.controller) {
+      navigator.serviceWorker.controller.postMessage({
+        type: "REQUEST_SHARE_TARGET_FILES",
+        shareId,
+      });
+    }
 
     // Clean up event listener on unmount
     return () => {
       navigator.serviceWorker?.removeEventListener("message", handleMessage);
     };
-  }, [shareId, loadSharedData]);
+  }, [shareId, shareTextData]);
 
   const handleClear = () => {
     setSharedData(null);
@@ -384,6 +374,13 @@ export function ShareTarget() {
     setSelectedSecretId("");
     setUploadSuccess(false);
     setUploadError(null);
+
+    if (shareId && navigator.serviceWorker?.controller) {
+      navigator.serviceWorker.controller.postMessage({
+        type: "CLEAR_SHARE_TARGET_FILES",
+        shareId,
+      });
+    }
   };
 
   const handleUpload = async () => {
@@ -402,21 +399,10 @@ export function ShareTarget() {
       // Encrypt and queue all files
       for (const file of sharedData.files) {
         try {
-          // Validate dataUrl
-          if (!file.dataUrl) {
-            throw new Error(`File ${file.name} has no data URL`);
-          }
-
           // Update encryption progress (0%)
           setEncryptionProgress((prev) => new Map(prev).set(file.name, 0));
 
-          // Fetch file data from dataUrl
-          const response = await fetch(file.dataUrl);
-          if (!response.ok) {
-            throw new Error(`Failed to fetch file data for ${file.name}`);
-          }
-          const blob = await response.blob();
-          const plaintext = new Uint8Array(await blob.arrayBuffer());
+          const plaintext = await readSharedFileBytes(file);
 
           // Update encryption progress (25%)
           setEncryptionProgress((prev) => new Map(prev).set(file.name, 25));
@@ -483,13 +469,13 @@ export function ShareTarget() {
       setIsEncrypting(false);
 
       // Process the queue (upload encrypted files)
-      const stats = await processFileQueue();
+      const stats = await processEncryptedFileQueue();
 
       if (stats.failed > 0) {
         setUploadError(
           `Failed to upload ${stats.failed} of ${sharedData.files.length} file(s)`
         );
-      } else if (stats.completed === stats.total) {
+      } else if (stats.total > 0 && stats.completed === stats.total) {
         setUploadSuccess(true);
         // Clear shared data after successful upload
         clearTimeoutRef.current = window.setTimeout(() => {

--- a/src/pages/ShareTarget.tsx
+++ b/src/pages/ShareTarget.tsx
@@ -189,6 +189,15 @@ function normalizeSharedFiles(
   });
 }
 
+function isAllowedLocalFileUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url, window.location.href);
+    return parsed.protocol === "data:" || parsed.protocol === "blob:";
+  } catch {
+    return false;
+  }
+}
+
 async function readSharedFileBytes(file: SharedFile): Promise<Uint8Array> {
   if (file.file) {
     return new Uint8Array(await file.file.arrayBuffer());
@@ -196,6 +205,12 @@ async function readSharedFileBytes(file: SharedFile): Promise<Uint8Array> {
 
   if (!file.dataUrl) {
     throw new Error(`File ${file.name} has no data URL`);
+  }
+
+  if (!isAllowedLocalFileUrl(file.dataUrl)) {
+    throw new Error(
+      `File ${file.name} has an invalid local file URL and cannot be uploaded`
+    );
   }
 
   const response = await fetch(file.dataUrl);

--- a/src/pages/ShareTarget.upload.test.tsx
+++ b/src/pages/ShareTarget.upload.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
@@ -13,6 +13,31 @@ import * as fileQueue from "../lib/fileQueue";
 // Mock modules
 vi.mock("../services/secretApi");
 vi.mock("../lib/fileQueue");
+
+function setupServiceWorkerMock() {
+  const listeners: Array<(event: MessageEvent) => void> = [];
+  const serviceWorker = {
+    controller: {
+      postMessage: vi.fn(),
+    },
+    addEventListener: vi.fn(
+      (type: string, listener: EventListenerOrEventListenerObject) => {
+        if (type === "message" && typeof listener === "function") {
+          listeners.push(listener as (event: MessageEvent) => void);
+        }
+      }
+    ),
+    removeEventListener: vi.fn(),
+  };
+
+  Object.defineProperty(navigator, "serviceWorker", {
+    value: serviceWorker,
+    configurable: true,
+    writable: true,
+  });
+
+  return { serviceWorker, listeners };
+}
 
 // Wrapper component with I18n
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -51,8 +76,8 @@ describe("ShareTarget - Upload Functionality", () => {
     // Mock addFileToQueue
     vi.mocked(fileQueue.addFileToQueue).mockResolvedValue("file-123");
 
-    // Mock processFileQueue
-    vi.mocked(fileQueue.processFileQueue).mockResolvedValue({
+    // Mock processEncryptedFileQueue
+    vi.mocked(fileQueue.processEncryptedFileQueue).mockResolvedValue({
       total: 1,
       completed: 1,
       failed: 0,
@@ -142,7 +167,7 @@ describe("ShareTarget - Upload Functionality", () => {
     await waitFor(
       () => {
         expect(fileQueue.addFileToQueue).toHaveBeenCalled();
-        expect(fileQueue.processFileQueue).toHaveBeenCalled();
+        expect(fileQueue.processEncryptedFileQueue).toHaveBeenCalled();
       },
       { timeout: 5000 }
     );
@@ -161,7 +186,7 @@ describe("ShareTarget - Upload Functionality", () => {
 
   it("should show upload progress during upload", async () => {
     // Mock slow upload
-    vi.mocked(fileQueue.processFileQueue).mockImplementation(
+    vi.mocked(fileQueue.processEncryptedFileQueue).mockImplementation(
       () =>
         new Promise((resolve) =>
           setTimeout(
@@ -222,7 +247,7 @@ describe("ShareTarget - Upload Functionality", () => {
 
   it("should handle upload errors gracefully", async () => {
     // Mock upload failure
-    vi.mocked(fileQueue.processFileQueue).mockResolvedValue({
+    vi.mocked(fileQueue.processEncryptedFileQueue).mockResolvedValue({
       total: 1,
       completed: 0,
       failed: 1,
@@ -364,7 +389,7 @@ describe("ShareTarget - Upload Functionality", () => {
   });
 
   it("should handle partial upload completion", async () => {
-    vi.mocked(fileQueue.processFileQueue).mockResolvedValue({
+    vi.mocked(fileQueue.processEncryptedFileQueue).mockResolvedValue({
       total: 3,
       completed: 1,
       failed: 0,
@@ -388,6 +413,99 @@ describe("ShareTarget - Upload Functionality", () => {
       expect(
         screen.getByText(/upload incomplete.*1 succeeded.*2 pending/i)
       ).toBeInTheDocument();
+    });
+  });
+
+  it("does not report success when no encrypted uploads were processed", async () => {
+    vi.mocked(fileQueue.processEncryptedFileQueue).mockResolvedValue({
+      total: 0,
+      completed: 0,
+      failed: 0,
+      pending: 0,
+      skipped: 0,
+    });
+
+    const user = userEvent.setup();
+    render(<ShareTarget />, { wrapper: Wrapper });
+
+    const selector = await screen.findByRole("combobox");
+    await user.selectOptions(selector, "secret-1");
+
+    const uploadBtn = await screen.findByRole("button", {
+      name: /save to secret/i,
+    });
+    await user.click(uploadBtn);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/upload incomplete.*0 succeeded.*0 pending/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("requests shared files from the service worker and uploads File objects without dataUrl", async () => {
+    const { serviceWorker, listeners } = setupServiceWorkerMock();
+
+    Object.defineProperty(window, "location", {
+      value: {
+        href: "http://localhost/share?title=Test&share_id=share-123",
+        pathname: "/share",
+        search: "?title=Test&share_id=share-123",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const user = userEvent.setup();
+    render(<ShareTarget />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(serviceWorker.controller.postMessage).toHaveBeenCalledWith({
+        type: "REQUEST_SHARE_TARGET_FILES",
+        shareId: "share-123",
+      });
+    });
+
+    const sharedFile = new File(["pdf-binary"], "handoff.pdf", {
+      type: "application/pdf",
+    });
+
+    await act(async () => {
+      listeners.forEach((listener) =>
+        listener(
+          new MessageEvent("message", {
+            data: {
+              type: "SHARE_TARGET_FILES",
+              shareId: "share-123",
+              files: [
+                {
+                  name: "handoff.pdf",
+                  type: "application/pdf",
+                  size: sharedFile.size,
+                  file: sharedFile,
+                },
+              ],
+            },
+          })
+        )
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/handoff\.pdf/i)).toBeInTheDocument();
+    });
+
+    const selector = await screen.findByRole("combobox");
+    await user.selectOptions(selector, "secret-1");
+
+    const uploadBtn = await screen.findByRole("button", {
+      name: /save to secret/i,
+    });
+    await user.click(uploadBtn);
+
+    await waitFor(() => {
+      expect(fileQueue.addFileToQueue).toHaveBeenCalled();
+      expect(fileQueue.processEncryptedFileQueue).toHaveBeenCalled();
     });
   });
 });

--- a/src/pages/ShareTarget.upload.test.tsx
+++ b/src/pages/ShareTarget.upload.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { I18nProvider } from "@lingui/react";
@@ -13,6 +13,11 @@ import * as fileQueue from "../lib/fileQueue";
 // Mock modules
 vi.mock("../services/secretApi");
 vi.mock("../lib/fileQueue");
+
+const originalServiceWorkerDescriptor = Object.getOwnPropertyDescriptor(
+  navigator,
+  "serviceWorker"
+);
 
 function setupServiceWorkerMock() {
   const listeners: Array<(event: MessageEvent) => void> = [];
@@ -106,6 +111,19 @@ describe("ShareTarget - Upload Functionality", () => {
       },
       writable: true,
     });
+  });
+
+  afterEach(() => {
+    if (originalServiceWorkerDescriptor) {
+      Object.defineProperty(
+        navigator,
+        "serviceWorker",
+        originalServiceWorkerDescriptor
+      );
+      return;
+    }
+
+    Reflect.deleteProperty(navigator, "serviceWorker");
   });
 
   it("should load and display secrets in selector", async () => {
@@ -507,5 +525,40 @@ describe("ShareTarget - Upload Functionality", () => {
       expect(fileQueue.addFileToQueue).toHaveBeenCalled();
       expect(fileQueue.processEncryptedFileQueue).toHaveBeenCalled();
     });
+  });
+
+  it("rejects non-local file URLs before fetching shared file data", async () => {
+    const user = userEvent.setup();
+
+    sessionStorage.setItem(
+      "share-target-files",
+      JSON.stringify([
+        {
+          name: "handoff.pdf",
+          type: "application/pdf",
+          size: 1024,
+          dataUrl: "https://attacker.example/file.pdf",
+        },
+      ])
+    );
+
+    render(<ShareTarget />, { wrapper: Wrapper });
+
+    const selector = await screen.findByRole("combobox");
+    await user.selectOptions(selector, "secret-1");
+
+    const uploadBtn = await screen.findByRole("button", {
+      name: /save to secret/i,
+    });
+    await user.click(uploadBtn);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/invalid local file url and cannot be uploaded/i)
+      ).toBeInTheDocument();
+    });
+
+    expect(fileQueue.addFileToQueue).not.toHaveBeenCalled();
+    expect(fileQueue.processEncryptedFileQueue).not.toHaveBeenCalled();
   });
 });

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -253,9 +253,10 @@ self.addEventListener("message", (event: ExtendableMessageEvent) => {
 
   if (event.data.type === "REQUEST_SHARE_TARGET_FILES") {
     const shareId = event.data.shareId;
-    const payload = typeof shareId === "string"
-      ? pendingShareTargetPayloads.get(shareId)
-      : undefined;
+    const payload =
+      typeof shareId === "string"
+        ? pendingShareTargetPayloads.get(shareId)
+        : undefined;
 
     if (!shareId || !payload) {
       source.postMessage({

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -90,51 +90,37 @@ const ALLOWED_TYPES = [
   "application/vnd.openxmlformats",
 ];
 
-/**
- * Store file in IndexedDB fileQueue
- * Service Worker cannot import from lib/fileQueue.ts, so we inline the logic
- *
- * Schema is duplicated from db.ts - use shared constants from db-constants.ts
- * to minimize sync risk.
- *
- * NOTE: Database connection is opened on each call. For typical Share Target use
- * cases (1-3 files), this is acceptable. Future optimization could cache the
- * connection if bulk operations become common.
- *
- * SCHEMA SYNC: Structure must match FileQueueEntry interface in db.ts.
- * - id: string
- * - file: Blob
- * - metadata: { name, type, size, timestamp }
- * - uploadState: "pending" | "uploading" | "completed" | "failed"
- * - retryCount: number
- * - createdAt: Date
- * - lastAttemptAt?: Date (optional, set during upload attempts)
- * - error?: string (optional, set on failure)
- * - secretId?: string (optional, target secret)
- */
-async function storeFileInQueue(
-  file: File,
-  metadata: { name: string; type: string; size: number; timestamp: number }
-): Promise<string> {
-  const db = await openDB(DB_NAME, DB_VERSION);
-  const id = crypto.randomUUID();
+interface ShareTargetTransferFile {
+  name: string;
+  type: string;
+  size: number;
+  dataUrl?: string;
+  file: File;
+}
 
-  // Structure matches FileQueueEntry from db.ts (required fields only)
-  await db.add("fileQueue", {
-    id,
-    file, // File extends Blob, no conversion needed
-    metadata,
-    uploadState: "pending",
-    retryCount: 0,
-    createdAt: new Date(),
-  });
+const SHARE_TARGET_TTL_MS = 5 * 60 * 1000;
+const pendingShareTargetPayloads = new Map<
+  string,
+  {
+    createdAt: number;
+    files: ShareTargetTransferFile[];
+  }
+>();
 
-  return id;
+function pruneExpiredShareTargetPayloads(): void {
+  const now = Date.now();
+
+  for (const [shareId, payload] of pendingShareTargetPayloads.entries()) {
+    if (now - payload.createdAt > SHARE_TARGET_TTL_MS) {
+      pendingShareTargetPayloads.delete(shareId);
+    }
+  }
 }
 
 async function handleShareTargetPost(request: Request): Promise<Response> {
   // Use a shareId to correlate messages and redirects across navigation
   const shareId = `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+  pruneExpiredShareTargetPayloads();
 
   try {
     const formData = await request.clone().formData();
@@ -166,22 +152,10 @@ async function handleShareTargetPost(request: Request): Promise<Response> {
       return true;
     });
 
-    // Store files in IndexedDB for persistent offline queue
-    const fileIds = await Promise.all(
-      allowedFiles.map(async (file) => {
-        const id = await storeFileInQueue(file, {
-          name: file.name,
-          type: file.type,
-          size: file.size,
-          timestamp: Date.now(),
-        });
-        return id;
-      })
-    );
-
-    // Generate lightweight file metadata for client notification
+    // Generate transient payload for client notification.
+    // Files stay in service worker memory until the share page requests them.
     const processedFiles = await Promise.all(
-      allowedFiles.map(async (file, index) => {
+      allowedFiles.map(async (file) => {
         // Convert file to Base64 for preview only for images and limited size
         // Reduced to 2MB to prevent memory issues (Base64 is ~33% larger)
         let dataUrl: string | undefined;
@@ -195,14 +169,21 @@ async function handleShareTargetPost(request: Request): Promise<Response> {
         }
 
         return {
-          id: fileIds[index],
           name: file.name,
           type: file.type,
           size: file.size,
           dataUrl,
+          file,
         };
       })
     );
+
+    if (processedFiles.length > 0) {
+      pendingShareTargetPayloads.set(shareId, {
+        createdAt: Date.now(),
+        files: processedFiles,
+      });
+    }
 
     // Build redirect URL with query parameters and shareId
     const redirectUrl = new URL("/share", self.location.origin);
@@ -211,11 +192,10 @@ async function handleShareTargetPost(request: Request): Promise<Response> {
     if (url) redirectUrl.searchParams.set("url", url);
     redirectUrl.searchParams.set("share_id", shareId);
 
-    // Notify clients about shared files (stored in IndexedDB)
-    // This ensures files are available when the redirect happens
+    // Notify existing clients early; newly opened clients can request the payload
+    // via REQUEST_SHARE_TARGET_FILES using the shareId from the redirect URL.
     await self.clients.matchAll({ type: "window" }).then((clients) => {
       if (clients.length > 0) {
-        // If there's an active client, notify it first
         for (const client of clients) {
           client.postMessage({
             type: "SHARE_TARGET_FILES",
@@ -258,6 +238,45 @@ async function handleShareTargetPost(request: Request): Promise<Response> {
     );
   }
 }
+
+self.addEventListener("message", (event: ExtendableMessageEvent) => {
+  if (!event.data || typeof event.data.type !== "string") {
+    return;
+  }
+
+  pruneExpiredShareTargetPayloads();
+
+  const source = event.source;
+  if (!source || !("postMessage" in source)) {
+    return;
+  }
+
+  if (event.data.type === "REQUEST_SHARE_TARGET_FILES") {
+    const shareId = event.data.shareId;
+    const payload = typeof shareId === "string"
+      ? pendingShareTargetPayloads.get(shareId)
+      : undefined;
+
+    if (!shareId || !payload) {
+      source.postMessage({
+        type: "SHARE_TARGET_ERROR",
+        shareId,
+        error: "Shared files are no longer available. Please share them again.",
+      });
+      return;
+    }
+
+    source.postMessage({
+      type: "SHARE_TARGET_FILES",
+      shareId,
+      files: payload.files,
+    });
+  } else if (event.data.type === "CLEAR_SHARE_TARGET_FILES") {
+    if (typeof event.data.shareId === "string") {
+      pendingShareTargetPayloads.delete(event.data.shareId);
+    }
+  }
+});
 
 /**
  * Background Sync handler for file uploads

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -117,9 +117,18 @@ function pruneExpiredShareTargetPayloads(): void {
   }
 }
 
+function generateShareId(): string {
+  if (typeof self.crypto.randomUUID === "function") {
+    return self.crypto.randomUUID();
+  }
+
+  const randomValue = self.crypto.getRandomValues(new Uint32Array(1))[0] ?? 0;
+  return `${Date.now()}-${randomValue.toString(16)}`;
+}
+
 async function handleShareTargetPost(request: Request): Promise<Response> {
   // Use a shareId to correlate messages and redirects across navigation
-  const shareId = `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+  const shareId = generateShareId();
   pruneExpiredShareTargetPayloads();
 
   try {


### PR DESCRIPTION
## Summary
- remove persistent plaintext Share Target file handoff and replace it with transient service-worker memory keyed by `share_id`
- request shared files explicitly from the service worker and clear transient payloads after use
- process shared uploads through the encrypted file queue and only show success after real encrypted upload completion
- keep the larger PR scoped to one security topic because the service worker, page flow, queue logic, and regression coverage must change together

## Testing
- npx vitest run src/lib/fileQueue.test.ts src/pages/ShareTarget.test.tsx src/pages/ShareTarget.upload.test.tsx
- npm run typecheck
- npm run lint

Fixes #504
