### PR TITLE
fix: clarify employee status and onboarding invitation feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- clarified the employee status rules in the create and edit UI by showing the full valid status set (`Applicant`, `Pre-Contract`, `Active`, `On Leave`, `Terminated`) and by explaining inline that onboarding invitations are only available in `Pre-Contract`
 - Aligned the frontend auth client, integration tests, and migration guide with the canonical backend auth/self-service surface so browser sessions now use `POST /v1/auth/login`, `POST /v1/auth/logout`, and `GET /v1/me` instead of legacy or guessed paths
 
 ### Removed
@@ -56,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- surfaced backend `send_invitation` validation errors inline in the employee create form, showed onboarding-invitation availability reasons on employee detail pages, and aligned the terminate action with the backend by allowing it for `on_leave` employees as well as `active` ones
 - Replaced the authenticated wildcard app-route redirect to `/` with a dedicated not-found state, so unknown non-onboarding URLs now fail clearly while protected feature routes continue to use the shared access-denied UX
 - distinguish temporary onboarding rate limits from invalid or expired invitation links in the onboarding completion flow, keep form-level `429` feedback inline instead of collapsing into the invalid-link screen, and surface a dedicated retry state when token validation is temporarily throttled
 - Centralized frontend UI capabilities for low-privilege users so scope-only accounts stay in self-service areas and direct navigation to elevated feature routes now resolves through one shared capability guard instead of mixed ad hoc checks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- clarified the employee status rules in the create and edit UI by showing the full valid status set (`Applicant`, `Pre-Contract`, `Active`, `On Leave`, `Terminated`) and by explaining inline that onboarding invitations are only available in `Pre-Contract`
+- Clarified the employee status rules in the create and edit UI by showing the full valid status set (`Applicant`, `Pre-Contract`, `Active`, `On Leave`, `Terminated`) and by explaining inline that onboarding invitations are only available in `Pre-Contract`.
 - Aligned the frontend auth client, integration tests, and migration guide with the canonical backend auth/self-service surface so browser sessions now use `POST /v1/auth/login`, `POST /v1/auth/logout`, and `GET /v1/me` instead of legacy or guessed paths
 
 ### Removed
@@ -57,7 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- surfaced backend `send_invitation` validation errors inline in the employee create form, showed onboarding-invitation availability reasons on employee detail pages, and aligned the terminate action with the backend by allowing it for `on_leave` employees as well as `active` ones
+- Surfaced backend `send_invitation` validation errors inline in the employee create form, showed onboarding-invitation availability reasons on employee detail pages, and aligned the terminate action with the backend by allowing it for `on_leave` employees as well as `active` ones.
 - Replaced the authenticated wildcard app-route redirect to `/` with a dedicated not-found state, so unknown non-onboarding URLs now fail clearly while protected feature routes continue to use the shared access-denied UX
 - distinguish temporary onboarding rate limits from invalid or expired invitation links in the onboarding completion flow, keep form-level `429` feedback inline instead of collapsing into the invalid-link screen, and surface a dedicated retry state when token validation is temporarily throttled
 - Centralized frontend UI capabilities for low-privilege users so scope-only accounts stay in self-service areas and direct navigation to elevated feature routes now resolves through one shared capability guard instead of mixed ad hoc checks

