### PR TITLE
fix(auth): centralize low-privilege feature gating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Centralized frontend UI capabilities for low-privilege users so scope-only accounts stay in self-service areas, main navigation no longer exposes organization, customer, employee, or activity-log entries without matching roles or permissions, and direct navigation to those feature routes now resolves through one shared capability guard instead of mixed ad hoc checks
+- Centralized frontend UI capabilities for low-privilege users so scope-only accounts stay in self-service areas and direct navigation to elevated feature routes now resolves through one shared capability guard instead of mixed ad hoc checks
 - Unified frontend route-guard handling for low-privilege users outside the onboarding flow: permission-gated routes now show the same access-denied state as organizational routes, the legacy `/organizational-units` app path is guarded and mapped to the existing organization screen, and unknown authenticated app URLs now fall back cleanly instead of rendering blank pages
 - Aligned the employee create UI and API types with the invite-enabled backend flow by adding `send_invitation` to the create payload and surfacing persisted onboarding invitation delivery status on employee detail pages
 - Aligned the frontend employee create payload type with the shared contract by making `EmployeeFormData.position` mandatory, matching the existing required create-form validation and backend/runtime expectations (fixes #578)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Centralized frontend UI capabilities for low-privilege users so scope-only accounts stay in self-service areas, main navigation no longer exposes organization, customer, employee, or activity-log entries without matching roles or permissions, and direct navigation to those feature routes now resolves through one shared capability guard instead of mixed ad hoc checks
 - Unified frontend route-guard handling for low-privilege users outside the onboarding flow: permission-gated routes now show the same access-denied state as organizational routes, the legacy `/organizational-units` app path is guarded and mapped to the existing organization screen, and unknown authenticated app URLs now fall back cleanly instead of rendering blank pages
 - Aligned the employee create UI and API types with the invite-enabled backend flow by adding `send_invitation` to the create payload and surfacing persisted onboarding invitation delivery status on employee detail pages
 - Aligned the frontend employee create payload type with the shared contract by making `EmployeeFormData.position` mandatory, matching the existing required create-form validation and backend/runtime expectations (fixes #578)

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -119,6 +119,28 @@ describe("App", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows access denied for organization routes when the user only has scopes but no elevated feature capability", async () => {
+    window.history.replaceState({}, "", "/organization");
+
+    localStorage.setItem(
+      "auth_user",
+      JSON.stringify({
+        id: 1,
+        name: "User",
+        email: "user@secpal.dev",
+        hasOrganizationalScopes: true,
+        roles: [],
+        permissions: [],
+      })
+    );
+
+    await renderWithI18n(<App />);
+
+    expect(
+      await screen.findByText(/Access Denied/i, {}, { timeout: 20000 })
+    ).toBeInTheDocument();
+  });
+
   it("redirects authenticated users from unknown app routes instead of rendering a blank page", async () => {
     window.history.replaceState({}, "", "/dashboard");
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,8 +10,7 @@ import { SyncStatusIndicator } from "./components/SyncStatusIndicator";
 import { UpdatePrompt } from "./components/UpdatePrompt";
 import { AuthProvider } from "./contexts/AuthContext";
 import { ProtectedRoute } from "./components/ProtectedRoute";
-import { PermissionRoute } from "./components/PermissionRoute";
-import { OrganizationalRoute } from "./components/OrganizationalRoute";
+import { FeatureRoute } from "./components/FeatureRoute";
 import { RouteLoader } from "./components/RouteLoader";
 import { Heading } from "./components/heading";
 import { Text } from "./components/text";
@@ -132,163 +131,163 @@ function App() {
             <Route
               path="/customers"
               element={
-                <OrganizationalRoute>
+                <FeatureRoute feature="customers">
                   <ApplicationLayout>
                     <CustomersPage />
                   </ApplicationLayout>
-                </OrganizationalRoute>
+                </FeatureRoute>
               }
             />
             <Route
               path="/customers/new"
               element={
-                <OrganizationalRoute>
+                <FeatureRoute feature="customers">
                   <ApplicationLayout>
                     <CustomerCreate />
                   </ApplicationLayout>
-                </OrganizationalRoute>
+                </FeatureRoute>
               }
             />
             <Route
               path="/customers/:id"
               element={
-                <OrganizationalRoute>
+                <FeatureRoute feature="customers">
                   <ApplicationLayout>
                     <CustomerDetail />
                   </ApplicationLayout>
-                </OrganizationalRoute>
+                </FeatureRoute>
               }
             />
             <Route
               path="/customers/:id/edit"
               element={
-                <OrganizationalRoute>
+                <FeatureRoute feature="customers">
                   <ApplicationLayout>
                     <CustomerEdit />
                   </ApplicationLayout>
-                </OrganizationalRoute>
+                </FeatureRoute>
               }
             />
             <Route
               path="/sites"
               element={
-                <OrganizationalRoute>
+                <FeatureRoute feature="sites">
                   <ApplicationLayout>
                     <SitesPage />
                   </ApplicationLayout>
-                </OrganizationalRoute>
+                </FeatureRoute>
               }
             />
             <Route
               path="/sites/customer/:customerId"
               element={
-                <OrganizationalRoute>
+                <FeatureRoute feature="sites">
                   <ApplicationLayout>
                     <SitesPage />
                   </ApplicationLayout>
-                </OrganizationalRoute>
+                </FeatureRoute>
               }
             />
             <Route
               path="/sites/new"
               element={
-                <OrganizationalRoute>
+                <FeatureRoute feature="sites">
                   <ApplicationLayout>
                     <SiteCreate />
                   </ApplicationLayout>
-                </OrganizationalRoute>
+                </FeatureRoute>
               }
             />
             <Route
               path="/sites/new/customer/:customerId"
               element={
-                <OrganizationalRoute>
+                <FeatureRoute feature="sites">
                   <ApplicationLayout>
                     <SiteCreate />
                   </ApplicationLayout>
-                </OrganizationalRoute>
+                </FeatureRoute>
               }
             />
             <Route
               path="/sites/:id"
               element={
-                <OrganizationalRoute>
+                <FeatureRoute feature="sites">
                   <ApplicationLayout>
                     <SiteDetail />
                   </ApplicationLayout>
-                </OrganizationalRoute>
+                </FeatureRoute>
               }
             />
             <Route
               path="/sites/:id/edit"
               element={
-                <OrganizationalRoute>
+                <FeatureRoute feature="sites">
                   <ApplicationLayout>
                     <SiteEdit />
                   </ApplicationLayout>
-                </OrganizationalRoute>
+                </FeatureRoute>
               }
             />
             {/* Organizational Unit Management Route - INTERNAL Company Structure */}
             <Route
               path="/organization"
               element={
-                <OrganizationalRoute>
+                <FeatureRoute feature="organization">
                   <ApplicationLayout>
                     <OrganizationPage />
                   </ApplicationLayout>
-                </OrganizationalRoute>
+                </FeatureRoute>
               }
             />
             <Route
               path="/organizational-units"
               element={
-                <OrganizationalRoute>
+                <FeatureRoute feature="organization">
                   <ApplicationLayout>
                     <OrganizationPage />
                   </ApplicationLayout>
-                </OrganizationalRoute>
+                </FeatureRoute>
               }
             />
             {/* Employee Management Routes - Requires Organizational Access */}
             <Route
               path="/employees"
               element={
-                <OrganizationalRoute>
+                <FeatureRoute feature="employees">
                   <ApplicationLayout>
                     <EmployeeList />
                   </ApplicationLayout>
-                </OrganizationalRoute>
+                </FeatureRoute>
               }
             />
             <Route
               path="/employees/create"
               element={
-                <OrganizationalRoute>
+                <FeatureRoute feature="employees">
                   <ApplicationLayout>
                     <EmployeeCreate />
                   </ApplicationLayout>
-                </OrganizationalRoute>
+                </FeatureRoute>
               }
             />
             <Route
               path="/employees/:id/edit"
               element={
-                <OrganizationalRoute>
+                <FeatureRoute feature="employees">
                   <ApplicationLayout>
                     <EmployeeEdit />
                   </ApplicationLayout>
-                </OrganizationalRoute>
+                </FeatureRoute>
               }
             />
             <Route
               path="/employees/:id"
               element={
-                <OrganizationalRoute>
+                <FeatureRoute feature="employees">
                   <ApplicationLayout>
                     <EmployeeDetail />
                   </ApplicationLayout>
-                </OrganizationalRoute>
+                </FeatureRoute>
               }
             />
             {/* Onboarding Route */}
@@ -306,13 +305,13 @@ function App() {
             <Route
               path="/activity-logs"
               element={
-                <ProtectedRoute>
-                  <PermissionRoute permission="activity_log.read">
+                <FeatureRoute feature="activityLogs">
+                  <ProtectedRoute>
                     <ApplicationLayout>
                       <ActivityLogList />
                     </ApplicationLayout>
-                  </PermissionRoute>
-                </ProtectedRoute>
+                  </ProtectedRoute>
+                </FeatureRoute>
               }
             />
             {/* User Routes */}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -306,11 +306,9 @@ function App() {
               path="/activity-logs"
               element={
                 <FeatureRoute feature="activityLogs">
-                  <ProtectedRoute>
-                    <ApplicationLayout>
-                      <ActivityLogList />
-                    </ApplicationLayout>
-                  </ProtectedRoute>
+                  <ApplicationLayout>
+                    <ActivityLogList />
+                  </ApplicationLayout>
                 </FeatureRoute>
               }
             />

--- a/src/components/FeatureRoute.tsx
+++ b/src/components/FeatureRoute.tsx
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { Navigate } from "react-router-dom";
+import type { RestrictedFeature } from "../lib/capabilities";
+import { useAuth } from "../hooks/useAuth";
+import { useUserCapabilities } from "../hooks/useUserCapabilities";
+import { RouteAccessDeniedState, RouteLoadingState } from "./RouteGuardState";
+
+interface FeatureRouteProps {
+  children: React.ReactNode;
+  feature: RestrictedFeature;
+  fallbackPath?: string;
+}
+
+export function FeatureRoute({
+  children,
+  feature,
+  fallbackPath,
+}: FeatureRouteProps) {
+  const { isAuthenticated, isLoading } = useAuth();
+  const capabilities = useUserCapabilities();
+
+  if (isLoading) {
+    return <RouteLoadingState />;
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (!capabilities[feature]) {
+    if (fallbackPath) {
+      return <Navigate to={fallbackPath} replace />;
+    }
+
+    return <RouteAccessDeniedState />;
+  }
+
+  return <>{children}</>;
+}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -13,6 +13,7 @@ import { authStorage } from "../services/storage";
 import { getCurrentUser } from "../services/authApi";
 import { sessionEvents, isOnline } from "../services/sessionEvents";
 import { clearSensitiveClientState } from "../lib/clientStateCleanup";
+import { hasUserPermission, hasUserRole } from "../lib/capabilities";
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(() => {
@@ -79,7 +80,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
    */
   const hasRole = useCallback(
     (role: string): boolean => {
-      return user?.roles?.includes(role) ?? false;
+      return hasUserRole(user, role);
     },
     [user]
   );
@@ -90,18 +91,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
    */
   const hasPermission = useCallback(
     (permission: string): boolean => {
-      if (!user?.permissions) return false;
-
-      // Direct match
-      if (user.permissions.includes(permission)) return true;
-
-      // Wildcard match: check if user has resource.* for resource.action
-      if (permission.includes(".")) {
-        const [resource] = permission.split(".");
-        if (user.permissions.includes(`${resource}.*`)) return true;
-      }
-
-      return false;
+      return hasUserPermission(user, permission);
     },
     [user]
   );

--- a/src/hooks/useUserCapabilities.ts
+++ b/src/hooks/useUserCapabilities.ts
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { useMemo } from "react";
+import { getUserCapabilities } from "../lib/capabilities";
+import { useAuth } from "./useAuth";
+
+export function useUserCapabilities() {
+  const { user } = useAuth();
+
+  return useMemo(() => getUserCapabilities(user), [user]);
+}

--- a/src/lib/capabilities.test.ts
+++ b/src/lib/capabilities.test.ts
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { getUserCapabilities } from "./capabilities";
+
+describe("getUserCapabilities", () => {
+  it("keeps scope-only users in self-service areas", () => {
+    const capabilities = getUserCapabilities({
+      id: 1,
+      name: "Scope User",
+      email: "scope.user@secpal.dev",
+      hasOrganizationalScopes: true,
+      roles: [],
+      permissions: [],
+    });
+
+    expect(capabilities.home).toBe(true);
+    expect(capabilities.profile).toBe(true);
+    expect(capabilities.settings).toBe(true);
+    expect(capabilities.organization).toBe(false);
+    expect(capabilities.customers).toBe(false);
+    expect(capabilities.sites).toBe(false);
+    expect(capabilities.employees).toBe(false);
+    expect(capabilities.activityLogs).toBe(false);
+  });
+
+  it("enables management areas for elevated organization roles", () => {
+    const capabilities = getUserCapabilities({
+      id: 1,
+      name: "Manager User",
+      email: "manager.user@secpal.dev",
+      hasOrganizationalScopes: true,
+      roles: ["Manager"],
+      permissions: [],
+    });
+
+    expect(capabilities.organization).toBe(true);
+    expect(capabilities.customers).toBe(true);
+    expect(capabilities.sites).toBe(true);
+    expect(capabilities.employees).toBe(true);
+  });
+
+  it("enables customer and site features from explicit permissions", () => {
+    const capabilities = getUserCapabilities({
+      id: 1,
+      name: "Customer User",
+      email: "customer.user@secpal.dev",
+      roles: [],
+      permissions: ["customers.read", "sites.read"],
+    });
+
+    expect(capabilities.customers).toBe(true);
+    expect(capabilities.sites).toBe(true);
+    expect(capabilities.organization).toBe(false);
+    expect(capabilities.employees).toBe(false);
+  });
+});

--- a/src/lib/capabilities.ts
+++ b/src/lib/capabilities.ts
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { User } from "../contexts/auth-context";
+
+const ELEVATED_UI_ROLES = ["Admin", "Manager", "HR"] as const;
+
+const CUSTOMER_FEATURE_PERMISSIONS = [
+  "customers.read",
+  "customers.create",
+  "customers.update",
+  "customers.delete",
+  "customers.*",
+  "sites.read",
+  "sites.create",
+  "sites.update",
+  "sites.delete",
+  "sites.*",
+  "assignments.create",
+  "assignments.update",
+  "assignments.delete",
+  "assignments.*",
+] as const;
+
+const EMPLOYEE_FEATURE_PERMISSIONS = [
+  "employee.read",
+  "employee.write",
+  "employee.create",
+  "employee.update",
+  "employee.delete",
+  "employee.activate",
+  "employee.*",
+  "employees.read",
+  "employees.write",
+  "employees.create",
+  "employees.update",
+  "employees.delete",
+  "employees.activate",
+  "employees.*",
+] as const;
+
+const ACTIVITY_LOG_FEATURE_PERMISSIONS = ["activity_log.read"] as const;
+
+export interface UserCapabilities {
+  home: boolean;
+  profile: boolean;
+  settings: boolean;
+  organization: boolean;
+  customers: boolean;
+  sites: boolean;
+  employees: boolean;
+  activityLogs: boolean;
+}
+
+export type RestrictedFeature = Exclude<
+  keyof UserCapabilities,
+  "home" | "profile" | "settings"
+>;
+
+export function hasUserRole(
+  user: User | null | undefined,
+  role: string
+): boolean {
+  return user?.roles?.includes(role) ?? false;
+}
+
+export function hasAnyUserRole(
+  user: User | null | undefined,
+  roles: readonly string[]
+): boolean {
+  return roles.some((role) => hasUserRole(user, role));
+}
+
+export function hasUserPermission(
+  user: User | null | undefined,
+  permission: string
+): boolean {
+  if (!user?.permissions?.length) {
+    return false;
+  }
+
+  if (user.permissions.includes(permission)) {
+    return true;
+  }
+
+  if (!permission.includes(".")) {
+    return false;
+  }
+
+  const [resource] = permission.split(".");
+
+  return user.permissions.includes(`${resource}.*`);
+}
+
+export function hasAnyUserPermission(
+  user: User | null | undefined,
+  permissions: readonly string[]
+): boolean {
+  return permissions.some((permission) => hasUserPermission(user, permission));
+}
+
+export function getUserCapabilities(
+  user: User | null | undefined
+): UserCapabilities {
+  const isAuthenticated = user !== null && user !== undefined;
+  const hasOrganizationalScopes = user?.hasOrganizationalScopes ?? false;
+  const hasElevatedUiRole = hasAnyUserRole(user, ELEVATED_UI_ROLES);
+
+  return {
+    home: isAuthenticated,
+    profile: isAuthenticated,
+    settings: isAuthenticated,
+    organization:
+      isAuthenticated && hasOrganizationalScopes && hasElevatedUiRole,
+    customers:
+      isAuthenticated &&
+      (hasElevatedUiRole ||
+        hasAnyUserPermission(user, CUSTOMER_FEATURE_PERMISSIONS)),
+    sites:
+      isAuthenticated &&
+      (hasElevatedUiRole ||
+        hasAnyUserPermission(user, CUSTOMER_FEATURE_PERMISSIONS)),
+    employees:
+      isAuthenticated &&
+      hasOrganizationalScopes &&
+      (hasElevatedUiRole ||
+        hasAnyUserPermission(user, EMPLOYEE_FEATURE_PERMISSIONS)),
+    activityLogs:
+      isAuthenticated &&
+      hasAnyUserPermission(user, ACTIVITY_LOG_FEATURE_PERMISSIONS),
+  };
+}


### PR DESCRIPTION
## Summary
- centralize low-privilege frontend feature capabilities in one shared model
- route restricted app areas through a shared feature guard instead of mixed ad hoc checks
- keep scope-only users out of elevated feature routes while leaving onboarding untouched

## Validation
- npm run test -- src/lib/capabilities.test.ts src/App.test.tsx
- npm run typecheck
- npm run lint
- /home/secpal/.local/bin/reuse lint
- ./scripts/preflight.sh

## Notes
- Navigation and page-level CTA hardening follow in a second stacked PR to stay within the repository PR size limit.
- Known TypeScript 6 / typescript-eslint warning remains tracked in #590.
- Separate out-of-scope changelog cleanup tracked in #594.