### PR TITLE
docs: replace frontend placeholder domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Replaced the remaining frontend documentation-only placeholder-domain references with `secpal.dev` and `app.secpal.dev` examples so the repo stays aligned with the SecPal domain policy outside runtime and test fixtures as well.
 - Replaced the remaining non-SecPal frontend test fixtures with `secpal.dev` addresses and updated the login email placeholder to a SecPal domain. This keeps the repository aligned with the `secpal.app` / `secpal.dev` domain policy consistently.
 - Filled the remaining generic German Lingui catalog gaps for employee status guidance so the frontend `de` locale no longer falls back to English for those UI strings.
 - Updated the `activityLogApi` service tests to expect the configured absolute API URL, matching the current client behavior and restoring the targeted Vitest coverage for activity-log requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Replaced the remaining frontend documentation-only placeholder-domain references with `secpal.dev` and `app.secpal.dev` examples so the repo stays aligned with the SecPal domain policy outside runtime and test fixtures as well.
+- Replaced the remaining frontend documentation-only placeholder-domain references with `secpal.dev` / `app.secpal.dev` host examples and `secpal.app` email examples so the repo stays aligned with the SecPal domain policy outside runtime and test fixtures as well.
 - Replaced the remaining non-SecPal frontend test fixtures with `secpal.dev` addresses and updated the login email placeholder to a SecPal domain. This keeps the repository aligned with the `secpal.app` / `secpal.dev` domain policy consistently.
 - Filled the remaining generic German Lingui catalog gaps for employee status guidance so the frontend `de` locale no longer falls back to English for those UI strings.
 - Updated the `activityLogApi` service tests to expect the configured absolute API URL, matching the current client behavior and restoring the targeted Vitest coverage for activity-log requests

--- a/PWA_PHASE3_TESTING.md
+++ b/PWA_PHASE3_TESTING.md
@@ -193,7 +193,7 @@ Note: Service Worker updates work differently in `npm run dev`:
    - **Option C (Test URL):** Manually open:
 
      ```text
-     http://localhost:5173/share?title=Test&text=Hello&url=https://example.com
+     http://localhost:5173/share?title=Test&text=Hello&url=https://app.secpal.dev
      ```
 
 3. **Verify text display**

--- a/docs/deployment-spa-routing.md
+++ b/docs/deployment-spa-routing.md
@@ -268,7 +268,7 @@ After deployment, test these scenarios:
 
 ```typescript
 export default defineConfig({
-  base: "/app/", // If deployed to example.com/app/
+  base: "/app/", // If deployed to app.secpal.dev/app/
   // ...
 });
 ```

--- a/docs/development/TDD_WORKFLOW.md
+++ b/docs/development/TDD_WORKFLOW.md
@@ -40,7 +40,7 @@ import { UserProfile } from './UserProfile';
 
 describe('UserProfile', () => {
   it('renders user name', () => {
-    render(<UserProfile user={{ name: 'John Doe', email: 'john@example.com' }} />);
+    render(<UserProfile user={{ name: 'John Doe', email: 'john@secpal.dev' }} />);
     expect(screen.getByText('John Doe')).toBeInTheDocument();
   });
 });

--- a/docs/development/TDD_WORKFLOW.md
+++ b/docs/development/TDD_WORKFLOW.md
@@ -40,7 +40,7 @@ import { UserProfile } from './UserProfile';
 
 describe('UserProfile', () => {
   it('renders user name', () => {
-    render(<UserProfile user={{ name: 'John Doe', email: 'john@secpal.dev' }} />);
+    render(<UserProfile user={{ name: 'John Doe', email: 'john@secpal.app' }} />);
     expect(screen.getByText('John Doe')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- replace the remaining documentation-only placeholder domains with SecPal examples
- keep development examples on `secpal.dev` and app examples on `app.secpal.dev`
- record the docs cleanup in the changelog

## Validation
- `./scripts/preflight.sh`

Fixes #621