### PR TITLE
feat(auth): add platform auth transport boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Added
 
 - Added a platform-aware frontend auth transport boundary that keeps browser/PWA flows on Sanctum session auth, sanitizes auth state before it enters React or local storage, and creates the explicit seam Android can later wire to a native bearer-token bridge without exposing raw tokens to JavaScript.
+
+### Changed
+
 - Corrected the frontend production API fallback and related examples to use the canonical `https://api.secpal.dev` host; `api.secpal.app` is deprecated and not deployed.
 - Separated customer and site feature visibility from assignment-mutation and cross-resource permissions, so only explicit collection access (`hasCustomerAccess` / `hasSiteAccess` or the matching read permission) unlocks those frontend areas and future custom roles cannot drift into implicit half-authorized states.
 - Aligned customer and site feature gating with the backend collection policy by honoring explicit `hasCustomerAccess` and `hasSiteAccess` auth-context flags, so scoped-assignment users can enter the same areas the API intentionally exposes while users without any effective access continue to see the shared access-denied state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added a platform-aware frontend auth transport boundary that keeps browser/PWA flows on Sanctum session auth, sanitizes auth state before it enters React or local storage, and creates the explicit seam Android can later wire to a native bearer-token bridge without exposing raw tokens to JavaScript.
 - Corrected the frontend production API fallback and related examples to use the canonical `https://api.secpal.dev` host; `api.secpal.app` is deprecated and not deployed.
 - Separated customer and site feature visibility from assignment-mutation and cross-resource permissions, so only explicit collection access (`hasCustomerAccess` / `hasSiteAccess` or the matching read permission) unlocks those frontend areas and future custom roles cannot drift into implicit half-authorized states.
 - Aligned customer and site feature gating with the backend collection policy by honoring explicit `hasCustomerAccess` and `hasSiteAccess` auth-context flags, so scoped-assignment users can enter the same areas the API intentionally exposes while users without any effective access continue to see the shared access-denied state.

--- a/src/components/application-layout.tsx
+++ b/src/components/application-layout.tsx
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import { useMemo } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { Trans } from "@lingui/macro";
 import { useAuth } from "../hooks/useAuth";
 import { useUserCapabilities } from "../hooks/useUserCapabilities";
