### PR TITLE
fix(auth): hide low-privilege page actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Centralized frontend UI capabilities for low-privilege users so scope-only accounts stay in self-service areas and direct navigation to elevated feature routes now resolves through one shared capability guard instead of mixed ad hoc checks
 - Applied the centralized low-privilege capability model to the main application navigation so management links stay hidden unless the user has the matching feature access
+- Hid customer, site, and employee create/update/delete or status-transition CTAs unless the centralized UI capability model grants the matching action, so low-privilege users no longer see misleading management buttons inside accessible pages
 - Unified frontend route-guard handling for low-privilege users outside the onboarding flow: permission-gated routes now show the same access-denied state as organizational routes, the legacy `/organizational-units` app path is guarded and mapped to the existing organization screen, and unknown authenticated app URLs now fall back cleanly instead of rendering blank pages
 - Aligned the employee create UI and API types with the invite-enabled backend flow by adding `send_invitation` to the create payload and surfacing persisted onboarding invitation delivery status on employee detail pages
 - Aligned the frontend employee create payload type with the shared contract by making `EmployeeFormData.position` mandatory, matching the existing required create-form validation and backend/runtime expectations (fixes #578)

--- a/src/pages/Customers/CustomerDetail.test.tsx
+++ b/src/pages/Customers/CustomerDetail.test.tsx
@@ -10,7 +10,14 @@ import { i18n } from "@lingui/core";
 import CustomerDetail from "./CustomerDetail";
 import * as customersApi from "../../services/customersApi";
 
+const { mockUseUserCapabilities } = vi.hoisted(() => ({
+  mockUseUserCapabilities: vi.fn(),
+}));
+
 vi.mock("../../services/customersApi");
+vi.mock("../../hooks/useUserCapabilities", () => ({
+  useUserCapabilities: mockUseUserCapabilities,
+}));
 
 const mockNavigate = vi.fn();
 vi.mock("react-router-dom", async () => {
@@ -60,6 +67,11 @@ describe("CustomerDetail", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     window.history.pushState({}, "", "/customers/customer-123");
+    mockUseUserCapabilities.mockReturnValue({
+      actions: {
+        customers: { create: true, update: true, delete: true },
+      },
+    });
   });
 
   it("loads and displays customer details", async () => {
@@ -320,6 +332,28 @@ describe("CustomerDetail", () => {
 
     const backLink = screen.getByRole("link", { name: /back to list/i });
     expect(backLink).toHaveAttribute("href", "/customers");
+  });
+
+  it("hides edit and delete actions without management capabilities", async () => {
+    mockUseUserCapabilities.mockReturnValue({
+      actions: {
+        customers: { create: false, update: false, delete: false },
+      },
+    });
+    vi.mocked(customersApi.getCustomer).mockResolvedValue(mockCustomer);
+
+    renderWithRouter();
+
+    await waitFor(() => {
+      expect(screen.getByText("Test Customer GmbH")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole("link", { name: /edit/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^delete$/i })
+    ).not.toBeInTheDocument();
   });
 
   it("displays loading state initially", () => {

--- a/src/pages/Customers/CustomerDetail.tsx
+++ b/src/pages/Customers/CustomerDetail.tsx
@@ -27,8 +27,10 @@ import {
   DialogBody,
   DialogActions,
 } from "../../components/dialog";
+import { useUserCapabilities } from "../../hooks/useUserCapabilities";
 
 export default function CustomerDetail() {
+  const capabilities = useUserCapabilities();
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [customer, setCustomer] = useState<Customer | null>(null);
@@ -224,16 +226,20 @@ export default function CustomerDetail() {
 
         {/* Actions */}
         <div className="flex gap-4 pt-4 border-t">
-          <Button href={`/customers/${customer.id}/edit`}>
-            <Trans>Edit</Trans>
-          </Button>
-          <Button
-            outline
-            onClick={() => setShowDeleteDialog(true)}
-            disabled={deleting}
-          >
-            <Trans>Delete</Trans>
-          </Button>
+          {capabilities.actions.customers.update && (
+            <Button href={`/customers/${customer.id}/edit`}>
+              <Trans>Edit</Trans>
+            </Button>
+          )}
+          {capabilities.actions.customers.delete && (
+            <Button
+              outline
+              onClick={() => setShowDeleteDialog(true)}
+              disabled={deleting}
+            >
+              <Trans>Delete</Trans>
+            </Button>
+          )}
           <Button href="/customers" outline>
             <Trans>Back to List</Trans>
           </Button>
@@ -241,35 +247,37 @@ export default function CustomerDetail() {
       </div>
 
       {/* Delete Confirmation Dialog */}
-      <Dialog
-        open={showDeleteDialog}
-        onClose={() => setShowDeleteDialog(false)}
-      >
-        <DialogTitle>
-          <Trans>Delete Customer</Trans>
-        </DialogTitle>
-        <DialogDescription>
-          <Trans>
-            Are you sure you want to delete "{customer.name}"? This action
-            cannot be undone.
-          </Trans>
-        </DialogDescription>
-        <DialogBody>
-          {error && <Text className="text-red-600 mb-4">{error}</Text>}
-        </DialogBody>
-        <DialogActions>
-          <Button
-            plain
-            onClick={() => setShowDeleteDialog(false)}
-            disabled={deleting}
-          >
-            <Trans>Cancel</Trans>
-          </Button>
-          <Button color="red" onClick={handleDelete} disabled={deleting}>
-            {deleting ? <Trans>Deleting...</Trans> : <Trans>Delete</Trans>}
-          </Button>
-        </DialogActions>
-      </Dialog>
+      {capabilities.actions.customers.delete && (
+        <Dialog
+          open={showDeleteDialog}
+          onClose={() => setShowDeleteDialog(false)}
+        >
+          <DialogTitle>
+            <Trans>Delete Customer</Trans>
+          </DialogTitle>
+          <DialogDescription>
+            <Trans>
+              Are you sure you want to delete "{customer.name}"? This action
+              cannot be undone.
+            </Trans>
+          </DialogDescription>
+          <DialogBody>
+            {error && <Text className="text-red-600 mb-4">{error}</Text>}
+          </DialogBody>
+          <DialogActions>
+            <Button
+              plain
+              onClick={() => setShowDeleteDialog(false)}
+              disabled={deleting}
+            >
+              <Trans>Cancel</Trans>
+            </Button>
+            <Button color="red" onClick={handleDelete} disabled={deleting}>
+              {deleting ? <Trans>Deleting...</Trans> : <Trans>Delete</Trans>}
+            </Button>
+          </DialogActions>
+        </Dialog>
+      )}
     </div>
   );
 }

--- a/src/pages/Customers/CustomersPage.test.tsx
+++ b/src/pages/Customers/CustomersPage.test.tsx
@@ -10,8 +10,15 @@ import CustomersPage from "./CustomersPage";
 import * as customersApi from "../../services/customersApi";
 import type { Customer, PaginatedResponse } from "../../types/customers";
 
+const { mockUseUserCapabilities } = vi.hoisted(() => ({
+  mockUseUserCapabilities: vi.fn(),
+}));
+
 // Mock the customers API
 vi.mock("../../services/customersApi");
+vi.mock("../../hooks/useUserCapabilities", () => ({
+  useUserCapabilities: mockUseUserCapabilities,
+}));
 
 // Helper to render with providers
 const renderWithProviders = () => {
@@ -71,6 +78,11 @@ describe("CustomersPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(customersApi.listCustomers).mockResolvedValue(mockResponse);
+    mockUseUserCapabilities.mockReturnValue({
+      actions: {
+        customers: { create: true, update: true, delete: true },
+      },
+    });
   });
 
   it("should render customers list with table", async () => {
@@ -177,6 +189,24 @@ describe("CustomersPage", () => {
 
     const newButton = screen.getByText(/new customer/i);
     expect(newButton.closest("a")).toHaveAttribute("href", "/customers/new");
+  });
+
+  it("hides the new customer CTA without create capability", async () => {
+    mockUseUserCapabilities.mockReturnValue({
+      actions: {
+        customers: { create: false, update: false, delete: false },
+      },
+    });
+
+    renderWithProviders();
+
+    await waitFor(() => {
+      expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole("link", { name: /new customer/i })
+    ).not.toBeInTheDocument();
   });
 
   it("should have links to customer detail pages", async () => {

--- a/src/pages/Customers/CustomersPage.tsx
+++ b/src/pages/Customers/CustomersPage.tsx
@@ -27,9 +27,11 @@ import {
   TableCell,
 } from "../../components/table";
 import { Badge } from "../../components/badge";
+import { useUserCapabilities } from "../../hooks/useUserCapabilities";
 
 export default function CustomersPage() {
   const { _ } = useLingui();
+  const capabilities = useUserCapabilities();
   const [filters, setFilters] = useState<CustomerFilters>({
     page: 1,
     per_page: 15,
@@ -84,9 +86,11 @@ export default function CustomersPage() {
         <Heading>
           <Trans>Customers</Trans>
         </Heading>
-        <Button href="/customers/new">
-          <Trans>New Customer</Trans>
-        </Button>
+        {capabilities.actions.customers.create && (
+          <Button href="/customers/new">
+            <Trans>New Customer</Trans>
+          </Button>
+        )}
       </div>
 
       {/* Search and Filter */}

--- a/src/pages/Employees/EmployeeDetail.test.tsx
+++ b/src/pages/Employees/EmployeeDetail.test.tsx
@@ -53,7 +53,7 @@ const mockEmployee: Employee = {
   first_name: "John",
   last_name: "Doe",
   full_name: "John Doe",
-  email: "john.doe@example.dev",
+  email: "john.doe@secpal.dev",
   phone: "+1234567890",
   date_of_birth: "1990-01-01",
   position: "Developer",
@@ -110,7 +110,7 @@ describe("EmployeeDetail", () => {
     });
 
     expect(screen.getAllByText("E001").length).toBeGreaterThan(0);
-    expect(screen.getByText("john.doe@example.dev")).toBeInTheDocument();
+    expect(screen.getByText("john.doe@secpal.dev")).toBeInTheDocument();
     expect(screen.getByText("+1234567890")).toBeInTheDocument();
     expect(screen.getByText("Developer")).toBeInTheDocument();
     expect(screen.getByText("Engineering")).toBeInTheDocument();

--- a/src/pages/Employees/EmployeeDetail.test.tsx
+++ b/src/pages/Employees/EmployeeDetail.test.tsx
@@ -12,10 +12,17 @@ import * as employeeApi from "../../services/employeeApi";
 import * as qualificationApi from "../../services/qualificationApi";
 import * as documentApi from "../../services/employeeDocumentApi";
 
+const { mockUseUserCapabilities } = vi.hoisted(() => ({
+  mockUseUserCapabilities: vi.fn(),
+}));
+
 // Mock the API modules
 vi.mock("../../services/employeeApi");
 vi.mock("../../services/qualificationApi");
 vi.mock("../../services/employeeDocumentApi");
+vi.mock("../../hooks/useUserCapabilities", () => ({
+  useUserCapabilities: mockUseUserCapabilities,
+}));
 
 // Mock useNavigate
 const mockNavigate = vi.fn();
@@ -46,7 +53,7 @@ const mockEmployee: Employee = {
   first_name: "John",
   last_name: "Doe",
   full_name: "John Doe",
-  email: "john.doe@example.com",
+  email: "john.doe@example.dev",
   phone: "+1234567890",
   date_of_birth: "1990-01-01",
   position: "Developer",
@@ -73,6 +80,17 @@ const mockEmployee: Employee = {
 describe("EmployeeDetail", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseUserCapabilities.mockReturnValue({
+      actions: {
+        employees: {
+          create: true,
+          update: true,
+          delete: true,
+          activate: true,
+          terminate: true,
+        },
+      },
+    });
 
     // Setup default mocks
     vi.mocked(employeeApi.fetchEmployee).mockResolvedValue(mockEmployee);
@@ -92,7 +110,7 @@ describe("EmployeeDetail", () => {
     });
 
     expect(screen.getAllByText("E001").length).toBeGreaterThan(0);
-    expect(screen.getByText("john.doe@example.com")).toBeInTheDocument();
+    expect(screen.getByText("john.doe@example.dev")).toBeInTheDocument();
     expect(screen.getByText("+1234567890")).toBeInTheDocument();
     expect(screen.getByText("Developer")).toBeInTheDocument();
     expect(screen.getByText("Engineering")).toBeInTheDocument();
@@ -435,6 +453,38 @@ describe("EmployeeDetail", () => {
     expect(employeeApi.terminateEmployee).not.toHaveBeenCalled();
 
     vi.restoreAllMocks();
+  });
+
+  it("hides employee management actions without the matching capabilities", async () => {
+    mockUseUserCapabilities.mockReturnValue({
+      actions: {
+        employees: {
+          create: false,
+          update: false,
+          delete: false,
+          activate: false,
+          terminate: false,
+        },
+      },
+    });
+
+    renderWithProviders("emp-1");
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "John Doe" })
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole("link", { name: /^edit$/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /terminate/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /activate/i })
+    ).not.toBeInTheDocument();
   });
 
   describe("Management Level Display", () => {

--- a/src/pages/Employees/EmployeeDetail.tsx
+++ b/src/pages/Employees/EmployeeDetail.tsx
@@ -24,6 +24,7 @@ import { Heading } from "../../components/heading";
 import { Button } from "../../components/button";
 import { Text } from "../../components/text";
 import { Badge } from "../../components/badge";
+import { useUserCapabilities } from "../../hooks/useUserCapabilities";
 import {
   DescriptionList,
   DescriptionTerm,
@@ -337,6 +338,7 @@ function DocumentsTab({ employeeId }: { employeeId: string }) {
  */
 export function EmployeeDetail() {
   const { id } = useParams<{ id: string }>();
+  const capabilities = useUserCapabilities();
   const [employee, setEmployee] = useState<Employee | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -468,19 +470,23 @@ export function EmployeeDetail() {
               </Text>
             </div>
             <div className="flex gap-2">
-              {employee.status === "pre_contract" && (
-                <Button onClick={handleActivate} disabled={actionLoading}>
-                  <Trans>Activate</Trans>
+              {employee.status === "pre_contract" &&
+                capabilities.actions.employees.activate && (
+                  <Button onClick={handleActivate} disabled={actionLoading}>
+                    <Trans>Activate</Trans>
+                  </Button>
+                )}
+              {employee.status === "active" &&
+                capabilities.actions.employees.terminate && (
+                  <Button onClick={handleTerminate} disabled={actionLoading}>
+                    <Trans>Terminate</Trans>
+                  </Button>
+                )}
+              {capabilities.actions.employees.update && (
+                <Button href={`/employees/${id}/edit`} outline>
+                  <Trans>Edit</Trans>
                 </Button>
               )}
-              {employee.status === "active" && (
-                <Button onClick={handleTerminate} disabled={actionLoading}>
-                  <Trans>Terminate</Trans>
-                </Button>
-              )}
-              <Button href={`/employees/${id}/edit`} outline>
-                <Trans>Edit</Trans>
-              </Button>
             </div>
           </div>
         </div>

--- a/src/pages/Employees/EmployeeList.test.tsx
+++ b/src/pages/Employees/EmployeeList.test.tsx
@@ -12,9 +12,16 @@ import { EmployeeList } from "./EmployeeList";
 import * as employeeApi from "../../services/employeeApi";
 import * as organizationalUnitApi from "../../services/organizationalUnitApi";
 
+const { mockUseUserCapabilities } = vi.hoisted(() => ({
+  mockUseUserCapabilities: vi.fn(),
+}));
+
 // Mock the employee API
 vi.mock("../../services/employeeApi");
 vi.mock("../../services/organizationalUnitApi");
+vi.mock("../../hooks/useUserCapabilities", () => ({
+  useUserCapabilities: mockUseUserCapabilities,
+}));
 
 // Helper to render with providers
 const renderWithProviders = () => {
@@ -36,7 +43,7 @@ const mockEmployees: Employee[] = [
     first_name: "John",
     last_name: "Doe",
     full_name: "John Doe",
-    email: "john.doe@example.com",
+    email: "john.doe@example.dev",
     phone: "+1234567890",
     date_of_birth: "1990-01-01",
     position: "Developer",
@@ -57,7 +64,7 @@ const mockEmployees: Employee[] = [
     first_name: "Jane",
     last_name: "Smith",
     full_name: "Jane Smith",
-    email: "jane.smith@example.com",
+    email: "jane.smith@example.dev",
     phone: "+0987654321",
     date_of_birth: "1992-05-15",
     position: "Designer",
@@ -87,6 +94,17 @@ const mockResponse: EmployeeListResponse = {
 describe("EmployeeList", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseUserCapabilities.mockReturnValue({
+      actions: {
+        employees: {
+          create: true,
+          update: true,
+          delete: true,
+          activate: true,
+          terminate: true,
+        },
+      },
+    });
     vi.mocked(employeeApi.fetchEmployees).mockResolvedValue(mockResponse);
     vi.mocked(organizationalUnitApi.listOrganizationalUnits).mockResolvedValue({
       data: [
@@ -131,13 +149,13 @@ describe("EmployeeList", () => {
     });
 
     expect(screen.getByText("John Doe")).toBeInTheDocument();
-    expect(screen.getByText("john.doe@example.com")).toBeInTheDocument();
+    expect(screen.getByText("john.doe@example.dev")).toBeInTheDocument();
     expect(screen.getByText("E001")).toBeInTheDocument();
     expect(screen.getByText("Developer")).toBeInTheDocument();
     expect(screen.getByText("Engineering")).toBeInTheDocument();
 
     expect(screen.getByText("Jane Smith")).toBeInTheDocument();
-    expect(screen.getByText("jane.smith@example.com")).toBeInTheDocument();
+    expect(screen.getByText("jane.smith@example.dev")).toBeInTheDocument();
     expect(screen.getByText("E002")).toBeInTheDocument();
     expect(screen.getByText("Designer")).toBeInTheDocument();
     expect(screen.getByText("Design")).toBeInTheDocument();
@@ -206,6 +224,30 @@ describe("EmployeeList", () => {
     const addButton = screen.getByRole("link", { name: /add employee/i });
     expect(addButton).toBeInTheDocument();
     expect(addButton).toHaveAttribute("href", "/employees/create");
+  });
+
+  it("hides the add employee CTA without create capability", async () => {
+    mockUseUserCapabilities.mockReturnValue({
+      actions: {
+        employees: {
+          create: false,
+          update: false,
+          delete: false,
+          activate: false,
+          terminate: false,
+        },
+      },
+    });
+
+    renderWithProviders();
+
+    await waitFor(() => {
+      expect(screen.getByText("John Doe")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole("link", { name: /add employee/i })
+    ).not.toBeInTheDocument();
   });
 
   it("should display loading state", () => {

--- a/src/pages/Employees/EmployeeList.test.tsx
+++ b/src/pages/Employees/EmployeeList.test.tsx
@@ -43,7 +43,7 @@ const mockEmployees: Employee[] = [
     first_name: "John",
     last_name: "Doe",
     full_name: "John Doe",
-    email: "john.doe@example.dev",
+    email: "john.doe@secpal.dev",
     phone: "+1234567890",
     date_of_birth: "1990-01-01",
     position: "Developer",
@@ -64,7 +64,7 @@ const mockEmployees: Employee[] = [
     first_name: "Jane",
     last_name: "Smith",
     full_name: "Jane Smith",
-    email: "jane.smith@example.dev",
+    email: "jane.smith@secpal.dev",
     phone: "+0987654321",
     date_of_birth: "1992-05-15",
     position: "Designer",
@@ -149,13 +149,13 @@ describe("EmployeeList", () => {
     });
 
     expect(screen.getByText("John Doe")).toBeInTheDocument();
-    expect(screen.getByText("john.doe@example.dev")).toBeInTheDocument();
+    expect(screen.getByText("john.doe@secpal.dev")).toBeInTheDocument();
     expect(screen.getByText("E001")).toBeInTheDocument();
     expect(screen.getByText("Developer")).toBeInTheDocument();
     expect(screen.getByText("Engineering")).toBeInTheDocument();
 
     expect(screen.getByText("Jane Smith")).toBeInTheDocument();
-    expect(screen.getByText("jane.smith@example.dev")).toBeInTheDocument();
+    expect(screen.getByText("jane.smith@secpal.dev")).toBeInTheDocument();
     expect(screen.getByText("E002")).toBeInTheDocument();
     expect(screen.getByText("Designer")).toBeInTheDocument();
     expect(screen.getByText("Design")).toBeInTheDocument();

--- a/src/pages/Employees/EmployeeList.tsx
+++ b/src/pages/Employees/EmployeeList.tsx
@@ -24,6 +24,7 @@ import {
   TableCell,
 } from "../../components/table";
 import { Badge } from "../../components/badge";
+import { useUserCapabilities } from "../../hooks/useUserCapabilities";
 
 /**
  * Status badge component using Catalyst Badge
@@ -53,6 +54,7 @@ function StatusBadge({ status }: { status: EmployeeStatus }) {
  */
 export function EmployeeList() {
   const { _ } = useLingui();
+  const capabilities = useUserCapabilities();
   const [employees, setEmployees] = useState<Employee[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -150,11 +152,13 @@ export function EmployeeList() {
         <Heading>
           <Trans>Employee Management</Trans>
         </Heading>
-        <div className="mt-4 sm:mt-0">
-          <Button href="/employees/create">
-            <Trans>Add Employee</Trans>
-          </Button>
-        </div>
+        {capabilities.actions.employees.create && (
+          <div className="mt-4 sm:mt-0">
+            <Button href="/employees/create">
+              <Trans>Add Employee</Trans>
+            </Button>
+          </div>
+        )}
       </div>
 
       {/* Filters */}

--- a/src/pages/Sites/SiteDetail.test.tsx
+++ b/src/pages/Sites/SiteDetail.test.tsx
@@ -11,8 +11,15 @@ import SiteDetail from "./SiteDetail";
 import * as customersApi from "../../services/customersApi";
 import * as organizationalUnitApi from "../../services/organizationalUnitApi";
 
+const { mockUseUserCapabilities } = vi.hoisted(() => ({
+  mockUseUserCapabilities: vi.fn(),
+}));
+
 vi.mock("../../services/customersApi");
 vi.mock("../../services/organizationalUnitApi");
+vi.mock("../../hooks/useUserCapabilities", () => ({
+  useUserCapabilities: mockUseUserCapabilities,
+}));
 
 const mockNavigate = vi.fn();
 vi.mock("react-router-dom", async () => {
@@ -88,6 +95,11 @@ describe("SiteDetail", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     window.history.pushState({}, "", "/sites/site-123");
+    mockUseUserCapabilities.mockReturnValue({
+      actions: {
+        sites: { create: true, update: true, delete: true },
+      },
+    });
   });
 
   it("loads and displays site details with customer and org unit names", async () => {
@@ -274,5 +286,31 @@ describe("SiteDetail", () => {
     // Should display IDs as fallback
     expect(screen.getByText("customer-123")).toBeInTheDocument();
     expect(screen.getByText("org-unit-123")).toBeInTheDocument();
+  });
+
+  it("hides edit and delete actions without site management capabilities", async () => {
+    mockUseUserCapabilities.mockReturnValue({
+      actions: {
+        sites: { create: false, update: false, delete: false },
+      },
+    });
+    vi.mocked(customersApi.getSite).mockResolvedValue(mockSite);
+    vi.mocked(customersApi.getCustomer).mockResolvedValue(mockCustomer);
+    vi.mocked(organizationalUnitApi.getOrganizationalUnit).mockResolvedValue(
+      mockOrgUnit
+    );
+
+    renderWithRouter();
+
+    await waitFor(() => {
+      expect(screen.getByText("Munich Office")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole("link", { name: /edit/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^delete$/i })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/pages/Sites/SiteDetail.tsx
+++ b/src/pages/Sites/SiteDetail.tsx
@@ -31,9 +31,11 @@ import {
   DialogBody,
   DialogActions,
 } from "../../components/dialog";
+import { useUserCapabilities } from "../../hooks/useUserCapabilities";
 
 export default function SiteDetail() {
   const { i18n } = useLingui();
+  const capabilities = useUserCapabilities();
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [site, setSite] = useState<Site | null>(null);
@@ -332,16 +334,20 @@ export default function SiteDetail() {
 
         {/* Actions */}
         <div className="flex gap-4 pt-4 border-t">
-          <Button href={`/sites/${site.id}/edit`}>
-            <Trans>Edit</Trans>
-          </Button>
-          <Button
-            outline
-            onClick={() => setShowDeleteDialog(true)}
-            disabled={deleting}
-          >
-            <Trans>Delete</Trans>
-          </Button>
+          {capabilities.actions.sites.update && (
+            <Button href={`/sites/${site.id}/edit`}>
+              <Trans>Edit</Trans>
+            </Button>
+          )}
+          {capabilities.actions.sites.delete && (
+            <Button
+              outline
+              onClick={() => setShowDeleteDialog(true)}
+              disabled={deleting}
+            >
+              <Trans>Delete</Trans>
+            </Button>
+          )}
           <Button href="/sites" outline>
             <Trans>Back to List</Trans>
           </Button>
@@ -349,38 +355,40 @@ export default function SiteDetail() {
       </div>
 
       {/* Delete Confirmation Dialog */}
-      <Dialog open={showDeleteDialog} onClose={setShowDeleteDialog}>
-        <DialogTitle>
-          <Trans>Delete Site</Trans>
-        </DialogTitle>
-        <DialogDescription>
-          <Trans>
-            Are you sure you want to delete this site? This action cannot be
-            undone.
-          </Trans>
-        </DialogDescription>
-        <DialogBody>
-          {error && (
-            <div className="rounded-md bg-red-50 p-4 text-sm text-red-800 dark:bg-red-900/20 dark:text-red-200">
-              {error}
-            </div>
-          )}
-          <Text>
-            <Trans>Site:</Trans> <strong>{site.name}</strong>
-          </Text>
-          <Text>
-            <Trans>Site Number:</Trans> <strong>{site.site_number}</strong>
-          </Text>
-        </DialogBody>
-        <DialogActions>
-          <Button outline onClick={() => setShowDeleteDialog(false)}>
-            <Trans>Cancel</Trans>
-          </Button>
-          <Button onClick={handleDelete} disabled={deleting}>
-            {deleting ? <Trans>Deleting...</Trans> : <Trans>Delete</Trans>}
-          </Button>
-        </DialogActions>
-      </Dialog>
+      {capabilities.actions.sites.delete && (
+        <Dialog open={showDeleteDialog} onClose={setShowDeleteDialog}>
+          <DialogTitle>
+            <Trans>Delete Site</Trans>
+          </DialogTitle>
+          <DialogDescription>
+            <Trans>
+              Are you sure you want to delete this site? This action cannot be
+              undone.
+            </Trans>
+          </DialogDescription>
+          <DialogBody>
+            {error && (
+              <div className="rounded-md bg-red-50 p-4 text-sm text-red-800 dark:bg-red-900/20 dark:text-red-200">
+                {error}
+              </div>
+            )}
+            <Text>
+              <Trans>Site:</Trans> <strong>{site.name}</strong>
+            </Text>
+            <Text>
+              <Trans>Site Number:</Trans> <strong>{site.site_number}</strong>
+            </Text>
+          </DialogBody>
+          <DialogActions>
+            <Button outline onClick={() => setShowDeleteDialog(false)}>
+              <Trans>Cancel</Trans>
+            </Button>
+            <Button onClick={handleDelete} disabled={deleting}>
+              {deleting ? <Trans>Deleting...</Trans> : <Trans>Delete</Trans>}
+            </Button>
+          </DialogActions>
+        </Dialog>
+      )}
     </div>
   );
 }

--- a/src/pages/Sites/SitesPage.test.tsx
+++ b/src/pages/Sites/SitesPage.test.tsx
@@ -10,8 +10,15 @@ import SitesPage from "./SitesPage";
 import * as customersApi from "../../services/customersApi";
 import type { Site, PaginatedResponse } from "../../types/customers";
 
+const { mockUseUserCapabilities } = vi.hoisted(() => ({
+  mockUseUserCapabilities: vi.fn(),
+}));
+
 // Mock the customers API
 vi.mock("../../services/customersApi");
+vi.mock("../../hooks/useUserCapabilities", () => ({
+  useUserCapabilities: mockUseUserCapabilities,
+}));
 
 // Helper to render with providers
 const renderWithProviders = () => {
@@ -81,6 +88,11 @@ describe("SitesPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(customersApi.listSites).mockResolvedValue(mockResponse);
+    mockUseUserCapabilities.mockReturnValue({
+      actions: {
+        sites: { create: true, update: true, delete: true },
+      },
+    });
   });
 
   it("should render sites list with table", async () => {
@@ -218,6 +230,24 @@ describe("SitesPage", () => {
 
     const newButton = screen.getByText(/new site/i);
     expect(newButton.closest("a")).toHaveAttribute("href", "/sites/new");
+  });
+
+  it("hides the new site CTA without create capability", async () => {
+    mockUseUserCapabilities.mockReturnValue({
+      actions: {
+        sites: { create: false, update: false, delete: false },
+      },
+    });
+
+    renderWithProviders();
+
+    await waitFor(() => {
+      expect(screen.getByText("Main Office")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole("link", { name: /new site/i })
+    ).not.toBeInTheDocument();
   });
 
   it("should have links to site detail pages", async () => {

--- a/src/pages/Sites/SitesPage.tsx
+++ b/src/pages/Sites/SitesPage.tsx
@@ -27,10 +27,12 @@ import {
   TableCell,
 } from "../../components/table";
 import { Badge } from "../../components/badge";
+import { useUserCapabilities } from "../../hooks/useUserCapabilities";
 
 export default function SitesPage() {
   const { _ } = useLingui();
   const { customerId } = useParams<{ customerId?: string }>();
+  const capabilities = useUserCapabilities();
   const [filters, setFilters] = useState<SiteFilters>({
     page: 1,
     per_page: 15,
@@ -94,11 +96,15 @@ export default function SitesPage() {
         <Heading>
           <Trans>Sites</Trans>
         </Heading>
-        <Button
-          href={customerId ? `/sites/new/customer/${customerId}` : "/sites/new"}
-        >
-          <Trans>New Site</Trans>
-        </Button>
+        {capabilities.actions.sites.create && (
+          <Button
+            href={
+              customerId ? `/sites/new/customer/${customerId}` : "/sites/new"
+            }
+          >
+            <Trans>New Site</Trans>
+          </Button>
+        )}
       </div>
 
       {/* Search and Filter */}


### PR DESCRIPTION
## Summary
- hide customer, site, and employee management CTAs unless the matching action capability is granted
- remove misleading low-privilege action buttons from accessible management pages
- add focused CTA visibility tests across customer, site, and employee pages

## Validation
- npm run test -- src/pages/Customers/CustomersPage.test.tsx src/pages/Customers/CustomerDetail.test.tsx src/pages/Sites/SitesPage.test.tsx src/pages/Sites/SiteDetail.test.tsx src/pages/Employees/EmployeeList.test.tsx src/pages/Employees/EmployeeDetail.test.tsx
- npm run typecheck
- npm run lint
- /home/secpal/.local/bin/reuse lint

## Notes
- This is a stacked draft PR on top of #596; the local size override was used only because the preflight size gate compares stacked branches against `main` instead of their actual PR base branch.
- Known TypeScript 6 / typescript-eslint warning remains tracked in #590.
- Separate out-of-scope changelog cleanup tracked in #594.