### PR TITLE
fix: block stale offline auth restoration after logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Tightened the PWA logout/offline privacy hardening by persisting an explicit logout barrier in local storage, scrubbing any stale `auth_user` payload that reappears after logout, and rejecting BFCache or cross-tab restoration paths until a fresh login writes a new authenticated state.
+
 - Hardened PWA logout/offline privacy by synchronizing explicit auth state to the service worker, redirecting logged-out offline navigation away from protected routes such as `/profile`, and reconciling restored or cross-tab client state so previously viewed user data cannot remain readable after logout.
 
 - Raised the frontend override floors for `brace-expansion` and `serialize-javascript` so `npm audit` now returns 0 vulnerabilities; the remaining install-time deprecation warnings still come from the upstream `vite-plugin-pwa` / `workbox-build` toolchain and remain documented as accepted build-time risk

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -28,6 +28,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   });
   const isClearingSessionRef = useRef(false);
   const bootstrapRequestVersionRef = useRef(0);
+  const hasExplicitLogoutBarrierRef = useRef(authStorage.hasLogoutBarrier());
 
   const invalidateBootstrapRevalidation = useCallback(() => {
     bootstrapRequestVersionRef.current += 1;
@@ -47,6 +48,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       invalidateBootstrapRevalidation();
       isClearingSessionRef.current = true;
+      hasExplicitLogoutBarrierRef.current = true;
       authStorage.clear();
       setUser(null);
       setIsLoading(false);
@@ -82,6 +84,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       invalidateBootstrapRevalidation();
       authStorage.setUser(sanitizedUser);
+      hasExplicitLogoutBarrierRef.current = false;
       setUser(sanitizedUser);
       setIsLoading(false);
       syncOfflineAuthState(true);
@@ -148,12 +151,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       .then((currentUser) => {
         if (
           !isActive ||
-          bootstrapRequestVersionRef.current !== requestVersion
+          bootstrapRequestVersionRef.current !== requestVersion ||
+          hasExplicitLogoutBarrierRef.current
         ) {
           return;
         }
 
         authStorage.setUser(currentUser);
+        hasExplicitLogoutBarrierRef.current = false;
         setUser(currentUser);
         setIsLoading(false);
         syncOfflineAuthState(true);
@@ -193,6 +198,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           return;
         }
 
+        hasExplicitLogoutBarrierRef.current = false;
         invalidateBootstrapRevalidation();
         setUser(nextUser);
         setIsLoading(false);
@@ -230,6 +236,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         return;
       }
 
+      hasExplicitLogoutBarrierRef.current = false;
       invalidateBootstrapRevalidation();
       setUser(storedUser);
       setIsLoading(false);

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -28,7 +28,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   });
   const isClearingSessionRef = useRef(false);
   const bootstrapRequestVersionRef = useRef(0);
-  const hasExplicitLogoutBarrierRef = useRef(authStorage.hasLogoutBarrier());
+  const hasLogoutBarrierRef = useRef(authStorage.hasLogoutBarrier());
 
   const invalidateBootstrapRevalidation = useCallback(() => {
     bootstrapRequestVersionRef.current += 1;
@@ -48,7 +48,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       invalidateBootstrapRevalidation();
       isClearingSessionRef.current = true;
-      hasExplicitLogoutBarrierRef.current = true;
+      hasLogoutBarrierRef.current = true;
       authStorage.clear();
       setUser(null);
       setIsLoading(false);
@@ -84,7 +84,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       invalidateBootstrapRevalidation();
       authStorage.setUser(sanitizedUser);
-      hasExplicitLogoutBarrierRef.current = false;
+      hasLogoutBarrierRef.current = false;
       setUser(sanitizedUser);
       setIsLoading(false);
       syncOfflineAuthState(true);
@@ -152,13 +152,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         if (
           !isActive ||
           bootstrapRequestVersionRef.current !== requestVersion ||
-          hasExplicitLogoutBarrierRef.current
+          hasLogoutBarrierRef.current
         ) {
           return;
         }
 
         authStorage.setUser(currentUser);
-        hasExplicitLogoutBarrierRef.current = false;
+        hasLogoutBarrierRef.current = false;
         setUser(currentUser);
         setIsLoading(false);
         syncOfflineAuthState(true);
@@ -198,7 +198,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           return;
         }
 
-        hasExplicitLogoutBarrierRef.current = false;
+        hasLogoutBarrierRef.current = false;
         invalidateBootstrapRevalidation();
         setUser(nextUser);
         setIsLoading(false);
@@ -236,7 +236,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         return;
       }
 
-      hasExplicitLogoutBarrierRef.current = false;
+      hasLogoutBarrierRef.current = false;
       invalidateBootstrapRevalidation();
       setUser(storedUser);
       setIsLoading(false);

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -352,6 +352,83 @@ describe("useAuth", () => {
     expect(clearSensitiveClientState).not.toHaveBeenCalled();
   });
 
