### PR TITLE
chore: sync frontend Copilot runtime governance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,11 +13,44 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
 - Apply SecPal core rules on every task: TDD first, fail fast, no bypass,
   one topic per change, and create a GitHub issue immediately for findings
   that cannot be fixed in the current scope.
+- Apply branch hygiene from the first local change: inspect branch state before
+  work, never start on local `main`, and do not mix unrelated uncommitted
+  changes into the current task.
 - Before any commit, PR, or merge, announce and verify the required checklist. Stop on the first failed check.
 - Update `CHANGELOG.md` in the same change set for real fixes, features, or breaking changes.
 - Keep GitHub-facing communication in English.
-- Domain policy is strict: use only `secpal.app` and `secpal.dev`.
+- Domain policy is strict: use `secpal.app` for production services and all
+  email addresses, and `secpal.dev` only for dev, staging, testing, and
+  examples.
+- Never reply to Copilot review comments with GitHub comment tools. Fix the
+  code, push, and resolve review threads through the approved non-comment
+  workflow.
+- For work that needs more than one PR, create an EPIC with linked sub-issues
+  before implementation.
+- Do not paste large verbatim code blocks into GitHub comments, issues, or PR
+  descriptions. Reference file paths and line numbers instead.
+- Treat warnings, audit findings, deprecation notices, and similar non-fatal
+  diagnostics from scripts, `composer`, `npm`, and related tooling as
+  actionable: review them, fix them in scope, or create a GitHub issue
+  immediately if they are real but out of scope.
 - Prefer small, user-visible fixes that match existing patterns. Avoid speculative abstractions.
+- When editing a file or license sidecar that contains
+  `SPDX-FileCopyrightText`, keep the year current: use a single year such as
+  `2026` if it is already the current year, otherwise extend it to a no-spaces
+  range ending in the current year such as `2025-2026`. If the edited file has
+  no inline header but a companion `.license` file exists, check and update
+  that `.license` file instead.
+
+## Branch Hygiene
+
+- Before any edit or other write action, run `git status --short --branch` and
+  understand the current branch plus local changes.
+- Never start implementation on local `main`. Create or switch to a dedicated topic branch first.
+- If a non-`main` branch already contains uncommitted changes, continue only
+  when they belong to the same task.
+- If existing changes are unrelated or unclear, stop and ask whether they
+  should be committed, stashed, or split before proceeding.
+- Never create mixed commits by reusing a dirty branch for a new topic.
 
 ## Required Checklist
 
@@ -25,6 +58,11 @@ Before any commit, PR, or merge, announce and verify at least:
 
 - the smallest relevant validation passed for the affected area: tests, typecheck, and lint when applicable
 - `CHANGELOG.md` was updated in the same change set for real changes
+- commits are GPG-signed
+- REUSE compliance was checked when the changed files require it
+- the local 4-pass review was completed before creating a PR
+- tooling warnings and audit/deprecation notices were reviewed and either fixed
+  or tracked immediately
 - no bypass was used, including `--no-verify` or force-push
 - repo-local instructions remain self-contained and do not rely on cross-repo inheritance
 - out-of-scope findings were turned into GitHub issues immediately

--- a/.github/instructions/org-shared.instructions.md
+++ b/.github/instructions/org-shared.instructions.md
@@ -17,5 +17,14 @@ At runtime, this file now acts as the repo-local overlay for the `frontend` repo
   applicable, no bypass, fail fast, one topic per change, immediate issue
   creation for out-of-scope findings, and `CHANGELOG.md` updates for real
   changes.
-- Use only `secpal.app` and `secpal.dev`.
+- Use `secpal.app` for production services and all email addresses, and
+  `secpal.dev` only for dev, staging, testing, and examples.
+- Never reply to Copilot review comments with GitHub comment tools; use the
+  approved non-comment review workflow instead.
+- Keep commits GPG-signed, use file and line references instead of verbatim code
+  quotes in GitHub communication, and require EPIC + sub-issues for work that
+  spans more than one PR.
+- Treat warnings, audit findings, deprecation notices, and similar non-fatal
+  diagnostics as actionable; fix them in scope or create a GitHub issue
+  immediately when they are real but out of scope.
 - Keep changes repo-local, minimal, and consistent with React, strict TypeScript, and generated API type conventions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `.github/copilot-instructions.md` now requires a branch hygiene check before any write action so frontend work never starts on local `main` and dirty non-`main` branches must be assessed before continuing
