### PR TITLE
fix: align customer and site gating with scoped access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- aligned customer and site feature gating with the backend collection policy by honoring explicit `hasCustomerAccess` and `hasSiteAccess` auth-context flags, so scoped-assignment users can enter the same areas the API intentionally exposes while users without any effective access continue to see the shared access-denied state
 - Clarified the employee status rules in the create and edit UI by showing the full valid status set (`Applicant`, `Pre-Contract`, `Active`, `On Leave`, `Terminated`) and by explaining inline that onboarding invitations are only available in `Pre-Contract`.
 - Aligned the frontend auth client, integration tests, and migration guide with the canonical backend auth/self-service surface so browser sessions now use `POST /v1/auth/login`, `POST /v1/auth/logout`, and `GET /v1/me` instead of legacy or guessed paths
 - Pinned frontend TypeScript back to the supported `5.9.x` line so `@typescript-eslint` linting no longer runs outside its declared compatibility range while the repository waits for official TypeScript 6 support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- aligned customer and site feature gating with the backend collection policy by honoring explicit `hasCustomerAccess` and `hasSiteAccess` auth-context flags, so scoped-assignment users can enter the same areas the API intentionally exposes while users without any effective access continue to see the shared access-denied state
+- Aligned customer and site feature gating with the backend collection policy by honoring explicit `hasCustomerAccess` and `hasSiteAccess` auth-context flags, so scoped-assignment users can enter the same areas the API intentionally exposes while users without any effective access continue to see the shared access-denied state.
 - Clarified the employee status rules in the create and edit UI by showing the full valid status set (`Applicant`, `Pre-Contract`, `Active`, `On Leave`, `Terminated`) and by explaining inline that onboarding invitations are only available in `Pre-Contract`.
 - Aligned the frontend auth client, integration tests, and migration guide with the canonical backend auth/self-service surface so browser sessions now use `POST /v1/auth/login`, `POST /v1/auth/logout`, and `GET /v1/me` instead of legacy or guessed paths
 - Pinned frontend TypeScript back to the supported `5.9.x` line so `@typescript-eslint` linting no longer runs outside its declared compatibility range while the repository waits for official TypeScript 6 support

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -554,7 +554,6 @@ describe("ApplicationLayout", () => {
           email: "john@secpal.dev",
           hasOrganizationalScopes: false,
           hasCustomerAccess: true,
-          hasSiteAccess: true,
           roles: [],
           permissions: [],
         })

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -545,6 +545,32 @@ describe("ApplicationLayout", () => {
       expect(screen.queryByText("Employees")).not.toBeInTheDocument();
     });
 
