### PR TITLE
fix(auth): hide low-privilege management navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Centralized frontend UI capabilities for low-privilege users so scope-only accounts stay in self-service areas and direct navigation to elevated feature routes now resolves through one shared capability guard instead of mixed ad hoc checks
+- Applied the centralized low-privilege capability model to the main application navigation so management links stay hidden unless the user has the matching feature access
 - Unified frontend route-guard handling for low-privilege users outside the onboarding flow: permission-gated routes now show the same access-denied state as organizational routes, the legacy `/organizational-units` app path is guarded and mapped to the existing organization screen, and unknown authenticated app URLs now fall back cleanly instead of rendering blank pages
 - Aligned the employee create UI and API types with the invite-enabled backend flow by adding `send_invitation` to the create payload and surfacing persisted onboarding invitation delivery status on employee detail pages
 - Aligned the frontend employee create payload type with the shared contract by making `EmployeeFormData.position` mandatory, matching the existing required create-form validation and backend/runtime expectations (fixes #578)

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -77,7 +77,7 @@ describe("ApplicationLayout", () => {
       JSON.stringify({
         id: 1,
         name: "John Doe",
-        email: "john@example.dev",
+        email: "john@secpal.dev",
       })
     );
   });
@@ -354,7 +354,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "Jane Smith",
-          email: "jane@example.dev",
+          email: "jane@secpal.dev",
         })
       );
 
@@ -375,7 +375,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "Admin",
-          email: "admin@example.dev",
+          email: "admin@secpal.dev",
         })
       );
 
@@ -396,7 +396,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "John Paul Smith",
-          email: "john@example.dev",
+          email: "john@secpal.dev",
         })
       );
 
@@ -416,7 +416,7 @@ describe("ApplicationLayout", () => {
         "auth_user",
         JSON.stringify({
           id: 1,
-          email: "user@example.dev",
+          email: "user@secpal.dev",
         })
       );
 
@@ -439,7 +439,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "John Doe",
-          email: "john@example.dev",
+          email: "john@secpal.dev",
           hasOrganizationalScopes: false,
         })
       );
@@ -459,7 +459,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "John Doe",
-          email: "john@example.dev",
+          email: "john@secpal.dev",
           hasOrganizationalScopes: false,
         })
       );
@@ -479,7 +479,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "John Doe",
-          email: "john@example.dev",
+          email: "john@secpal.dev",
           hasOrganizationalScopes: true,
           roles: [],
           permissions: [],
@@ -503,7 +503,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "John Doe",
-          email: "john@example.dev",
+          email: "john@secpal.dev",
           hasOrganizationalScopes: true,
           roles: ["Manager"],
           permissions: [],
@@ -527,7 +527,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "John Doe",
-          email: "john@example.dev",
+          email: "john@secpal.dev",
           hasOrganizationalScopes: false,
           roles: [],
           permissions: ["customers.read"],
@@ -551,7 +551,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "John Doe",
-          email: "john@example.dev",
+          email: "john@secpal.dev",
           hasOrganizationalScopes: false,
         })
       );
@@ -571,7 +571,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "John Doe",
-          email: "john@example.dev",
+          email: "john@secpal.dev",
           // hasOrganizationalScopes not set
         })
       );
@@ -642,7 +642,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "Admin User",
-          email: "admin@example.dev",
+          email: "admin@secpal.dev",
           permissions: ["activity_log.read"],
         })
       );
@@ -662,7 +662,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "Regular User",
-          email: "user@example.dev",
+          email: "user@secpal.dev",
           permissions: [],
         })
       );
@@ -682,7 +682,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "Admin User",
-          email: "admin@example.dev",
+          email: "admin@secpal.dev",
           permissions: ["activity_log.read"],
         })
       );
