### PR TITLE
fix(auth): align canonical auth surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- aligned the frontend auth client, integration tests, and migration guide with the canonical backend auth/self-service surface so browser sessions now use `POST /v1/auth/login`, `POST /v1/auth/logout`, and `GET /v1/me` instead of legacy or guessed paths
+
 ### Removed
 
 - Removed the deleted legacy product module from the frontend, including its obsolete routes, navigation entries, offline caches, background sync wiring, and associated documentation so the repository no longer ships or documents that retired area in 0.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- aligned the frontend auth client, integration tests, and migration guide with the canonical backend auth/self-service surface so browser sessions now use `POST /v1/auth/login`, `POST /v1/auth/logout`, and `GET /v1/me` instead of legacy or guessed paths
+- Aligned the frontend auth client, integration tests, and migration guide with the canonical backend auth/self-service surface so browser sessions now use `POST /v1/auth/login`, `POST /v1/auth/logout`, and `GET /v1/me` instead of legacy or guessed paths
 
 ### Removed
 

--- a/docs/authentication-migration.md
+++ b/docs/authentication-migration.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2025-2026 SecPal
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
@@ -79,14 +79,14 @@ sequenceDiagram
     Browser->>Frontend: User submits login form
     Frontend->>Backend: GET /sanctum/csrf-cookie
     Backend-->>Frontend: Set-Cookie: XSRF-TOKEN=...
-    Frontend->>Backend: POST /v1/auth/token<br/>(email, password, X-XSRF-TOKEN header)
+    Frontend->>Backend: POST /v1/auth/login<br/>(email, password, X-XSRF-TOKEN header)
     Backend->>Database: Verify credentials
     Backend-->>Frontend: Set-Cookie: laravel_session=...; HttpOnly<br/>Response: { user: {...} }
     Frontend->>Browser: Update UI (user logged in)
 
     Note over Browser,Database: Authenticated Request
     Browser->>Frontend: User requests protected resource
-    Frontend->>Backend: GET /v1/user/profile<br/>(credentials: include, cookies sent automatically)
+    Frontend->>Backend: GET /v1/me<br/>(credentials: include, cookies sent automatically)
     Backend->>Database: Validate session
     Backend-->>Frontend: 200 OK { data: {...} }
 
@@ -94,9 +94,11 @@ sequenceDiagram
     Browser->>Frontend: User clicks logout
     Frontend->>Backend: POST /v1/auth/logout<br/>(X-XSRF-TOKEN header, cookies)
     Backend->>Database: Revoke session
-    Backend-->>Frontend: Set-Cookie: laravel_session=deleted; Max-Age=0<br/>204 No Content
+    Backend-->>Frontend: Set-Cookie: laravel_session=deleted; Max-Age=0<br/>200 OK { message: "Logged out successfully" }
     Frontend->>Browser: Update UI (user logged out)
 ```
+
+The SPA flow uses `POST /v1/auth/login`, `POST /v1/auth/logout`, and `GET /v1/me` as its canonical auth/self-service surface. `POST /v1/auth/token` remains reserved for Android, native, CLI, and other Bearer-token clients.
 
 ### CSRF Token Flow
 

--- a/docs/authentication-migration.md
+++ b/docs/authentication-migration.md
@@ -88,7 +88,7 @@ sequenceDiagram
     Browser->>Frontend: User requests protected resource
     Frontend->>Backend: GET /v1/me<br/>(credentials: include, cookies sent automatically)
     Backend->>Database: Validate session
-    Backend-->>Frontend: 200 OK { data: {...} }
+    Backend-->>Frontend: 200 OK { id: ..., name: ..., email: ..., roles: [...], permissions: [...] }
 
     Note over Browser,Database: Logout Flow
     Browser->>Frontend: User clicks logout

--- a/src/services/authApi.test.ts
+++ b/src/services/authApi.test.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -267,7 +267,7 @@ describe("authApi", () => {
   });
 
   describe("logout", () => {
-    it("sends POST request to /v1/auth/session/logout with credentials", async () => {
+    it("sends POST request to /v1/auth/logout with credentials", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
@@ -276,7 +276,7 @@ describe("authApi", () => {
       await logout();
 
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("/v1/auth/session/logout"),
+        expect.stringContaining("/v1/auth/logout"),
         expect.objectContaining({
           method: "POST",
           credentials: "include",

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -76,11 +76,11 @@ export async function login(
 }
 
 /**
- * Logout - end current session (for SPA cookie auth)
+ * Logout - end current session using the canonical auth endpoint
  * @throws {AuthApiError} If logout fails
  */
 export async function logout(): Promise<void> {
-  const response = await apiFetch(`${getApiBaseUrl()}/v1/auth/session/logout`, {
+  const response = await apiFetch(`${getApiBaseUrl()}/v1/auth/logout`, {
     method: "POST",
     headers: {
       Accept: "application/json",

--- a/tests/integration/auth/cookieAuth.test.ts
+++ b/tests/integration/auth/cookieAuth.test.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -158,7 +158,7 @@ describe("Cookie-based Authentication Integration", () => {
         json: async () => ({ data: "protected resource" }),
       } as Response);
 
-      const response = await fetch("https://api.secpal.app/v1/user/profile", {
+      const response = await fetch("https://api.secpal.app/v1/me", {
         credentials: "include",
         headers: {
           "X-XSRF-TOKEN": "csrf-token",
@@ -182,7 +182,7 @@ describe("Cookie-based Authentication Integration", () => {
         statusText: "Unauthorized",
       } as Response);
 
-      const response = await fetch("https://api.secpal.app/v1/user/profile", {
+      const response = await fetch("https://api.secpal.app/v1/me", {
         credentials: "include",
       });
 
@@ -205,9 +205,9 @@ describe("Cookie-based Authentication Integration", () => {
 
       await logout();
 
-      // Verify logout request was sent with credentials (SPA uses /v1/auth/session/logout)
+      // Verify logout request was sent with credentials (SPA uses /v1/auth/logout)
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("/v1/auth/session/logout"),
+        expect.stringContaining("/v1/auth/logout"),
         expect.objectContaining({
           method: "POST",
           credentials: "include",


### PR DESCRIPTION
## Summary
- switch the browser-session auth client to the canonical logout endpoint
- align frontend tests and migration docs with `POST /v1/auth/login`, `POST /v1/auth/logout`, and `GET /v1/me`
- remove guessed self-service path usage from the authenticated browser flow

## Issue
Fixes #612

## Validation
- `npm run test -- --run src/services/authApi.test.ts tests/integration/auth/cookieAuth.test.ts`
- `npm run typecheck`
- `npm run lint`
- local pre-push/preflight hook passed

## Notes
- lint still emits the existing TypeScript-eslint compatibility warning tracked in #590
