### PR TITLE
test: align activity log API URL expectations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Updated the `activityLogApi` service tests to expect the configured absolute API URL, matching the current client behavior and restoring the targeted Vitest coverage for activity-log requests
 - Surfaced backend `send_invitation` validation errors inline in the employee create form, showed onboarding-invitation availability reasons on employee detail pages, and aligned the terminate action with the backend by allowing it for `on_leave` employees as well as `active` ones.
 - Replaced the authenticated wildcard app-route redirect to `/` with a dedicated not-found state, so unknown non-onboarding URLs now fail clearly while protected feature routes continue to use the shared access-denied UX
 - distinguish temporary onboarding rate limits from invalid or expired invitation links in the onboarding completion flow, keep form-level `429` feedback inline instead of collapsing into the invalid-link screen, and surface a dedicated retry state when token validation is temporarily throttled

--- a/src/services/activityLogApi.test.ts
+++ b/src/services/activityLogApi.test.ts
@@ -1,7 +1,8 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { apiConfig } from "../config";
 import { fetchActivityLogs, verifyActivityLog } from "./activityLogApi";
 import type {
   Activity,
@@ -83,7 +84,7 @@ describe("activityLogApi", () => {
 
       // Now includes verification parameter by default
       expect(csrf.apiFetch).toHaveBeenCalledWith(
-        "/v1/activity-logs?include_verification=1"
+        `${apiConfig.baseUrl}/v1/activity-logs?include_verification=1`
       );
       expect(result).toEqual(mockResponse);
       expect(result.data).toHaveLength(1);
@@ -235,7 +236,7 @@ describe("activityLogApi", () => {
       const result = await verifyActivityLog("log-1");
 
       expect(csrf.apiFetch).toHaveBeenCalledWith(
-        "/v1/activity-logs/log-1/verify"
+        `${apiConfig.baseUrl}/v1/activity-logs/log-1/verify`
       );
       expect(result).toEqual({ data: mockVerification });
       expect(result.data.verification.chain_valid).toBe(true);
@@ -372,7 +373,9 @@ describe("activityLogApi", () => {
       const { fetchActivityLog } = await import("./activityLogApi");
       const result = await fetchActivityLog("log-1");
 
-      expect(csrf.apiFetch).toHaveBeenCalledWith("/v1/activity-logs/log-1");
+      expect(csrf.apiFetch).toHaveBeenCalledWith(
+        `${apiConfig.baseUrl}/v1/activity-logs/log-1`
+      );
       expect(result.data.id).toBe("log-1");
       expect(result.data.log_name).toBe("authentication");
     });


### PR DESCRIPTION
## Summary
- update the activity log API tests to expect the configured absolute API base URL
- keep the service test expectations aligned with the current `apiFetch` call shape
- document the targeted test fix in the frontend changelog

## Validation
- `npm run test:run -- src/services/activityLogApi.test.ts`
- `npx eslint src/services/activityLogApi.test.ts --ext ts,tsx --report-unused-disable-directives --max-warnings 0`
- `npm run typecheck`
- `reuse lint`

Fixes #599