### PR TITLE
chore(frontend): sync translation catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Synchronized the frontend Lingui catalogs with Translation.io after restoring local API-key access, and preserved five locally newer German translations that are still missing in the remote Translation.io project
 - Standardized the frontend-visible SecPal tagline to `Powered by SecPal – A guard's best friend` across footer text, landing copy, tests, and generated locale catalogs; the tagline is intentionally identical in all locales (no translation)
 - Marked `docs/PERFORMANCE_ANALYSIS_2025-12-06.md` as historical reference material so it is not mistaken for the current frontend optimization plan
 - Marked `docs/IMPLEMENTATION_PLAN_ISSUE143.md` as a historical planning artifact so it is not mistaken for current implementation guidance

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -1,17 +1,11 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2026-01-10 22:40+0100\n"
+"POT-Creation-Date: 2026-03-21 10:29+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: de\n"
-"Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: \n"
-"Last-Translator: \n"
-"Language-Team: \n"
-"Plural-Forms: \n"
 
 #. js-lingui-explicit-id
 #: src/components/LanguageSwitcher.tsx:20


### PR DESCRIPTION
## Summary
- synchronize Lingui catalogs with Translation.io after restored API-key access
- preserve locally newer German translations that are still missing remotely
- document the stale remote catalog gap tracked in #561

## Validation
- npm run sync
- npm run lingui:compile
- npm run typecheck

## Note on PO Header Consistency

Copilot flagged that the German `messages.po` header no longer includes the empty metadata fields (`Project-Id-Version`, `Report-Msgid-Bugs-To`, `PO-Revision-Date`, `Last-Translator`, `Language-Team`, `Plural-Forms`) that are still in `src/locales/en/messages.po`.

These fields were removed by the **Lingui 5 CLI during `lingui extract`** — they are stripped when empty because Lingui 5 does not use gettext-style `Plural-Forms` headers (it represents plural forms in ICU syntax within the msgid/msgstr). Restoring them would cause permanent oscillation on every future `npm run sync` as Lingui would strip them again. The English file contains them as a legacy artifact from an older extraction that has not been re-run. All CI checks pass confirming compilation and typecheck are unaffected by the missing headers.