### PR TITLE
feat(frontend): schedule offline sync retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Offline sync queue retry scheduling now persists `nextRetryAt` timestamps so pending operations can wait for their backoff window instead of retrying immediately on every local processing pass
 - `.github/instructions/react-typescript.instructions.md` - targeted React and strict TypeScript guidance for frontend source and test files
 - `.github/instructions/github-workflows.instructions.md` - targeted workflow and Dependabot guidance for GitHub automation files in this repo
 - `.github/instructions/org-shared.instructions.md` — org-wide Copilot principles (TDD, quality gates, PR protocol) auto-loaded for all files via `applyTo: "**"`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Offline sync queue retry scheduling now persists `nextRetryAt` timestamps so pending operations can wait for their backoff window instead of retrying immediately on every local processing pass
+- Sync status UI now surfaces the next scheduled offline retry time and hides the manual sync trigger while pending operations are still in their backoff window
 - `.github/instructions/react-typescript.instructions.md` - targeted React and strict TypeScript guidance for frontend source and test files
 - `.github/instructions/github-workflows.instructions.md` - targeted workflow and Dependabot guidance for GitHub automation files in this repo
 - `.github/instructions/org-shared.instructions.md` — org-wide Copilot principles (TDD, quality gates, PR protocol) auto-loaded for all files via `applyTo: "**"`

--- a/src/components/SyncStatusIndicator.test.tsx
+++ b/src/components/SyncStatusIndicator.test.tsx
@@ -82,7 +82,7 @@ describe("SyncStatusIndicator", () => {
   it("should show the next scheduled retry time for pending operations in backoff", async () => {
     vi.mocked(useOnlineStatusModule.useOnlineStatus).mockReturnValue(true);
 
-    const futureRetryAt = new Date("2026-03-15T17:00:00.000Z");
+    const futureRetryAt = new Date(Date.now() + 60 * 60 * 1000);
 
     await db.syncQueue.add({
       id: "retry-1",
@@ -90,7 +90,7 @@ describe("SyncStatusIndicator", () => {
       entity: "guards",
       data: {},
       status: "pending",
-      createdAt: new Date("2026-03-15T16:55:00.000Z"),
+      createdAt: new Date(),
       attempts: 1,
       nextRetryAt: futureRetryAt,
     });

--- a/src/components/SyncStatusIndicator.test.tsx
+++ b/src/components/SyncStatusIndicator.test.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
@@ -77,6 +77,36 @@ describe("SyncStatusIndicator", () => {
     await waitFor(() => {
       expect(screen.getByText(/2 operation\(s\) pending/i)).toBeInTheDocument();
     });
+  });
+
+  it("should show the next scheduled retry time for pending operations in backoff", async () => {
+    vi.mocked(useOnlineStatusModule.useOnlineStatus).mockReturnValue(true);
+
+    const futureRetryAt = new Date("2026-03-15T17:00:00.000Z");
+
+    await db.syncQueue.add({
+      id: "retry-1",
+      type: "create",
+      entity: "guards",
+      data: {},
+      status: "pending",
+      createdAt: new Date("2026-03-15T16:55:00.000Z"),
+      attempts: 1,
+      nextRetryAt: futureRetryAt,
+    });
+
+    renderWithI18n(<SyncStatusIndicator apiBaseUrl="https://api.secpal.dev" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 operation\(s\) pending/i)).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/next retry:/i)).toBeInTheDocument();
+    });
+
+      expect(screen.getByText(new RegExp(futureRetryAt.toLocaleTimeString(), "i"))).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /sync now/i })).toBeNull();
   });
 
   it("should show error operations count", async () => {

--- a/src/components/SyncStatusIndicator.test.tsx
+++ b/src/components/SyncStatusIndicator.test.tsx
@@ -105,7 +105,9 @@ describe("SyncStatusIndicator", () => {
       expect(screen.getByText(/next retry:/i)).toBeInTheDocument();
     });
 
-      expect(screen.getByText(new RegExp(futureRetryAt.toLocaleTimeString(), "i"))).toBeInTheDocument();
+    expect(
+      screen.getByText(new RegExp(futureRetryAt.toLocaleTimeString(), "i"))
+    ).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /sync now/i })).toBeNull();
   });
 

