### PR TITLE
fix: align customer and site feature visibility with explicit access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Separated customer and site feature visibility from assignment-mutation and cross-resource permissions, so only explicit collection access (`hasCustomerAccess` / `hasSiteAccess` or the matching read permission) unlocks those frontend areas and future custom roles cannot drift into implicit half-authorized states.
 - Aligned customer and site feature gating with the backend collection policy by honoring explicit `hasCustomerAccess` and `hasSiteAccess` auth-context flags, so scoped-assignment users can enter the same areas the API intentionally exposes while users without any effective access continue to see the shared access-denied state.
 - Clarified the employee status rules in the create and edit UI by showing the full valid status set (`Applicant`, `Pre-Contract`, `Active`, `On Leave`, `Terminated`) and by explaining inline that onboarding invitations are only available in `Pre-Contract`.
 - Aligned the frontend auth client, integration tests, and migration guide with the canonical backend auth/self-service surface so browser sessions now use `POST /v1/auth/login`, `POST /v1/auth/logout`, and `GET /v1/me` instead of legacy or guessed paths

--- a/src/lib/capabilities.test.ts
+++ b/src/lib/capabilities.test.ts
@@ -64,6 +64,32 @@ describe("getUserCapabilities", () => {
     expect(capabilities.actions.sites.create).toBe(false);
   });
 
+  it("does not leak the site feature from customer-only read access", () => {
+    const capabilities = getUserCapabilities({
+      id: 1,
+      name: "Customer Reader",
+      email: "customer.reader@secpal.dev",
+      roles: [],
+      permissions: ["customers.read"],
+    });
+
+    expect(capabilities.customers).toBe(true);
+    expect(capabilities.sites).toBe(false);
+  });
+
+  it("does not unlock customer or site features from assignment mutation permissions alone", () => {
+    const capabilities = getUserCapabilities({
+      id: 1,
+      name: "Assignment Operator",
+      email: "assignment.operator@secpal.dev",
+      roles: [],
+      permissions: ["assignments.create"],
+    });
+
+    expect(capabilities.customers).toBe(false);
+    expect(capabilities.sites).toBe(false);
+  });
+
   it("enables customer and site features from backend scoped-access flags", () => {
     const capabilities = getUserCapabilities({
       id: 1,

--- a/src/lib/capabilities.ts
+++ b/src/lib/capabilities.ts
@@ -5,22 +5,12 @@ import type { User } from "../contexts/auth-context";
 
 const ELEVATED_UI_ROLES = ["Admin", "Manager", "HR"] as const;
 
-const CUSTOMER_FEATURE_PERMISSIONS = [
+const CUSTOMER_FEATURE_VIEW_PERMISSIONS = [
   "customers.read",
-  "customers.create",
-  "customers.update",
-  "customers.delete",
   "customers.*",
-  "sites.read",
-  "sites.create",
-  "sites.update",
-  "sites.delete",
-  "sites.*",
-  "assignments.create",
-  "assignments.update",
-  "assignments.delete",
-  "assignments.*",
 ] as const;
+
+const SITE_FEATURE_VIEW_PERMISSIONS = ["sites.read", "sites.*"] as const;
 
 const EMPLOYEE_FEATURE_PERMISSIONS = [
   "employee.read",
@@ -244,12 +234,12 @@ export function getUserCapabilities(
       isAuthenticated &&
       (hasElevatedUiRole ||
         hasCustomerAccess ||
-        hasAnyUserPermission(user, CUSTOMER_FEATURE_PERMISSIONS)),
+        hasAnyUserPermission(user, CUSTOMER_FEATURE_VIEW_PERMISSIONS)),
     sites:
       isAuthenticated &&
       (hasElevatedUiRole ||
         hasSiteAccess ||
-        hasAnyUserPermission(user, CUSTOMER_FEATURE_PERMISSIONS)),
+        hasAnyUserPermission(user, SITE_FEATURE_VIEW_PERMISSIONS)),
     employees:
       isAuthenticated &&
       hasOrganizationalScopes &&


### PR DESCRIPTION
# Description

Align customer and site feature visibility with explicit collection access instead of implicit cross-resource or assignment-mutation permissions.

## Summary

- restrict customer feature visibility to `hasCustomerAccess` or customer read permissions
- restrict site feature visibility to `hasSiteAccess` or site read permissions
- add regression tests covering customer-only and assignment-mutation-only edge cases
- document the behavioral change in the frontend changelog

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] `npm test -- --run src/lib/capabilities.test.ts`
- [x] `./scripts/preflight.sh`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
