### PR TITLE
fix: use api.secpal.dev as production API host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Corrected the frontend production API fallback and related examples to use the canonical `https://api.secpal.dev` host; `api.secpal.app` is deprecated and not deployed.
 - Separated customer and site feature visibility from assignment-mutation and cross-resource permissions, so only explicit collection access (`hasCustomerAccess` / `hasSiteAccess` or the matching read permission) unlocks those frontend areas and future custom roles cannot drift into implicit half-authorized states.
 - Aligned customer and site feature gating with the backend collection policy by honoring explicit `hasCustomerAccess` and `hasSiteAccess` auth-context flags, so scoped-assignment users can enter the same areas the API intentionally exposes while users without any effective access continue to see the shared access-denied state.
 - Clarified the employee status rules in the create and edit UI by showing the full valid status set (`Applicant`, `Pre-Contract`, `Active`, `On Leave`, `Terminated`) and by explaining inline that onboarding invitations are only available in `Pre-Contract`.
@@ -376,7 +377,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **PWA Service Worker API_URL mode detection** (#249)
   - Updated `vite.config.ts` to use mode-aware API_URL detection matching `src/config.ts`
   - Development mode now uses empty string (Vite proxy forwards `/v1/*` to DDEV backend)
-  - Production mode uses `https://api.secpal.app` as fallback
+  - Production mode uses `https://api.secpal.dev` as fallback
   - **Benefit:** Service worker cache patterns now correctly match local proxy configuration, fixing cache misses in development mode
   - Related to: PR #248 (Vite proxy configuration for local DDEV development)
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ await logout();
 import { fetchWithCsrf } from "@/services/csrf";
 
 // For state-changing requests (POST, PUT, PATCH, DELETE)
-const response = await fetchWithCsrf("https://api.secpal.app/v1/secrets", {
+const response = await fetchWithCsrf("https://api.secpal.dev/v1/secrets", {
   method: "POST",
   headers: { "Content-Type": "application/json" },
   body: JSON.stringify({ title: "My Secret" }),
@@ -151,7 +151,7 @@ const response = await fetchWithCsrf("https://api.secpal.app/v1/secrets", {
 // ✅ 419 retry handled automatically
 
 // For GET requests (no CSRF needed)
-const response = await fetch("https://api.secpal.app/v1/secrets", {
+const response = await fetch("https://api.secpal.dev/v1/secrets", {
   credentials: "include", // REQUIRED: Sends cookies
 });
 ```

--- a/docs/authentication-migration.md
+++ b/docs/authentication-migration.md
@@ -133,13 +133,20 @@ VITE_API_URL=http://api.secpal.dev
 
 ```env
 # Sanctum Configuration
-SANCTUM_STATEFUL_DOMAINS=localhost:5173,secpal.app,www.secpal.app
+SANCTUM_STATEFUL_DOMAINS=localhost:5173,app.secpal.dev
 SESSION_DOMAIN=localhost
 SESSION_SECURE_COOKIE=false  # true in production
 SESSION_DRIVER=cookie
 
 # CORS Configuration
-CORS_ALLOWED_ORIGINS=http://localhost:5173,https://secpal.app
+CORS_ALLOWED_ORIGINS=http://localhost:5173,https://app.secpal.dev
+```
+
+Production SPA baseline:
+
+```env
+SANCTUM_STATEFUL_DOMAINS=app.secpal.dev
+CORS_ALLOWED_ORIGINS=https://app.secpal.dev
 ```
 
 ### Running Locally
@@ -215,7 +222,7 @@ await logoutAll();
 import { fetchWithCsrf } from "@/services/csrf";
 
 // For state-changing requests (POST, PUT, PATCH, DELETE)
-const response = await fetchWithCsrf("https://api.secpal.app/v1/secrets", {
+const response = await fetchWithCsrf("https://api.secpal.dev/v1/secrets", {
   method: "POST",
   headers: {
     "Content-Type": "application/json",
@@ -232,7 +239,7 @@ const response = await fetchWithCsrf("https://api.secpal.app/v1/secrets", {
 
 ```typescript
 // For GET requests (no CSRF protection needed)
-const response = await fetch("https://api.secpal.app/v1/secrets", {
+const response = await fetch("https://api.secpal.dev/v1/secrets", {
   credentials: "include", // REQUIRED: Sends cookies
   headers: {
     Accept: "application/json",
@@ -378,7 +385,7 @@ fetch(url, {
 'supports_credentials' => true,
 'allowed_origins' => [
     'http://localhost:5173',
-    'https://secpal.app',
+    'https://app.secpal.dev',
 ],
 ```
 
@@ -420,7 +427,7 @@ await fetchWithCsrf(url, {
 
 ```env
 # Backend .env
-SANCTUM_STATEFUL_DOMAINS=localhost:5173,secpal.app
+SANCTUM_STATEFUL_DOMAINS=localhost:5173,app.secpal.dev
 SESSION_DOMAIN=localhost
 ```
 
@@ -517,16 +524,16 @@ All supported browsers must:
 ```env
 # Backend production .env
 SESSION_SECURE_COOKIE=true  # REQUIRED in production
-SANCTUM_STATEFUL_DOMAINS=secpal.app,www.secpal.app
+SANCTUM_STATEFUL_DOMAINS=app.secpal.dev
 ```
 
 ### Domain Configuration
 
 ```env
 # Backend production .env
-SESSION_DOMAIN=.secpal.app  # Allows subdomains
-APP_URL=https://secpal.app
-FRONTEND_URL=https://secpal.app
+SESSION_DOMAIN=.secpal.dev  # Allows app/api subdomains
+APP_URL=https://api.secpal.dev
+FRONTEND_URL=https://app.secpal.dev
 ```
 
 ### Security Headers

--- a/docs/authentication-migration.md
+++ b/docs/authentication-migration.md
@@ -122,8 +122,9 @@ The SPA flow uses `POST /v1/auth/login`, `POST /v1/auth/logout`, and `GET /v1/me
 **Frontend `.env.local`:**
 
 ```env
-# Development API endpoint
-VITE_API_URL=http://api.secpal.dev
+# Development API endpoint (leave empty to use Vite proxy, or use https:// for a remote dev server)
+# VITE_API_URL=           # empty = Vite proxy → recommended for local DDEV
+# VITE_API_URL=https://api.secpal.dev   # explicit remote dev/testing server
 
 # No token-related variables needed anymore!
 # ❌ OLD: VITE_AUTH_TOKEN_KEY (removed)

--- a/docs/deployment-spa-routing.md
+++ b/docs/deployment-spa-routing.md
@@ -195,19 +195,19 @@ server {
 
 **Build-time variables** (set before `npm run build`):
 
-- `VITE_API_URL` - Backend API URL (e.g., `https://api.secpal.app`)
+- `VITE_API_URL` - Backend API URL (e.g., `https://api.secpal.dev`)
 
 **Example (.env.production):**
 
 ```env
-VITE_API_URL=https://api.secpal.app
+VITE_API_URL=https://api.secpal.dev
 ```
 
 **Load environment:**
 
 ```bash
 # Production build
-VITE_API_URL=https://api.secpal.app npm run build
+VITE_API_URL=https://api.secpal.dev npm run build
 
 # Or use .env.production file
 npm run build
@@ -222,7 +222,7 @@ Before deploying to production:
 - ✅ HTTPS enabled (Let's Encrypt, Certbot)
 - ✅ Security headers configured (`.htaccess` includes them)
 - ✅ CORS configured on backend (API must allow frontend domain)
-- ✅ `VITE_API_URL` points to production API
+- ✅ `VITE_API_URL` points to the canonical `api.secpal.dev` production API
 - ✅ No `.env` files committed to Git
 - ✅ Service Worker registered (PWA functionality)
 - ✅ CSP headers if needed (restrict script sources)

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("config", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("uses secpal.dev as the production API fallback", async () => {
+    vi.stubEnv("MODE", "production");
+    vi.stubEnv("VITE_API_URL", "");
+
+    const { getApiBaseUrl } = await import("./config");
+
+    expect(getApiBaseUrl()).toBe("https://api.secpal.dev");
+  });
+
+  it("prefers VITE_API_URL when explicitly configured", async () => {
+    vi.stubEnv("MODE", "production");
+    vi.stubEnv("VITE_API_URL", "https://tenant.secpal.dev");
+
+    const { getApiBaseUrl } = await import("./config");
+
+    expect(getApiBaseUrl()).toBe("https://tenant.secpal.dev");
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,7 +20,7 @@ export const apiConfig = {
    * - Development with DDEV: (empty string, Vite proxy handles routing)
    * - Development without proxy: http://localhost:8000
    * - Demo/Testing: https://api.secpal.dev
-   * - Production: https://api.secpal.app
+   * - Production: https://api.secpal.dev
    * - Customer On-Premise: tenant-specific SecPal domain provided during deployment
    *
    * Note: The backend uses apiPrefix: '' in Laravel's bootstrap/app.php,
@@ -32,7 +32,7 @@ export const apiConfig = {
    */
   baseUrl:
     import.meta.env.VITE_API_URL ||
-    (import.meta.env.MODE === "production" ? "https://api.secpal.app" : ""),
+    (import.meta.env.MODE === "production" ? "https://api.secpal.dev" : ""),
 
   /**
    * API timeout in milliseconds

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,7 +20,8 @@ export const apiConfig = {
    * - Development with DDEV: (empty string, Vite proxy handles routing)
    * - Development without proxy: http://localhost:8000
    * - Demo/Testing: https://api.secpal.dev
-   * - Production: https://api.secpal.dev
+   * - Production: https://api.secpal.dev (canonical production endpoint;
+   *   api.secpal.app was deprecated before deployment — see PR #632)
    * - Customer On-Premise: tenant-specific SecPal domain provided during deployment
    *
    * Note: The backend uses apiPrefix: '' in Laravel's bootstrap/app.php,

--- a/tests/integration/auth/cookieAuth.test.ts
+++ b/tests/integration/auth/cookieAuth.test.ts
@@ -158,7 +158,7 @@ describe("Cookie-based Authentication Integration", () => {
         json: async () => ({ data: "protected resource" }),
       } as Response);
 
-      const response = await fetch("https://api.secpal.app/v1/me", {
+      const response = await fetch("https://api.secpal.dev/v1/me", {
         credentials: "include",
         headers: {
           "X-XSRF-TOKEN": "csrf-token",
@@ -182,7 +182,7 @@ describe("Cookie-based Authentication Integration", () => {
         statusText: "Unauthorized",
       } as Response);
 
-      const response = await fetch("https://api.secpal.app/v1/me", {
+      const response = await fetch("https://api.secpal.dev/v1/me", {
         credentials: "include",
       });
 

--- a/tests/integration/auth/csrfProtection.test.ts
+++ b/tests/integration/auth/csrfProtection.test.ts
@@ -32,7 +32,7 @@ describe("CSRF Protection Integration", () => {
         json: async () => ({ success: true }),
       } as Response);
 
-      await fetchWithCsrf("https://api.secpal.app/v1/resource", {
+      await fetchWithCsrf("https://api.secpal.dev/v1/resource", {
         method: "POST",
         body: JSON.stringify({ data: "test" }),
       });
@@ -63,7 +63,7 @@ describe("CSRF Protection Integration", () => {
         status: 200,
       } as Response);
 
-      await fetchWithCsrf("https://api.secpal.app/v1/resource/1", {
+      await fetchWithCsrf("https://api.secpal.dev/v1/resource/1", {
         method: "PUT",
         body: JSON.stringify({ name: "updated" }),
       });
@@ -84,7 +84,7 @@ describe("CSRF Protection Integration", () => {
         status: 200,
       } as Response);
 
-      await fetchWithCsrf("https://api.secpal.app/v1/resource/1", {
+      await fetchWithCsrf("https://api.secpal.dev/v1/resource/1", {
         method: "PATCH",
         body: JSON.stringify({ status: "active" }),
       });
@@ -105,7 +105,7 @@ describe("CSRF Protection Integration", () => {
         status: 204,
       } as Response);
 
-      await fetchWithCsrf("https://api.secpal.app/v1/resource/1", {
+      await fetchWithCsrf("https://api.secpal.dev/v1/resource/1", {
         method: "DELETE",
       });
 
@@ -143,7 +143,7 @@ describe("CSRF Protection Integration", () => {
       } as Response);
 
       const response = await fetchWithCsrf(
-        "https://api.secpal.app/v1/resource",
+        "https://api.secpal.dev/v1/resource",
         {
           method: "POST",
           body: JSON.stringify({ data: "test" }),
@@ -180,7 +180,7 @@ describe("CSRF Protection Integration", () => {
       } as Response);
 
       const response = await fetchWithCsrf(
-        "https://api.secpal.app/v1/resource",
+        "https://api.secpal.dev/v1/resource",
         {
           method: "POST",
           body: JSON.stringify({ data: "test" }),
@@ -239,7 +239,7 @@ describe("CSRF Protection Integration", () => {
       } as Response);
 
       // Should throw CsrfError with specific message
-      const error = await fetchWithCsrf("https://api.secpal.app/v1/resource", {
+      const error = await fetchWithCsrf("https://api.secpal.dev/v1/resource", {
         method: "POST",
       }).catch((e) => e);
 
@@ -273,7 +273,7 @@ describe("CSRF Protection Integration", () => {
       } as Response);
 
       const response = await fetchWithCsrf(
-        "https://api.secpal.app/v1/resource",
+        "https://api.secpal.dev/v1/resource",
         {
           method: "POST",
         }
@@ -334,7 +334,7 @@ describe("CSRF Protection Integration", () => {
           json: async () => ({ success: true }),
         } as Response);
 
-        await fetchWithCsrf(`https://api.secpal.app/v1/resource`, {
+        await fetchWithCsrf(`https://api.secpal.dev/v1/resource`, {
           method,
           body:
             method !== "DELETE" ? JSON.stringify({ data: "test" }) : undefined,
@@ -362,7 +362,7 @@ describe("CSRF Protection Integration", () => {
         json: async () => ({ data: "public data" }),
       } as Response);
 
-      const response = await fetchWithCsrf("https://api.secpal.app/v1/public", {
+      const response = await fetchWithCsrf("https://api.secpal.dev/v1/public", {
         method: "GET",
       });
 
@@ -390,7 +390,7 @@ describe("CSRF Protection Integration", () => {
       } as Response);
 
       const response = await fetchWithCsrf(
-        "https://api.secpal.app/v1/resource",
+        "https://api.secpal.dev/v1/resource",
         {
           method: "POST",
         }
@@ -411,7 +411,7 @@ describe("CSRF Protection Integration", () => {
       } as Response);
 
       const response = await fetchWithCsrf(
-        "https://api.secpal.app/v1/resource",
+        "https://api.secpal.dev/v1/resource",
         {
           method: "POST",
         }
@@ -432,7 +432,7 @@ describe("CSRF Protection Integration", () => {
       } as Response);
 
       const response = await fetchWithCsrf(
-        "https://api.secpal.app/v1/resource",
+        "https://api.secpal.dev/v1/resource",
         {
           method: "POST",
         }
@@ -453,7 +453,7 @@ describe("CSRF Protection Integration", () => {
         status: 200,
       } as Response);
 
-      await fetchWithCsrf("https://api.secpal.app/v1/resource", {
+      await fetchWithCsrf("https://api.secpal.dev/v1/resource", {
         method: "POST",
         body: JSON.stringify({ test: true }),
       });
@@ -489,7 +489,7 @@ describe("CSRF Protection Integration", () => {
         status: 200,
       } as Response);
 
-      await fetchWithCsrf("https://api.secpal.app/v1/resource", {
+      await fetchWithCsrf("https://api.secpal.dev/v1/resource", {
         method: "POST",
       });
 


### PR DESCRIPTION
## Summary
- switch the frontend production API fallback from the deprecated `api.secpal.app` host to `api.secpal.dev`
- update browser-facing docs and integration tests to use the canonical production API host
- add a regression test for the production fallback in `src/config.ts`

## Validation
- `CI=1 npm run test -- src/config.test.ts tests/integration/auth/csrfProtection.test.ts tests/integration/auth/cookieAuth.test.ts`
- `npm run typecheck`
- `npx eslint src/config.ts src/config.test.ts tests/integration/auth/csrfProtection.test.ts tests/integration/auth/cookieAuth.test.ts`
- `reuse lint`

## Notes
- Build-time plugin timing warning tracked separately in #631
- Remaining contract-side deprecated host references are tracked separately in SecPal/contracts#153
