### PR TITLE
fix(deps): pin glob to ^13.0.6 to replace deprecated glob@11 transitive dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Pinned the transitive `glob` resolution to `^13.0.6` via `overrides` so the
-  deprecated `glob@11.1.0` (pulled in by `@lingui/cli` and `workbox-build`) is
-  replaced by a current, non-deprecated release; the remaining deprecated
-  transitive packages inside `workbox-build@7.4.0` (`sourcemap-codec@1.4.8`,
-  `source-map@0.8.0-beta.0`) are blocked upstream and tracked separately
-  (closes #558, remaining items blocked by upstream `vite-plugin-pwa` /
-  `workbox-build`)
-
 ### Removed
 
 - Removed the deleted legacy product module from the frontend, including its obsolete routes, navigation entries, offline caches, background sync wiring, and associated documentation so the repository no longer ships or documents that retired area in 0.x
@@ -36,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Pinned the transitive `glob` resolution to `^13.0.6` via `overrides` so the
+  deprecated `glob@11.1.0` (pulled in by `@lingui/cli` and `workbox-build`) is
+  replaced by a current, non-deprecated release; the remaining deprecated
+  transitive packages inside `workbox-build@7.4.0` (`sourcemap-codec@1.4.8`,
+  `source-map@0.8.0-beta.0`) are blocked upstream and tracked separately
+  (closes #558, remaining items blocked by upstream `vite-plugin-pwa` /
+  `workbox-build`)
 - Pinned third-party GitHub Actions in frontend workflows to immutable commit SHAs so Lighthouse and Codecov automation no longer depend on floating action tags at runtime
 - Pinned the transitive `flatted` resolution to `3.4.2` so Vitest UI and ESLint cache tooling no longer ship the vulnerable parser affected by CVE-2026-33228 / GHSA-rf6f-7fwh-wjgh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Pinned the transitive `glob` resolution to `^13.0.6` via `overrides` so the
+  deprecated `glob@11.1.0` (pulled in by `@lingui/cli` and `workbox-build`) is
+  replaced by a current, non-deprecated release; the remaining deprecated
+  transitive packages inside `workbox-build@7.4.0` (`sourcemap-codec@1.4.8`,
+  `source-map@0.8.0-beta.0`) are blocked upstream and tracked separately
+  (closes #558, remaining items blocked by upstream `vite-plugin-pwa` /
+  `workbox-build`)
+
 ### Removed
 
 - Removed the deleted legacy product module from the frontend, including its obsolete routes, navigation entries, offline caches, background sync wiring, and associated documentation so the repository no longer ships or documents that retired area in 0.x

--- a/package-lock.json
+++ b/package-lock.json
@@ -2720,16 +2720,6 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
-      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -8311,23 +8301,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/forwarded-parse": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
@@ -8573,25 +8546,18 @@
       }
     },
     "node_modules/glob": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -9585,22 +9551,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/jackspeak": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
-      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^9.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/jake": {
@@ -11059,13 +11009,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -12488,19 +12431,6 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/sirv": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,8 @@
     "flatted": "3.4.2",
     "@isaacs/brace-expansion": ">=5.0.1",
     "minimatch": ">=10.2.4",
-    "yauzl": "3.2.1"
+    "yauzl": "3.2.1",
+    "glob": "^13.0.6"
   },
   "engines": {
     "node": ">=20.0.0",


### PR DESCRIPTION
## Summary

Replaces the deprecated `glob@11.1.0` in the transitive dependency tree by
adding a global npm `overrides` pin for `glob@^13.0.6`.

### Why

`glob@11.1.0` is marked as deprecated on npm with: *"Old versions of glob are
not supported, and contain widely publicised security vulnerabilities"*.  Both
`@lingui/cli@5.9.3` and `workbox-build@7.4.0` (via `vite-plugin-pwa`) resolved
to this version.  `glob@13` ships dual CJS / ESM exports and is a drop-in
replacement for the function signatures used by those tools.

### What changed

| File | Change |
|------|--------|
| `package.json` | Added `"glob": "^13.0.6"` to `overrides` |
| `package-lock.json` | Lockfile updated; 5 packages removed (old glob sub-deps), 1 changed |
| `CHANGELOG.md` | Entry added under `[Unreleased]` |

### Validation

- `npm install` → 0 vulnerabilities
- `npm run build` → production build success (Vite 8, workbox PWA manifest generated)
- `npm run test` → 1128 tests across 80 files pass
- `npm run lint` → 0 warnings
- `npm run typecheck` → clean
- `npm run format:check` → all files compliant
- REUSE lint → compliant
- Domain policy check → passed

### Remaining known items (out of scope)

`sourcemap-codec@1.4.8` and `source-map@0.8.0-beta.0` are locked inside
`workbox-build@7.4.0`, the latest release of that package.  They cannot be
replaced via npm `overrides` without risking breaking the workbox service-worker
build.  These are tracked as part of issue #559 (vite-plugin-pwa Vite 8 peer
mismatch); once upstream ships a version of `vite-plugin-pwa` / `workbox-build`
with updated internals those will be resolved.

### Local 4-pass review

- **Pass 1** – Coding standards: single `overrides` entry, consistent with the
  existing style in `package.json`; CHANGELOG format matches Keep a Changelog
  1.1.0; no comments or docstrings added beyond what's necessary.
- **Pass 2** – Domain / licence policy: no domain literals affected; no new SPDX
  headers required (only `package.json` and `package-lock.json` changed; both
  covered by root `REUSE.toml`).
- **Pass 3** – Best practices: override is the npm-native mechanism to pin
  transitive deps; no new direct dependency added; YAGNI satisfied.
- **Pass 4** – Security: `glob@13.0.6` is the current, patched release; `npm
  audit` reports 0 vulnerabilities post-change; no sensitive data paths touched.

Closes #558