--- a/src/components/SyncStatusIndicator.tsx
+++ b/src/components/SyncStatusIndicator.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { useCallback, useEffect, useState } from "react";
@@ -40,6 +40,21 @@ export function SyncStatusIndicator({ apiBaseUrl }: { apiBaseUrl: string }) {
     () => db.syncQueue.where("status").equals("error").count(),
     []
   );
+
+  const nextRetryAt = useLiveQuery(async () => {
+    const pendingOperations = await db.syncQueue
+      .where("status")
+      .equals("pending")
+      .toArray();
+
+    const futureRetryTimes = pendingOperations
+      .map((operation) => operation.nextRetryAt)
+      .filter((retryAt): retryAt is Date => retryAt instanceof Date)
+      .filter((retryAt) => retryAt.getTime() > Date.now())
+      .sort((left, right) => left.getTime() - right.getTime());
+
+    return futureRetryTimes[0] ?? null;
+  }, []);
 
   const handleManualSync = useCallback(async () => {
     if (!isOnline || isSyncing) return;
@@ -133,6 +148,12 @@ export function SyncStatusIndicator({ apiBaseUrl }: { apiBaseUrl: string }) {
             </p>
           )}
 
+          {nextRetryAt && (
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              <Trans>Next retry:</Trans> {nextRetryAt.toLocaleTimeString()}
+            </p>
+          )}
+
           {/* Error Message */}
           {syncError && (
             <p className="text-xs text-red-600 dark:text-red-400">
@@ -142,15 +163,19 @@ export function SyncStatusIndicator({ apiBaseUrl }: { apiBaseUrl: string }) {
         </div>
 
         {/* Manual Sync Button */}
-        {!isSyncing && isOnline && pendingOps && pendingOps > 0 && (
-          <button
-            onClick={handleManualSync}
-            className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
-            aria-label="Sync now"
-          >
-            <Trans>Sync</Trans>
-          </button>
-        )}
+        {!isSyncing &&
+          isOnline &&
+          pendingOps &&
+          pendingOps > 0 &&
+          !nextRetryAt && (
+            <button
+              onClick={handleManualSync}
+              className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+              aria-label="Sync now"
+            >
+              <Trans>Sync</Trans>
+            </button>
+          )}
 
         {/* Offline Notice */}
         {!isOnline && (

--- a/src/components/SyncStatusIndicator.tsx
+++ b/src/components/SyncStatusIndicator.tsx
@@ -29,6 +29,10 @@ export function SyncStatusIndicator({ apiBaseUrl }: { apiBaseUrl: string }) {
   const [isSyncing, setIsSyncing] = useState(false);
   const [lastSyncTime, setLastSyncTime] = useState<Date | null>(null);
   const [syncError, setSyncError] = useState<string | null>(null);
+  // Incremented by a timer when the earliest nextRetryAt window elapses so
+  // the live queries re-evaluate and the UI transitions without waiting for
+  // an unrelated DB write.
+  const [retryTimerTick, setRetryTimerTick] = useState(0);
 
   // Live query for pending operations
   const pendingOps = useLiveQuery(
@@ -42,6 +46,7 @@ export function SyncStatusIndicator({ apiBaseUrl }: { apiBaseUrl: string }) {
   );
 
   const nextRetryAt = useLiveQuery(async () => {
+    void retryTimerTick;
     const pendingOperations = await db.syncQueue
       .where("status")
       .equals("pending")
@@ -54,7 +59,20 @@ export function SyncStatusIndicator({ apiBaseUrl }: { apiBaseUrl: string }) {
       .sort((left, right) => left.getTime() - right.getTime());
 
     return futureRetryTimes[0] ?? null;
-  }, []);
+  }, [retryTimerTick]);
+
+  // True when at least one pending operation is due right now (no future nextRetryAt).
+  const hasDueOps = useLiveQuery(async () => {
+    void retryTimerTick;
+    const pending = await db.syncQueue
+      .where("status")
+      .equals("pending")
+      .toArray();
+
+    return pending.some(
+      (op) => !op.nextRetryAt || op.nextRetryAt.getTime() <= Date.now()
+    );
+  }, [retryTimerTick]);
 
   const handleManualSync = useCallback(async () => {
     if (!isOnline || isSyncing) return;
@@ -85,6 +103,20 @@ export function SyncStatusIndicator({ apiBaseUrl }: { apiBaseUrl: string }) {
       setIsSyncing(false);
     }
   }, [isOnline, isSyncing, apiBaseUrl]);
+
+  // Re-evaluate retry queries once the earliest scheduled retry window elapses
+  // so the UI updates and the manual sync button appears without waiting for
+  // an unrelated IndexedDB write.
+  useEffect(() => {
+    if (!nextRetryAt) return;
+    const delay = nextRetryAt.getTime() - Date.now();
+    if (delay <= 0) {
+      setRetryTimerTick((t) => t + 1);
+      return;
+    }
+    const timer = setTimeout(() => setRetryTimerTick((t) => t + 1), delay);
+    return () => clearTimeout(timer);
+  }, [nextRetryAt]);
 
   // Auto-sync when coming online (only trigger on online status change)
   useEffect(() => {
@@ -163,19 +195,15 @@ export function SyncStatusIndicator({ apiBaseUrl }: { apiBaseUrl: string }) {
         </div>
 
         {/* Manual Sync Button */}
-        {!isSyncing &&
-          isOnline &&
-          pendingOps &&
-          pendingOps > 0 &&
-          !nextRetryAt && (
-            <button
-              onClick={handleManualSync}
-              className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
-              aria-label="Sync now"
-            >
-              <Trans>Sync</Trans>
-            </button>
-          )}
+        {!isSyncing && isOnline && hasDueOps && (
+          <button
+            onClick={handleManualSync}
+            className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+            aria-label="Sync now"
+          >
+            <Trans>Sync</Trans>
+          </button>
+        )}
 
         {/* Offline Notice */}
         {!isOnline && (

--- a/src/lib/apiCache.test.ts
+++ b/src/lib/apiCache.test.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
@@ -120,6 +120,7 @@ describe("API Cache Utilities", () => {
       expect(queued?.entity).toBe("guard");
       expect(queued?.status).toBe("pending");
       expect(queued?.attempts).toBe(0);
+      expect(queued?.nextRetryAt).toBeUndefined();
     });
 
     it("should generate unique IDs for operations", async () => {
@@ -505,7 +506,44 @@ describe("API Cache Utilities", () => {
       expect(success).toBe(false);
 
       const updated = await db.syncQueue.get(id);
+      expect(updated?.status).toBe("pending");
       expect(updated?.error).toBe("Network error");
+      expect(updated?.nextRetryAt).toBeInstanceOf(Date);
+
+      vi.unstubAllGlobals();
+    });
+
+    it("should skip retry when next retry is scheduled in the future", async () => {
+      const mockFetch = vi.fn();
+      vi.stubGlobal("fetch", mockFetch);
+
+      const id = await addToSyncQueue({
+        type: "create",
+        entity: "guards",
+        data: {},
+      });
+
+      const futureRetryAt = new Date(Date.now() + 60_000);
+      await db.syncQueue.update(id, {
+        attempts: 1,
+        lastAttemptAt: new Date(),
+        nextRetryAt: futureRetryAt,
+      });
+
+      const operation = await db.syncQueue.get(id);
+      if (!operation) throw new Error("Operation not found");
+
+      const success = await retrySyncOperation(
+        operation,
+        "https://api.secpal.dev"
+      );
+
+      expect(success).toBe(false);
+      expect(mockFetch).not.toHaveBeenCalled();
+
+      const updated = await db.syncQueue.get(id);
+      expect(updated?.attempts).toBe(1);
+      expect(updated?.nextRetryAt?.getTime()).toBe(futureRetryAt.getTime());
 
       vi.unstubAllGlobals();
     });
@@ -618,6 +656,47 @@ describe("API Cache Utilities", () => {
       expect(stats.total).toBe(3);
       expect(stats.synced).toBe(2);
       expect(stats.failed).toBe(1);
+
+      vi.unstubAllGlobals();
+    });
+
+    it("should keep future-scheduled retries pending without processing them", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const dueOperationId = await addToSyncQueue({
+        type: "create",
+        entity: "guards",
+        data: { name: "Due" },
+      });
+      const delayedOperationId = await addToSyncQueue({
+        type: "create",
+        entity: "guards",
+        data: { name: "Delayed" },
+      });
+
+      await db.syncQueue.update(delayedOperationId, {
+        attempts: 1,
+        lastAttemptAt: new Date(),
+        nextRetryAt: new Date(Date.now() + 60_000),
+      });
+
+      const stats = await processSyncQueue("https://api.secpal.dev");
+
+      expect(stats.total).toBe(2);
+      expect(stats.synced).toBe(1);
+      expect(stats.failed).toBe(0);
+      expect(stats.pending).toBe(1);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      const dueOperation = await db.syncQueue.get(dueOperationId);
+      const delayedOperation = await db.syncQueue.get(delayedOperationId);
+      expect(dueOperation?.status).toBe("synced");
+      expect(delayedOperation?.status).toBe("pending");
+      expect(delayedOperation?.nextRetryAt).toBeInstanceOf(Date);
 
       vi.unstubAllGlobals();
     });

--- a/src/lib/apiCache.ts
+++ b/src/lib/apiCache.ts
@@ -168,12 +168,16 @@ export async function cleanExpiredCache(): Promise<number> {
  *
  * @param id - Operation ID
  * @param status - New status
- * @param error - Optional error message
+ * @param error - Optional error message to store on failure
+ * @param nextRetryAt - When set, the operation will not be retried before this
+ *   timestamp. Pass `undefined` to clear a previously scheduled retry (e.g. on
+ *   success) or when the operation has permanently failed.
  *
  * @example
  * ```ts
  * await updateSyncOperationStatus('abc-123', 'synced');
  * await updateSyncOperationStatus('def-456', 'error', 'Network timeout');
+ * await updateSyncOperationStatus('ghi-789', 'pending', 'Timeout', new Date(Date.now() + 5_000));
  * ```
  */
 export async function updateSyncOperationStatus(
@@ -307,9 +311,18 @@ export async function retrySyncOperation(
     // Mark as error if this was the final attempt, otherwise keep pending
     const finalAttemptThreshold = apiConfig.retry.maxAttempts - 1;
     const shouldFail = operation.attempts >= finalAttemptThreshold;
+    // Schedule based on post-increment attempt count so the displayed retry
+    // time matches the actual backoff window on the next retrySyncOperation call.
     const scheduledRetryAt = shouldFail
       ? undefined
-      : new Date(Date.now() + backoffDelay);
+      : new Date(
+          Date.now() +
+            Math.pow(
+              apiConfig.retry.backoffMultiplier,
+              operation.attempts + 1
+            ) *
+              1000
+        );
 
     await updateSyncOperationStatus(
       operation.id,

--- a/src/lib/apiCache.ts
+++ b/src/lib/apiCache.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { db } from "./db";
@@ -179,7 +179,8 @@ export async function cleanExpiredCache(): Promise<number> {
 export async function updateSyncOperationStatus(
   id: string,
   status: SyncOperation["status"],
-  error?: string
+  error?: string,
+  nextRetryAt?: Date
 ): Promise<void> {
   const operation = await db.syncQueue.get(id);
   if (!operation) {
@@ -191,6 +192,7 @@ export async function updateSyncOperationStatus(
     error,
     lastAttemptAt: new Date(),
     attempts: operation.attempts + 1,
+    nextRetryAt,
   });
 }
 
@@ -226,6 +228,10 @@ export async function retrySyncOperation(
   // Exponential backoff using configured multiplier
   const backoffDelay =
     Math.pow(apiConfig.retry.backoffMultiplier, operation.attempts) * 1000;
+  if (operation.nextRetryAt && operation.nextRetryAt.getTime() > Date.now()) {
+    return false;
+  }
+
   if (operation.lastAttemptAt) {
     const timeSinceLastAttempt = Date.now() - operation.lastAttemptAt.getTime();
     if (timeSinceLastAttempt < backoffDelay) {
@@ -278,14 +284,20 @@ export async function retrySyncOperation(
     }
 
     if (response.ok) {
-      await updateSyncOperationStatus(operation.id, "synced");
+      await updateSyncOperationStatus(
+        operation.id,
+        "synced",
+        undefined,
+        undefined
+      );
       return true;
     } else {
       const errorText = await response.text();
       await updateSyncOperationStatus(
         operation.id,
         "error",
-        `HTTP ${response.status}: ${errorText}`
+        `HTTP ${response.status}: ${errorText}`,
+        undefined
       );
       return false;
     }
@@ -294,10 +306,16 @@ export async function retrySyncOperation(
       error instanceof Error ? error.message : "Unknown error";
     // Mark as error if this was the final attempt, otherwise keep pending
     const finalAttemptThreshold = apiConfig.retry.maxAttempts - 1;
+    const shouldFail = operation.attempts >= finalAttemptThreshold;
+    const scheduledRetryAt = shouldFail
+      ? undefined
+      : new Date(Date.now() + backoffDelay);
+
     await updateSyncOperationStatus(
       operation.id,
-      operation.attempts >= finalAttemptThreshold ? "error" : "pending",
-      errorMessage
+      shouldFail ? "error" : "pending",
+      errorMessage,
+      scheduledRetryAt
     );
     return false;
   }

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -171,6 +171,25 @@ describe("IndexedDB Database", () => {
       const retrieved = await db.syncQueue.get("retry-test");
       expect(retrieved?.attempts).toBe(1);
     });
+
+    it("should persist a scheduled next retry timestamp", async () => {
+      const nextRetryAt = new Date(Date.now() + 30_000);
+      const operation: SyncOperation = {
+        id: "retry-schedule-test",
+        type: "create",
+        entity: "guard",
+        data: {},
+        status: "pending",
+        createdAt: new Date(),
+        attempts: 1,
+        nextRetryAt,
+      };
+
+      await db.syncQueue.add(operation);
+
+      const retrieved = await db.syncQueue.get("retry-schedule-test");
+      expect(retrieved?.nextRetryAt?.getTime()).toBe(nextRetryAt.getTime());
+    });
   });
 
   describe("API Cache Table", () => {
@@ -222,8 +241,8 @@ describe("IndexedDB Database", () => {
       expect(db.name).toBe("SecPalDB");
     });
 
-    it("should have version 6", () => {
-      expect(db.verno).toBe(6);
+    it("should have version 7", () => {
+      expect(db.verno).toBe(7);
     });
 
     it("should have all required tables", () => {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -26,6 +26,7 @@ export interface SyncOperation {
   createdAt: Date;
   attempts: number;
   lastAttemptAt?: Date;
+  nextRetryAt?: Date;
   error?: string;
 }
 
@@ -168,6 +169,18 @@ db.version(5).stores({
 db.version(6).stores({
   guards: "id, email, lastSynced",
   syncQueue: "id, entity, status, createdAt, attempts",
+  apiCache: "url, expiresAt",
+  analytics: "++id, synced, timestamp, sessionId, type",
+  fileQueue: null,
+  secretCache: null,
+  organizationalUnitCache:
+    "id, type, parent_id, updated_at, cachedAt, pendingSync",
+});
+
+// Schema version 7 - Add scheduled retry timestamps for sync operations
+db.version(7).stores({
+  guards: "id, email, lastSynced",
+  syncQueue: "id, entity, status, createdAt, attempts, nextRetryAt",
   apiCache: "url, expiresAt",
   analytics: "++id, synced, timestamp, sessionId, type",
   fileQueue: null,


### PR DESCRIPTION
## Summary

- persist `nextRetryAt` on offline sync operations so network failures wait for their backoff window instead of retrying on every local processing pass
- upgrade the IndexedDB schema to store scheduled retry timestamps in the sync queue
- add regression coverage for future-scheduled retries and pending queue processing behavior
- document the retry-scheduling hardening in `CHANGELOG.md`

## Validation

- `npm exec vitest run src/lib/apiCache.test.ts src/lib/db.test.ts`
- `npm run typecheck`
- `npm run lint -- src/lib/apiCache.ts src/lib/db.ts src/lib/apiCache.test.ts src/lib/db.test.ts`

Refs #68