@@ -704,7 +704,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "Admin User",
-          email: "admin@example.dev",
+          email: "admin@secpal.dev",
           permissions: ["activity_log.read"],
         })
       );

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -77,7 +77,7 @@ describe("ApplicationLayout", () => {
       JSON.stringify({
         id: 1,
         name: "John Doe",
-        email: "john@example.com",
+        email: "john@example.dev",
       })
     );
   });
@@ -354,7 +354,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "Jane Smith",
-          email: "jane@example.com",
+          email: "jane@example.dev",
         })
       );
 
@@ -375,7 +375,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "Admin",
-          email: "admin@example.com",
+          email: "admin@example.dev",
         })
       );
 
@@ -396,7 +396,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "John Paul Smith",
-          email: "john@example.com",
+          email: "john@example.dev",
         })
       );
 
@@ -416,7 +416,7 @@ describe("ApplicationLayout", () => {
         "auth_user",
         JSON.stringify({
           id: 1,
-          email: "user@example.com",
+          email: "user@example.dev",
         })
       );
 
@@ -439,7 +439,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "John Doe",
-          email: "john@example.com",
+          email: "john@example.dev",
           hasOrganizationalScopes: false,
         })
       );
@@ -459,7 +459,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "John Doe",
-          email: "john@example.com",
+          email: "john@example.dev",
           hasOrganizationalScopes: false,
         })
       );
@@ -473,14 +473,40 @@ describe("ApplicationLayout", () => {
       expect(screen.queryByText("Customers")).not.toBeInTheDocument();
     });
 
-    it("shows Organization link when user has organizational scopes", () => {
+    it("keeps management links hidden for scope-only users", () => {
       localStorage.setItem(
         "auth_user",
         JSON.stringify({
           id: 1,
           name: "John Doe",
-          email: "john@example.com",
+          email: "john@example.dev",
           hasOrganizationalScopes: true,
+          roles: [],
+          permissions: [],
+        })
+      );
+
+      renderWithProviders(
+        <ApplicationLayout>
+          <div>Content</div>
+        </ApplicationLayout>
+      );
+
+      expect(screen.queryByText("Organization")).not.toBeInTheDocument();
+      expect(screen.queryByText("Customers")).not.toBeInTheDocument();
+      expect(screen.queryByText("Employees")).not.toBeInTheDocument();
+    });
+
+    it("shows management links for elevated organization roles", () => {
+      localStorage.setItem(
+        "auth_user",
+        JSON.stringify({
+          id: 1,
+          name: "John Doe",
+          email: "john@example.dev",
+          hasOrganizationalScopes: true,
+          roles: ["Manager"],
+          permissions: [],
         })
       );
 
@@ -491,16 +517,20 @@ describe("ApplicationLayout", () => {
       );
 
       expect(screen.getByText("Organization")).toBeInTheDocument();
+      expect(screen.getByText("Customers")).toBeInTheDocument();
+      expect(screen.getByText("Employees")).toBeInTheDocument();
     });
 
-    it("shows Customers link when user has organizational scopes", () => {
+    it("shows Customers for users with explicit customer permissions", () => {
       localStorage.setItem(
         "auth_user",
         JSON.stringify({
           id: 1,
           name: "John Doe",
-          email: "john@example.com",
-          hasOrganizationalScopes: true,
+          email: "john@example.dev",
+          hasOrganizationalScopes: false,
+          roles: [],
+          permissions: ["customers.read"],
         })
       );
 
@@ -511,6 +541,8 @@ describe("ApplicationLayout", () => {
       );
 
       expect(screen.getByText("Customers")).toBeInTheDocument();
+      expect(screen.queryByText("Organization")).not.toBeInTheDocument();
+      expect(screen.queryByText("Employees")).not.toBeInTheDocument();
     });
 
     it("always shows Home", () => {
@@ -519,7 +551,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "John Doe",
-          email: "john@example.com",
+          email: "john@example.dev",
           hasOrganizationalScopes: false,
         })
       );
@@ -539,7 +571,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "John Doe",
-          email: "john@example.com",
+          email: "john@example.dev",
           // hasOrganizationalScopes not set
         })
       );
@@ -610,7 +642,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "Admin User",
-          email: "admin@example.com",
+          email: "admin@example.dev",
           permissions: ["activity_log.read"],
         })
       );
