### PR TITLE
fix(deps): document vite-plugin-pwa Vite 8 peer mismatch in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -9,8 +9,8 @@
 lockfile-version=3
 
 # Required to suppress the peer-dependency conflict from vite-plugin-pwa@1.2.0,
-# which declares peer support only through Vite 7 but works correctly with
-# Vite 8.  There is no upstream release of vite-plugin-pwa that adds Vite 8 to
-# its peerDependencies range as of 2026-03-22; tracked in issue #559.
+# which currently declares peer support only through Vite 7. This project
+# builds with Vite 8 using this configuration; see issue #559 for up-to-date
+# compatibility details and tracking.
 # Also prevents npm from adding/removing "peer": true entries across npm versions.
 legacy-peer-deps=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal Contributors
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: CC0-1.0
 
 # Prevent peer dependency variations across npm versions
@@ -8,6 +8,9 @@
 # Force consistent lockfile format (v3 is default since npm 9)
 lockfile-version=3
 
-# Disable automatic peer dependency installation
-# This prevents npm from adding/removing "peer": true entries
+# Required to suppress the peer-dependency conflict from vite-plugin-pwa@1.2.0,
+# which declares peer support only through Vite 7 but works correctly with
+# Vite 8.  There is no upstream release of vite-plugin-pwa that adds Vite 8 to
+# its peerDependencies range as of 2026-03-22; tracked in issue #559.
+# Also prevents npm from adding/removing "peer": true entries across npm versions.
 legacy-peer-deps=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `.npmrc` to document that `legacy-peer-deps=true` is specifically
+  required to suppress the `vite-plugin-pwa@1.2.0` peer-dependency conflict
+  with Vite 8; the plugin declares peer support only through Vite 7 and there
+  is no upstream release adding Vite 8 to its range as of 2026-03-22
+  (closes #559); the SPDX copyright year range was extended to `2025-2026`
+
 ### Removed
 
 - Removed the deleted legacy product module from the frontend, including its obsolete routes, navigation entries, offline caches, background sync wiring, and associated documentation so the repository no longer ships or documents that retired area in 0.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Updated `.npmrc` to document that `legacy-peer-deps=true` is specifically
-  required to suppress the `vite-plugin-pwa@1.2.0` peer-dependency conflict
-  with Vite 8; the plugin declares peer support only through Vite 7 and there
-  is no upstream release adding Vite 8 to its range as of 2026-03-22
-  (closes #559); the SPDX copyright year range was extended to `2025-2026`
-
 ### Removed
 
 - Removed the deleted legacy product module from the frontend, including its obsolete routes, navigation entries, offline caches, background sync wiring, and associated documentation so the repository no longer ships or documents that retired area in 0.x
@@ -73,6 +65,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated `.npmrc` to document that `legacy-peer-deps=true` is specifically
+  required to suppress the `vite-plugin-pwa@1.2.0` peer-dependency conflict
+  with Vite 8; the plugin currently declares peer support only through Vite 7
+  (see #559 for status); the SPDX copyright year range was extended to `2025-2026`
 - `.github/copilot-instructions.md` now requires a branch hygiene check before any write action so frontend work never starts on local `main` and dirty non-`main` branches must be assessed before continuing
 - `.github/copilot-instructions.md` now requires stale `SPDX-FileCopyrightText` years in edited files and license sidecars to be normalized to `YYYY` or `YYYY-YYYY` without spaces
 - `.github/copilot-instructions.md` now clarifies that if an edited file has no inline SPDX header, its companion `.license` file must be checked and updated instead


### PR DESCRIPTION
## Summary

Makes the existing `legacy-peer-deps=true` setting in `.npmrc` self-documenting
by explaining that its primary reason in this repository is the peer-dependency
conflict between `vite-plugin-pwa@1.2.0` and Vite 8.

### Why

`vite-plugin-pwa@1.2.0` (the current latest release, published 2025-11-27)
declares `peerDependencies` only through Vite 7:
`"^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"`.  The frontend runs
Vite 8.  There is no upstream release that adds `^8.0.0` to that range.

`npm ls vite vite-plugin-pwa` reports `invalid` for the peer constraint and
`npm install` without `legacy-peer-deps=true` would fail.  The setting was
already in place for an unrelated lockfile-consistency reason, but the comment
did not explain the vite-plugin-pwa scenario.  This left the technical debt
invisible to future maintainers.

### What changed

| File | Change |
|------|--------|
| `.npmrc` | Comment updated to name `vite-plugin-pwa@1.2.0` + Vite 8 as the root cause; SPDX year extended to `2025-2026` |
| `CHANGELOG.md` | Entry added under `[Unreleased]` |

No functional code change; the `legacy-peer-deps=true` setting was already
present and continues to serve as the workaround.

### Validation

- `npm install` → 0 vulnerabilities, no errors
- `npm run build` → production build success
- `npm run format:check` → compliant
- `npm run lint` → 0 warnings
- REUSE lint → compliant
- Domain policy check → passed

### What this does NOT fix

The peer-dependency constraint on `vite-plugin-pwa@1.2.0` itself cannot be
overridden through npm `overrides` (which only affect installed versions, not
declared peer constraints).  Once the upstream plugin ships a release that adds
`^8.0.0` to its peer range, `legacy-peer-deps=true` can be re-evaluated and the
tracking comment can be removed.

The internal `workbox-build@7.4.0` deprecated packages (`sourcemap-codec@1.4.8`,
`source-map@0.8.0-beta.0`) are also unresolvable without an upstream
`vite-plugin-pwa` / `workbox-build` update.

### Local 4-pass review

- **Pass 1** – Coding standards: comment follows existing `.npmrc` style;
  CHANGELOG entry is concise and matches Keep a Changelog 1.1.0 format.
- **Pass 2** – Domain / licence policy: SPDX year updated to `2025-2026` as
  required for edited files; no domain literals added.
- **Pass 3** – Best practices: comment-only change; YAGNI; no new dependency or
  behaviour added.
- **Pass 4** – Security: no code touched; `npm audit` shows 0 vulnerabilities;
  no sensitive paths involved.

Closes #559
