### PR TITLE
fix(routes): unify low-privilege route guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Unified frontend route-guard handling for low-privilege users outside the onboarding flow: permission-gated routes now show the same access-denied state as organizational routes, the legacy `/organizational-units` app path is guarded and mapped to the existing organization screen, and unknown authenticated app URLs now fall back cleanly instead of rendering blank pages
 - Aligned the employee create UI and API types with the invite-enabled backend flow by adding `send_invitation` to the create payload and surfacing persisted onboarding invitation delivery status on employee detail pages
 - Aligned the frontend employee create payload type with the shared contract by making `EmployeeFormData.position` mandatory, matching the existing required create-form validation and backend/runtime expectations (fixes #578)
 - Made the employee create form fail loudly instead of silently by adding Catalyst-aligned submit summaries, inline field errors, first-invalid-field focus, clearer required-field guidance for Date of Birth, Organizational Unit, Status, Contract Type, and the Leadership Position/Management Level relationship, plus structured handling for API validation errors

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -50,7 +50,7 @@ describe("App", () => {
         : {
             id: 1,
             name: "Fallback User",
-            email: "fallback@example.com",
+            email: "fallback@secpal.dev",
           };
     });
   });
@@ -87,7 +87,7 @@ describe("App", () => {
       JSON.stringify({
         id: 1,
         name: "User",
-        email: "user@example.com",
+        email: "user@secpal.dev",
         permissions: [],
       })
     );
@@ -107,7 +107,7 @@ describe("App", () => {
       JSON.stringify({
         id: 1,
         name: "User",
-        email: "user@example.com",
+        email: "user@secpal.dev",
         hasOrganizationalScopes: false,
       })
     );
@@ -127,7 +127,7 @@ describe("App", () => {
       JSON.stringify({
         id: 1,
         name: "User",
-        email: "user@example.com",
+        email: "user@secpal.dev",
       })
     );
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -92,8 +92,45 @@ describe("App", () => {
       })
     );
 
-    // This test verifies that the route structure includes PermissionRoute
-    // Actual redirect behavior is tested in PermissionRoute.test.tsx
+    await renderWithI18n(<App />);
+
+    expect(
+      await screen.findByText(/Access Denied/i, {}, { timeout: 20000 })
+    ).toBeInTheDocument();
+  });
+
+  it("shows access denied for the legacy organizational-units app route when the user lacks organizational access", async () => {
+    window.history.replaceState({}, "", "/organizational-units");
+
+    localStorage.setItem(
+      "auth_user",
+      JSON.stringify({
+        id: 1,
+        name: "User",
+        email: "user@example.com",
+        hasOrganizationalScopes: false,
+      })
+    );
+
+    await renderWithI18n(<App />);
+
+    expect(
+      await screen.findByText(/Access Denied/i, {}, { timeout: 20000 })
+    ).toBeInTheDocument();
+  });
+
+  it("redirects authenticated users from unknown app routes instead of rendering a blank page", async () => {
+    window.history.replaceState({}, "", "/dashboard");
+
+    localStorage.setItem(
+      "auth_user",
+      JSON.stringify({
+        id: 1,
+        name: "User",
+        email: "user@example.com",
+      })
+    );
+
     await renderWithI18n(<App />);
 
     expect(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { lazy, Suspense } from "react";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { Trans } from "@lingui/macro";
 import { ApplicationLayout } from "./components/application-layout";
 import { OfflineIndicator } from "./components/OfflineIndicator";
@@ -240,6 +240,16 @@ function App() {
                 </OrganizationalRoute>
               }
             />
+            <Route
+              path="/organizational-units"
+              element={
+                <OrganizationalRoute>
+                  <ApplicationLayout>
+                    <OrganizationPage />
+                  </ApplicationLayout>
+                </OrganizationalRoute>
+              }
+            />
             {/* Employee Management Routes - Requires Organizational Access */}
             <Route
               path="/employees"
@@ -323,6 +333,14 @@ function App() {
                   <ApplicationLayout>
                     <ProfilePage />
                   </ApplicationLayout>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="*"
+              element={
+                <ProtectedRoute>
+                  <Navigate to="/" replace />
                 </ProtectedRoute>
               }
             />

--- a/src/components/OrganizationalRoute.test.tsx
+++ b/src/components/OrganizationalRoute.test.tsx
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { I18nProvider } from "@lingui/react";
+import { i18n } from "@lingui/core";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { OrganizationalRoute } from "./OrganizationalRoute";
+import * as authHook from "../hooks/useAuth";
+
+vi.mock("../hooks/useAuth");
+
+describe("OrganizationalRoute", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    i18n.load("en", {});
+    i18n.activate("en");
+  });
+
+  it("renders children when the user has organizational access", () => {
+    vi.mocked(authHook.useAuth).mockReturnValue({
+      hasPermission: vi.fn(),
+      isLoading: false,
+      isAuthenticated: true,
+      user: null,
+      login: vi.fn(),
+      logout: vi.fn(),
+      hasRole: vi.fn(),
+      hasOrganizationalAccess: vi.fn(() => true),
+    });
+
+    render(
+      <I18nProvider i18n={i18n}>
+        <MemoryRouter initialEntries={["/organization"]}>
+          <Routes>
+            <Route
+              path="/organization"
+              element={
+                <OrganizationalRoute>
+                  <div>Organization Content</div>
+                </OrganizationalRoute>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </I18nProvider>
+    );
+
+    expect(screen.getByText("Organization Content")).toBeInTheDocument();
+  });
+
+  it("shows access denied when the user lacks organizational access", () => {
+    vi.mocked(authHook.useAuth).mockReturnValue({
+      hasPermission: vi.fn(),
+      isLoading: false,
+      isAuthenticated: true,
+      user: null,
+      login: vi.fn(),
+      logout: vi.fn(),
+      hasRole: vi.fn(),
+      hasOrganizationalAccess: vi.fn(() => false),
+    });
+
+    render(
+      <I18nProvider i18n={i18n}>
+        <MemoryRouter initialEntries={["/organization"]}>
+          <Routes>
+            <Route
+              path="/organization"
+              element={
+                <OrganizationalRoute>
+                  <div>Organization Content</div>
+                </OrganizationalRoute>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </I18nProvider>
+    );
+
+    expect(screen.getByText("Access Denied")).toBeInTheDocument();
+    expect(
+      screen.getByText(/You do not have permission to access this feature/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Organization Content")
+    ).not.toBeInTheDocument();
+  });
+
+  it("redirects unauthenticated users to login", () => {
+    vi.mocked(authHook.useAuth).mockReturnValue({
+      hasPermission: vi.fn(),
+      isLoading: false,
+      isAuthenticated: false,
+      user: null,
+      login: vi.fn(),
+      logout: vi.fn(),
+      hasRole: vi.fn(),
+      hasOrganizationalAccess: vi.fn(() => false),
+    });
+
+    render(
+      <I18nProvider i18n={i18n}>
+        <MemoryRouter initialEntries={["/organization"]}>
+          <Routes>
+            <Route
+              path="/organization"
+              element={
+                <OrganizationalRoute>
+                  <div>Organization Content</div>
+                </OrganizationalRoute>
+              }
+            />
+            <Route path="/login" element={<div>Login Page</div>} />
+          </Routes>
+        </MemoryRouter>
+      </I18nProvider>
+    );
+
+    expect(screen.getByText("Login Page")).toBeInTheDocument();
+  });
+});

--- a/src/components/OrganizationalRoute.test.tsx
+++ b/src/components/OrganizationalRoute.test.tsx
@@ -83,9 +83,7 @@ describe("OrganizationalRoute", () => {
     expect(
       screen.getByText(/You do not have permission to access this feature/i)
     ).toBeInTheDocument();
-    expect(
-      screen.queryByText("Organization Content")
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Organization Content")).not.toBeInTheDocument();
   });
 
   it("redirects unauthenticated users to login", () => {

--- a/src/components/OrganizationalRoute.tsx
+++ b/src/components/OrganizationalRoute.tsx
@@ -1,10 +1,12 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { Navigate } from "react-router-dom";
-import { Trans } from "@lingui/macro";
 import { useAuth } from "../hooks/useAuth";
-import { Text } from "./text";
+import {
+  RouteAccessDeniedState,
+  RouteLoadingState,
+} from "./RouteGuardState";
 
 interface OrganizationalRouteProps {
   children: React.ReactNode;
@@ -18,17 +20,7 @@ export function OrganizationalRoute({ children }: OrganizationalRouteProps) {
   const { isAuthenticated, isLoading, hasOrganizationalAccess } = useAuth();
 
   if (isLoading) {
-    return (
-      <div
-        className="flex min-h-screen items-center justify-center"
-        role="status"
-        aria-live="polite"
-      >
-        <div className="text-lg">
-          <Trans>Loading...</Trans>
-        </div>
-      </div>
-    );
+    return <RouteLoadingState />;
   }
 
   if (!isAuthenticated) {
@@ -36,21 +28,7 @@ export function OrganizationalRoute({ children }: OrganizationalRouteProps) {
   }
 
   if (!hasOrganizationalAccess()) {
-    return (
-      <div className="flex min-h-screen items-center justify-center p-4">
-        <div className="max-w-md text-center">
-          <Text className="text-lg font-semibold mb-2">
-            <Trans>Access Denied</Trans>
-          </Text>
-          <Text className="text-zinc-500 dark:text-zinc-400">
-            <Trans>
-              You do not have permission to access this feature. Contact your
-              administrator if you believe this is an error.
-            </Trans>
-          </Text>
-        </div>
-      </div>
-    );
+    return <RouteAccessDeniedState />;
   }
 
   return <>{children}</>;

--- a/src/components/OrganizationalRoute.tsx
+++ b/src/components/OrganizationalRoute.tsx
@@ -3,10 +3,7 @@
 
 import { Navigate } from "react-router-dom";
 import { useAuth } from "../hooks/useAuth";
-import {
-  RouteAccessDeniedState,
-  RouteLoadingState,
-} from "./RouteGuardState";
+import { RouteAccessDeniedState, RouteLoadingState } from "./RouteGuardState";
 
 interface OrganizationalRouteProps {
   children: React.ReactNode;

--- a/src/components/PermissionRoute.test.tsx
+++ b/src/components/PermissionRoute.test.tsx
@@ -51,7 +51,7 @@ describe("PermissionRoute", () => {
     expect(screen.getByText("Protected Content")).toBeInTheDocument();
   });
 
-  it("should redirect when user lacks required permission", () => {
+  it("should show access denied when user lacks required permission", () => {
     vi.mocked(authHook.useAuth).mockReturnValue({
       hasPermission: vi.fn(() => false),
       isLoading: false,

--- a/src/components/PermissionRoute.test.tsx
+++ b/src/components/PermissionRoute.test.tsx
@@ -4,6 +4,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { I18nProvider } from "@lingui/react";
+import { i18n } from "@lingui/core";
 import { PermissionRoute } from "./PermissionRoute";
 import * as authHook from "../hooks/useAuth";
 
@@ -13,6 +15,8 @@ vi.mock("../hooks/useAuth");
 describe("PermissionRoute", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    i18n.load("en", {});
+    i18n.activate("en");
   });
 
   it("should render children when user has required permission", () => {
@@ -28,18 +32,20 @@ describe("PermissionRoute", () => {
     });
 
     render(
-      <MemoryRouter initialEntries={["/test"]}>
-        <Routes>
-          <Route
-            path="/test"
-            element={
-              <PermissionRoute permission="test.read">
-                <div>Protected Content</div>
-              </PermissionRoute>
-            }
-          />
-        </Routes>
-      </MemoryRouter>
+      <I18nProvider i18n={i18n}>
+        <MemoryRouter initialEntries={["/test"]}>
+          <Routes>
+            <Route
+              path="/test"
+              element={
+                <PermissionRoute permission="test.read">
+                  <div>Protected Content</div>
+                </PermissionRoute>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </I18nProvider>
     );
 
     expect(screen.getByText("Protected Content")).toBeInTheDocument();
@@ -58,23 +64,26 @@ describe("PermissionRoute", () => {
     });
 
     render(
-      <MemoryRouter initialEntries={["/test"]}>
-        <Routes>
-          <Route
-            path="/test"
-            element={
-              <PermissionRoute permission="test.read">
-                <div>Protected Content</div>
-              </PermissionRoute>
-            }
-          />
-          <Route path="/" element={<div>Home Page</div>} />
-        </Routes>
-      </MemoryRouter>
+      <I18nProvider i18n={i18n}>
+        <MemoryRouter initialEntries={["/test"]}>
+          <Routes>
+            <Route
+              path="/test"
+              element={
+                <PermissionRoute permission="test.read">
+                  <div>Protected Content</div>
+                </PermissionRoute>
+              }
+            />
+            <Route path="/" element={<div>Home Page</div>} />
+          </Routes>
+        </MemoryRouter>
+      </I18nProvider>
     );
 
     expect(screen.queryByText("Protected Content")).not.toBeInTheDocument();
-    expect(screen.getByText("Home Page")).toBeInTheDocument();
+    expect(screen.getByText("Access Denied")).toBeInTheDocument();
+    expect(screen.queryByText("Home Page")).not.toBeInTheDocument();
   });
 
   it("should redirect to custom fallback path when specified", () => {
@@ -90,19 +99,21 @@ describe("PermissionRoute", () => {
     });
 
     render(
-      <MemoryRouter initialEntries={["/test"]}>
-        <Routes>
-          <Route
-            path="/test"
-            element={
-              <PermissionRoute permission="test.read" fallbackPath="/denied">
-                <div>Protected Content</div>
-              </PermissionRoute>
-            }
-          />
-          <Route path="/denied" element={<div>Access Denied Page</div>} />
-        </Routes>
-      </MemoryRouter>
+      <I18nProvider i18n={i18n}>
+        <MemoryRouter initialEntries={["/test"]}>
+          <Routes>
+            <Route
+              path="/test"
+              element={
+                <PermissionRoute permission="test.read" fallbackPath="/denied">
+                  <div>Protected Content</div>
+                </PermissionRoute>
+              }
+            />
+            <Route path="/denied" element={<div>Access Denied Page</div>} />
+          </Routes>
+        </MemoryRouter>
+      </I18nProvider>
     );
 
     expect(screen.queryByText("Protected Content")).not.toBeInTheDocument();
@@ -122,18 +133,20 @@ describe("PermissionRoute", () => {
     });
 
     render(
-      <MemoryRouter initialEntries={["/test"]}>
-        <Routes>
-          <Route
-            path="/test"
-            element={
-              <PermissionRoute permission="test.read">
-                <div>Protected Content</div>
-              </PermissionRoute>
-            }
-          />
-        </Routes>
-      </MemoryRouter>
+      <I18nProvider i18n={i18n}>
+        <MemoryRouter initialEntries={["/test"]}>
+          <Routes>
+            <Route
+              path="/test"
+              element={
+                <PermissionRoute permission="test.read">
+                  <div>Protected Content</div>
+                </PermissionRoute>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </I18nProvider>
     );
 
     expect(screen.getByText("Loading...")).toBeInTheDocument();
@@ -153,20 +166,56 @@ describe("PermissionRoute", () => {
     });
 
     render(
-      <MemoryRouter initialEntries={["/test"]}>
-        <Routes>
-          <Route
-            path="/test"
-            element={
-              <PermissionRoute permission="activity_log.read">
-                <div>Activity Logs</div>
-              </PermissionRoute>
-            }
-          />
-        </Routes>
-      </MemoryRouter>
+      <I18nProvider i18n={i18n}>
+        <MemoryRouter initialEntries={["/test"]}>
+          <Routes>
+            <Route
+              path="/test"
+              element={
+                <PermissionRoute permission="activity_log.read">
+                  <div>Activity Logs</div>
+                </PermissionRoute>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </I18nProvider>
     );
 
     expect(screen.getByText("Activity Logs")).toBeInTheDocument();
+  });
+
+  it("should redirect unauthenticated users to login", () => {
+    vi.mocked(authHook.useAuth).mockReturnValue({
+      hasPermission: vi.fn(() => false),
+      isLoading: false,
+      isAuthenticated: false,
+      user: null,
+      login: vi.fn(),
+      logout: vi.fn(),
+      hasRole: vi.fn(),
+      hasOrganizationalAccess: vi.fn(),
+    });
+
+    render(
+      <I18nProvider i18n={i18n}>
+        <MemoryRouter initialEntries={["/test"]}>
+          <Routes>
+            <Route
+              path="/test"
+              element={
+                <PermissionRoute permission="test.read">
+                  <div>Protected Content</div>
+                </PermissionRoute>
+              }
+            />
+            <Route path="/login" element={<div>Login Page</div>} />
+          </Routes>
+        </MemoryRouter>
+      </I18nProvider>
+    );
+
+    expect(screen.getByText("Login Page")).toBeInTheDocument();
+    expect(screen.queryByText("Access Denied")).not.toBeInTheDocument();
   });
 });

--- a/src/components/PermissionRoute.tsx
+++ b/src/components/PermissionRoute.tsx
@@ -1,8 +1,12 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { Navigate } from "react-router-dom";
 import { useAuth } from "../hooks/useAuth";
+import {
+  RouteAccessDeniedState,
+  RouteLoadingState,
+} from "./RouteGuardState";
 
 interface PermissionRouteProps {
   children: React.ReactNode;
@@ -14,7 +18,8 @@ interface PermissionRouteProps {
  * PermissionRoute Component
  *
  * Protects routes by requiring a specific permission.
- * Redirects to fallback path (default: "/") if permission is missing.
+ * Shows a consistent access denied state by default and only redirects when an
+ * explicit fallback path is provided.
  *
  * @example
  * <PermissionRoute permission="activity_log.read">
@@ -24,25 +29,24 @@ interface PermissionRouteProps {
 export function PermissionRoute({
   children,
   permission,
-  fallbackPath = "/",
+  fallbackPath,
 }: PermissionRouteProps) {
-  const { hasPermission, isLoading } = useAuth();
+  const { hasPermission, isAuthenticated, isLoading } = useAuth();
 
   if (isLoading) {
-    return (
-      <div
-        className="flex min-h-screen items-center justify-center"
-        role="status"
-        aria-live="polite"
-      >
-        <div className="text-lg">Loading...</div>
-      </div>
-    );
+    return <RouteLoadingState />;
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
   }
 
   if (!hasPermission(permission)) {
-    // Show error message briefly then redirect
-    return <Navigate to={fallbackPath} replace />;
+    if (fallbackPath) {
+      return <Navigate to={fallbackPath} replace />;
+    }
+
+    return <RouteAccessDeniedState />;
   }
 
   return <>{children}</>;

--- a/src/components/PermissionRoute.tsx
+++ b/src/components/PermissionRoute.tsx
@@ -3,10 +3,7 @@
 
 import { Navigate } from "react-router-dom";
 import { useAuth } from "../hooks/useAuth";
-import {
-  RouteAccessDeniedState,
-  RouteLoadingState,
-} from "./RouteGuardState";
+import { RouteAccessDeniedState, RouteLoadingState } from "./RouteGuardState";
 
 interface PermissionRouteProps {
   children: React.ReactNode;

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,8 +1,9 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { Navigate } from "react-router-dom";
 import { useAuth } from "../hooks/useAuth";
+import { RouteLoadingState } from "./RouteGuardState";
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
@@ -12,15 +13,7 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
   const { isAuthenticated, isLoading } = useAuth();
 
   if (isLoading) {
-    return (
-      <div
-        className="flex min-h-screen items-center justify-center"
-        role="status"
-        aria-live="polite"
-      >
-        <div className="text-lg">Loading...</div>
-      </div>
-    );
+    return <RouteLoadingState />;
   }
 
   if (!isAuthenticated) {

--- a/src/components/RouteGuardState.tsx
+++ b/src/components/RouteGuardState.tsx
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { Trans } from "@lingui/macro";
+import { Text } from "./text";
+
+export function RouteLoadingState() {
+  return (
+    <div
+      className="flex min-h-screen items-center justify-center"
+      role="status"
+      aria-live="polite"
+    >
+      <div className="text-lg">
+        <Trans>Loading...</Trans>
+      </div>
+    </div>
+  );
+}
+
+export function RouteAccessDeniedState() {
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <div className="max-w-md text-center">
+        <Text className="mb-2 text-lg font-semibold">
+          <Trans>Access Denied</Trans>
+        </Text>
+        <Text className="text-zinc-500 dark:text-zinc-400">
+          <Trans>
+            You do not have permission to access this feature. Contact your
+            administrator if you believe this is an error.
+          </Trans>
+        </Text>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- unify low-privilege route handling outside the onboarding flow with a shared access-denied and loading state
- guard the legacy /organizational-units app path and add a protected catch-all redirect so unknown app routes do not render blank pages
- add focused route-guard regression coverage and document the behavioral change in the changelog

## Testing
- npm run test:run -- src/components/PermissionRoute.test.tsx src/components/OrganizationalRoute.test.tsx src/App.test.tsx
- npm run typecheck
- npx eslint src/App.tsx src/components/ProtectedRoute.tsx src/components/PermissionRoute.tsx src/components/OrganizationalRoute.tsx src/components/RouteGuardState.tsx src/components/PermissionRoute.test.tsx src/components/OrganizationalRoute.test.tsx src/App.test.tsx
- reuse lint

## Notes
- onboarding and /v1/onboarding* flows are intentionally unchanged in this PR
- existing TypeScript 6 vs typescript-eslint support warning is tracked separately in #590