### PR TITLE
test(frontend): stabilize flaky vitest hotspots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Stabilized several interaction-heavy frontend tests by reusing the shared test i18n instance, mocking lazy dialog and listbox edges, and making async form/upload assertions deterministic in Vitest
+- Hardened the `EmployeeCreate` success-path test to wait for loaded organizational-unit options and async navigation, reducing full-suite timeout flakiness
+- Hardened additional full-suite-sensitive submit flows in `Login`, `ApplicationLayout`, and `CustomerCreate` tests to reduce timing-dependent Vitest failures
 
 ### Added
 

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -39,6 +39,23 @@ const renderWithProviders = (
   );
 };
 
+async function openUserMenu() {
+  const userMenuButton = screen.getByRole("button", {
+    name: /user menu/i,
+  });
+
+  fireEvent.click(userMenuButton);
+
+  await waitFor(
+    () => {
+      expect(userMenuButton).toHaveAttribute("aria-expanded", "true");
+    },
+    { timeout: 15000 }
+  );
+
+  return userMenuButton;
+}
+
 describe("ApplicationLayout", () => {
   const SLOW_TEST_TIMEOUT = 20000;
   const QUERY_TIMEOUT = 15000;
@@ -166,18 +183,13 @@ describe("ApplicationLayout", () => {
     it(
       "opens navbar dropdown when clicking user menu button",
       async () => {
-        const user = userEvent.setup();
-
         renderWithProviders(
           <ApplicationLayout>
             <div>Content</div>
           </ApplicationLayout>
         );
 
-        const userMenuButton = screen.getByRole("button", {
-          name: /user menu/i,
-        });
-        await user.click(userMenuButton);
+        await openUserMenu();
 
         expect(
           await screen.findByRole(
@@ -196,18 +208,13 @@ describe("ApplicationLayout", () => {
     it(
       "has profile link in navbar dropdown",
       async () => {
-        const user = userEvent.setup();
-
         renderWithProviders(
           <ApplicationLayout>
             <div>Content</div>
           </ApplicationLayout>
         );
 
-        const userMenuButton = screen.getByRole("button", {
-          name: /user menu/i,
-        });
-        await user.click(userMenuButton);
+        await openUserMenu();
 
         const profileItem = await screen.findByRole(
           "menuitem",
@@ -225,18 +232,13 @@ describe("ApplicationLayout", () => {
     it(
       "has settings link in navbar dropdown",
       async () => {
-        const user = userEvent.setup();
-
         renderWithProviders(
           <ApplicationLayout>
             <div>Content</div>
           </ApplicationLayout>
         );
 
-        const userMenuButton = screen.getByRole("button", {
-          name: /user menu/i,
-        });
-        await user.click(userMenuButton);
+        await openUserMenu();
 
         const settingsItem = await screen.findByRole(
           "menuitem",
@@ -262,10 +264,7 @@ describe("ApplicationLayout", () => {
           </ApplicationLayout>
         );
 
-        const userMenuButton = screen.getByRole("button", {
-          name: /user menu/i,
-        });
-        await user.click(userMenuButton);
+        await openUserMenu();
 
         const signOutItem = await screen.findByRole(
           "menuitem",
@@ -295,15 +294,7 @@ describe("ApplicationLayout", () => {
         </ApplicationLayout>
       );
 
-      // Open dropdown (navbar user menu)
-      const dropdownButton = screen.getByRole("button", {
-        name: /user menu/i,
-      });
-      fireEvent.click(dropdownButton);
-
-      await waitFor(() => {
-        expect(screen.getByText("Sign out")).toBeInTheDocument();
-      });
+      await openUserMenu();
 
       // Click sign out
       const signOutButton = screen.getByRole("menuitem", { name: /sign out/i });
@@ -333,15 +324,7 @@ describe("ApplicationLayout", () => {
         </ApplicationLayout>
       );
 
-      // Open dropdown (navbar user menu)
-      const dropdownButton = screen.getByRole("button", {
-        name: /user menu/i,
-      });
-      fireEvent.click(dropdownButton);
-
-      await waitFor(() => {
-        expect(screen.getByText("Sign out")).toBeInTheDocument();
-      });
+      await openUserMenu();
 
       // Click sign out
       const signOutButton = screen.getByRole("menuitem", { name: /sign out/i });
@@ -367,15 +350,7 @@ describe("ApplicationLayout", () => {
         </ApplicationLayout>
       );
 
-      // Open dropdown (navbar user menu)
-      const dropdownButton = screen.getByRole("button", {
-        name: /user menu/i,
-      });
-      fireEvent.click(dropdownButton);
-
-      await waitFor(() => {
-        expect(screen.getByText("Sign out")).toBeInTheDocument();
-      });
+      await openUserMenu();
 
       // Click sign out
       const signOutButton = screen.getByRole("menuitem", { name: /sign out/i });

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -17,6 +17,8 @@ vi.mock("../lib/clientStateCleanup", () => ({
   clearSensitiveClientState: vi.fn().mockResolvedValue(undefined),
 }));
 
+const QUERY_TIMEOUT = 15000;
+
 // Mock ResizeObserver for HeadlessUI Menu component
 beforeAll(() => {
   global.ResizeObserver = class ResizeObserver {
@@ -50,7 +52,7 @@ async function openUserMenu() {
     () => {
       expect(userMenuButton).toHaveAttribute("aria-expanded", "true");
     },
-    { timeout: 15000 }
+    { timeout: QUERY_TIMEOUT }
   );
 
   return userMenuButton;
@@ -58,7 +60,6 @@ async function openUserMenu() {
 
 describe("ApplicationLayout", () => {
   const SLOW_TEST_TIMEOUT = 20000;
-  const QUERY_TIMEOUT = 15000;
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/pages/Customers/CustomerCreate.test.tsx
+++ b/src/pages/Customers/CustomerCreate.test.tsx
@@ -14,6 +14,8 @@ import * as customersApi from "../../services/customersApi";
 vi.mock("../../services/customersApi");
 
 const SLOW_TEST_TIMEOUT = 20000;
+const VERY_SLOW_TEST_TIMEOUT = 40000;
+const QUERY_TIMEOUT = 15000;
 
 const mockNavigate = vi.fn();
 vi.mock("react-router-dom", async () => {
@@ -54,7 +56,7 @@ describe("CustomerCreate", () => {
         screen.getByRole("button", { name: /cancel/i })
       ).toBeInTheDocument();
     },
-    SLOW_TEST_TIMEOUT
+    VERY_SLOW_TEST_TIMEOUT
   );
 
   it("renders contact fields", () => {
@@ -134,7 +136,6 @@ describe("CustomerCreate", () => {
   it(
     "submits form with contact information",
     async () => {
-      const user = userEvent.setup();
       const mockCustomer = {
         id: "customer-456",
         name: "Customer with Contact",
@@ -186,28 +187,38 @@ describe("CustomerCreate", () => {
         target: { value: "+49 123 456789" },
       });
 
-      // Submit
-      await user.click(
-        screen.getByRole("button", { name: /create customer/i })
+      await waitFor(
+        () => {
+          expect(screen.getByRole("textbox", { name: /phone/i })).toHaveValue(
+            "+49 123 456789"
+          );
+        },
+        { timeout: QUERY_TIMEOUT }
       );
 
-      await waitFor(() => {
-        expect(customersApi.createCustomer).toHaveBeenCalledWith({
-          name: "Customer with Contact",
-          billing_address: {
-            street: "Street 1",
-            city: "City",
-            postal_code: "12345",
-            country: "DE",
-          },
-          contact: {
-            name: "John Doe",
-            email: "john@example.com",
-            phone: "+49 123 456789",
-          },
-          is_active: true,
-        });
-      });
+      // Submit
+      fireEvent.click(screen.getByRole("button", { name: /create customer/i }));
+
+      await waitFor(
+        () => {
+          expect(customersApi.createCustomer).toHaveBeenCalledWith({
+            name: "Customer with Contact",
+            billing_address: {
+              street: "Street 1",
+              city: "City",
+              postal_code: "12345",
+              country: "DE",
+            },
+            contact: {
+              name: "John Doe",
+              email: "john@example.com",
+              phone: "+49 123 456789",
+            },
+            is_active: true,
+          });
+        },
+        { timeout: QUERY_TIMEOUT }
+      );
     },
     SLOW_TEST_TIMEOUT
   );

--- a/src/pages/Customers/CustomerCreate.test.tsx
+++ b/src/pages/Customers/CustomerCreate.test.tsx
@@ -14,7 +14,6 @@ import * as customersApi from "../../services/customersApi";
 vi.mock("../../services/customersApi");
 
 const SLOW_TEST_TIMEOUT = 20000;
-const VERY_SLOW_TEST_TIMEOUT = 40000;
 const QUERY_TIMEOUT = 15000;
 
 const mockNavigate = vi.fn();
@@ -39,25 +38,19 @@ describe("CustomerCreate", () => {
     vi.clearAllMocks();
   });
 
-  it(
-    "renders the form with all required fields",
-    () => {
-      renderWithRouter(<CustomerCreate />);
+  it("renders the form with all required fields", () => {
+    renderWithRouter(<CustomerCreate />);
 
-      expect(screen.getByLabelText(/customer name/i)).toBeInTheDocument();
-      expect(screen.getByLabelText(/street/i)).toBeInTheDocument();
-      expect(screen.getByLabelText(/postal code/i)).toBeInTheDocument();
-      expect(screen.getByLabelText(/city/i)).toBeInTheDocument();
-      expect(screen.getByLabelText(/country/i)).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: /create customer/i })
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: /cancel/i })
-      ).toBeInTheDocument();
-    },
-    VERY_SLOW_TEST_TIMEOUT
-  );
+    expect(screen.getByLabelText(/customer name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/street/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/postal code/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/city/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/country/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /create customer/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+  });
 
   it("renders contact fields", () => {
     renderWithRouter(<CustomerCreate />);

--- a/src/pages/Employees/EmployeeCreate.test.tsx
+++ b/src/pages/Employees/EmployeeCreate.test.tsx
@@ -16,6 +16,7 @@ vi.mock("../../services/employeeApi");
 vi.mock("../../services/organizationalUnitApi");
 
 const SLOW_TEST_TIMEOUT = 20000;
+const VERY_SLOW_TEST_TIMEOUT = 30000;
 const QUERY_TIMEOUT = 15000;
 
 // Mock useNavigate
@@ -210,7 +211,7 @@ describe("EmployeeCreate", () => {
       },
       { timeout: QUERY_TIMEOUT }
     );
-  }, 30000);
+  }, VERY_SLOW_TEST_TIMEOUT);
 
   it(
     "should display error on create failure",

--- a/src/pages/Employees/EmployeeCreate.test.tsx
+++ b/src/pages/Employees/EmployeeCreate.test.tsx
@@ -16,6 +16,7 @@ vi.mock("../../services/employeeApi");
 vi.mock("../../services/organizationalUnitApi");
 
 const SLOW_TEST_TIMEOUT = 20000;
+const QUERY_TIMEOUT = 15000;
 
 // Mock useNavigate
 const mockNavigate = vi.fn();
@@ -37,11 +38,7 @@ const renderWithProviders = (component: React.ReactNode) => {
 };
 
 function submitEmployeeCreateForm() {
-  const submitButton = screen.getByRole("button", { name: /create employee/i });
-  const form = submitButton.closest("form");
-
-  expect(form).not.toBeNull();
-  fireEvent.submit(form!);
+  fireEvent.click(screen.getByRole("button", { name: /create employee/i }));
 }
 
 const mockOrganizationalUnits = [
@@ -146,6 +143,11 @@ describe("EmployeeCreate", () => {
       expect(organizationalUnitApi.listOrganizationalUnits).toHaveBeenCalled();
     });
 
+    await waitFor(() => {
+      expect(screen.getByText("Main Office")).toBeInTheDocument();
+      expect(screen.getByLabelText(/organizational unit/i)).not.toBeDisabled();
+    });
+
     // Fill in form
     fireEvent.change(screen.getByLabelText(/first name/i), {
       target: { value: "John" },
@@ -174,27 +176,41 @@ describe("EmployeeCreate", () => {
       target: { value: "unit-1" },
     });
 
+    await waitFor(() => {
+      expect(screen.getByLabelText(/organizational unit/i)).toHaveValue(
+        "unit-1"
+      );
+    });
+
     // Submit
     submitEmployeeCreateForm();
 
-    await waitFor(() => {
-      expect(mockCreateEmployee).toHaveBeenCalledWith({
-        first_name: "John",
-        last_name: "Doe",
-        email: "john.doe@example.com",
-        phone: "+1234567890",
-        date_of_birth: "1990-01-01",
-        position: "Developer",
-        contract_start_date: "2025-01-01",
-        organizational_unit_id: "unit-1",
-        management_level: 0,
-        status: "pre_contract",
-        contract_type: "full_time",
-      });
-    });
+    await waitFor(
+      () => {
+        expect(mockCreateEmployee).toHaveBeenCalledWith({
+          first_name: "John",
+          last_name: "Doe",
+          email: "john.doe@example.com",
+          phone: "+1234567890",
+          date_of_birth: "1990-01-01",
+          position: "Developer",
+          contract_start_date: "2025-01-01",
+          organizational_unit_id: "unit-1",
+          management_level: 0,
+          status: "pre_contract",
+          contract_type: "full_time",
+        });
+      },
+      { timeout: QUERY_TIMEOUT }
+    );
 
-    expect(mockNavigate).toHaveBeenCalledWith("/employees/emp-123");
-  }, 20000);
+    await waitFor(
+      () => {
+        expect(mockNavigate).toHaveBeenCalledWith("/employees/emp-123");
+      },
+      { timeout: QUERY_TIMEOUT }
+    );
+  }, 30000);
 
   it(
     "should display error on create failure",

--- a/src/pages/Employees/EmployeeCreate.test.tsx
+++ b/src/pages/Employees/EmployeeCreate.test.tsx
@@ -112,106 +112,114 @@ describe("EmployeeCreate", () => {
     });
   });
 
-  it("should create employee and navigate on success", async () => {
-    const mockCreateEmployee = vi.mocked(employeeApi.createEmployee);
-    mockCreateEmployee.mockResolvedValue({
-      id: "emp-123",
-      employee_number: "EMP001",
-      first_name: "John",
-      last_name: "Doe",
-      full_name: "John Doe",
-      email: "john.doe@example.com",
-      phone: "+1234567890",
-      date_of_birth: "1990-01-01",
-      hire_date: "2025-01-01",
-      contract_start_date: "2025-01-01",
-      position: "Developer",
-      status: "active",
-      contract_type: "full_time",
-      management_level: 0,
-      organizational_unit: {
-        id: "unit-1",
-        name: "Main Office",
-      },
-      user: undefined,
-      created_at: "2025-01-01T00:00:00Z",
-      updated_at: "2025-01-01T00:00:00Z",
-    });
+  it(
+    "should create employee and navigate on success",
+    async () => {
+      const mockCreateEmployee = vi.mocked(employeeApi.createEmployee);
+      mockCreateEmployee.mockResolvedValue({
+        id: "emp-123",
+        employee_number: "EMP001",
+        first_name: "John",
+        last_name: "Doe",
+        full_name: "John Doe",
+        email: "john.doe@example.com",
+        phone: "+1234567890",
+        date_of_birth: "1990-01-01",
+        hire_date: "2025-01-01",
+        contract_start_date: "2025-01-01",
+        position: "Developer",
+        status: "active",
+        contract_type: "full_time",
+        management_level: 0,
+        organizational_unit: {
+          id: "unit-1",
+          name: "Main Office",
+        },
+        user: undefined,
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+      });
 
-    renderWithProviders(<EmployeeCreate />);
+      renderWithProviders(<EmployeeCreate />);
 
-    await waitFor(() => {
-      expect(organizationalUnitApi.listOrganizationalUnits).toHaveBeenCalled();
-    });
+      await waitFor(() => {
+        expect(
+          organizationalUnitApi.listOrganizationalUnits
+        ).toHaveBeenCalled();
+      });
 
-    await waitFor(() => {
-      expect(screen.getByText("Main Office")).toBeInTheDocument();
-      expect(screen.getByLabelText(/organizational unit/i)).not.toBeDisabled();
-    });
+      await waitFor(() => {
+        expect(screen.getByText("Main Office")).toBeInTheDocument();
+        expect(
+          screen.getByLabelText(/organizational unit/i)
+        ).not.toBeDisabled();
+      });
 
-    // Fill in form
-    fireEvent.change(screen.getByLabelText(/first name/i), {
-      target: { value: "John" },
-    });
-    fireEvent.change(screen.getByLabelText(/last name/i), {
-      target: { value: "Doe" },
-    });
-    fireEvent.change(screen.getByLabelText(/email/i), {
-      target: { value: "john.doe@example.com" },
-    });
-    fireEvent.change(screen.getByLabelText(/phone/i), {
-      target: { value: "+1234567890" },
-    });
-    fireEvent.change(screen.getByLabelText(/date of birth/i), {
-      target: { value: "01/01/1990" },
-    });
-    fireEvent.blur(screen.getByLabelText(/date of birth/i));
-    fireEvent.change(screen.getByLabelText("Position *"), {
-      target: { value: "Developer" },
-    });
-    fireEvent.change(screen.getByLabelText(/contract start date/i), {
-      target: { value: "01/01/2025" },
-    });
-    fireEvent.blur(screen.getByLabelText(/contract start date/i));
-    fireEvent.change(screen.getByLabelText(/organizational unit/i), {
-      target: { value: "unit-1" },
-    });
+      // Fill in form
+      fireEvent.change(screen.getByLabelText(/first name/i), {
+        target: { value: "John" },
+      });
+      fireEvent.change(screen.getByLabelText(/last name/i), {
+        target: { value: "Doe" },
+      });
+      fireEvent.change(screen.getByLabelText(/email/i), {
+        target: { value: "john.doe@example.com" },
+      });
+      fireEvent.change(screen.getByLabelText(/phone/i), {
+        target: { value: "+1234567890" },
+      });
+      fireEvent.change(screen.getByLabelText(/date of birth/i), {
+        target: { value: "01/01/1990" },
+      });
+      fireEvent.blur(screen.getByLabelText(/date of birth/i));
+      fireEvent.change(screen.getByLabelText("Position *"), {
+        target: { value: "Developer" },
+      });
+      fireEvent.change(screen.getByLabelText(/contract start date/i), {
+        target: { value: "01/01/2025" },
+      });
+      fireEvent.blur(screen.getByLabelText(/contract start date/i));
+      fireEvent.change(screen.getByLabelText(/organizational unit/i), {
+        target: { value: "unit-1" },
+      });
 
-    await waitFor(() => {
-      expect(screen.getByLabelText(/organizational unit/i)).toHaveValue(
-        "unit-1"
+      await waitFor(() => {
+        expect(screen.getByLabelText(/organizational unit/i)).toHaveValue(
+          "unit-1"
+        );
+      });
+
+      // Submit
+      submitEmployeeCreateForm();
+
+      await waitFor(
+        () => {
+          expect(mockCreateEmployee).toHaveBeenCalledWith({
+            first_name: "John",
+            last_name: "Doe",
+            email: "john.doe@example.com",
+            phone: "+1234567890",
+            date_of_birth: "1990-01-01",
+            position: "Developer",
+            contract_start_date: "2025-01-01",
+            organizational_unit_id: "unit-1",
+            management_level: 0,
+            status: "pre_contract",
+            contract_type: "full_time",
+          });
+        },
+        { timeout: QUERY_TIMEOUT }
       );
-    });
 
-    // Submit
-    submitEmployeeCreateForm();
-
-    await waitFor(
-      () => {
-        expect(mockCreateEmployee).toHaveBeenCalledWith({
-          first_name: "John",
-          last_name: "Doe",
-          email: "john.doe@example.com",
-          phone: "+1234567890",
-          date_of_birth: "1990-01-01",
-          position: "Developer",
-          contract_start_date: "2025-01-01",
-          organizational_unit_id: "unit-1",
-          management_level: 0,
-          status: "pre_contract",
-          contract_type: "full_time",
-        });
-      },
-      { timeout: QUERY_TIMEOUT }
-    );
-
-    await waitFor(
-      () => {
-        expect(mockNavigate).toHaveBeenCalledWith("/employees/emp-123");
-      },
-      { timeout: QUERY_TIMEOUT }
-    );
-  }, VERY_SLOW_TEST_TIMEOUT);
+      await waitFor(
+        () => {
+          expect(mockNavigate).toHaveBeenCalledWith("/employees/emp-123");
+        },
+        { timeout: QUERY_TIMEOUT }
+      );
+    },
+    VERY_SLOW_TEST_TIMEOUT
+  );
 
   it(
     "should display error on create failure",

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -121,6 +121,10 @@ describe("Login", () => {
     const passwordInput = screen.getByLabelText(/password/i);
     const submitButton = screen.getByRole("button", { name: /log in/i });
 
+    await waitFor(() => {
+      expect(submitButton).toBeEnabled();
+    });
+
     fireEvent.change(emailInput, { target: { value: "test@example.com" } });
     fireEvent.change(passwordInput, { target: { value: "password123" } });
     fireEvent.click(submitButton);


### PR DESCRIPTION
## Summary
- stabilize the full-suite-sensitive EmployeeCreate success path with deterministic org-unit readiness checks
- harden Login, ApplicationLayout, and CustomerCreate interaction flows against timing-dependent failures
- document the flaky-test stabilization in CHANGELOG.md

## Validation
- npm run lint
- npm run typecheck
- npm run test:run

Closes #520