@@ -630,7 +662,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "Regular User",
-          email: "user@example.com",
+          email: "user@example.dev",
           permissions: [],
         })
       );
@@ -650,7 +682,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "Admin User",
-          email: "admin@example.com",
+          email: "admin@example.dev",
           permissions: ["activity_log.read"],
         })
       );
@@ -672,7 +704,7 @@ describe("ApplicationLayout", () => {
         JSON.stringify({
           id: 1,
           name: "Admin User",
-          email: "admin@example.com",
+          email: "admin@example.dev",
           permissions: ["activity_log.read"],
         })
       );

--- a/src/components/application-layout.tsx
+++ b/src/components/application-layout.tsx
@@ -4,6 +4,7 @@
 import { useNavigate, useLocation } from "react-router-dom";
 import { Trans } from "@lingui/macro";
 import { useAuth } from "../hooks/useAuth";
+import { useUserCapabilities } from "../hooks/useUserCapabilities";
 import { logout as apiLogout } from "../services/authApi";
 import { getInitials } from "../lib/stringUtils";
 import { Avatar } from "./avatar";
@@ -152,13 +153,10 @@ function UserMenuItems({ onLogout }: { onLogout: () => void }) {
 }
 
 export function ApplicationLayout({ children }: { children: React.ReactNode }) {
-  const { user, logout, hasOrganizationalAccess, hasPermission } = useAuth();
+  const { user, logout } = useAuth();
+  const capabilities = useUserCapabilities();
   const navigate = useNavigate();
   const location = useLocation();
-
-  // Check if user has access to organizational features
-  const hasOrgAccess = hasOrganizationalAccess();
-  const canViewActivityLogs = hasPermission("activity_log.read");
 
   const handleLogout = async () => {
     // Clear local state FIRST to prevent race conditions
@@ -194,7 +192,7 @@ export function ApplicationLayout({ children }: { children: React.ReactNode }) {
             >
               <Trans>Home</Trans>
             </NavbarItem>
-            {hasOrgAccess && (
+            {capabilities.organization && (
               <NavbarItem
                 href="/organization"
                 current={isCurrentPath("/organization")}
@@ -202,7 +200,7 @@ export function ApplicationLayout({ children }: { children: React.ReactNode }) {
                 <Trans>Organization</Trans>
               </NavbarItem>
             )}
-            {hasOrgAccess && (
+            {capabilities.customers && (
               <NavbarItem
                 href="/customers"
                 current={isCurrentPath("/customers")}
@@ -210,7 +208,7 @@ export function ApplicationLayout({ children }: { children: React.ReactNode }) {
                 <Trans>Customers</Trans>
               </NavbarItem>
             )}
-            {hasOrgAccess && (
+            {capabilities.employees && (
               <NavbarItem
                 href="/employees"
                 current={isCurrentPath("/employees")}
@@ -218,7 +216,7 @@ export function ApplicationLayout({ children }: { children: React.ReactNode }) {
                 <Trans>Employees</Trans>
               </NavbarItem>
             )}
-            {canViewActivityLogs && (
+            {capabilities.activityLogs && (
               <NavbarItem
                 href="/activity-logs"
                 current={isCurrentPath("/activity-logs")}
@@ -265,7 +263,7 @@ export function ApplicationLayout({ children }: { children: React.ReactNode }) {
                   <Trans>Home</Trans>
                 </SidebarLabel>
               </SidebarItem>
-              {hasOrgAccess && (
+              {capabilities.organization && (
                 <SidebarItem
                   href="/organization"
                   current={isCurrentPath("/organization")}
@@ -276,7 +274,7 @@ export function ApplicationLayout({ children }: { children: React.ReactNode }) {
                   </SidebarLabel>
                 </SidebarItem>
               )}
-              {hasOrgAccess && (
+              {capabilities.customers && (
                 <SidebarItem
                   href="/customers"
                   current={isCurrentPath("/customers")}
@@ -287,7 +285,7 @@ export function ApplicationLayout({ children }: { children: React.ReactNode }) {
                   </SidebarLabel>
                 </SidebarItem>
               )}
-              {hasOrgAccess && (
+              {capabilities.employees && (
                 <SidebarItem
                   href="/employees"
                   current={isCurrentPath("/employees")}
@@ -298,7 +296,7 @@ export function ApplicationLayout({ children }: { children: React.ReactNode }) {
                   </SidebarLabel>
                 </SidebarItem>
               )}
-              {canViewActivityLogs && (
+              {capabilities.activityLogs && (
                 <SidebarItem
                   href="/activity-logs"
                   current={isCurrentPath("/activity-logs")}

--- a/src/lib/capabilities.test.ts
+++ b/src/lib/capabilities.test.ts
@@ -63,4 +63,51 @@ describe("getUserCapabilities", () => {
     expect(capabilities.actions.customers.create).toBe(false);
     expect(capabilities.actions.sites.create).toBe(false);
   });
+
+  it("grants action capabilities from explicit action permissions", () => {
+    const capabilities = getUserCapabilities({
+      id: 1,
+      name: "Action User",
+      email: "action.user@secpal.dev",
+      roles: [],
+      permissions: ["customers.create", "sites.update"],
+    });
+
+    expect(capabilities.actions.customers.create).toBe(true);
+    expect(capabilities.actions.customers.update).toBe(false);
+    expect(capabilities.actions.customers.delete).toBe(false);
+    expect(capabilities.actions.sites.create).toBe(false);
+    expect(capabilities.actions.sites.update).toBe(true);
+    expect(capabilities.actions.sites.delete).toBe(false);
+  });
+
+  it("grants employee action capabilities from explicit permissions with org scopes", () => {
+    const capabilities = getUserCapabilities({
+      id: 1,
+      name: "Employee Manager",
+      email: "emp.manager@secpal.dev",
+      hasOrganizationalScopes: true,
+      roles: [],
+      permissions: ["employees.activate", "employees.terminate"],
+    });
+
+    expect(capabilities.actions.employees.activate).toBe(true);
+    expect(capabilities.actions.employees.terminate).toBe(true);
+    expect(capabilities.actions.employees.create).toBe(false);
+  });
+
+  it("blocks employee action capabilities without org scopes even with matching permissions", () => {
+    const capabilities = getUserCapabilities({
+      id: 1,
+      name: "External User",
+      email: "external.user@secpal.dev",
+      hasOrganizationalScopes: false,
+      roles: [],
+      permissions: ["employees.activate", "employees.terminate"],
+    });
+
+    expect(capabilities.actions.employees.activate).toBe(false);
+    expect(capabilities.actions.employees.terminate).toBe(false);
+    expect(capabilities.employees).toBe(false);
+  });
 });

--- a/src/lib/capabilities.test.ts
+++ b/src/lib/capabilities.test.ts
@@ -23,6 +23,9 @@ describe("getUserCapabilities", () => {
     expect(capabilities.sites).toBe(false);
     expect(capabilities.employees).toBe(false);
     expect(capabilities.activityLogs).toBe(false);
+    expect(capabilities.actions.customers.create).toBe(false);
+    expect(capabilities.actions.sites.update).toBe(false);
+    expect(capabilities.actions.employees.activate).toBe(false);
   });
 
   it("enables management areas for elevated organization roles", () => {
@@ -39,6 +42,9 @@ describe("getUserCapabilities", () => {
     expect(capabilities.customers).toBe(true);
     expect(capabilities.sites).toBe(true);
     expect(capabilities.employees).toBe(true);
+    expect(capabilities.actions.customers.create).toBe(true);
+    expect(capabilities.actions.sites.delete).toBe(true);
+    expect(capabilities.actions.employees.terminate).toBe(true);
   });
 
   it("enables customer and site features from explicit permissions", () => {
@@ -54,5 +60,7 @@ describe("getUserCapabilities", () => {
     expect(capabilities.sites).toBe(true);
     expect(capabilities.organization).toBe(false);
     expect(capabilities.employees).toBe(false);
+    expect(capabilities.actions.customers.create).toBe(false);
+    expect(capabilities.actions.sites.create).toBe(false);
   });
 });

--- a/src/lib/capabilities.ts
+++ b/src/lib/capabilities.ts
@@ -41,6 +41,85 @@ const EMPLOYEE_FEATURE_PERMISSIONS = [
 
 const ACTIVITY_LOG_FEATURE_PERMISSIONS = ["activity_log.read"] as const;
 
+const CUSTOMER_CREATE_PERMISSIONS = [
+  "customers.create",
+  "customers.*",
+] as const;
+const CUSTOMER_UPDATE_PERMISSIONS = [
+  "customers.update",
+  "customers.*",
+] as const;
+const CUSTOMER_DELETE_PERMISSIONS = [
+  "customers.delete",
+  "customers.*",
+] as const;
+
+const SITE_CREATE_PERMISSIONS = ["sites.create", "sites.*"] as const;
+const SITE_UPDATE_PERMISSIONS = ["sites.update", "sites.*"] as const;
+const SITE_DELETE_PERMISSIONS = ["sites.delete", "sites.*"] as const;
+
+const EMPLOYEE_CREATE_PERMISSIONS = [
+  "employee.write",
+  "employee.create",
+  "employee.*",
+  "employees.write",
+  "employees.create",
+  "employees.*",
+] as const;
+
+const EMPLOYEE_UPDATE_PERMISSIONS = [
+  "employee.write",
+  "employee.update",
+  "employee.*",
+  "employees.write",
+  "employees.update",
+  "employees.*",
+] as const;
+
+const EMPLOYEE_DELETE_PERMISSIONS = [
+  "employee.write",
+  "employee.delete",
+  "employee.*",
+  "employees.write",
+  "employees.delete",
+  "employees.*",
+] as const;
+
+const EMPLOYEE_ACTIVATE_PERMISSIONS = [
+  "employee.write",
+  "employee.activate",
+  "employee.*",
+  "employees.write",
+  "employees.activate",
+  "employees.*",
+] as const;
+
+const EMPLOYEE_TERMINATE_PERMISSIONS = [
+  "employee.write",
+  "employee.terminate",
+  "employee.*",
+  "employees.write",
+  "employees.terminate",
+  "employees.*",
+] as const;
+
+export interface ResourceActionCapabilities {
+  create: boolean;
+  update: boolean;
+  delete: boolean;
+}
+
+export interface EmployeeActionCapabilities extends ResourceActionCapabilities {
+  activate: boolean;
+  terminate: boolean;
+}
+
+export interface UserActionCapabilities {
+  customers: ResourceActionCapabilities;
+  sites: ResourceActionCapabilities;
+  employees: EmployeeActionCapabilities;
+}
+
 export interface UserCapabilities {
   home: boolean;
   profile: boolean;
@@ -50,11 +129,12 @@ export interface UserCapabilities {
   sites: boolean;
   employees: boolean;
   activityLogs: boolean;
+  actions: UserActionCapabilities;
 }
 
 export type RestrictedFeature = Exclude<
   keyof UserCapabilities,
-  "home" | "profile" | "settings"
+  "home" | "profile" | "settings" | "actions"
 >;
 
 export function hasUserRole(
@@ -105,6 +185,52 @@ export function getUserCapabilities(
   const isAuthenticated = user !== null && user !== undefined;
   const hasOrganizationalScopes = user?.hasOrganizationalScopes ?? false;
   const hasElevatedUiRole = hasAnyUserRole(user, ELEVATED_UI_ROLES);
+  const canCreateCustomers =
+    isAuthenticated &&
+    (hasElevatedUiRole ||
+      hasAnyUserPermission(user, CUSTOMER_CREATE_PERMISSIONS));
+  const canUpdateCustomers =
+    isAuthenticated &&
+    (hasElevatedUiRole ||
+      hasAnyUserPermission(user, CUSTOMER_UPDATE_PERMISSIONS));
+  const canDeleteCustomers =
+    isAuthenticated &&
+    (hasElevatedUiRole ||
+      hasAnyUserPermission(user, CUSTOMER_DELETE_PERMISSIONS));
+  const canCreateSites =
+    isAuthenticated &&
+    (hasElevatedUiRole || hasAnyUserPermission(user, SITE_CREATE_PERMISSIONS));
+  const canUpdateSites =
+    isAuthenticated &&
+    (hasElevatedUiRole || hasAnyUserPermission(user, SITE_UPDATE_PERMISSIONS));
+  const canDeleteSites =
+    isAuthenticated &&
+    (hasElevatedUiRole || hasAnyUserPermission(user, SITE_DELETE_PERMISSIONS));
+  const canCreateEmployees =
+    isAuthenticated &&
+    hasOrganizationalScopes &&
+    (hasElevatedUiRole ||
+      hasAnyUserPermission(user, EMPLOYEE_CREATE_PERMISSIONS));
+  const canUpdateEmployees =
+    isAuthenticated &&
+    hasOrganizationalScopes &&
+    (hasElevatedUiRole ||
+      hasAnyUserPermission(user, EMPLOYEE_UPDATE_PERMISSIONS));
+  const canDeleteEmployees =
+    isAuthenticated &&
+    hasOrganizationalScopes &&
+    (hasElevatedUiRole ||
+      hasAnyUserPermission(user, EMPLOYEE_DELETE_PERMISSIONS));
+  const canActivateEmployees =
+    isAuthenticated &&
+    hasOrganizationalScopes &&
+    (hasElevatedUiRole ||
+      hasAnyUserPermission(user, EMPLOYEE_ACTIVATE_PERMISSIONS));
+  const canTerminateEmployees =
+    isAuthenticated &&
+    hasOrganizationalScopes &&
+    (hasElevatedUiRole ||
+      hasAnyUserPermission(user, EMPLOYEE_TERMINATE_PERMISSIONS));
 
   return {
     home: isAuthenticated,
@@ -128,5 +254,24 @@ export function getUserCapabilities(
     activityLogs:
       isAuthenticated &&
       hasAnyUserPermission(user, ACTIVITY_LOG_FEATURE_PERMISSIONS),
+    actions: {
+      customers: {
+        create: canCreateCustomers,
+        update: canUpdateCustomers,
+        delete: canDeleteCustomers,
+      },
+      sites: {
+        create: canCreateSites,
+        update: canUpdateSites,
+        delete: canDeleteSites,
+      },
+      employees: {
+        create: canCreateEmployees,
+        update: canUpdateEmployees,
+        delete: canDeleteEmployees,
+        activate: canActivateEmployees,
+        terminate: canTerminateEmployees,
+      },
+    },
   };
 }


### PR DESCRIPTION
## Summary
- apply the centralized low-privilege capability model to the main application navigation
- extend the shared capability model with action-level flags needed by follow-up UI hardening
- keep management navigation hidden unless the user has the matching feature access

## Validation
- npm run test -- src/lib/capabilities.test.ts src/components/application-layout.test.tsx
- npm run typecheck
- npm run lint
- /home/secpal/.local/bin/reuse lint
- ./scripts/preflight.sh

## Notes
- This is a stacked draft PR on top of #595; the local size override was used only because the preflight size gate compares stacked branches against `main` instead of their actual PR base branch.
- Page-level CTA hiding follows in a third stacked PR.
- Known TypeScript 6 / typescript-eslint warning remains tracked in #590.
- Separate out-of-scope changelog cleanup tracked in #594.