-import { logout as apiLogout } from "../services/authApi";
+import { getAuthTransport } from "../services/authTransport";
 import { getInitials } from "../lib/stringUtils";
 import { Avatar } from "./avatar";
 import {
@@ -155,6 +156,7 @@ function UserMenuItems({ onLogout }: { onLogout: () => void }) {
 export function ApplicationLayout({ children }: { children: React.ReactNode }) {
   const { user, logout } = useAuth();
   const capabilities = useUserCapabilities();
+  const authTransport = useMemo(() => getAuthTransport(), []);
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -163,7 +165,7 @@ export function ApplicationLayout({ children }: { children: React.ReactNode }) {
     logout();
 
     try {
-      await apiLogout();
+      await authTransport.logout();
     } catch (error) {
       console.error("Logout API call failed:", error);
     } finally {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -186,7 +186,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
 
       try {
-        const nextUser = JSON.parse(event.newValue) as User;
+        const nextUser = authStorage.getUser();
+
+        if (!nextUser) {
+          clearAuthenticatedState(true);
+          return;
+        }
 
         invalidateBootstrapRevalidation();
         setUser(nextUser);

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -9,14 +9,16 @@ import React, {
   useRef,
 } from "react";
 import { AuthContext, type User } from "./auth-context";
+import { getAuthTransport } from "../services/authTransport";
+import { sanitizeAuthUser } from "../services/authState";
 import { authStorage } from "../services/storage";
-import { getCurrentUser } from "../services/authApi";
 import { sessionEvents, isOnline } from "../services/sessionEvents";
 import { clearSensitiveClientState } from "../lib/clientStateCleanup";
 import { hasUserPermission, hasUserRole } from "../lib/capabilities";
 import { syncOfflineSessionAccess } from "../lib/serviceWorkerSession";
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const authTransport = useMemo(() => getAuthTransport(), []);
   const [user, setUser] = useState<User | null>(() => {
     return authStorage.getUser();
   });
@@ -71,13 +73,24 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const login = useCallback(
     (newUser: User) => {
+      const sanitizedUser = sanitizeAuthUser(newUser);
+
+      if (!sanitizedUser) {
+        clearAuthenticatedState(true);
+        return;
+      }
+
       invalidateBootstrapRevalidation();
-      authStorage.setUser(newUser);
-      setUser(newUser);
+      authStorage.setUser(sanitizedUser);
+      setUser(sanitizedUser);
       setIsLoading(false);
       syncOfflineAuthState(true);
     },
-    [invalidateBootstrapRevalidation, syncOfflineAuthState]
+    [
+      clearAuthenticatedState,
+      invalidateBootstrapRevalidation,
+      syncOfflineAuthState,
+    ]
   );
 
   const logout = useCallback(() => {
@@ -130,7 +143,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const requestVersion = bootstrapRequestVersionRef.current + 1;
     bootstrapRequestVersionRef.current = requestVersion;
 
-    void getCurrentUser()
+    void authTransport
+      .getCurrentUser()
       .then((currentUser) => {
         if (
           !isActive ||
@@ -158,7 +172,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     return () => {
       isActive = false;
     };
-  }, [clearAuthenticatedState, syncOfflineAuthState]);
+  }, [authTransport, clearAuthenticatedState, syncOfflineAuthState]);
 
   useEffect(() => {
     const handleStorage = (event: StorageEvent) => {

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -420,6 +420,9 @@ describe("useAuth", () => {
     });
 
     act(() => {
+      // Write the corrupt value so localStorage matches the event (real browser
+      // cross-tab writes keep newValue and the actual storage in sync).
+      localStorage.setItem("auth_user", "{invalid json{{");
       window.dispatchEvent(
         new StorageEvent("storage", {
           key: "auth_user",

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,13 +1,13 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { useState, useEffect, FormEvent } from "react";
+import { useState, useEffect, useMemo, FormEvent } from "react";
 import { useNavigate } from "react-router-dom";
 import { Trans } from "@lingui/macro";
 import { useAuth } from "../hooks/useAuth";
 import { useLoginRateLimiter } from "../hooks/useLoginRateLimiter";
 import { useOnlineStatus } from "../hooks/useOnlineStatus";
-import { login as apiLogin, AuthApiError } from "../services/authApi";
+import { getAuthTransport, AuthApiError } from "../services/authTransport";
 import { checkHealth, HealthStatus } from "../services/healthApi";
 import { AuthLayout } from "../components/auth-layout";
 import { Footer } from "../components/Footer";
@@ -20,6 +20,7 @@ import { Input } from "../components/input";
 export function Login() {
   const navigate = useNavigate();
   const { login } = useAuth();
+  const authTransport = useMemo(() => getAuthTransport(), []);
   const {
     remainingAttempts,
     isLocked,
@@ -107,7 +108,7 @@ export function Login() {
     setIsSubmitting(true);
 
     try {
-      const response = await apiLogin({ email, password });
+      const response = await authTransport.login({ email, password });
       resetAttempts(); // Clear rate limit state on successful login
       login(response.user);
       navigate("/");

--- a/src/services/authState.test.ts
+++ b/src/services/authState.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, expect, it } from "vitest";
-import { sanitizeAuthUser } from "./authState";
+import { sanitizeAuthUser, sanitizePersistedAuthUser } from "./authState";
 
 describe("authState", () => {
   it("keeps employee data in ephemeral auth state by default", () => {
@@ -26,20 +26,15 @@ describe("authState", () => {
   });
 
   it("drops employee data when building persisted auth state", () => {
-    const sanitizedUser = sanitizeAuthUser(
-      {
-        id: 1,
-        name: "Test User",
-        email: "test@secpal.app",
-        employee: {
-          management_level: 7,
-          personnel_number: "EMP-12345",
-        },
+    const sanitizedUser = sanitizePersistedAuthUser({
+      id: 1,
+      name: "Test User",
+      email: "test@secpal.app",
+      employee: {
+        management_level: 7,
+        personnel_number: "EMP-12345",
       },
-      {
-        includeEmployee: false,
-      }
-    );
+    });
 
     expect(sanitizedUser).toEqual({
       id: 1,

--- a/src/services/authState.test.ts
+++ b/src/services/authState.test.ts
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { sanitizeAuthUser } from "./authState";
+
+describe("authState", () => {
+  it("keeps employee data in ephemeral auth state by default", () => {
+    const sanitizedUser = sanitizeAuthUser({
+      id: 1,
+      name: "Test User",
+      email: "test@secpal.app",
+      employee: {
+        management_level: 7,
+      },
+    });
+
+    expect(sanitizedUser).toEqual({
+      id: 1,
+      name: "Test User",
+      email: "test@secpal.app",
+      employee: {
+        management_level: 7,
+      },
+    });
+  });
+
+  it("drops employee data when building persisted auth state", () => {
+    const sanitizedUser = sanitizeAuthUser(
+      {
+        id: 1,
+        name: "Test User",
+        email: "test@secpal.app",
+        employee: {
+          management_level: 7,
+          personnel_number: "EMP-12345",
+        },
+      },
+      {
+        includeEmployee: false,
+      }
+    );
+
+    expect(sanitizedUser).toEqual({
+      id: 1,
+      name: "Test User",
+      email: "test@secpal.app",
+    });
+    expect(sanitizedUser).not.toHaveProperty("employee");
+  });
+});

--- a/src/services/authState.ts
+++ b/src/services/authState.ts
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { User } from "../contexts/auth-context";
+
+function sanitizeStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const sanitizedValues = value.filter(
+    (entry): entry is string => typeof entry === "string"
+  );
+
+  return sanitizedValues.length > 0 ? sanitizedValues : undefined;
+}
+
+function sanitizeBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+export function sanitizeAuthUser(value: unknown): User | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+
+  const candidate = value as Record<string, unknown>;
+
+  if (
+    typeof candidate.id !== "number" ||
+    !Number.isFinite(candidate.id) ||
+    typeof candidate.name !== "string" ||
+    typeof candidate.email !== "string"
+  ) {
+    return null;
+  }
+
+  const sanitizedUser: User = {
+    id: candidate.id,
+    name: candidate.name,
+    email: candidate.email,
+  };
+
+  const roles = sanitizeStringArray(candidate.roles);
+  if (roles) {
+    sanitizedUser.roles = roles;
+  }
+
+  const permissions = sanitizeStringArray(candidate.permissions);
+  if (permissions) {
+    sanitizedUser.permissions = permissions;
+  }
+
+  const hasOrganizationalScopes = sanitizeBoolean(
+    candidate.hasOrganizationalScopes
+  );
+  if (hasOrganizationalScopes !== undefined) {
+    sanitizedUser.hasOrganizationalScopes = hasOrganizationalScopes;
+  }
+
+  const hasCustomerAccess = sanitizeBoolean(candidate.hasCustomerAccess);
+  if (hasCustomerAccess !== undefined) {
+    sanitizedUser.hasCustomerAccess = hasCustomerAccess;
+  }
+
+  const hasSiteAccess = sanitizeBoolean(candidate.hasSiteAccess);
+  if (hasSiteAccess !== undefined) {
+    sanitizedUser.hasSiteAccess = hasSiteAccess;
+  }
+
+  if (
+    "employee" in candidate &&
+    (typeof candidate.employee === "object" || candidate.employee === null)
+  ) {
+    sanitizedUser.employee = candidate.employee as User["employee"];
+  }
+
+  return sanitizedUser;
+}

--- a/src/services/authState.ts
+++ b/src/services/authState.ts
@@ -3,6 +3,10 @@
 
 import type { User } from "../contexts/auth-context";
 
+export interface SanitizeAuthUserOptions {
+  includeEmployee?: boolean;
+}
+
 function sanitizeStringArray(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) {
     return undefined;
@@ -19,10 +23,15 @@ function sanitizeBoolean(value: unknown): boolean | undefined {
   return typeof value === "boolean" ? value : undefined;
 }
 
-export function sanitizeAuthUser(value: unknown): User | null {
+export function sanitizeAuthUser(
+  value: unknown,
+  options: SanitizeAuthUserOptions = {}
+): User | null {
   if (typeof value !== "object" || value === null) {
     return null;
   }
+
+  const includeEmployee = options.includeEmployee ?? true;
 
   const candidate = value as Record<string, unknown>;
 
@@ -69,6 +78,7 @@ export function sanitizeAuthUser(value: unknown): User | null {
   }
 
   if (
+    includeEmployee &&
     "employee" in candidate &&
     (typeof candidate.employee === "object" || candidate.employee === null)
   ) {

--- a/src/services/authState.ts
+++ b/src/services/authState.ts
@@ -7,6 +7,8 @@ export interface SanitizeAuthUserOptions {
   includeEmployee?: boolean;
 }
 
+export type PersistedAuthUser = Omit<User, "employee">;
+
 function sanitizeStringArray(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) {
     return undefined;
@@ -86,4 +88,45 @@ export function sanitizeAuthUser(
   }
 
   return sanitizedUser;
+}
+
+export function sanitizePersistedAuthUser(
+  value: unknown
+): PersistedAuthUser | null {
+  const sanitizedUser = sanitizeAuthUser(value, {
+    includeEmployee: false,
+  });
+
+  if (!sanitizedUser) {
+    return null;
+  }
+
+  const persistedAuthUser: PersistedAuthUser = {
+    id: sanitizedUser.id,
+    name: sanitizedUser.name,
+    email: sanitizedUser.email,
+  };
+
+  if (sanitizedUser.roles) {
+    persistedAuthUser.roles = sanitizedUser.roles;
+  }
+
+  if (sanitizedUser.permissions) {
+    persistedAuthUser.permissions = sanitizedUser.permissions;
+  }
+
+  if (sanitizedUser.hasOrganizationalScopes !== undefined) {
+    persistedAuthUser.hasOrganizationalScopes =
+      sanitizedUser.hasOrganizationalScopes;
+  }
+
+  if (sanitizedUser.hasCustomerAccess !== undefined) {
+    persistedAuthUser.hasCustomerAccess = sanitizedUser.hasCustomerAccess;
+  }
+
+  if (sanitizedUser.hasSiteAccess !== undefined) {
+    persistedAuthUser.hasSiteAccess = sanitizedUser.hasSiteAccess;
+  }
+
+  return persistedAuthUser;
 }

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -155,4 +155,102 @@ describe("authTransport", () => {
       "Native auth login returned an invalid or unsafe auth user payload"
     );
   });
+
+  it("rejects invalid native getCurrentUser payloads before they enter auth state", async () => {
+    const nativeBridge: NativeAuthBridge = {
+      login: vi.fn().mockResolvedValue(undefined),
+      logout: vi.fn().mockResolvedValue(undefined),
+      getCurrentUser: vi.fn().mockResolvedValue({ token: "native-secret" }),
+    };
+
+    const transport = resolveAuthTransport({ nativeBridge });
+
+    await expect(transport.getCurrentUser()).rejects.toThrow(
+      "Native auth current-user fetch returned an invalid or unsafe auth user payload"
+    );
+  });
+
+  it("delegates browser-session logout to the authApi", async () => {
+    mockBrowserLogout.mockResolvedValueOnce(undefined);
+
+    const transport = getAuthTransport();
+    await transport.logout();
+
+    expect(mockBrowserLogout).toHaveBeenCalledOnce();
+  });
+
+  it("delegates browser-session logoutAll to the authApi", async () => {
+    mockBrowserLogoutAll.mockResolvedValueOnce(undefined);
+
+    const transport = getAuthTransport();
+    await transport.logoutAll();
+
+    expect(mockBrowserLogoutAll).toHaveBeenCalledOnce();
+  });
+
+  it("delegates browser-session getCurrentUser to the authApi and sanitizes the payload", async () => {
+    mockBrowserGetCurrentUser.mockResolvedValueOnce({
+      id: 2,
+      name: "Session User",
+      email: "session@secpal.app",
+      roles: ["Viewer"],
+      token: "should-not-leak",
+    });
+
+    const transport = getAuthTransport();
+    const user = await transport.getCurrentUser();
+
+    expect(mockBrowserGetCurrentUser).toHaveBeenCalledOnce();
+    expect(user).toEqual({
+      id: 2,
+      name: "Session User",
+      email: "session@secpal.app",
+      roles: ["Viewer"],
+    });
+    expect(user).not.toHaveProperty("token");
+  });
+
+  it("delegates native bridge logout to the bridge", async () => {
+    const nativeBridge: NativeAuthBridge = {
+      login: vi.fn().mockResolvedValue(undefined),
+      logout: vi.fn().mockResolvedValue(undefined),
+      logoutAll: vi.fn().mockResolvedValue(undefined),
+      getCurrentUser: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const transport = resolveAuthTransport({ nativeBridge });
+    await transport.logout();
+
+    expect(nativeBridge.logout).toHaveBeenCalledOnce();
+    expect(mockBrowserLogout).not.toHaveBeenCalled();
+  });
+
+  it("delegates native bridge logoutAll to the bridge when supported", async () => {
+    const nativeBridge: NativeAuthBridge = {
+      login: vi.fn().mockResolvedValue(undefined),
+      logout: vi.fn().mockResolvedValue(undefined),
+      logoutAll: vi.fn().mockResolvedValue(undefined),
+      getCurrentUser: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const transport = resolveAuthTransport({ nativeBridge });
+    await transport.logoutAll();
+
+    expect(nativeBridge.logoutAll).toHaveBeenCalledOnce();
+    expect(mockBrowserLogoutAll).not.toHaveBeenCalled();
+  });
+
+  it("throws when native bridge logoutAll is not implemented", async () => {
+    const nativeBridge: NativeAuthBridge = {
+      login: vi.fn().mockResolvedValue(undefined),
+      logout: vi.fn().mockResolvedValue(undefined),
+      getCurrentUser: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const transport = resolveAuthTransport({ nativeBridge });
+
+    await expect(transport.logoutAll()).rejects.toThrow(
+      "Native auth transport does not support logout-all"
+    );
+  });
 });

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { NativeAuthBridge } from "./authTransport";
+import { getAuthTransport, resolveAuthTransport } from "./authTransport";
+
+const {
+  mockBrowserLogin,
+  mockBrowserLogout,
+  mockBrowserLogoutAll,
+  mockBrowserGetCurrentUser,
+} = vi.hoisted(() => ({
+  mockBrowserLogin: vi.fn(),
+  mockBrowserLogout: vi.fn(),
+  mockBrowserLogoutAll: vi.fn(),
+  mockBrowserGetCurrentUser: vi.fn(),
+}));
+
+vi.mock("./authApi", async () => {
+  const actual = await vi.importActual("./authApi");
+
+  return {
+    ...actual,
+    login: mockBrowserLogin,
+    logout: mockBrowserLogout,
+    logoutAll: mockBrowserLogoutAll,
+    getCurrentUser: mockBrowserGetCurrentUser,
+  };
+});
+
+describe("authTransport", () => {
+  const authTransportGlobal = globalThis as {
+    SecPalNativeAuthBridge?: NativeAuthBridge;
+  };
+  const originalNativeBridge = authTransportGlobal.SecPalNativeAuthBridge;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete authTransportGlobal.SecPalNativeAuthBridge;
+  });
+
+  afterEach(() => {
+    if (originalNativeBridge) {
+      authTransportGlobal.SecPalNativeAuthBridge = originalNativeBridge;
+      return;
+    }
+
+    delete authTransportGlobal.SecPalNativeAuthBridge;
+  });
+
+  it("defaults to the browser-session transport when no native bridge is present", async () => {
+    mockBrowserLogin.mockResolvedValueOnce({
+      user: {
+        id: 1,
+        name: "Browser User",
+        email: "browser@secpal.app",
+        roles: ["Admin"],
+        token: "should-not-leak",
+      },
+    });
+
+    const transport = getAuthTransport();
+    const result = await transport.login({
+      email: "browser@secpal.app",
+      password: "password123",
+    });
+
+    expect(transport.kind).toBe("browser-session");
+    expect(mockBrowserLogin).toHaveBeenCalledWith({
+      email: "browser@secpal.app",
+      password: "password123",
+    });
+    expect(result).toEqual({
+      user: {
+        id: 1,
+        name: "Browser User",
+        email: "browser@secpal.app",
+        roles: ["Admin"],
+      },
+    });
+    expect(result.user).not.toHaveProperty("token");
+  });
+
+  it("uses a native bridge transport and strips raw token fields from auth state", async () => {
+    const nativeBridge: NativeAuthBridge = {
+      login: vi.fn().mockResolvedValue({
+        user: {
+          id: 7,
+          name: "Native User",
+          email: "native@secpal.app",
+          permissions: ["profile.read"],
+          token: "native-secret",
+          refreshToken: "native-refresh-secret",
+        },
+      }),
+      logout: vi.fn().mockResolvedValue(undefined),
+      logoutAll: vi.fn().mockResolvedValue(undefined),
+      getCurrentUser: vi.fn().mockResolvedValue({
+        id: 7,
+        name: "Native User",
+        email: "native@secpal.app",
+        permissions: ["profile.read"],
+        token: "native-secret",
+      }),
+    };
+
+    const transport = resolveAuthTransport({ nativeBridge });
+    const loginResult = await transport.login({
+      email: "native@secpal.app",
+      password: "password123",
+    });
+    const currentUser = await transport.getCurrentUser();
+
+    expect(transport.kind).toBe("native-bridge");
+    expect(nativeBridge.login).toHaveBeenCalledWith({
+      email: "native@secpal.app",
+      password: "password123",
+    });
+    expect(mockBrowserLogin).not.toHaveBeenCalled();
+    expect(loginResult).toEqual({
+      user: {
+        id: 7,
+        name: "Native User",
+        email: "native@secpal.app",
+        permissions: ["profile.read"],
+      },
+    });
+    expect(loginResult.user).not.toHaveProperty("token");
+    expect(currentUser).toEqual({
+      id: 7,
+      name: "Native User",
+      email: "native@secpal.app",
+      permissions: ["profile.read"],
+    });
+    expect(currentUser).not.toHaveProperty("token");
+  });
+
+  it("rejects invalid native payloads before they can become auth state", async () => {
+    const nativeBridge: NativeAuthBridge = {
+      login: vi.fn().mockResolvedValue({ token: "native-secret" }),
+      logout: vi.fn().mockResolvedValue(undefined),
+      logoutAll: vi.fn().mockResolvedValue(undefined),
+      getCurrentUser: vi.fn().mockResolvedValue({ token: "native-secret" }),
+    };
+
+    const transport = resolveAuthTransport({ nativeBridge });
+
+    await expect(
+      transport.login({
+        email: "native@secpal.app",
+        password: "password123",
+      })
+    ).rejects.toThrow(
+      "Native auth login returned an invalid or unsafe auth user payload"
+    );
+  });
+});

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -30,9 +30,8 @@ vi.mock("./authApi", async () => {
 });
 
 describe("authTransport", () => {
-  const authTransportGlobal = globalThis as {
-    SecPalNativeAuthBridge?: NativeAuthBridge;
-  };
+  const authTransportGlobal = globalThis as Record<string, unknown>;
+  const hadNativeBridge = "SecPalNativeAuthBridge" in authTransportGlobal;
   const originalNativeBridge = authTransportGlobal.SecPalNativeAuthBridge;
 
   beforeEach(() => {
@@ -41,12 +40,11 @@ describe("authTransport", () => {
   });
 
   afterEach(() => {
-    if (originalNativeBridge) {
+    if (hadNativeBridge) {
       authTransportGlobal.SecPalNativeAuthBridge = originalNativeBridge;
-      return;
+    } else {
+      delete authTransportGlobal.SecPalNativeAuthBridge;
     }
-
-    delete authTransportGlobal.SecPalNativeAuthBridge;
   });
 
   it("defaults to the browser-session transport when no native bridge is present", async () => {

--- a/src/services/authTransport.ts
+++ b/src/services/authTransport.ts
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { User } from "../contexts/auth-context";
+import {
+  AuthApiError,
+  getCurrentUser as getBrowserSessionCurrentUser,
+  login as loginWithBrowserSession,
+  logout as logoutBrowserSession,
+  logoutAll as logoutAllBrowserSessions,
+} from "./authApi";
+import { sanitizeAuthUser } from "./authState";
+
+export { AuthApiError } from "./authApi";
+
+export interface AuthCredentials {
+  email: string;
+  password: string;
+}
+
+export interface AuthLoginResult {
+  user: User;
+}
+
+export type AuthTransportKind = "browser-session" | "native-bridge";
+
+export interface NativeAuthBridge {
+  login(credentials: AuthCredentials): Promise<unknown>;
+  logout(): Promise<void>;
+  logoutAll?(): Promise<void>;
+  getCurrentUser(): Promise<unknown>;
+}
+
+export interface AuthTransport {
+  readonly kind: AuthTransportKind;
+  login(credentials: AuthCredentials): Promise<AuthLoginResult>;
+  logout(): Promise<void>;
+  logoutAll(): Promise<void>;
+  getCurrentUser(): Promise<User>;
+}
+
+function sanitizeAuthPayload(payload: unknown, operation: string): User {
+  const candidate =
+    typeof payload === "object" && payload !== null && "user" in payload
+      ? (payload as Record<string, unknown>).user
+      : payload;
+
+  const sanitizedUser = sanitizeAuthUser(candidate);
+
+  if (!sanitizedUser) {
+    throw new AuthApiError(
+      `${operation} returned an invalid or unsafe auth user payload`
+    );
+  }
+
+  return sanitizedUser;
+}
+
+const browserSessionAuthTransport: AuthTransport = {
+  kind: "browser-session",
+  async login(credentials): Promise<AuthLoginResult> {
+    const result = await loginWithBrowserSession(credentials);
+
+    return {
+      user: sanitizeAuthPayload(result, "Browser-session login"),
+    };
+  },
+  async logout(): Promise<void> {
+    await logoutBrowserSession();
+  },
+  async logoutAll(): Promise<void> {
+    await logoutAllBrowserSessions();
+  },
+  async getCurrentUser(): Promise<User> {
+    const user = await getBrowserSessionCurrentUser();
+
+    return sanitizeAuthPayload(user, "Browser-session current-user fetch");
+  },
+};
+
+function createNativeBridgeAuthTransport(
+  nativeAuthBridge: NativeAuthBridge
+): AuthTransport {
+  return {
+    kind: "native-bridge",
+    async login(credentials): Promise<AuthLoginResult> {
+      const result = await nativeAuthBridge.login(credentials);
+
+      return {
+        user: sanitizeAuthPayload(result, "Native auth login"),
+      };
+    },
+    async logout(): Promise<void> {
+      await nativeAuthBridge.logout();
+    },
+    async logoutAll(): Promise<void> {
+      if (typeof nativeAuthBridge.logoutAll !== "function") {
+        throw new AuthApiError(
+          "Native auth transport does not support logout-all"
+        );
+      }
+
+      await nativeAuthBridge.logoutAll();
+    },
+    async getCurrentUser(): Promise<User> {
+      const user = await nativeAuthBridge.getCurrentUser();
+
+      return sanitizeAuthPayload(user, "Native auth current-user fetch");
+    },
+  };
+}
+
+function isNativeAuthBridge(value: unknown): value is NativeAuthBridge {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+
+  return (
+    typeof candidate.login === "function" &&
+    typeof candidate.logout === "function" &&
+    typeof candidate.getCurrentUser === "function"
+  );
+}
+
+function getNativeAuthBridge(): NativeAuthBridge | null {
+  const candidate = (globalThis as { SecPalNativeAuthBridge?: unknown })
+    .SecPalNativeAuthBridge;
+
+  return isNativeAuthBridge(candidate) ? candidate : null;
+}
+
+export function resolveAuthTransport(options?: {
+  nativeBridge?: NativeAuthBridge | null;
+}): AuthTransport {
+  const nativeBridge = options?.nativeBridge ?? getNativeAuthBridge();
+
+  return nativeBridge
+    ? createNativeBridgeAuthTransport(nativeBridge)
+    : browserSessionAuthTransport;
+}
+
+export function getAuthTransport(): AuthTransport {
+  return resolveAuthTransport();
+}

--- a/src/services/authTransport.ts
+++ b/src/services/authTransport.ts
@@ -134,7 +134,10 @@ function getNativeAuthBridge(): NativeAuthBridge | null {
 export function resolveAuthTransport(options?: {
   nativeBridge?: NativeAuthBridge | null;
 }): AuthTransport {
-  const nativeBridge = options?.nativeBridge ?? getNativeAuthBridge();
+  const nativeBridge =
+    options?.nativeBridge !== undefined
+      ? options.nativeBridge
+      : getNativeAuthBridge();
 
   return nativeBridge
     ? createNativeBridgeAuthTransport(nativeBridge)

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -43,7 +43,9 @@ class LocalStorageAuthStorage implements AuthStorage {
     if (!storedUser) return null;
 
     try {
-      const sanitizedUser = sanitizeAuthUser(JSON.parse(storedUser));
+      const sanitizedUser = sanitizeAuthUser(JSON.parse(storedUser), {
+        includeEmployee: false,
+      });
 
       if (!sanitizedUser) {
         this.removeUser();
@@ -59,7 +61,9 @@ class LocalStorageAuthStorage implements AuthStorage {
   }
 
   setUser(user: User): void {
-    const sanitizedUser = sanitizeAuthUser(user);
+    const sanitizedUser = sanitizeAuthUser(user, {
+      includeEmployee: false,
+    });
 
     if (!sanitizedUser) {
       this.removeUser();

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import type { User } from "../contexts/auth-context";
-import { sanitizeAuthUser } from "./authState";
+import { sanitizePersistedAuthUser } from "./authState";
 
 /**
  * Storage abstraction layer for auth data
@@ -43,9 +43,7 @@ class LocalStorageAuthStorage implements AuthStorage {
     if (!storedUser) return null;
 
     try {
-      const sanitizedUser = sanitizeAuthUser(JSON.parse(storedUser), {
-        includeEmployee: false,
-      });
+      const sanitizedUser = sanitizePersistedAuthUser(JSON.parse(storedUser));
 
       if (!sanitizedUser) {
         this.removeUser();
@@ -61,9 +59,7 @@ class LocalStorageAuthStorage implements AuthStorage {
   }
 
   setUser(user: User): void {
-    const sanitizedUser = sanitizeAuthUser(user, {
-      includeEmployee: false,
-    });
+    const sanitizedUser = sanitizePersistedAuthUser(user);
 
     if (!sanitizedUser) {
       this.removeUser();

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -1,7 +1,8 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import type { User } from "../contexts/auth-context";
+import { sanitizeAuthUser } from "./authState";
 
 /**
  * Storage abstraction layer for auth data
@@ -42,7 +43,14 @@ class LocalStorageAuthStorage implements AuthStorage {
     if (!storedUser) return null;
 
     try {
-      return JSON.parse(storedUser) as User;
+      const sanitizedUser = sanitizeAuthUser(JSON.parse(storedUser));
+
+      if (!sanitizedUser) {
+        this.removeUser();
+        return null;
+      }
+
+      return sanitizedUser;
     } catch (error) {
       console.error("Failed to parse stored user data:", error);
       this.removeUser();
@@ -51,7 +59,14 @@ class LocalStorageAuthStorage implements AuthStorage {
   }
 
   setUser(user: User): void {
-    localStorage.setItem(this.USER_KEY, JSON.stringify(user));
+    const sanitizedUser = sanitizeAuthUser(user);
+
+    if (!sanitizedUser) {
+      this.removeUser();
+      return;
+    }
+
+    localStorage.setItem(this.USER_KEY, JSON.stringify(sanitizedUser));
   }
 
   removeUser(): void {


### PR DESCRIPTION
## Summary
- add a platform-aware frontend auth transport boundary for browser-session auth and the future Android native bridge path
- sanitize auth state before it enters React state or localStorage so raw tokens or unsafe payload fields cannot leak into the shared UI
- keep existing browser/PWA Sanctum session behavior intact while adding focused transport-boundary tests and updating the changelog

## Cross-Repo Context
- shared-frontend transport split for SecPal/android#55

## Validation
- `npm test -- --run src/services/authTransport.test.ts src/services/authApi.test.ts tests/integration/auth/cookieAuth.test.ts src/hooks/useAuth.test.ts src/pages/Login.test.tsx src/components/application-layout.test.tsx`
- `npm run typecheck`
- `npx eslint src/services/authState.ts src/services/authTransport.ts src/services/authTransport.test.ts src/services/storage.ts src/contexts/AuthContext.tsx src/pages/Login.tsx src/components/application-layout.tsx`
- `./scripts/preflight.sh`

Refs SecPal/android#55