--- a/src/pages/Employees/EmployeeCreate.test.tsx
+++ b/src/pages/Employees/EmployeeCreate.test.tsx
@@ -526,8 +526,8 @@ describe("EmployeeCreate", () => {
     expect(
       screen.getAllByText(
         /invitations are only available for employees in pre-contract status/i
-      ).length
-    ).toBeGreaterThan(0);
+      )
+    ).toHaveLength(2);
     expect(
       screen.getByText(
         /applicant\s*\/\s*pre-contract\s*\/\s*active\s*\/\s*on leave\s*\/\s*terminated/i

--- a/src/pages/Employees/EmployeeCreate.test.tsx
+++ b/src/pages/Employees/EmployeeCreate.test.tsx
@@ -524,8 +524,69 @@ describe("EmployeeCreate", () => {
     expect(invitationSwitch).toBeDisabled();
     expect(invitationSwitch).not.toBeChecked();
     expect(
-      screen.getByText(
+      screen.getAllByText(
         /invitations are only available for employees in pre-contract status/i
+      ).length
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getByText(
+        /applicant\s*\/\s*pre-contract\s*\/\s*active\s*\/\s*on leave\s*\/\s*terminated/i
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("should show send invitation validation errors inline when the API rejects the request", async () => {
+    vi.mocked(employeeApi.createEmployee).mockRejectedValue(
+      new ApiError("Validation failed", 422, {
+        send_invitation: [
+          "Invitation sending is only available when employee status is pre_contract. Received: active.",
+        ],
+      })
+    );
+
+    renderWithProviders(<EmployeeCreate />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Main Office")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText(/first name/i), {
+      target: { value: "John" },
+    });
+    fireEvent.change(screen.getByLabelText(/last name/i), {
+      target: { value: "Doe" },
+    });
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "john.doe@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText(/date of birth/i), {
+      target: { value: "01/01/1990" },
+    });
+    fireEvent.blur(screen.getByLabelText(/date of birth/i));
+    fireEvent.change(screen.getByLabelText("Position *"), {
+      target: { value: "Developer" },
+    });
+    fireEvent.change(screen.getByLabelText(/contract start date/i), {
+      target: { value: "01/01/2025" },
+    });
+    fireEvent.blur(screen.getByLabelText(/contract start date/i));
+    fireEvent.change(screen.getByLabelText(/organizational unit/i), {
+      target: { value: "unit-1" },
+    });
+
+    submitEmployeeCreateForm();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /we couldn't submit the form yet\. please review the highlighted fields/i
+        )
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(
+        /invitation sending is only available when employee status is pre_contract\. received: active\./i
       )
     ).toBeInTheDocument();
   });

--- a/src/pages/Employees/EmployeeCreate.tsx
+++ b/src/pages/Employees/EmployeeCreate.tsx
@@ -24,6 +24,7 @@ import {
 import { Input } from "../../components/input";
 import { Select } from "../../components/select";
 import { Switch } from "../../components/switch";
+import { EmployeeStatusOptions } from "./EmployeeStatusOptions";
 
 type EmployeeFormField = keyof EmployeeFormData;
 type EmployeeFormErrors = Partial<Record<EmployeeFormField, string>>;
@@ -427,7 +428,11 @@ export function EmployeeCreate() {
   }
 
   function handleStatusChange(status: EmployeeStatus) {
-    setFormData((prev) => ({ ...prev, status }));
+    setFormData((prev) => ({
+      ...prev,
+      status,
+      ...(status !== "pre_contract" && { send_invitation: false }),
+    }));
     clearFieldError("status");
     clearFieldError("send_invitation");
     clearSubmitMessages();
@@ -825,21 +830,7 @@ export function EmployeeCreate() {
                       handleStatusChange(e.target.value as EmployeeStatus)
                     }
                   >
-                    <option value="applicant">
-                      <Trans>Applicant</Trans>
-                    </option>
-                    <option value="pre_contract">
-                      <Trans>Pre-Contract</Trans>
-                    </option>
-                    <option value="active">
-                      <Trans>Active</Trans>
-                    </option>
-                    <option value="on_leave">
-                      <Trans>On Leave</Trans>
-                    </option>
-                    <option value="terminated">
-                      <Trans>Terminated</Trans>
-                    </option>
+                    <EmployeeStatusOptions />
                   </Select>
                   {fieldErrors.status && (
                     <ErrorMessage id={getFieldErrorId("status")}>
@@ -847,7 +838,7 @@ export function EmployeeCreate() {
                     </ErrorMessage>
                   )}
                   <Text className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
-                    Applicant / Pre-Contract / Active / On Leave / Terminated
+                    <Trans>Applicant / Pre-Contract / Active / On Leave / Terminated</Trans>
                   </Text>
                   <Text className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
                     {inviteSupported ? (

--- a/src/pages/Employees/EmployeeCreate.tsx
+++ b/src/pages/Employees/EmployeeCreate.tsx
@@ -38,6 +38,7 @@ const fieldOrder: EmployeeFormField[] = [
   "organizational_unit_id",
   "management_level",
   "status",
+  "send_invitation",
   "contract_type",
 ];
 
@@ -428,6 +429,7 @@ export function EmployeeCreate() {
   function handleStatusChange(status: EmployeeStatus) {
     setFormData((prev) => ({ ...prev, status }));
     clearFieldError("status");
+    clearFieldError("send_invitation");
     clearSubmitMessages();
   }
 
@@ -844,6 +846,22 @@ export function EmployeeCreate() {
                       {fieldErrors.status}
                     </ErrorMessage>
                   )}
+                  <Text className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+                    Applicant / Pre-Contract / Active / On Leave / Terminated
+                  </Text>
+                  <Text className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
+                    {inviteSupported ? (
+                      <Trans>
+                        Pre-Contract is the only status that allows onboarding
+                        invitations.
+                      </Trans>
+                    ) : (
+                      <Trans>
+                        Invitations are only available for employees in
+                        pre-contract status.
+                      </Trans>
+                    )}
+                  </Text>
                 </Field>
 
                 <Field>
@@ -906,6 +924,10 @@ export function EmployeeCreate() {
                     <Switch
                       id="send_invitation"
                       name="send_invitation"
+                      aria-invalid={
+                        fieldErrors.send_invitation ? true : undefined
+                      }
+                      aria-describedby={getAriaDescribedBy("send_invitation")}
                       checked={
                         Boolean(formData.send_invitation) && inviteSupported
                       }
@@ -918,6 +940,11 @@ export function EmployeeCreate() {
                       }
                     />
                   </div>
+                  {fieldErrors.send_invitation && (
+                    <ErrorMessage id={getFieldErrorId("send_invitation")}>
+                      {fieldErrors.send_invitation}
+                    </ErrorMessage>
+                  )}
                 </Field>
               </div>
             </FieldGroup>

--- a/src/pages/Employees/EmployeeCreate.tsx
+++ b/src/pages/Employees/EmployeeCreate.tsx
@@ -838,7 +838,9 @@ export function EmployeeCreate() {
                     </ErrorMessage>
                   )}
                   <Text className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
-                    <Trans>Applicant / Pre-Contract / Active / On Leave / Terminated</Trans>
+                    <Trans>
+                      Applicant / Pre-Contract / Active / On Leave / Terminated
+                    </Trans>
                   </Text>
                   <Text className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
                     {inviteSupported ? (

--- a/src/pages/Employees/EmployeeDetail.test.tsx
+++ b/src/pages/Employees/EmployeeDetail.test.tsx
@@ -297,6 +297,54 @@ describe("EmployeeDetail", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("should show terminate button for on-leave employees", async () => {
+    vi.mocked(employeeApi.fetchEmployee).mockResolvedValue({
+      ...mockEmployee,
+      status: "on_leave",
+    });
+
+    renderWithProviders("emp-1");
+
+    await waitFor(() => {
+      expect(screen.getByText("On Leave")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("button", { name: /terminate/i })
+    ).toBeInTheDocument();
+  });
+
+  it("should explain when onboarding invitations are unavailable for the current status", async () => {
+    vi.mocked(employeeApi.fetchEmployee).mockResolvedValue({
+      ...mockEmployee,
+      status: "active",
+      onboarding_invitation: {
+        status: "not_requested",
+        requested_at: null,
+        token_created_at: null,
+        mail_sent_at: null,
+        mail_failed_at: null,
+        failure_reason: null,
+        available: false,
+        eligible_statuses: ["pre_contract"],
+        rule_message:
+          "Onboarding invitations are only available while the employee is in pre_contract status.",
+      },
+    });
+
+    renderWithProviders("emp-1");
+
+    await waitFor(() => {
+      expect(screen.getByText("Not requested")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(
+        /onboarding invitations are only available while the employee is in pre_contract status\./i
+      )
+    ).toBeInTheDocument();
+  });
+
   it("should switch between tabs", async () => {
     renderWithProviders("emp-1");
 

--- a/src/pages/Employees/EmployeeDetail.tsx
+++ b/src/pages/Employees/EmployeeDetail.tsx
@@ -163,7 +163,17 @@ function ProfileTab({ employee }: { employee: Employee }) {
       </DescriptionTerm>
       <DescriptionDetails>
         {onboardingInvitation ? (
-          <InvitationStatusLabel status={onboardingInvitation.status} />
+          <div className="space-y-1">
+            <div>
+              <InvitationStatusLabel status={onboardingInvitation.status} />
+            </div>
+            {onboardingInvitation.available === false &&
+              onboardingInvitation.rule_message && (
+                <Text className="text-sm text-zinc-500 dark:text-zinc-400">
+                  {onboardingInvitation.rule_message}
+                </Text>
+              )}
+          </div>
         ) : (
           "-"
         )}
@@ -476,7 +486,7 @@ export function EmployeeDetail() {
                     <Trans>Activate</Trans>
                   </Button>
                 )}
-              {employee.status === "active" &&
+              {(employee.status === "active" || employee.status === "on_leave") &&
                 capabilities.actions.employees.terminate && (
                   <Button onClick={handleTerminate} disabled={actionLoading}>
                     <Trans>Terminate</Trans>

--- a/src/pages/Employees/EmployeeDetail.tsx
+++ b/src/pages/Employees/EmployeeDetail.tsx
@@ -486,7 +486,8 @@ export function EmployeeDetail() {
                     <Trans>Activate</Trans>
                   </Button>
                 )}
-              {(employee.status === "active" || employee.status === "on_leave") &&
+              {(employee.status === "active" ||
+                employee.status === "on_leave") &&
                 capabilities.actions.employees.terminate && (
                   <Button onClick={handleTerminate} disabled={actionLoading}>
                     <Trans>Terminate</Trans>

--- a/src/pages/Employees/EmployeeEdit.test.tsx
+++ b/src/pages/Employees/EmployeeEdit.test.tsx
@@ -293,6 +293,35 @@ describe("EmployeeEdit", () => {
     });
   });
 
+  it("should allow changing the employee status to on leave", async () => {
+    const mockUpdateEmployee = vi.mocked(employeeApi.updateEmployee);
+    mockUpdateEmployee.mockResolvedValue({
+      ...mockEmployee,
+      status: "on_leave",
+    });
+
+    renderWithProviders("emp-1");
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/first name/i)).toHaveValue("John");
+    });
+
+    fireEvent.change(screen.getByLabelText(/status/i), {
+      target: { value: "on_leave" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mockUpdateEmployee).toHaveBeenCalledWith(
+        "emp-1",
+        expect.objectContaining({
+          status: "on_leave",
+        })
+      );
+    });
+  });
+
   it("should show loading state while fetching employee", async () => {
     vi.mocked(employeeApi.fetchEmployee).mockImplementation(
       () => new Promise(() => {})

--- a/src/pages/Employees/EmployeeEdit.tsx
+++ b/src/pages/Employees/EmployeeEdit.tsx
@@ -575,7 +575,9 @@ export function EmployeeEdit() {
                     <EmployeeStatusOptions />
                   </Select>
                   <Text className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
-                    <Trans>Applicant / Pre-Contract / Active / On Leave / Terminated</Trans>
+                    <Trans>
+                      Applicant / Pre-Contract / Active / On Leave / Terminated
+                    </Trans>
                   </Text>
                   <Text className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
                     <Trans>

--- a/src/pages/Employees/EmployeeEdit.tsx
+++ b/src/pages/Employees/EmployeeEdit.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Trans, msg } from "@lingui/macro";
 import { useLingui } from "@lingui/react";
-import type { Employee, EmployeeFormData } from "@/types/api";
+import type { Employee, EmployeeFormData, EmployeeStatus } from "@/types/api";
 import { fetchEmployee, updateEmployee } from "../../services/employeeApi";
 import { listOrganizationalUnits } from "../../services/organizationalUnitApi";
 import type { OrganizationalUnit } from "../../types/organizational";
@@ -558,6 +558,45 @@ export function EmployeeEdit() {
                     </span>
                   </Field>
                 </div>
+
+                <Field>
+                  <Label>
+                    <Trans>Status</Trans> *
+                  </Label>
+                  <Select
+                    name="status"
+                    required
+                    value={formData.status}
+                    onChange={(e) =>
+                      handleChange("status", e.target.value as EmployeeStatus)
+                    }
+                  >
+                    <option value="applicant">
+                      <Trans>Applicant</Trans>
+                    </option>
+                    <option value="pre_contract">
+                      <Trans>Pre-Contract</Trans>
+                    </option>
+                    <option value="active">
+                      <Trans>Active</Trans>
+                    </option>
+                    <option value="on_leave">
+                      <Trans>On Leave</Trans>
+                    </option>
+                    <option value="terminated">
+                      <Trans>Terminated</Trans>
+                    </option>
+                  </Select>
+                  <Text className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+                    Applicant / Pre-Contract / Active / On Leave / Terminated
+                  </Text>
+                  <Text className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
+                    <Trans>
+                      Invitations are only available for employees in
+                      pre-contract status.
+                    </Trans>
+                  </Text>
+                </Field>
               </div>
             </FieldGroup>
           </Fieldset>

--- a/src/pages/Employees/EmployeeEdit.tsx
+++ b/src/pages/Employees/EmployeeEdit.tsx
@@ -22,6 +22,7 @@ import {
 import { Input } from "../../components/input";
 import { Select } from "../../components/select";
 import { Switch } from "../../components/switch";
+import { EmployeeStatusOptions } from "./EmployeeStatusOptions";
 
 /**
  * Employee Edit Form
@@ -571,24 +572,10 @@ export function EmployeeEdit() {
                       handleChange("status", e.target.value as EmployeeStatus)
                     }
                   >
-                    <option value="applicant">
-                      <Trans>Applicant</Trans>
-                    </option>
-                    <option value="pre_contract">
-                      <Trans>Pre-Contract</Trans>
-                    </option>
-                    <option value="active">
-                      <Trans>Active</Trans>
-                    </option>
-                    <option value="on_leave">
-                      <Trans>On Leave</Trans>
-                    </option>
-                    <option value="terminated">
-                      <Trans>Terminated</Trans>
-                    </option>
+                    <EmployeeStatusOptions />
                   </Select>
                   <Text className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
-                    Applicant / Pre-Contract / Active / On Leave / Terminated
+                    <Trans>Applicant / Pre-Contract / Active / On Leave / Terminated</Trans>
                   </Text>
                   <Text className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
                     <Trans>

--- a/src/pages/Employees/EmployeeStatusOptions.tsx
+++ b/src/pages/Employees/EmployeeStatusOptions.tsx
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { Trans } from "@lingui/macro";
+
+export function EmployeeStatusOptions() {
+  return (
+    <>
+      <option value="applicant">
+        <Trans>Applicant</Trans>
+      </option>
+      <option value="pre_contract">
+        <Trans>Pre-Contract</Trans>
+      </option>
+      <option value="active">
+        <Trans>Active</Trans>
+      </option>
+      <option value="on_leave">
+        <Trans>On Leave</Trans>
+      </option>
+      <option value="terminated">
+        <Trans>Terminated</Trans>
+      </option>
+    </>
+  );
+}

--- a/src/types/api/employees.ts
+++ b/src/types/api/employees.ts
@@ -41,6 +41,9 @@ export type EmployeeOnboardingInvitationStatus =
 
 export interface EmployeeOnboardingInvitation {
   status: EmployeeOnboardingInvitationStatus;
+  available?: boolean;
+  eligible_statuses?: EmployeeStatus[];
+  rule_message?: string | null;
   requested_at?: string | null;
   token_created_at?: string | null;
   mail_sent_at?: string | null;


### PR DESCRIPTION
Fixes SecPal/api#660
Part of: SecPal/api#658

## Summary
- clarify the full employee status set in the create and edit UI
- explain the `pre_contract`-only onboarding invitation rule before submission
- surface backend `send_invitation` validation errors inline in the create form
- show unavailable invitation reasons on the employee detail page and align terminate actions with backend lifecycle rules

## Validation
- `npm run typecheck`
- `npm run lint`
- `npx vitest run src/pages/Employees/EmployeeCreate.test.tsx src/pages/Employees/EmployeeEdit.test.tsx src/pages/Employees/EmployeeDetail.test.tsx`
- `reuse lint`

## Notes
- existing TypeScript 6 compatibility warning is tracked separately in SecPal/frontend#614