+- `.github/copilot-instructions.md` now requires stale `SPDX-FileCopyrightText` years in edited files and license sidecars to be normalized to `YYYY` or `YYYY-YYYY` without spaces
+- `.github/copilot-instructions.md` now clarifies that if an edited file has no inline SPDX header, its companion `.license` file must be checked and updated instead
+- repo-local frontend instructions and overlays now also restate Copilot review handling, signed-commit checks, EPIC/sub-issue requirements, REUSE checks, 4-pass review, and the `secpal.app` vs `secpal.dev` use-case split so project-wide governance is locally complete
+- repo-local frontend instructions and overlays now also require warning, audit, and deprecation notices from scripts and package managers to be reviewed and either fixed or tracked immediately
+
 ### Removed
 
 - Removed the deleted legacy product module from the frontend, including its obsolete routes, navigation entries, offline caches, background sync wiring, and associated documentation so the repository no longer ships or documents that retired area in 0.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- `.github/copilot-instructions.md` now requires a branch hygiene check before any write action so frontend work never starts on local `main` and dirty non-`main` branches must be assessed before continuing
-- `.github/copilot-instructions.md` now requires stale `SPDX-FileCopyrightText` years in edited files and license sidecars to be normalized to `YYYY` or `YYYY-YYYY` without spaces
-- `.github/copilot-instructions.md` now clarifies that if an edited file has no inline SPDX header, its companion `.license` file must be checked and updated instead
-- repo-local frontend instructions and overlays now also restate Copilot review handling, signed-commit checks, EPIC/sub-issue requirements, REUSE checks, 4-pass review, and the `secpal.app` vs `secpal.dev` use-case split so project-wide governance is locally complete
-- repo-local frontend instructions and overlays now also require warning, audit, and deprecation notices from scripts and package managers to be reviewed and either fixed or tracked immediately
-
 ### Removed
 
 - Removed the deleted legacy product module from the frontend, including its obsolete routes, navigation entries, offline caches, background sync wiring, and associated documentation so the repository no longer ships or documents that retired area in 0.x
@@ -65,6 +57,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `.github/copilot-instructions.md` now requires a branch hygiene check before any write action so frontend work never starts on local `main` and dirty non-`main` branches must be assessed before continuing
+- `.github/copilot-instructions.md` now requires stale `SPDX-FileCopyrightText` years in edited files and license sidecars to be normalized to `YYYY` or `YYYY-YYYY` without spaces
+- `.github/copilot-instructions.md` now clarifies that if an edited file has no inline SPDX header, its companion `.license` file must be checked and updated instead
+- repo-local frontend instructions and overlays now also restate Copilot review handling, signed-commit checks, EPIC/sub-issue requirements, REUSE checks, 4-pass review, and the `secpal.app` vs `secpal.dev` use-case split so project-wide governance is locally complete
+- repo-local frontend instructions and overlays now also require warning, audit, and deprecation notices from scripts and package managers to be reviewed and either fixed or tracked immediately
 - Synchronized the frontend Lingui catalogs with Translation.io after restoring local API-key access, and preserved five locally newer German translations that are still missing in the remote Translation.io project
 - Standardized the frontend-visible SecPal tagline to `Powered by SecPal – A guard's best friend` across footer text, landing copy, tests, and generated locale catalogs; the tagline is intentionally identical in all locales (no translation)
 - Marked `docs/PERFORMANCE_ANALYSIS_2025-12-06.md` as historical reference material so it is not mistaken for the current frontend optimization plan


### PR DESCRIPTION
## Summary
- align repo-local Copilot instructions with project-wide branch hygiene and SPDX year rules
- restate global review, signed-commit, EPIC, REUSE, and warning-triage requirements locally
- track the observed npm deprecation warnings separately in #564 to keep this PR governance-only

## Validation
- ./scripts/preflight.sh