### PR TITLE
fix: require employee create position payload field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Aligned the frontend employee create payload type with the shared contract by making `EmployeeFormData.position` mandatory, matching the existing required create-form validation and backend/runtime expectations (fixes #578)
 - Made the employee create form fail loudly instead of silently by adding Catalyst-aligned submit summaries, inline field errors, first-invalid-field focus, clearer required-field guidance for Date of Birth, Organizational Unit, Status, Contract Type, and the Leadership Position/Management Level relationship, plus structured handling for API validation errors
 - Synchronized the employee create Lingui catalogs and finalized the shipped German validation and helper copy so the recent form-usability messages are present in both source and compiled locale bundles
 - Replaced the incomplete `public/logo-light.svg` and `public/logo-dark.svg` placeholder contents with valid SVG logo assets that render the canonical frontend light and dark branding outputs correctly

--- a/src/services/employeeApi.test.ts
+++ b/src/services/employeeApi.test.ts
@@ -11,6 +11,9 @@ import {
   terminateEmployee,
 } from "./employeeApi";
 
+type IsOptional<T, K extends keyof T> =
+  Record<never, never> extends Pick<T, K> ? true : false;
+
 // Mock the global fetch
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
@@ -31,6 +34,28 @@ describe("employeeApi - JSON Parsing Error Handling", () => {
   });
 
   describe("createEmployee", () => {
+    it("should keep contract-required employee create fields mandatory in the type", () => {
+      const dateOfBirthIsOptional: IsOptional<
+        EmployeeFormData,
+        "date_of_birth"
+      > = false;
+      const positionIsOptional: IsOptional<EmployeeFormData, "position"> =
+        false;
+      const contractStartDateIsOptional: IsOptional<
+        EmployeeFormData,
+        "contract_start_date"
+      > = false;
+      const organizationalUnitIdIsOptional: IsOptional<
+        EmployeeFormData,
+        "organizational_unit_id"
+      > = false;
+
+      expect(dateOfBirthIsOptional).toBe(false);
+      expect(positionIsOptional).toBe(false);
+      expect(contractStartDateIsOptional).toBe(false);
+      expect(organizationalUnitIdIsOptional).toBe(false);
+    });
+
     it("should throw error when JSON parsing fails on success response", async () => {
       const mockEmployee: EmployeeFormData = {
         first_name: "John",

--- a/src/types/api/employees.ts
+++ b/src/types/api/employees.ts
@@ -81,7 +81,7 @@ export interface EmployeeFormData {
   phone?: string;
   date_of_birth: string;
   contract_start_date: string;
-  position?: string;
+  position: string;
   organizational_unit_id: string;
   management_level: number;
   hire_date?: string;


### PR DESCRIPTION
# Description

This issue is still current and justified: the frontend already enforced the employee create minimum dataset at runtime, but `EmployeeFormData` still allowed `position` to be omitted at the type level. This change aligns the frontend create payload type with the shared contract and existing runtime validation by making `EmployeeFormData.position` mandatory and adding a focused regression test for the required create fields.

Fixes #578

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] `npm run typecheck`
- [x] `npx vitest run src/services/employeeApi.test.ts`
- [x] `npx eslint src/types/api/employees.ts src/services/employeeApi.test.ts`
- [x] `npx prettier --check CHANGELOG.md src/types/api/employees.ts src/services/employeeApi.test.ts`
- [x] `reuse lint`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Notes

Known `npm` deprecation warnings from `workbox-build` transitive dependencies (`sourcemap-codec`, `source-map`) were observed during push, but they are pre-existing upstream warnings and are already tracked separately outside this PR scope.