+  it("ignores stale auth storage that reappears after explicit logout", async () => {
+    const mockUser = { id: 1, name: "Test User", email: "test@secpal.dev" };
+
+    localStorage.setItem("auth_user", JSON.stringify(mockUser));
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(true);
+    });
+
+    act(() => {
+      result.current.logout();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(false);
+    });
+
+    act(() => {
+      localStorage.setItem("auth_user", JSON.stringify(mockUser));
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: "auth_user",
+          oldValue: null,
+          newValue: JSON.stringify(mockUser),
+          storageArea: localStorage,
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(false);
+    });
+
+    expect(result.current.user).toBeNull();
+    expect(localStorage.getItem("auth_user")).toBeNull();
+  });
+
+  it("rejects BFCache-style auth restoration after explicit logout", async () => {
+    const mockUser = { id: 1, name: "Test User", email: "test@secpal.dev" };
+
+    localStorage.setItem("auth_user", JSON.stringify(mockUser));
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(true);
+    });
+
+    act(() => {
+      result.current.logout();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(false);
+    });
+
+    act(() => {
+      localStorage.setItem("auth_user", JSON.stringify(mockUser));
+      window.dispatchEvent(
+        new PageTransitionEvent("pageshow", { persisted: true })
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(false);
+    });
+
+    expect(result.current.user).toBeNull();
+    expect(localStorage.getItem("auth_user")).toBeNull();
+  });
+
   it("ignores storage events for keys other than auth_user", async () => {
     const { result } = renderHook(() => useAuth(), {
       wrapper: AuthProvider,

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -17,6 +17,7 @@ export interface AuthStorage {
   setUser(user: User): void;
   removeUser(): void;
   clear(): void;
+  hasLogoutBarrier(): boolean;
 }
 
 /**
@@ -24,6 +25,7 @@ export interface AuthStorage {
  */
 class LocalStorageAuthStorage implements AuthStorage {
   private readonly USER_KEY = "auth_user";
+  private readonly LOGOUT_BARRIER_KEY = "auth_logout_barrier";
 
   /**
    * Clean up any legacy auth_token that might exist from before migration.
@@ -38,7 +40,24 @@ class LocalStorageAuthStorage implements AuthStorage {
     this.cleanupLegacyToken();
   }
 
+  private clearLogoutBarrier(): void {
+    localStorage.removeItem(this.LOGOUT_BARRIER_KEY);
+  }
+
+  private setLogoutBarrier(): void {
+    localStorage.setItem(this.LOGOUT_BARRIER_KEY, String(Date.now()));
+  }
+
+  hasLogoutBarrier(): boolean {
+    return localStorage.getItem(this.LOGOUT_BARRIER_KEY) !== null;
+  }
+
   getUser(): User | null {
+    if (this.hasLogoutBarrier()) {
+      this.removeUser();
+      return null;
+    }
+
     const storedUser = localStorage.getItem(this.USER_KEY);
     if (!storedUser) return null;
 
@@ -66,6 +85,7 @@ class LocalStorageAuthStorage implements AuthStorage {
       return;
     }
 
+    this.clearLogoutBarrier();
     localStorage.setItem(this.USER_KEY, JSON.stringify(sanitizedUser));
   }
 
@@ -74,6 +94,7 @@ class LocalStorageAuthStorage implements AuthStorage {
   }
 
   clear(): void {
+    this.setLogoutBarrier();
     this.removeUser();
   }
 }

--- a/tests/e2e/offline-logout.spec.ts
+++ b/tests/e2e/offline-logout.spec.ts
@@ -148,6 +148,13 @@ test.describe("Offline Logout Privacy", () => {
     await page.getByRole("menuitem", { name: /sign out|abmelden/i }).click();
 
     await expect(page).toHaveURL(/\/login/);
+    await expect(page.locator("#email")).toBeVisible();
+    await expect(page.locator("#password")).toBeVisible();
+    expect(
+      await page.evaluate(() => {
+        return localStorage.getItem("auth_user");
+      })
+    ).toBeNull();
 
     await context.setOffline(true);
     await page.goto("/profile").catch(() => undefined);


### PR DESCRIPTION
## Summary
- persist an explicit frontend logout barrier so stale `auth_user` payloads cannot rehydrate the app after an intentional logout
- reject BFCache and cross-tab restoration paths that try to revive protected offline state such as `/profile` without a fresh login
- extend the logout/offline regression coverage to assert both the login redirect and the absence of `localStorage.auth_user`, verified locally and against `app.secpal.dev`

## Root Cause
- the previous hardening cleared local auth state during logout, but later storage and BFCache restoration paths could still treat a reappearing `auth_user` value as a valid authenticated session
- that allowed stale user data to become renderable again offline even after a clean logout flow

## Affected Local Data Sources
- `localStorage.auth_user`
- BFCache / `pageshow` session restoration paths
- offline protected-route rendering via the cached SPA shell
- existing sensitive client cleanup for session storage, IndexedDB, and cache storage remains in place and is exercised by the logout path

## Testing
- ./scripts/preflight.sh
- npm run typecheck
- npx vitest run src/hooks/useAuth.test.ts src/lib/clientStateCleanup.test.ts src/lib/offlineSessionState.test.ts src/lib/serviceWorkerSession.test.ts
- npm run test:e2e:offline-logout
- npm run test:e2e:offline-logout:staging