### PR TITLE
chore(deps): clean frontend preflight audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Raised the frontend override floors for `brace-expansion` and `serialize-javascript` so `npm audit` now returns 0 vulnerabilities; the remaining install-time deprecation warnings still come from the upstream `vite-plugin-pwa` / `workbox-build` toolchain and remain documented as accepted build-time risk
+
 - Pinned the transitive `picomatch` resolution to `2.3.2` for 2.x consumers and
   `4.0.4` for 4.x consumers via `overrides`, so the frontend no longer ships
   the vulnerable glob-matching releases flagged by Dependabot security alerts for

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -14,8 +14,6 @@ This document tracks known issues that are outside our direct control and requir
 When running `npm ci` or fresh `npm install`, you may still see deprecation warnings for the following packages:
 
 ```text
-npm warn deprecated glob@11.1.0: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update.
-
 npm warn deprecated sourcemap-codec@1.4.8: Please use @jridgewell/sourcemap-codec instead
 
 npm warn deprecated source-map@0.8.0-beta.0: The work that was done in this beta
@@ -26,9 +24,10 @@ npm warn deprecated source-map@0.8.0-beta.0: The work that was done in this beta
 
 These are **transitive dependencies** from packages that currently have no compatible upstream replacement in this repo's supported toolchain:
 
-- `vite-plugin-pwa@1.2.0` → `workbox-build@7.4.0` → `glob@11.1.0`
 - `vite-plugin-pwa@1.2.0` → `workbox-build@7.4.0` → `@rollup/plugin-replace@2.x` / `magic-string@0.25.9` → `sourcemap-codec@1.4.8`
 - `vite-plugin-pwa@1.2.0` → `workbox-build@7.4.0` → `source-map@0.8.0-beta.0`
+
+The previously observed `vite-plugin-pwa@1.2.0` → `workbox-build@7.4.0` → `glob@11.1.0` warning was resolved on 2026-03-27 because the existing `"glob": "^13.0.6"` override in `package.json` causes npm to resolve all glob requests (including `^11.0.1` from workbox-build) to the non-deprecated `glob@13.0.6`.
 
 The previously observed `@lhci/cli` → `chrome-launcher` → `rimraf` / `glob@7.2.3` / `inflight@1.0.6` chain was removed from regular installs on 2026-03-21 by switching local Lighthouse CLI usage to on-demand `npx` execution.
 
@@ -43,7 +42,7 @@ The previously tracked `npm audit` findings for `brace-expansion` and `serialize
 
 ### Why We Can't Fix This Directly
 
-1. **`workbox-build@7.4.0`** is still the latest release and still depends on `glob@11.1.0`, `sourcemap-codec@1.4.8`, and `source-map@0.8.0-beta.0`
+1. **`workbox-build@7.4.0`** is still the latest release and still depends on `sourcemap-codec@1.4.8` and `source-map@0.8.0-beta.0`
 2. **`vite-plugin-pwa@1.2.0`** is still the latest release and still depends on `workbox-build@7.4.0`
 3. **npm overrides** would force unverified major-version replacements into build tooling
 4. **Forking/patching** would create permanent maintenance overhead for non-runtime warnings

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal Contributors
+SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 SPDX-License-Identifier: CC0-1.0
 -->
 
@@ -9,7 +9,7 @@ This document tracks known issues that are outside our direct control and requir
 
 ## npm Deprecation Warnings
 
-### Status: Partially Mitigated, Awaiting Upstream Fixes
+### Status: Audit Clean, Remaining Deprecations Await Upstream Fixes
 
 When running `npm ci` or fresh `npm install`, you may still see deprecation warnings for the following packages:
 
@@ -32,9 +32,11 @@ These are **transitive dependencies** from packages that currently have no compa
 
 The previously observed `@lhci/cli` → `chrome-launcher` → `rimraf` / `glob@7.2.3` / `inflight@1.0.6` chain was removed from regular installs on 2026-03-21 by switching local Lighthouse CLI usage to on-demand `npx` execution.
 
+The previously tracked `npm audit` findings for `brace-expansion` and `serialize-javascript` were eliminated on 2026-03-27 by raising the frontend override floors to patched releases. `npm audit` now reports 0 vulnerabilities in this repository.
+
 ### Impact Assessment
 
-- **Security**: ✅ No known CVEs
+- **Security**: ✅ `npm audit` is clean; no known runtime CVEs remain in the current dependency graph
 - **Deprecated Build Tooling**: ⚠️ Limited to build-time and local tooling paths, not shipped runtime code
 - **Functionality**: ✅ All features work correctly
 - **Build Process**: ✅ No impact on build or runtime
@@ -49,6 +51,7 @@ The previously observed `@lhci/cli` → `chrome-launcher` → `rimraf` / `glob@7
 ### What We're Doing
 
 - ✅ Removed the direct `@lhci/cli` install path from normal dependency installation
+- ✅ Raised `brace-expansion` and `serialize-javascript` override floors so `npm audit` now returns 0 vulnerabilities
 - ✅ Monitoring upstream repositories for updates
 - ✅ Testing new versions as they're released
 - ✅ Documented in this file for team awareness
@@ -78,9 +81,9 @@ We will update dependencies as soon as stable upstream releases make that possib
 
 ---
 
-**Last Updated**: 2026-03-21
+**Last Updated**: 2026-03-27
 **Reviewed By**: SecPal Team
-**Status**: Accepted Risk (Non-Critical)
+**Status**: Accepted Risk (Deprecations Only)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6564,9 +6564,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12232,9 +12232,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
-      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/package-lock.json.license
+++ b/package-lock.json.license
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2025-2026 SecPal
 SPDX-License-Identifier: CC0-1.0

--- a/package.json
+++ b/package.json
@@ -117,10 +117,11 @@
   "overrides": {
     "tmp": "^0.2.4",
     "rollup": ">=4.59.0",
-    "serialize-javascript": ">=7.0.3",
+    "serialize-javascript": ">=7.0.5",
     "flatted": "3.4.2",
     "picomatch@^2": "2.3.2",
     "picomatch@^4": "4.0.4",
+    "brace-expansion": ">=5.0.5",
     "@isaacs/brace-expansion": ">=5.0.1",
     "minimatch": ">=10.2.4",
     "yauzl": "3.2.1",

--- a/package.json.license
+++ b/package.json.license
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2025-2026 SecPal
 SPDX-License-Identifier: CC0-1.0


### PR DESCRIPTION
## Summary
- raise safe override floors for `brace-expansion` and `serialize-javascript`
- regenerate the frontend lockfile so `npm audit` returns 0 vulnerabilities
- document that the remaining install-time deprecation warnings are upstream `vite-plugin-pwa` / `workbox-build` limitations

## Validation
- `npm audit --json`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `reuse lint`

## Notes
- remaining `sourcemap-codec` / `source-map` install warnings are documented accepted build-time risk
- the separate ESLint peer-mismatch follow-up is tracked in #616

Fixes #602