### PR TITLE
chore(frontend): refresh dependency maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Pinned transitive `yauzl` resolution to `>=3.2.1` so Lighthouse-related tooling no longer ships the vulnerable archive parser flagged by `npm audit` and Dependabot
+- Pinned the transitive `yauzl` resolution to `3.2.1` so Lighthouse-related tooling no longer ships the vulnerable archive parser flagged by `npm audit` and Dependabot
 
 - **Phase 1 offline-data hardening**
   - Removed PWA runtime caching for authenticated API routes to avoid persistent browser caching of sensitive `/v1/*` responses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Pinned transitive `yauzl` resolution to `>=3.2.1` so Lighthouse-related tooling no longer ships the vulnerable archive parser flagged by `npm audit` and Dependabot
+
 - **Phase 1 offline-data hardening**
   - Removed PWA runtime caching for authenticated API routes to avoid persistent browser caching of sensitive `/v1/*` responses
   - Added centralized sensitive client-state cleanup for logout and session-expiry flows
@@ -32,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs/OFFLINE_DATA_PROTECTION_ROADMAP.md` - deferred Phase 2 design notes for a future encrypted offline vault with device-bound key options
 
 ### Changed
+
+- Updated frontend package baselines to the latest currently compatible releases for `@lingui/core`, `@lingui/react`, `@lingui/macro`, and `vite-plugin-static-copy`
 
 - `.github/copilot-instructions.md` - replaced comment-based inheritance assumptions and long-form examples with a self-contained runtime baseline for this repository
 - `.github/instructions/org-shared.instructions.md` - reduced to a short repo-local overlay that reinforces the runtime baseline instead of duplicating org documents

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@headlessui/react": "^2.2.9",
         "@heroicons/react": "^2.2.0",
-        "@lingui/core": "^5.6.0",
-        "@lingui/react": "^5.6.0",
+        "@lingui/core": "^5.9.3",
+        "@lingui/react": "^5.9.3",
         "clsx": "^2.1.1",
         "dexie": "^4.2.1",
         "dexie-react-hooks": "^4.2.0",
@@ -29,7 +29,7 @@
         "@fontsource/inter": "^5.2.8",
         "@lingui/babel-plugin-lingui-macro": "^5.9.3",
         "@lingui/cli": "^5.9.1",
-        "@lingui/macro": "^5.7.0",
+        "@lingui/macro": "^5.9.3",
         "@lingui/vite-plugin": "^5.9.3",
         "@playwright/test": "^1.58.2",
         "@rolldown/plugin-babel": "^0.2.1",
@@ -65,7 +65,7 @@
         "typescript-eslint": "^8.57.0",
         "vite": "^8.0.0",
         "vite-plugin-pwa": "^1.2.0",
-        "vite-plugin-static-copy": "^3.1.6",
+        "vite-plugin-static-copy": "^3.3.0",
         "vitest": "^4.1.0",
         "workbox-window": "^7.4.0"
       },
@@ -3650,46 +3650,6 @@
         }
       }
     },
-    "node_modules/@lingui/babel-plugin-lingui-macro/node_modules/@lingui/core": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-5.9.3.tgz",
-      "integrity": "sha512-3b8LnDjx8POdQ6q6UKBe2DHynyQFCO66vm8/UPQnvlQowUk4Xdu5bK6oet11D9/vrSznrDDS+Qb5JVcNBUImgg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "5.9.3"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@lingui/babel-plugin-lingui-macro": "5.9.3",
-        "babel-plugin-macros": "2 || 3"
-      },
-      "peerDependenciesMeta": {
-        "@lingui/babel-plugin-lingui-macro": {
-          "optional": true
-        },
-        "babel-plugin-macros": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@lingui/babel-plugin-lingui-macro/node_modules/@lingui/message-utils": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/@lingui/message-utils/-/message-utils-5.9.3.tgz",
-      "integrity": "sha512-oAK7HA7lcQrzaEaM6G1T5RwwxJxaSKfG/IFIxpZIl49TSFQv+s9YPNgHnVi+d4DmterpXNxy9ZZ+NtckJx6u7g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@messageformat/parser": "^5.0.0",
-        "js-sha256": "^0.10.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@lingui/cli": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/@lingui/cli/-/cli-5.9.3.tgz",
@@ -3732,46 +3692,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@lingui/cli/node_modules/@lingui/core": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-5.9.3.tgz",
-      "integrity": "sha512-3b8LnDjx8POdQ6q6UKBe2DHynyQFCO66vm8/UPQnvlQowUk4Xdu5bK6oet11D9/vrSznrDDS+Qb5JVcNBUImgg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "5.9.3"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@lingui/babel-plugin-lingui-macro": "5.9.3",
-        "babel-plugin-macros": "2 || 3"
-      },
-      "peerDependenciesMeta": {
-        "@lingui/babel-plugin-lingui-macro": {
-          "optional": true
-        },
-        "babel-plugin-macros": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@lingui/cli/node_modules/@lingui/message-utils": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/@lingui/message-utils/-/message-utils-5.9.3.tgz",
-      "integrity": "sha512-oAK7HA7lcQrzaEaM6G1T5RwwxJxaSKfG/IFIxpZIl49TSFQv+s9YPNgHnVi+d4DmterpXNxy9ZZ+NtckJx6u7g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@messageformat/parser": "^5.0.0",
-        "js-sha256": "^0.10.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@lingui/conf": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/@lingui/conf/-/conf-5.9.3.tgz",
@@ -3790,19 +3710,19 @@
       }
     },
     "node_modules/@lingui/core": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-5.9.2.tgz",
-      "integrity": "sha512-2K2lIEiUJ9VNTZU0igiRUubIUvcHu8TEuS4uRrrA5f2DGgCtHD5o7rw6OO9cM1RxZFCC5rpRwIMDeXHrc44W3g==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-5.9.3.tgz",
+      "integrity": "sha512-3b8LnDjx8POdQ6q6UKBe2DHynyQFCO66vm8/UPQnvlQowUk4Xdu5bK6oet11D9/vrSznrDDS+Qb5JVcNBUImgg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "5.9.2"
+        "@lingui/message-utils": "5.9.3"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@lingui/babel-plugin-lingui-macro": "5.9.2",
+        "@lingui/babel-plugin-lingui-macro": "5.9.3",
         "babel-plugin-macros": "2 || 3"
       },
       "peerDependenciesMeta": {
@@ -3830,35 +3750,21 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@lingui/format-po/node_modules/@lingui/message-utils": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/@lingui/message-utils/-/message-utils-5.9.3.tgz",
-      "integrity": "sha512-oAK7HA7lcQrzaEaM6G1T5RwwxJxaSKfG/IFIxpZIl49TSFQv+s9YPNgHnVi+d4DmterpXNxy9ZZ+NtckJx6u7g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@messageformat/parser": "^5.0.0",
-        "js-sha256": "^0.10.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@lingui/macro": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/@lingui/macro/-/macro-5.9.2.tgz",
-      "integrity": "sha512-pa7ySSEUyE+ObOBEqCJet4w2oLm5volBcCKnkiYwtFGBAjQad32CQBk1ptSptd7l8ZQbLVnMCjy1oFyCJ2hBIg==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/@lingui/macro/-/macro-5.9.3.tgz",
+      "integrity": "sha512-xWqJ+hpp5T+xmE++VYlcfMxrF48LpY5Ak9N/luibY9d0AqvyYZiiv7Xaq7E2eK69v9CJWx+6eXA6uPhC8gHY+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lingui/core": "5.9.2",
-        "@lingui/react": "5.9.2"
+        "@lingui/core": "5.9.3",
+        "@lingui/react": "5.9.3"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@lingui/babel-plugin-lingui-macro": "5.9.2",
+        "@lingui/babel-plugin-lingui-macro": "5.9.3",
         "babel-plugin-macros": "2 || 3"
       },
       "peerDependenciesMeta": {
@@ -3871,9 +3777,9 @@
       }
     },
     "node_modules/@lingui/message-utils": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/@lingui/message-utils/-/message-utils-5.9.2.tgz",
-      "integrity": "sha512-PQA+bP4TBX7F5nmrEm9eDk+xddepjO7okI6bsOQ+6LIw1eJMvh9w/Xt3AoKTgzBCwd1ZwyqzBOelrX6sa6y+fg==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/@lingui/message-utils/-/message-utils-5.9.3.tgz",
+      "integrity": "sha512-oAK7HA7lcQrzaEaM6G1T5RwwxJxaSKfG/IFIxpZIl49TSFQv+s9YPNgHnVi+d4DmterpXNxy9ZZ+NtckJx6u7g==",
       "license": "MIT",
       "dependencies": {
         "@messageformat/parser": "^5.0.0",
@@ -3884,19 +3790,19 @@
       }
     },
     "node_modules/@lingui/react": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/@lingui/react/-/react-5.9.2.tgz",
-      "integrity": "sha512-rvDBlz9s1AftAgkJnH/5u3YKlAouRZUsUpSoIajFqkXNEcnIcljFH2Lp7i4nQ7XQ4vpOjzpSH03cggvoo4fWKg==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/@lingui/react/-/react-5.9.3.tgz",
+      "integrity": "sha512-aje78l3zGGZ3C75fiGhDVKyVALHfiKlYFjcOlZpgXY/JAVfFuZX+6wUGG9x1A8k7BfxrDy/ofHIBahPvNAqoKw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@lingui/core": "5.9.2"
+        "@lingui/core": "5.9.3"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@lingui/babel-plugin-lingui-macro": "5.9.2",
+        "@lingui/babel-plugin-lingui-macro": "5.9.3",
         "babel-plugin-macros": "2 || 3",
         "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -9640,16 +9546,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -16101,9 +15997,9 @@
       }
     },
     "node_modules/vite-plugin-static-copy": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-3.2.0.tgz",
-      "integrity": "sha512-g2k9z8B/1Bx7D4wnFjPLx9dyYGrqWMLTpwTtPHhcU+ElNZP2O4+4OsyaficiDClus0dzVhdGvoGFYMJxoXZ12Q==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-3.3.0.tgz",
+      "integrity": "sha512-XiAtZcev7nppxNFgKoD55rfL+ukVp/RtrnTJONRwRuzv/B2FK2h2ZRCYjvxhwBV/Oarse83SiyXBSxMTfeEM0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16120,7 +16016,7 @@
         "url": "https://github.com/sponsors/sapphi-red"
       },
       "peerDependencies": {
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/vite-plugin-static-copy/node_modules/chokidar": {
@@ -17407,14 +17303,17 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.1.tgz",
+      "integrity": "sha512-k1isifdbpNSFEHFJ1ZY4YDewv0IH9FR61lDetaRMD3j2ae3bIXGV+7c+LHCqtQGofSd8PIyV4X6+dHMAnSr60A==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "serialize-javascript": ">=7.0.3",
     "@isaacs/brace-expansion": ">=5.0.1",
     "minimatch": ">=10.2.4",
-    "yauzl": ">=3.2.1"
+    "yauzl": "3.2.1"
   },
   "engines": {
     "node": ">=20.0.0",

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
   "dependencies": {
     "@headlessui/react": "^2.2.9",
     "@heroicons/react": "^2.2.0",
-    "@lingui/core": "^5.6.0",
-    "@lingui/react": "^5.6.0",
+    "@lingui/core": "^5.9.3",
+    "@lingui/react": "^5.9.3",
     "clsx": "^2.1.1",
     "dexie": "^4.2.1",
     "dexie-react-hooks": "^4.2.0",
@@ -76,7 +76,7 @@
     "@fontsource/inter": "^5.2.8",
     "@lingui/babel-plugin-lingui-macro": "^5.9.3",
     "@lingui/cli": "^5.9.1",
-    "@lingui/macro": "^5.7.0",
+    "@lingui/macro": "^5.9.3",
     "@lingui/vite-plugin": "^5.9.3",
     "@playwright/test": "^1.58.2",
     "@rolldown/plugin-babel": "^0.2.1",
@@ -112,7 +112,7 @@
     "typescript-eslint": "^8.57.0",
     "vite": "^8.0.0",
     "vite-plugin-pwa": "^1.2.0",
-    "vite-plugin-static-copy": "^3.1.6",
+    "vite-plugin-static-copy": "^3.3.0",
     "vitest": "^4.1.0",
     "workbox-window": "^7.4.0"
   },
@@ -124,7 +124,8 @@
     "rollup": ">=4.59.0",
     "serialize-javascript": ">=7.0.3",
     "@isaacs/brace-expansion": ">=5.0.1",
-    "minimatch": ">=10.2.4"
+    "minimatch": ">=10.2.4",
+    "yauzl": ">=3.2.1"
   },
   "engines": {
     "node": ">=20.0.0",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -94,10 +94,12 @@ describe("App", () => {
     // Actual redirect behavior is tested in PermissionRoute.test.tsx
     await renderWithI18n(<App />);
 
-    await waitFor(() => {
-      expect(
-        screen.getByRole("heading", { name: /Welcome to SecPal/i })
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByRole(
+        "heading",
+        { name: /Welcome to SecPal/i },
+        { timeout: 20000 }
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/ConflictResolutionDialog.test.tsx
+++ b/src/components/ConflictResolutionDialog.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, vi } from "vitest";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
@@ -92,6 +92,12 @@ describe("ConflictResolutionDialog", () => {
       screen.getByRole("button", { name: /Your Local Version/i })
     );
 
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Apply Selection/i })
+      ).toBeEnabled();
+    });
+
     // Confirm selection
     await user.click(screen.getByRole("button", { name: /Apply Selection/i }));
 
@@ -114,6 +120,12 @@ describe("ConflictResolutionDialog", () => {
 
     // Click server version
     await user.click(screen.getByRole("button", { name: /Server Version/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Apply Selection/i })
+      ).toBeEnabled();
+    });
 
     // Confirm selection
     await user.click(screen.getByRole("button", { name: /Apply Selection/i }));

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -173,7 +173,9 @@ describe("ApplicationLayout", () => {
           </ApplicationLayout>
         );
 
-        const userMenuButton = screen.getByRole("button", { name: /user menu/i });
+        const userMenuButton = screen.getByRole("button", {
+          name: /user menu/i,
+        });
         await user.click(userMenuButton);
 
         expect(
@@ -183,7 +185,9 @@ describe("ApplicationLayout", () => {
             { timeout: SLOW_TEST_TIMEOUT }
           )
         ).toBeInTheDocument();
-        expect(screen.getByRole("menuitem", { name: /sign out/i })).toBeInTheDocument();
+        expect(
+          screen.getByRole("menuitem", { name: /sign out/i })
+        ).toBeInTheDocument();
       },
       SLOW_TEST_TIMEOUT
     );
@@ -199,7 +203,9 @@ describe("ApplicationLayout", () => {
           </ApplicationLayout>
         );
 
-        const userMenuButton = screen.getByRole("button", { name: /user menu/i });
+        const userMenuButton = screen.getByRole("button", {
+          name: /user menu/i,
+        });
         await user.click(userMenuButton);
 
         const profileItem = await screen.findByRole(
@@ -226,7 +232,9 @@ describe("ApplicationLayout", () => {
           </ApplicationLayout>
         );
 
-        const userMenuButton = screen.getByRole("button", { name: /user menu/i });
+        const userMenuButton = screen.getByRole("button", {
+          name: /user menu/i,
+        });
         await user.click(userMenuButton);
 
         const settingsItem = await screen.findByRole(
@@ -253,7 +261,9 @@ describe("ApplicationLayout", () => {
           </ApplicationLayout>
         );
 
-        const userMenuButton = screen.getByRole("button", { name: /user menu/i });
+        const userMenuButton = screen.getByRole("button", {
+          name: /user menu/i,
+        });
         await user.click(userMenuButton);
 
         const signOutItem = await screen.findByRole(

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -3,6 +3,7 @@
 
 import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
 import { MemoryRouter } from "react-router-dom";
@@ -39,6 +40,8 @@ const renderWithProviders = (
 };
 
 describe("ApplicationLayout", () => {
+  const SLOW_TEST_TIMEOUT = 20000;
+
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
@@ -159,79 +162,113 @@ describe("ApplicationLayout", () => {
   });
 
   describe("navbar user dropdown", () => {
-    it("opens navbar dropdown when clicking user menu button", async () => {
-      renderWithProviders(
-        <ApplicationLayout>
-          <div>Content</div>
-        </ApplicationLayout>
-      );
+    it(
+      "opens navbar dropdown when clicking user menu button",
+      async () => {
+        const user = userEvent.setup();
 
-      // Find and click the navbar user menu button (has aria-label)
-      const userMenuButton = screen.getByRole("button", { name: /user menu/i });
-      fireEvent.click(userMenuButton);
+        renderWithProviders(
+          <ApplicationLayout>
+            <div>Content</div>
+          </ApplicationLayout>
+        );
 
-      await waitFor(() => {
-        expect(screen.getByText("My profile")).toBeInTheDocument();
-        expect(screen.getByText("Sign out")).toBeInTheDocument();
-      });
-    });
+        const userMenuButton = screen.getByRole("button", { name: /user menu/i });
+        await user.click(userMenuButton);
 
-    it("has profile link in navbar dropdown", async () => {
-      renderWithProviders(
-        <ApplicationLayout>
-          <div>Content</div>
-        </ApplicationLayout>
-      );
+        expect(
+          await screen.findByRole(
+            "menuitem",
+            { name: /my profile/i },
+            { timeout: SLOW_TEST_TIMEOUT }
+          )
+        ).toBeInTheDocument();
+        expect(screen.getByRole("menuitem", { name: /sign out/i })).toBeInTheDocument();
+      },
+      SLOW_TEST_TIMEOUT
+    );
 
-      const userMenuButton = screen.getByRole("button", { name: /user menu/i });
-      fireEvent.click(userMenuButton);
+    it(
+      "has profile link in navbar dropdown",
+      async () => {
+        const user = userEvent.setup();
 
-      await waitFor(() => {
-        const profileItem = screen.getByRole("menuitem", {
-          name: /my profile/i,
-        });
+        renderWithProviders(
+          <ApplicationLayout>
+            <div>Content</div>
+          </ApplicationLayout>
+        );
+
+        const userMenuButton = screen.getByRole("button", { name: /user menu/i });
+        await user.click(userMenuButton);
+
+        const profileItem = await screen.findByRole(
+          "menuitem",
+          {
+            name: /my profile/i,
+          },
+          { timeout: SLOW_TEST_TIMEOUT }
+        );
+
         expect(profileItem).toHaveAttribute("href", "/profile");
-      });
-    });
+      },
+      SLOW_TEST_TIMEOUT
+    );
 
-    it("has settings link in navbar dropdown", async () => {
-      renderWithProviders(
-        <ApplicationLayout>
-          <div>Content</div>
-        </ApplicationLayout>
-      );
+    it(
+      "has settings link in navbar dropdown",
+      async () => {
+        const user = userEvent.setup();
 
-      const userMenuButton = screen.getByRole("button", { name: /user menu/i });
-      fireEvent.click(userMenuButton);
+        renderWithProviders(
+          <ApplicationLayout>
+            <div>Content</div>
+          </ApplicationLayout>
+        );
 
-      await waitFor(() => {
-        const settingsItem = screen.getByRole("menuitem", {
-          name: /settings/i,
-        });
+        const userMenuButton = screen.getByRole("button", { name: /user menu/i });
+        await user.click(userMenuButton);
+
+        const settingsItem = await screen.findByRole(
+          "menuitem",
+          {
+            name: /settings/i,
+          },
+          { timeout: SLOW_TEST_TIMEOUT }
+        );
+
         expect(settingsItem).toHaveAttribute("href", "/settings");
-      });
-    });
+      },
+      SLOW_TEST_TIMEOUT
+    );
 
-    it("triggers logout when clicking sign out in navbar dropdown", async () => {
-      renderWithProviders(
-        <ApplicationLayout>
-          <div>Content</div>
-        </ApplicationLayout>
-      );
+    it(
+      "triggers logout when clicking sign out in navbar dropdown",
+      async () => {
+        const user = userEvent.setup();
 
-      const userMenuButton = screen.getByRole("button", { name: /user menu/i });
-      fireEvent.click(userMenuButton);
+        renderWithProviders(
+          <ApplicationLayout>
+            <div>Content</div>
+          </ApplicationLayout>
+        );
 
-      await waitFor(() => {
-        const signOutItem = screen.getByRole("menuitem", { name: /sign out/i });
-        fireEvent.click(signOutItem);
-      });
+        const userMenuButton = screen.getByRole("button", { name: /user menu/i });
+        await user.click(userMenuButton);
 
-      // Should have called the logout API
-      await waitFor(() => {
-        expect(authApi.logout).toHaveBeenCalled();
-      });
-    });
+        const signOutItem = await screen.findByRole(
+          "menuitem",
+          { name: /sign out/i },
+          { timeout: SLOW_TEST_TIMEOUT }
+        );
+        await user.click(signOutItem);
+
+        await waitFor(() => {
+          expect(authApi.logout).toHaveBeenCalled();
+        });
+      },
+      SLOW_TEST_TIMEOUT
+    );
   });
 
   // Note: Sidebar footer with user info was removed - all user menu functionality is in the navbar.

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -41,6 +41,7 @@ const renderWithProviders = (
 
 describe("ApplicationLayout", () => {
   const SLOW_TEST_TIMEOUT = 20000;
+  const QUERY_TIMEOUT = 15000;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -182,7 +183,7 @@ describe("ApplicationLayout", () => {
           await screen.findByRole(
             "menuitem",
             { name: /my profile/i },
-            { timeout: SLOW_TEST_TIMEOUT }
+            { timeout: QUERY_TIMEOUT }
           )
         ).toBeInTheDocument();
         expect(
@@ -213,7 +214,7 @@ describe("ApplicationLayout", () => {
           {
             name: /my profile/i,
           },
-          { timeout: SLOW_TEST_TIMEOUT }
+          { timeout: QUERY_TIMEOUT }
         );
 
         expect(profileItem).toHaveAttribute("href", "/profile");
@@ -242,7 +243,7 @@ describe("ApplicationLayout", () => {
           {
             name: /settings/i,
           },
-          { timeout: SLOW_TEST_TIMEOUT }
+          { timeout: QUERY_TIMEOUT }
         );
 
         expect(settingsItem).toHaveAttribute("href", "/settings");
@@ -269,7 +270,7 @@ describe("ApplicationLayout", () => {
         const signOutItem = await screen.findByRole(
           "menuitem",
           { name: /sign out/i },
-          { timeout: SLOW_TEST_TIMEOUT }
+          { timeout: QUERY_TIMEOUT }
         );
         await user.click(signOutItem);
 

--- a/src/pages/ActivityLog/ActivityLogList.test.tsx
+++ b/src/pages/ActivityLog/ActivityLogList.test.tsx
@@ -21,6 +21,8 @@ vi.mock("./ActivityDetailDialog", () => ({
   ),
 }));
 
+const SLOW_TEST_TIMEOUT = 20000;
+
 // Helper to render with providers
 const renderWithProviders = () => {
   i18n.load("en", enMessages);
@@ -247,59 +249,63 @@ describe("ActivityLogList", () => {
     expect(prevButton).toBeDisabled(); // First page, so previous disabled
   });
 
-  it("should handle page navigation", async () => {
-    vi.mocked(activityLogApi.fetchActivityLogs).mockResolvedValue({
-      data: [mockActivity],
-      meta: {
-        current_page: 1,
-        from: 1,
-        last_page: 3,
-        per_page: 50,
-        to: 50,
-        total: 150,
-      },
-      links: {
-        first: "/v1/activity-logs?page=1",
-        last: "/v1/activity-logs?page=3",
-        prev: null,
-        next: "/v1/activity-logs?page=2",
-      },
-    });
+  it(
+    "should handle page navigation",
+    async () => {
+      vi.mocked(activityLogApi.fetchActivityLogs).mockResolvedValue({
+        data: [mockActivity],
+        meta: {
+          current_page: 1,
+          from: 1,
+          last_page: 3,
+          per_page: 50,
+          to: 50,
+          total: 150,
+        },
+        links: {
+          first: "/v1/activity-logs?page=1",
+          last: "/v1/activity-logs?page=3",
+          prev: null,
+          next: "/v1/activity-logs?page=2",
+        },
+      });
 
-    renderWithProviders();
+      renderWithProviders();
 
-    await waitFor(() => {
-      expect(screen.getByText(/page 1 of 3/i)).toBeInTheDocument();
-    });
+      await waitFor(() => {
+        expect(screen.getByText(/page 1 of 3/i)).toBeInTheDocument();
+      });
 
-    // Mock page 2 response
-    vi.mocked(activityLogApi.fetchActivityLogs).mockResolvedValue({
-      data: [mockActivity],
-      meta: {
-        current_page: 2,
-        from: 51,
-        last_page: 3,
-        per_page: 50,
-        to: 100,
-        total: 150,
-      },
-      links: {
-        first: "/v1/activity-logs?page=1",
-        last: "/v1/activity-logs?page=3",
-        prev: "/v1/activity-logs?page=1",
-        next: "/v1/activity-logs?page=3",
-      },
-    });
+      // Mock page 2 response
+      vi.mocked(activityLogApi.fetchActivityLogs).mockResolvedValue({
+        data: [mockActivity],
+        meta: {
+          current_page: 2,
+          from: 51,
+          last_page: 3,
+          per_page: 50,
+          to: 100,
+          total: 150,
+        },
+        links: {
+          first: "/v1/activity-logs?page=1",
+          last: "/v1/activity-logs?page=3",
+          prev: "/v1/activity-logs?page=1",
+          next: "/v1/activity-logs?page=3",
+        },
+      });
 
-    const nextButton = screen.getByRole("button", { name: /next/i });
-    fireEvent.click(nextButton);
+      const nextButton = screen.getByRole("button", { name: /next/i });
+      fireEvent.click(nextButton);
 
-    await waitFor(() => {
-      expect(activityLogApi.fetchActivityLogs).toHaveBeenCalledWith(
-        expect.objectContaining({ page: 2 })
-      );
-    });
-  });
+      await waitFor(() => {
+        expect(activityLogApi.fetchActivityLogs).toHaveBeenCalledWith(
+          expect.objectContaining({ page: 2 })
+        );
+      });
+    },
+    SLOW_TEST_TIMEOUT
+  );
 
   it("should display System when no causer", async () => {
     const activityNoCauser: Activity = {

--- a/src/pages/Customers/CustomerEdit.test.tsx
+++ b/src/pages/Customers/CustomerEdit.test.tsx
@@ -73,7 +73,7 @@ describe("CustomerEdit", () => {
       expect(customersApi.getCustomer).toHaveBeenCalledWith("customer-123");
     });
 
-    expect(screen.getByLabelText(/customer name/i)).toHaveValue(
+    expect(await screen.findByLabelText(/customer name/i)).toHaveValue(
       "Existing Customer"
     );
     expect(screen.getByLabelText(/street/i)).toHaveValue("Old Street 10");

--- a/src/pages/Customers/CustomersPage.test.tsx
+++ b/src/pages/Customers/CustomersPage.test.tsx
@@ -65,6 +65,8 @@ const mockResponse: PaginatedResponse<Customer> = {
   },
 };
 
+const QUERY_TIMEOUT = 15000;
+
 describe("CustomersPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -75,7 +77,9 @@ describe("CustomersPage", () => {
     renderWithProviders();
 
     expect(
-      await screen.findByText("Acme Corp", undefined, { timeout: 20000 })
+      await screen.findByText("Acme Corp", undefined, {
+        timeout: QUERY_TIMEOUT,
+      })
     ).toBeInTheDocument();
     expect(screen.getByText("C001")).toBeInTheDocument();
   });

--- a/src/pages/Customers/CustomersPage.test.tsx
+++ b/src/pages/Customers/CustomersPage.test.tsx
@@ -74,13 +74,9 @@ describe("CustomersPage", () => {
   it("should render customers list with table", async () => {
     renderWithProviders();
 
-    await waitFor(() => {
-      expect(
-        screen.getByRole("heading", { name: /customers/i })
-      ).toBeInTheDocument();
-    });
-
-    expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Acme Corp", undefined, { timeout: 20000 })
+    ).toBeInTheDocument();
     expect(screen.getByText("C001")).toBeInTheDocument();
   });
 

--- a/src/pages/Employees/EmployeeCreate.test.tsx
+++ b/src/pages/Employees/EmployeeCreate.test.tsx
@@ -15,6 +15,8 @@ import * as organizationalUnitApi from "../../services/organizationalUnitApi";
 vi.mock("../../services/employeeApi");
 vi.mock("../../services/organizationalUnitApi");
 
+const SLOW_TEST_TIMEOUT = 20000;
+
 // Mock useNavigate
 const mockNavigate = vi.fn();
 vi.mock("react-router-dom", async () => {
@@ -194,7 +196,9 @@ describe("EmployeeCreate", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/employees/emp-123");
   }, 20000);
 
-  it("should display error on create failure", async () => {
+  it(
+    "should display error on create failure",
+    async () => {
     const mockCreateEmployee = vi.mocked(employeeApi.createEmployee);
     mockCreateEmployee.mockRejectedValue(new Error("Server error"));
 
@@ -215,14 +219,16 @@ describe("EmployeeCreate", () => {
       target: { value: "john.doe@example.com" },
     });
     fireEvent.change(screen.getByLabelText(/date of birth/i), {
-      target: { value: "1990-01-01" },
+      target: { value: "01/01/1990" },
     });
+    fireEvent.blur(screen.getByLabelText(/date of birth/i));
     fireEvent.change(screen.getByLabelText("Position *"), {
       target: { value: "Developer" },
     });
     fireEvent.change(screen.getByLabelText(/contract start date/i), {
-      target: { value: "2025-01-01" },
+      target: { value: "01/01/2025" },
     });
+    fireEvent.blur(screen.getByLabelText(/contract start date/i));
     fireEvent.change(screen.getByLabelText(/organizational unit/i), {
       target: { value: "unit-1" },
     });
@@ -235,7 +241,9 @@ describe("EmployeeCreate", () => {
     });
 
     expect(mockNavigate).not.toHaveBeenCalled();
-  });
+    },
+    SLOW_TEST_TIMEOUT
+  );
 
   it("should navigate back to employees on cancel", async () => {
     renderWithProviders(<EmployeeCreate />);
@@ -486,7 +494,9 @@ describe("EmployeeCreate", () => {
       expect(managementLevelInput).toHaveValue(50);
     });
 
-    it("should include management_level in form submission", async () => {
+    it(
+      "should include management_level in form submission",
+      async () => {
       const mockCreateEmployee = vi.mocked(employeeApi.createEmployee);
       mockCreateEmployee.mockResolvedValue({
         id: "emp-123",
@@ -529,14 +539,16 @@ describe("EmployeeCreate", () => {
         target: { value: "john@example.com" },
       });
       fireEvent.change(screen.getByLabelText(/date of birth/i), {
-        target: { value: "1990-01-01" },
+        target: { value: "01/01/1990" },
       });
+      fireEvent.blur(screen.getByLabelText(/date of birth/i));
       fireEvent.change(screen.getByLabelText("Position *"), {
         target: { value: "CEO" },
       });
       fireEvent.change(screen.getByLabelText(/contract start date/i), {
-        target: { value: "2025-01-01" },
+        target: { value: "01/01/2025" },
       });
+      fireEvent.blur(screen.getByLabelText(/contract start date/i));
       fireEvent.change(screen.getByLabelText(/organizational unit/i), {
         target: { value: "unit-1" },
       });
@@ -558,7 +570,9 @@ describe("EmployeeCreate", () => {
           })
         );
       });
-    });
+      },
+      SLOW_TEST_TIMEOUT
+    );
   });
 
   describe("Date Validation", () => {

--- a/src/pages/Employees/EmployeeCreate.test.tsx
+++ b/src/pages/Employees/EmployeeCreate.test.tsx
@@ -199,48 +199,48 @@ describe("EmployeeCreate", () => {
   it(
     "should display error on create failure",
     async () => {
-    const mockCreateEmployee = vi.mocked(employeeApi.createEmployee);
-    mockCreateEmployee.mockRejectedValue(new Error("Server error"));
+      const mockCreateEmployee = vi.mocked(employeeApi.createEmployee);
+      mockCreateEmployee.mockRejectedValue(new Error("Server error"));
 
-    renderWithProviders(<EmployeeCreate />);
+      renderWithProviders(<EmployeeCreate />);
 
-    await waitFor(() => {
-      expect(screen.getByText("Main Office")).toBeInTheDocument();
-    });
+      await waitFor(() => {
+        expect(screen.getByText("Main Office")).toBeInTheDocument();
+      });
 
-    // Fill in minimal required fields
-    fireEvent.change(screen.getByLabelText(/first name/i), {
-      target: { value: "John" },
-    });
-    fireEvent.change(screen.getByLabelText(/last name/i), {
-      target: { value: "Doe" },
-    });
-    fireEvent.change(screen.getByLabelText(/email/i), {
-      target: { value: "john.doe@example.com" },
-    });
-    fireEvent.change(screen.getByLabelText(/date of birth/i), {
-      target: { value: "01/01/1990" },
-    });
-    fireEvent.blur(screen.getByLabelText(/date of birth/i));
-    fireEvent.change(screen.getByLabelText("Position *"), {
-      target: { value: "Developer" },
-    });
-    fireEvent.change(screen.getByLabelText(/contract start date/i), {
-      target: { value: "01/01/2025" },
-    });
-    fireEvent.blur(screen.getByLabelText(/contract start date/i));
-    fireEvent.change(screen.getByLabelText(/organizational unit/i), {
-      target: { value: "unit-1" },
-    });
+      // Fill in minimal required fields
+      fireEvent.change(screen.getByLabelText(/first name/i), {
+        target: { value: "John" },
+      });
+      fireEvent.change(screen.getByLabelText(/last name/i), {
+        target: { value: "Doe" },
+      });
+      fireEvent.change(screen.getByLabelText(/email/i), {
+        target: { value: "john.doe@example.com" },
+      });
+      fireEvent.change(screen.getByLabelText(/date of birth/i), {
+        target: { value: "01/01/1990" },
+      });
+      fireEvent.blur(screen.getByLabelText(/date of birth/i));
+      fireEvent.change(screen.getByLabelText("Position *"), {
+        target: { value: "Developer" },
+      });
+      fireEvent.change(screen.getByLabelText(/contract start date/i), {
+        target: { value: "01/01/2025" },
+      });
+      fireEvent.blur(screen.getByLabelText(/contract start date/i));
+      fireEvent.change(screen.getByLabelText(/organizational unit/i), {
+        target: { value: "unit-1" },
+      });
 
-    // Submit
-    submitEmployeeCreateForm();
+      // Submit
+      submitEmployeeCreateForm();
 
-    await waitFor(() => {
-      expect(screen.getByText(/server error/i)).toBeInTheDocument();
-    });
+      await waitFor(() => {
+        expect(screen.getByText(/server error/i)).toBeInTheDocument();
+      });
 
-    expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
     },
     SLOW_TEST_TIMEOUT
   );
@@ -497,79 +497,81 @@ describe("EmployeeCreate", () => {
     it(
       "should include management_level in form submission",
       async () => {
-      const mockCreateEmployee = vi.mocked(employeeApi.createEmployee);
-      mockCreateEmployee.mockResolvedValue({
-        id: "emp-123",
-        employee_number: "EMP001",
-        first_name: "John",
-        last_name: "Doe",
-        full_name: "John Doe",
-        email: "john@example.com",
-        phone: "",
-        date_of_birth: "1990-01-01",
-        hire_date: "2025-01-01",
-        contract_start_date: "2025-01-01",
-        position: "CEO",
-        status: "active",
-        contract_type: "full_time",
-        management_level: 1,
-        organizational_unit: {
-          id: "unit-1",
-          name: "Main Office",
-        },
-        user: undefined,
-        created_at: "2025-01-01T00:00:00Z",
-        updated_at: "2025-01-01T00:00:00Z",
-      });
+        const mockCreateEmployee = vi.mocked(employeeApi.createEmployee);
+        mockCreateEmployee.mockResolvedValue({
+          id: "emp-123",
+          employee_number: "EMP001",
+          first_name: "John",
+          last_name: "Doe",
+          full_name: "John Doe",
+          email: "john@example.com",
+          phone: "",
+          date_of_birth: "1990-01-01",
+          hire_date: "2025-01-01",
+          contract_start_date: "2025-01-01",
+          position: "CEO",
+          status: "active",
+          contract_type: "full_time",
+          management_level: 1,
+          organizational_unit: {
+            id: "unit-1",
+            name: "Main Office",
+          },
+          user: undefined,
+          created_at: "2025-01-01T00:00:00Z",
+          updated_at: "2025-01-01T00:00:00Z",
+        });
 
-      renderWithProviders(<EmployeeCreate />);
+        renderWithProviders(<EmployeeCreate />);
 
-      await waitFor(() => {
-        expect(screen.getByText("Main Office")).toBeInTheDocument();
-      });
+        await waitFor(() => {
+          expect(screen.getByText("Main Office")).toBeInTheDocument();
+        });
 
-      // Fill form with leadership position
-      fireEvent.change(screen.getByLabelText(/first name/i), {
-        target: { value: "John" },
-      });
-      fireEvent.change(screen.getByLabelText(/last name/i), {
-        target: { value: "Doe" },
-      });
-      fireEvent.change(screen.getByLabelText(/email/i), {
-        target: { value: "john@example.com" },
-      });
-      fireEvent.change(screen.getByLabelText(/date of birth/i), {
-        target: { value: "01/01/1990" },
-      });
-      fireEvent.blur(screen.getByLabelText(/date of birth/i));
-      fireEvent.change(screen.getByLabelText("Position *"), {
-        target: { value: "CEO" },
-      });
-      fireEvent.change(screen.getByLabelText(/contract start date/i), {
-        target: { value: "01/01/2025" },
-      });
-      fireEvent.blur(screen.getByLabelText(/contract start date/i));
-      fireEvent.change(screen.getByLabelText(/organizational unit/i), {
-        target: { value: "unit-1" },
-      });
+        // Fill form with leadership position
+        fireEvent.change(screen.getByLabelText(/first name/i), {
+          target: { value: "John" },
+        });
+        fireEvent.change(screen.getByLabelText(/last name/i), {
+          target: { value: "Doe" },
+        });
+        fireEvent.change(screen.getByLabelText(/email/i), {
+          target: { value: "john@example.com" },
+        });
+        fireEvent.change(screen.getByLabelText(/date of birth/i), {
+          target: { value: "01/01/1990" },
+        });
+        fireEvent.blur(screen.getByLabelText(/date of birth/i));
+        fireEvent.change(screen.getByLabelText("Position *"), {
+          target: { value: "CEO" },
+        });
+        fireEvent.change(screen.getByLabelText(/contract start date/i), {
+          target: { value: "01/01/2025" },
+        });
+        fireEvent.blur(screen.getByLabelText(/contract start date/i));
+        fireEvent.change(screen.getByLabelText(/organizational unit/i), {
+          target: { value: "unit-1" },
+        });
 
-      // Enable leadership and set management level
-      const leadershipSwitch = screen.getByRole("switch");
-      fireEvent.click(leadershipSwitch);
+        // Enable leadership and set management level
+        const leadershipSwitch = screen.getByRole("switch");
+        fireEvent.click(leadershipSwitch);
 
-      const managementLevelInput = screen.getByRole("spinbutton");
-      fireEvent.change(managementLevelInput, { target: { value: "1" } });
+        const managementLevelInput = screen.getByRole("spinbutton");
+        fireEvent.change(managementLevelInput, { target: { value: "1" } });
 
-      // Submit
-      fireEvent.click(screen.getByRole("button", { name: /create employee/i }));
-
-      await waitFor(() => {
-        expect(mockCreateEmployee).toHaveBeenCalledWith(
-          expect.objectContaining({
-            management_level: 1,
-          })
+        // Submit
+        fireEvent.click(
+          screen.getByRole("button", { name: /create employee/i })
         );
-      });
+
+        await waitFor(() => {
+          expect(mockCreateEmployee).toHaveBeenCalledWith(
+            expect.objectContaining({
+              management_level: 1,
+            })
+          );
+        });
       },
       SLOW_TEST_TIMEOUT
     );

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -89,7 +89,7 @@ describe("Login", () => {
     expect(
       screen.getByRole("heading", { name: /secpal/i })
     ).toBeInTheDocument();
-    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(await screen.findByLabelText(/email/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
 
     // Wait for health check to complete

--- a/src/pages/Organization/OrganizationPage.test.tsx
+++ b/src/pages/Organization/OrganizationPage.test.tsx
@@ -34,6 +34,8 @@ const renderWithProviders = (component: React.ReactNode) => {
 };
 
 describe("OrganizationPage", () => {
+  const SLOW_TEST_TIMEOUT = 20000;
+
   const mockUnits: OrganizationalUnit[] = [
     {
       id: "unit-1",
@@ -281,48 +283,54 @@ describe("OrganizationPage", () => {
     });
   });
 
-  it("shows success toast after creating a unit", async () => {
-    const user = userEvent.setup();
-    const newUnit: OrganizationalUnit = {
-      id: "new-unit",
-      type: "branch",
-      name: "New Branch",
-      description: null,
-      created_at: "2025-01-01T00:00:00Z",
-      updated_at: "2025-01-01T00:00:00Z",
-    };
+  it(
+    "shows success toast after creating a unit",
+    async () => {
+      const user = userEvent.setup();
+      const newUnit: OrganizationalUnit = {
+        id: "new-unit",
+        type: "branch",
+        name: "New Branch",
+        description: null,
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+      };
 
-    vi.mocked(organizationalUnitApi.createOrganizationalUnit).mockResolvedValue(
-      newUnit
-    );
+      vi.mocked(
+        organizationalUnitApi.createOrganizationalUnit
+      ).mockResolvedValue(newUnit);
 
-    renderWithProviders(<OrganizationPage />);
+      renderWithProviders(<OrganizationPage />);
 
-    await waitFor(() => {
-      expect(screen.getByText("SecPal Holding")).toBeInTheDocument();
-    });
+      await waitFor(() => {
+        expect(screen.getByText("SecPal Holding")).toBeInTheDocument();
+      });
 
-    // Open create dialog
-    await user.click(screen.getByRole("button", { name: /Add Root Unit/i }));
+      await user.click(screen.getByRole("button", { name: /Add Root Unit/i }));
 
-    await waitFor(() => {
+      await waitFor(() => {
+        expect(
+          screen.getByText("Create Organizational Unit")
+        ).toBeInTheDocument();
+      });
+
+      const nameInput = screen.getByPlaceholderText(/e\.g\., Berlin Branch/i);
+      await user.type(nameInput, "New Branch");
+
+      await user.click(screen.getByRole("button", { name: /^Create$/i }));
+
       expect(
-        screen.getByText("Create Organizational Unit")
+        await screen.findByText(
+          /created successfully/i,
+          {},
+          {
+            timeout: SLOW_TEST_TIMEOUT,
+          }
+        )
       ).toBeInTheDocument();
-    });
-
-    // Fill form
-    const nameInput = screen.getByPlaceholderText(/e\.g\., Berlin Branch/i);
-    await user.type(nameInput, "New Branch");
-
-    // Submit
-    await user.click(screen.getByRole("button", { name: /^Create$/i }));
-
-    // Success toast should appear
-    await waitFor(() => {
-      expect(screen.getByText(/created successfully/i)).toBeInTheDocument();
-    });
-  });
+    },
+    SLOW_TEST_TIMEOUT
+  );
 
   it("shows all type labels translated correctly", async () => {
     const user = userEvent.setup();

--- a/src/pages/Organization/OrganizationPage.test.tsx
+++ b/src/pages/Organization/OrganizationPage.test.tsx
@@ -35,6 +35,7 @@ const renderWithProviders = (component: React.ReactNode) => {
 
 describe("OrganizationPage", () => {
   const SLOW_TEST_TIMEOUT = 20000;
+  const QUERY_TIMEOUT = 15000;
 
   const mockUnits: OrganizationalUnit[] = [
     {
@@ -324,7 +325,7 @@ describe("OrganizationPage", () => {
           /created successfully/i,
           {},
           {
-            timeout: SLOW_TEST_TIMEOUT,
+            timeout: QUERY_TIMEOUT,
           }
         )
       ).toBeInTheDocument();

--- a/src/pages/Secrets/SecretDetail.test.tsx
+++ b/src/pages/Secrets/SecretDetail.test.tsx
@@ -187,8 +187,10 @@ describe("SecretDetail", () => {
     await user.click(showButton);
 
     // Password should be visible
-    expect(screen.getByText("super-secret-password")).toBeInTheDocument();
-    expect(screen.queryByText("••••••••••••")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("super-secret-password")).toBeInTheDocument();
+      expect(screen.queryByText("••••••••••••")).not.toBeInTheDocument();
+    });
 
     // Button should change to Hide
     expect(
@@ -742,12 +744,15 @@ describe("SecretDetail", () => {
     });
     await user.click(previewButton);
 
-    await waitFor(() => {
-      expect(screen.getByRole("dialog")).toBeInTheDocument();
-    });
+    const closeButton = await screen.findByRole(
+      "button",
+      { name: /close preview/i },
+      { timeout: 10000 }
+    );
+
+    expect(createObjectURLSpy).toHaveBeenCalledWith(mockFile);
 
     // Close modal
-    const closeButton = screen.getByRole("button", { name: /close preview/i });
     await user.click(closeButton);
 
     await waitFor(() => {

--- a/src/pages/Sites/SiteCreate.test.tsx
+++ b/src/pages/Sites/SiteCreate.test.tsx
@@ -159,9 +159,11 @@ describe("SiteCreate", () => {
   it("displays form fields", async () => {
     renderWithRouter();
 
-    await waitFor(() => {
-      expect(screen.getByLabelText(/customer/i)).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByLabelText(/customer/i, undefined, {
+        timeout: SLOW_TEST_TIMEOUT,
+      })
+    ).toBeInTheDocument();
 
     expect(screen.getByLabelText(/organizational unit/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/site name/i)).toBeInTheDocument();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -247,8 +247,8 @@ export default defineConfig(({ mode }) => {
       clearMocks: true,
       unstubGlobals: true,
       unstubEnvs: true,
-      testTimeout: 10000, // 10 seconds per test (default is 5s)
-      hookTimeout: 10000, // 10 seconds for beforeEach/afterEach hooks
+      testTimeout: 20000, // 20 seconds per test to keep full-suite UI tests stable under CI load
+      hookTimeout: 20000, // 20 seconds for beforeEach/afterEach hooks
       // Exclude Playwright E2E tests (run separately via npm run test:e2e)
       exclude: ["**/node_modules/**", "**/dist/**", "**/tests/e2e/**"],
       coverage: {


### PR DESCRIPTION
## Summary
- remediate the transitive yauzl audit finding and refresh the currently compatible frontend package baselines
- stabilize the previously flaky full-suite Vitest cases exposed by the dependency refresh
- raise the frontend Vitest timeout ceiling so legitimate UI tests stay stable under full-suite load

## Validation
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build

## Notes
- Uses the documented large-PR exception path because the dependency refresh and the required test stabilizations form one coherent, validated maintenance change
