### PR TITLE
fix(frontend): silence PWA build deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Replaced the deprecated PWA service-worker build setting `inlineDynamicImports` with `codeSplitting: false` via the plugin's custom SW build hook so `npm run build` no longer emits the Vite 8 deprecation warning
 - Stabilized several interaction-heavy frontend tests by reusing the shared test i18n instance, mocking lazy dialog and listbox edges, and making async form/upload assertions deterministic in Vitest
 - Hardened the `EmployeeCreate` success-path test to wait for loaded organizational-unit options and async navigation, reducing full-suite timeout flakiness
 - Hardened additional full-suite-sensitive submit flows in `Login`, `ApplicationLayout`, and `CustomerCreate` tests to reduce timing-dependent Vitest failures

--- a/src/lib/pwaInjectManifestBuildConfig.test.ts
+++ b/src/lib/pwaInjectManifestBuildConfig.test.ts
@@ -42,4 +42,34 @@ describe("applyInjectManifestCodeSplittingFix", () => {
       entryFileNames: "sw.mjs",
     });
   });
+
+  it("updates matching entries when rollup output is an array", () => {
+    const inlineConfig = {
+      build: {
+        rollupOptions: {
+          output: [
+            {
+              entryFileNames: "sw.mjs",
+              inlineDynamicImports: true,
+            },
+            {
+              entryFileNames: "other-[name].js",
+            },
+          ],
+        },
+      },
+    };
+
+    applyInjectManifestCodeSplittingFix(inlineConfig);
+
+    expect(inlineConfig.build.rollupOptions.output).toEqual([
+      {
+        entryFileNames: "sw.mjs",
+        codeSplitting: false,
+      },
+      {
+        entryFileNames: "other-[name].js",
+      },
+    ]);
+  });
 });

--- a/src/lib/pwaInjectManifestBuildConfig.test.ts
+++ b/src/lib/pwaInjectManifestBuildConfig.test.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { applyInjectManifestCodeSplittingFix } from "./pwaInjectManifestBuildConfig";
+
+describe("applyInjectManifestCodeSplittingFix", () => {
+  it("replaces the deprecated inlineDynamicImports flag with codeSplitting false", () => {
+    const inlineConfig = {
+      build: {
+        rollupOptions: {
+          output: {
+            entryFileNames: "sw.mjs",
+            inlineDynamicImports: true,
+          },
+        },
+      },
+    };
+
+    applyInjectManifestCodeSplittingFix(inlineConfig);
+
+    expect(inlineConfig.build.rollupOptions.output).toEqual({
+      entryFileNames: "sw.mjs",
+      codeSplitting: false,
+    });
+  });
+
+  it("leaves other build outputs unchanged", () => {
+    const inlineConfig = {
+      build: {
+        rollupOptions: {
+          output: {
+            entryFileNames: "sw.mjs",
+          },
+        },
+      },
+    };
+
+    applyInjectManifestCodeSplittingFix(inlineConfig);
+
+    expect(inlineConfig.build.rollupOptions.output).toEqual({
+      entryFileNames: "sw.mjs",
+    });
+  });
+});

--- a/src/lib/pwaInjectManifestBuildConfig.ts
+++ b/src/lib/pwaInjectManifestBuildConfig.ts
@@ -13,10 +13,18 @@ type ServiceWorkerRollupOptions = {
   output?: ServiceWorkerBuildOutput | ServiceWorkerBuildOutput[];
 };
 
-function isSingleOutput(
-  output: ServiceWorkerRollupOptions["output"]
-): output is ServiceWorkerBuildOutput {
-  return Boolean(output) && !Array.isArray(output);
+function patchOutput(
+  output: ServiceWorkerBuildOutput
+): ServiceWorkerBuildOutput {
+  if (output.inlineDynamicImports !== true) {
+    return output;
+  }
+
+  const patched = { ...output };
+
+  delete patched.inlineDynamicImports;
+
+  return { ...patched, codeSplitting: false };
 }
 
 export function applyInjectManifestCodeSplittingFix(
@@ -26,20 +34,15 @@ export function applyInjectManifestCodeSplittingFix(
     | ServiceWorkerRollupOptions
     | undefined;
 
-  if (!rollupOptions || !isSingleOutput(rollupOptions.output)) {
+  if (!rollupOptions?.output) {
     return;
   }
 
-  if (rollupOptions.output.inlineDynamicImports !== true) {
+  if (Array.isArray(rollupOptions.output)) {
+    rollupOptions.output = rollupOptions.output.map(patchOutput);
+
     return;
   }
 
-  const output = { ...rollupOptions.output };
-
-  delete output.inlineDynamicImports;
-
-  rollupOptions.output = {
-    ...output,
-    codeSplitting: false,
-  };
+  rollupOptions.output = patchOutput(rollupOptions.output);
 }

--- a/src/lib/pwaInjectManifestBuildConfig.ts
+++ b/src/lib/pwaInjectManifestBuildConfig.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { InlineConfig } from "vite";
+
+type ServiceWorkerBuildOutput = {
+  inlineDynamicImports?: boolean;
+  codeSplitting?: boolean;
+  [key: string]: unknown;
+};
+
+type ServiceWorkerRollupOptions = {
+  output?: ServiceWorkerBuildOutput | ServiceWorkerBuildOutput[];
+};
+
+function isSingleOutput(
+  output: ServiceWorkerRollupOptions["output"]
+): output is ServiceWorkerBuildOutput {
+  return Boolean(output) && !Array.isArray(output);
+}
+
+export function applyInjectManifestCodeSplittingFix(
+  inlineConfig: InlineConfig
+): void {
+  const rollupOptions = inlineConfig.build?.rollupOptions as
+    | ServiceWorkerRollupOptions
+    | undefined;
+
+  if (!rollupOptions || !isSingleOutput(rollupOptions.output)) {
+    return;
+  }
+
+  if (rollupOptions.output.inlineDynamicImports !== true) {
+    return;
+  }
+
+  const output = { ...rollupOptions.output };
+
+  delete output.inlineDynamicImports;
+
+  rollupOptions.output = {
+    ...output,
+    codeSplitting: false,
+  };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,7 @@ import { viteStaticCopy } from "vite-plugin-static-copy";
 import { visualizer } from "rollup-plugin-visualizer";
 import path from "path";
 import { fileURLToPath } from "url";
+import { applyInjectManifestCodeSplittingFix } from "./src/lib/pwaInjectManifestBuildConfig";
 import { buildPwaRuntimeCaching } from "./src/lib/pwaRuntimeCaching";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -69,6 +70,9 @@ export default defineConfig(({ mode }) => {
       VitePWA({
         registerType: "prompt",
         strategies: "injectManifest",
+        integration: {
+          configureCustomSWViteBuild: applyInjectManifestCodeSplittingFix,
+        },
         srcDir: "src",
         filename: "sw.ts",
         injectRegister: "auto",


### PR DESCRIPTION
## Summary
- replace the deprecated injectManifest service-worker build flag with `codeSplitting: false` via the official `vite-plugin-pwa` integration hook
- add targeted test coverage for the service-worker build config adjustment
- update the changelog for the frontend build warning fix

## Validation
- npm run test -- src/lib/pwaInjectManifestBuildConfig.test.ts
- npx eslint vite.config.ts src/lib/pwaInjectManifestBuildConfig.ts src/lib/pwaInjectManifestBuildConfig.test.ts
- npm run typecheck
- npm run build
- pre-push preflight hook