+    it("shows Customers for users with backend scoped-access flags", () => {
+      localStorage.setItem(
+        "auth_user",
+        JSON.stringify({
+          id: 1,
+          name: "John Doe",
+          email: "john@secpal.dev",
+          hasOrganizationalScopes: false,
+          hasCustomerAccess: true,
+          hasSiteAccess: true,
+          roles: [],
+          permissions: [],
+        })
+      );
+
+      renderWithProviders(
+        <ApplicationLayout>
+          <div>Content</div>
+        </ApplicationLayout>
+      );
+
+      expect(screen.getByText("Customers")).toBeInTheDocument();
+      expect(screen.queryByText("Organization")).not.toBeInTheDocument();
+      expect(screen.queryByText("Employees")).not.toBeInTheDocument();
+    });
+
     it("always shows Home", () => {
       localStorage.setItem(
         "auth_user",

--- a/src/contexts/auth-context.ts
+++ b/src/contexts/auth-context.ts
@@ -11,6 +11,8 @@ export interface User {
   roles?: string[];
   permissions?: string[];
   hasOrganizationalScopes?: boolean;
+  hasCustomerAccess?: boolean;
+  hasSiteAccess?: boolean;
   employee?: Employee | null; // User's employee record (if they are an employee)
 }
 

--- a/src/lib/capabilities.test.ts
+++ b/src/lib/capabilities.test.ts
@@ -64,6 +64,23 @@ describe("getUserCapabilities", () => {
     expect(capabilities.actions.sites.create).toBe(false);
   });
 
+  it("enables customer and site features from backend scoped-access flags", () => {
+    const capabilities = getUserCapabilities({
+      id: 1,
+      name: "Scoped Access User",
+      email: "scoped.access@secpal.dev",
+      roles: [],
+      permissions: [],
+      hasCustomerAccess: true,
+      hasSiteAccess: true,
+    });
+
+    expect(capabilities.customers).toBe(true);
+    expect(capabilities.sites).toBe(true);
+    expect(capabilities.actions.customers.create).toBe(false);
+    expect(capabilities.actions.sites.delete).toBe(false);
+  });
+
   it("grants action capabilities from explicit action permissions", () => {
     const capabilities = getUserCapabilities({
       id: 1,

--- a/src/lib/capabilities.ts
+++ b/src/lib/capabilities.ts
@@ -184,6 +184,8 @@ export function getUserCapabilities(
 ): UserCapabilities {
   const isAuthenticated = user !== null && user !== undefined;
   const hasOrganizationalScopes = user?.hasOrganizationalScopes ?? false;
+  const hasCustomerAccess = user?.hasCustomerAccess ?? false;
+  const hasSiteAccess = user?.hasSiteAccess ?? false;
   const hasElevatedUiRole = hasAnyUserRole(user, ELEVATED_UI_ROLES);
   const canCreateCustomers =
     isAuthenticated &&
@@ -241,10 +243,12 @@ export function getUserCapabilities(
     customers:
       isAuthenticated &&
       (hasElevatedUiRole ||
+        hasCustomerAccess ||
         hasAnyUserPermission(user, CUSTOMER_FEATURE_PERMISSIONS)),
     sites:
       isAuthenticated &&
       (hasElevatedUiRole ||
+        hasSiteAccess ||
         hasAnyUserPermission(user, CUSTOMER_FEATURE_PERMISSIONS)),
     employees:
       isAuthenticated &&

--- a/src/services/authApi.test.ts
+++ b/src/services/authApi.test.ts
@@ -95,6 +95,8 @@ describe("authApi", () => {
           roles: ["Admin"],
           permissions: ["users.read", "customers.*"],
           hasOrganizationalScopes: true,
+          hasCustomerAccess: true,
+          hasSiteAccess: true,
         },
       };
 
@@ -116,6 +118,8 @@ describe("authApi", () => {
       expect(result.user.roles).toEqual(["Admin"]);
       expect(result.user.permissions).toEqual(["users.read", "customers.*"]);
       expect(result.user.hasOrganizationalScopes).toBe(true);
+      expect(result.user.hasCustomerAccess).toBe(true);
+      expect(result.user.hasSiteAccess).toBe(true);
     });
 
     it("sends login request with email and password only (no device_name for SPA)", async () => {

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -18,6 +18,8 @@ interface LoginResponse {
     roles?: string[];
     permissions?: string[];
     hasOrganizationalScopes?: boolean;
+    hasCustomerAccess?: boolean;
+    hasSiteAccess?: boolean;
   };
 }
 


### PR DESCRIPTION
## Summary
- extend frontend auth types with scoped collection-access flags
- derive customer and site capabilities from backend-provided scoped-access state
- cover the new gating path in capability, auth-api, and application-layout tests

## Validation
- `npm test -- --run src/lib/capabilities.test.ts src/components/application-layout.test.tsx src/services/authApi.test.ts`
- `npm run typecheck`
- `npm run lint -- src/lib/capabilities.ts src/contexts/auth-context.ts src/services/authApi.ts src/lib/capabilities.test.ts src/components/application-layout.test.tsx src/services/authApi.test.ts`
- `reuse lint`
- local preflight during push

Fixes SecPal/.github#263
