### PR TITLE
fix(deps): pin flatted 3.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Pinned the transitive `flatted` resolution to `3.4.2` so Vitest UI and ESLint cache tooling no longer ship the vulnerable parser affected by CVE-2026-33228 / GHSA-rf6f-7fwh-wjgh
+
 - Pinned the transitive `yauzl` resolution to `3.2.1` so Lighthouse-related tooling no longer ships the vulnerable archive parser flagged by `npm audit` and Dependabot
 
 - **Phase 1 offline-data hardening**

--- a/package-lock.json
+++ b/package-lock.json
@@ -9656,9 +9656,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.0.tgz",
-      "integrity": "sha512-kC6Bb+ooptOIvWj5B63EQWkF0FEnNjV2ZNkLMLZRDDduIiWeFF4iKnslwhiWxjAdbg4NzTNo6h0qLuvFrcx+Sw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "tmp": "^0.2.4",
     "rollup": ">=4.59.0",
     "serialize-javascript": ">=7.0.3",
+    "flatted": "3.4.2",
     "@isaacs/brace-expansion": ">=5.0.1",
     "minimatch": ">=10.2.4",
     "yauzl": "3.2.1"


### PR DESCRIPTION
## Summary
- pin the transitive flatted resolution to 3.4.2
- regenerate the lockfile so @vitest/ui and ESLint cache tooling resolve the patched package
- document the security fix in the changelog

## Validation
- npm audit
- npm run typecheck
- npm run lint
- npm run test:run

## Security
- addresses CVE-2026-33228 / GHSA-rf6f-7fwh-wjgh in transitive flatted usage