### PR TITLE
fix(auth): clean post-logout client state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Tightened the PWA post-logout cleanup path so authenticated analytics state is disabled and cleared on logout, `/v1/auth/*` and `/v1/me` requests explicitly bypass browser caches, and offline logout regressions now cover both `/profile` and `/settings` to prevent stale protected content from reappearing.
+
 - Tightened the PWA logout/offline privacy hardening by persisting an explicit logout barrier in local storage, scrubbing any stale `auth_user` payload that reappears after logout, and rejecting BFCache or cross-tab restoration paths until a fresh login writes a new authenticated state.
 
 - Hardened PWA logout/offline privacy by synchronizing explicit auth state to the service worker, redirecting logged-out offline navigation away from protected routes such as `/profile`, and reconciling restored or cross-tab client state so previously viewed user data cannot remain readable after logout.

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -16,6 +16,7 @@ import { sessionEvents, isOnline } from "../services/sessionEvents";
 import { clearSensitiveClientState } from "../lib/clientStateCleanup";
 import { hasUserPermission, hasUserRole } from "../lib/capabilities";
 import { syncOfflineSessionAccess } from "../lib/serviceWorkerSession";
+import { analytics } from "../lib/analytics";
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const authTransport = useMemo(() => getAuthTransport(), []);
@@ -40,6 +41,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     });
   }, []);
 
+  const resetAnalyticsState = useCallback(() => {
+    if (!analytics) {
+      return;
+    }
+
+    void analytics.resetForLogout().catch((error: unknown) => {
+      console.warn("Failed to reset analytics state during logout:", error);
+    });
+  }, []);
+
   const clearAuthenticatedState = useCallback(
     (clearSensitiveState: boolean) => {
       if (isClearingSessionRef.current) {
@@ -50,6 +61,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       isClearingSessionRef.current = true;
       hasLogoutBarrierRef.current = true;
       authStorage.clear();
+      resetAnalyticsState();
       setUser(null);
       setIsLoading(false);
       syncOfflineAuthState(false);
@@ -70,7 +82,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           isClearingSessionRef.current = false;
         });
     },
-    [invalidateBootstrapRevalidation, syncOfflineAuthState]
+    [invalidateBootstrapRevalidation, resetAnalyticsState, syncOfflineAuthState]
   );
 
   const login = useCallback(
@@ -128,6 +140,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const hasOrganizationalAccess = useCallback((): boolean => {
     return user?.hasOrganizationalScopes ?? false;
   }, [user]);
+
+  useEffect(() => {
+    if (!analytics) {
+      return;
+    }
+
+    if (!user) {
+      resetAnalyticsState();
+      return;
+    }
+
+    analytics.resumeAuthenticatedSession(String(user.id));
+  }, [resetAnalyticsState, user]);
 
   // Bootstrap: revalidate any stored session on app load/refresh when online.
   // Uses getCurrentUser() to confirm the session and clear it if invalid.

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -142,17 +142,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [user]);
 
   useEffect(() => {
-    if (!analytics) {
-      return;
-    }
-
-    if (!user) {
-      resetAnalyticsState();
+    if (!analytics || !user) {
       return;
     }
 
     analytics.resumeAuthenticatedSession(String(user.id));
-  }, [resetAnalyticsState, user]);
+  }, [user]);
 
   // Bootstrap: revalidate any stored session on app load/refresh when online.
   // Uses getCurrentUser() to confirm the session and clear it if invalid.

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -45,6 +45,8 @@ describe("useAuth", () => {
   beforeEach(() => {
     localStorage.clear();
     vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
     sessionEvents.reset();
     mockGetCurrentUser.mockResolvedValue({
       id: 1,
@@ -427,6 +429,23 @@ describe("useAuth", () => {
 
     expect(result.current.user).toBeNull();
     expect(localStorage.getItem("auth_user")).toBeNull();
+  });
+
+  it("does not bootstrap /v1/me when a logout barrier blocks stale auth storage", () => {
+    const staleUser = { id: 1, name: "Stale User", email: "stale@secpal.dev" };
+
+    localStorage.setItem("auth_user", JSON.stringify(staleUser));
+    localStorage.setItem("auth_logout_barrier", String(Date.now()));
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    expect(result.current.user).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+    expect(localStorage.getItem("auth_user")).toBeNull();
+    expect(mockGetCurrentUser).not.toHaveBeenCalled();
   });
 
   it("ignores storage events for keys other than auth_user", async () => {

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -10,6 +10,7 @@ vi.mock("./db", () => ({
   db: {
     analytics: {
       add: vi.fn().mockResolvedValue(1),
+      clear: vi.fn().mockResolvedValue(undefined),
       where: vi.fn(() => ({
         equals: vi.fn(() => ({
           toArray: vi.fn().mockResolvedValue([]),
@@ -38,6 +39,7 @@ describe("OfflineAnalytics", () => {
     vi.clearAllMocks();
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -52,13 +54,15 @@ describe("OfflineAnalytics", () => {
     });
 
     it("should set userId", () => {
-      analytics!.setUserId("test-user-123");
+      analytics!.resumeAuthenticatedSession("test-user-123");
       // User ID will be included in subsequent events
     });
   });
 
   describe("track", () => {
     it("should track basic event", async () => {
+      analytics!.resumeAuthenticatedSession("test-user-123");
+
       await analytics!.track("page_view", "navigation", "view_home");
 
       expect(db.analytics!.add).toHaveBeenCalledWith(
@@ -74,6 +78,8 @@ describe("OfflineAnalytics", () => {
     });
 
     it("should track event with options", async () => {
+      analytics!.resumeAuthenticatedSession("test-user-123");
+
       await analytics!.track("button_click", "interaction", "submit", {
         label: "login-button",
         value: 1,
@@ -93,7 +99,7 @@ describe("OfflineAnalytics", () => {
     });
 
     it("should include userId if set", async () => {
-      analytics!.setUserId("user-456");
+      analytics!.resumeAuthenticatedSession("user-456");
 
       await analytics!.track("page_view", "navigation", "view_dashboard");
 
@@ -105,7 +111,9 @@ describe("OfflineAnalytics", () => {
     });
 
     it("should handle tracking errors gracefully", async () => {
-      const consoleWarn = vi.spyOn(console, "warn");
+      analytics!.resumeAuthenticatedSession("test-user-123");
+
+      const consoleWarn = vi.mocked(console.warn);
       const error = new Error("Database error");
       vi.mocked(db.analytics!.add).mockRejectedValueOnce(error);
 
@@ -120,6 +128,8 @@ describe("OfflineAnalytics", () => {
 
   describe("convenience methods", () => {
     it("should track page view", async () => {
+      analytics!.resumeAuthenticatedSession("test-user-123");
+
       await analytics!.trackPageView("/dashboard", "Dashboard");
 
       expect(db.analytics!.add).toHaveBeenCalledWith(
@@ -134,6 +144,8 @@ describe("OfflineAnalytics", () => {
     });
 
     it("should track click", async () => {
+      analytics!.resumeAuthenticatedSession("test-user-123");
+
       await analytics!.trackClick("submit-button", { form: "login" });
 
       expect(db.analytics!.add).toHaveBeenCalledWith(
@@ -148,6 +160,8 @@ describe("OfflineAnalytics", () => {
     });
 
     it("should track form submit", async () => {
+      analytics!.resumeAuthenticatedSession("test-user-123");
+
       await analytics!.trackFormSubmit("login-form", true, { method: "email" });
 
       expect(db.analytics!.add).toHaveBeenCalledWith(
@@ -163,6 +177,8 @@ describe("OfflineAnalytics", () => {
     });
 
     it("should track form submit failure", async () => {
+      analytics!.resumeAuthenticatedSession("test-user-123");
+
       await analytics!.trackFormSubmit("login-form", false);
 
       expect(db.analytics!.add).toHaveBeenCalledWith(
@@ -173,6 +189,8 @@ describe("OfflineAnalytics", () => {
     });
 
     it("should track error without stack by default", async () => {
+      analytics!.resumeAuthenticatedSession("test-user-123");
+
       const error = new Error("Test error");
       await analytics!.trackError(error, { component: "LoginForm" });
 
@@ -194,6 +212,8 @@ describe("OfflineAnalytics", () => {
     });
 
     it("should track error with stack when explicitly requested", async () => {
+      analytics!.resumeAuthenticatedSession("test-user-123");
+
       const error = new Error("Test error with stack");
       await analytics!.trackError(error, { component: "LoginForm" }, true);
 
@@ -212,6 +232,8 @@ describe("OfflineAnalytics", () => {
     });
 
     it("should track performance", async () => {
+      analytics!.resumeAuthenticatedSession("test-user-123");
+
       await analytics!.trackPerformance("page_load", 1234, { page: "/home" });
 
       expect(db.analytics!.add).toHaveBeenCalledWith(
@@ -226,6 +248,8 @@ describe("OfflineAnalytics", () => {
     });
 
     it("should track feature usage", async () => {
+      analytics!.resumeAuthenticatedSession("test-user-123");
+
       await analytics!.trackFeatureUsage("dark-mode", { enabled: true });
 
       expect(db.analytics!.add).toHaveBeenCalledWith(
@@ -242,6 +266,8 @@ describe("OfflineAnalytics", () => {
 
   describe("syncEvents", () => {
     it("should sync unsynced events when online", async () => {
+      analytics!.resumeAuthenticatedSession("test-user-123");
+
       const mockEvents = [
         {
           id: 1,
@@ -278,7 +304,26 @@ describe("OfflineAnalytics", () => {
       ]);
     });
 
+    it("clears persisted analytics state and disables tracking on logout reset", async () => {
+      analytics!.resumeAuthenticatedSession("user-456");
+
+      await analytics!.trackPageView("/dashboard", "Dashboard");
+      expect(db.analytics!.add).toHaveBeenCalledTimes(1);
+
+      vi.clearAllMocks();
+
+      await analytics!.resetForLogout();
+
+      expect(db.analytics!.clear).toHaveBeenCalledTimes(1);
+
+      await analytics!.trackPageView("/login", "Login");
+
+      expect(db.analytics!.add).not.toHaveBeenCalled();
+    });
+
     it("should not sync when no unsynced events", async () => {
+      analytics!.resumeAuthenticatedSession("test-user-123");
+
       vi.mocked(db.analytics!.where).mockReturnValue({
         equals: vi.fn().mockReturnValue({
           toArray: vi.fn().mockResolvedValue([]),
@@ -292,7 +337,9 @@ describe("OfflineAnalytics", () => {
     });
 
     it("should handle sync errors gracefully", async () => {
-      const consoleWarn = vi.spyOn(console, "warn");
+      analytics!.resumeAuthenticatedSession("test-user-123");
+
+      const consoleWarn = vi.mocked(console.warn);
       const error = new Error("Sync failed");
       vi.mocked(db.analytics!.where).mockImplementation(() => {
         throw error;
@@ -307,6 +354,8 @@ describe("OfflineAnalytics", () => {
     });
 
     it("should cancel pending debounced sync when manual sync is triggered", async () => {
+      analytics!.resumeAuthenticatedSession("test-user-123");
+
       // Simulate a debounced sync being scheduled
       const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
 
@@ -328,6 +377,8 @@ describe("OfflineAnalytics", () => {
     });
 
     it("should not create duplicate syncs from debounce and manual trigger", async () => {
+      analytics!.resumeAuthenticatedSession("test-user-123");
+
       const mockEvents = [
         {
           id: 1,
@@ -451,7 +502,9 @@ describe("OfflineAnalytics", () => {
     });
 
     it("should trigger sync when coming online", async () => {
-      const syncSpy = vi.spyOn(analytics!, "syncEvents");
+      const syncSpy = vi
+        .spyOn(analytics!, "syncEvents")
+        .mockResolvedValue(undefined);
 
       // Simulate coming online
       window.dispatchEvent(new Event("online"));

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -53,6 +53,68 @@ describe("OfflineAnalytics", () => {
       expect(analytics).toBeDefined();
     });
 
+    it("uses crypto.getRandomValues when randomUUID is unavailable", () => {
+      const originalCrypto = Object.getOwnPropertyDescriptor(
+        globalThis,
+        "crypto"
+      );
+      const getRandomValues = vi.fn((values: Uint8Array) => {
+        values.set([
+          0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa,
+          0xbb, 0xcc, 0xdd, 0xee, 0xff,
+        ]);
+        return values;
+      });
+
+      Object.defineProperty(globalThis, "crypto", {
+        configurable: true,
+        value: {
+          getRandomValues,
+          randomUUID: undefined,
+        } as unknown as Crypto,
+      });
+
+      try {
+        const sessionId = analytics!["generateSessionId"]();
+
+        expect(getRandomValues).toHaveBeenCalledTimes(1);
+        expect(sessionId).toBe("session_00112233445566778899aabbccddeeff");
+      } finally {
+        if (originalCrypto) {
+          Object.defineProperty(globalThis, "crypto", originalCrypto);
+        }
+      }
+    });
+
+    it("falls back to deterministic session ids when web crypto is unavailable", () => {
+      const originalCrypto = Object.getOwnPropertyDescriptor(
+        globalThis,
+        "crypto"
+      );
+      const consoleWarn = vi.mocked(console.warn);
+
+      Object.defineProperty(globalThis, "crypto", {
+        configurable: true,
+        value: undefined,
+      });
+
+      try {
+        const firstSessionId = analytics!["generateSessionId"]();
+        const secondSessionId = analytics!["generateSessionId"]();
+
+        expect(firstSessionId).toMatch(/^session_\d+_\d+$/);
+        expect(secondSessionId).toMatch(/^session_\d+_\d+$/);
+        expect(firstSessionId).not.toBe(secondSessionId);
+        expect(consoleWarn).toHaveBeenCalledWith(
+          "Web Crypto not available, falling back to deterministic session ID generation"
+        );
+      } finally {
+        if (originalCrypto) {
+          Object.defineProperty(globalThis, "crypto", originalCrypto);
+        }
+      }
+    });
+
     it("should set userId", () => {
       analytics!.resumeAuthenticatedSession("test-user-123");
       // User ID will be included in subsequent events

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -10,6 +10,7 @@ class OfflineAnalytics {
   private sessionId: string;
   private userId?: string;
   private trackingEnabled: boolean;
+  private fallbackSessionSequence: number = 0;
   private isOnline: boolean;
   private syncInterval?: number;
   private syncTimeout?: number;
@@ -39,7 +40,7 @@ class OfflineAnalytics {
 
   /**
    * Generate a unique session ID using cryptographically secure random
-   * Falls back to timestamp + Math.random for older browsers
+   * Falls back to a deterministic unique suffix when Web Crypto is unavailable
    */
   private generateSessionId(): string {
     // Prefer crypto.randomUUID for cryptographic security
@@ -47,17 +48,24 @@ class OfflineAnalytics {
       return `session_${crypto.randomUUID()}`;
     }
 
-    // Fallback for older browsers using Math.random()
-    // SECURITY NOTE: This is acceptable because:
-    // 1. Session IDs are NOT used for authentication or authorization
-    // 2. They are only used for grouping analytics events (non-security context)
-    // 3. Collision risk is negligible (timestamp ensures uniqueness across sessions)
-    // 4. No PII is stored (privacy-first design)
-    // 5. Primary path uses crypto.randomUUID (cryptographically secure)
+    if (typeof crypto !== "undefined" && crypto.getRandomValues) {
+      const randomBytes = new Uint8Array(16);
+      crypto.getRandomValues(randomBytes);
+
+      const randomHex = Array.from(randomBytes, (byte) =>
+        byte.toString(16).padStart(2, "0")
+      ).join("");
+
+      return `session_${randomHex}`;
+    }
+
+    // Final fallback keeps IDs unique without using insecure randomness.
     console.warn(
-      "crypto.randomUUID not available, falling back to timestamp-based session ID"
+      "Web Crypto not available, falling back to deterministic session ID generation"
     );
-    return `session_${Date.now()}_${Math.random().toString(36).substring(2)}`;
+
+    this.fallbackSessionSequence += 1;
+    return `session_${Date.now()}_${this.fallbackSessionSequence}`;
   }
 
   /**

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { db, type AnalyticsEvent, type AnalyticsEventType } from "./db";
@@ -9,6 +9,7 @@ export type { AnalyticsEvent, AnalyticsEventType };
 class OfflineAnalytics {
   private sessionId: string;
   private userId?: string;
+  private trackingEnabled: boolean;
   private isOnline: boolean;
   private syncInterval?: number;
   private syncTimeout?: number;
@@ -19,6 +20,7 @@ class OfflineAnalytics {
 
   constructor() {
     this.sessionId = this.generateSessionId();
+    this.trackingEnabled = false;
     this.isOnline = typeof navigator !== "undefined" && navigator.onLine;
 
     // Bind event handlers for cleanup
@@ -59,10 +61,40 @@ class OfflineAnalytics {
   }
 
   /**
-   * Set the current user ID for analytics
+   * Resume analytics for an authenticated session.
+   * Rotates the local analytics session when moving from logged-out to logged-in
+   * or when the authenticated user changes.
+   */
+  resumeAuthenticatedSession(userId: string): void {
+    if (!this.trackingEnabled || this.userId !== userId) {
+      this.sessionId = this.generateSessionId();
+    }
+
+    this.trackingEnabled = true;
+    this.userId = userId;
+  }
+
+  /**
+   * Backwards-compatible alias for older call sites.
    */
   setUserId(userId: string): void {
-    this.userId = userId;
+    this.resumeAuthenticatedSession(userId);
+  }
+
+  /**
+   * Reset analytics after logout so no user- or session-linked local data remains.
+   */
+  async resetForLogout(): Promise<void> {
+    this.trackingEnabled = false;
+    this.userId = undefined;
+    this.sessionId = this.generateSessionId();
+
+    if (this.syncTimeout) {
+      clearTimeout(this.syncTimeout);
+      this.syncTimeout = undefined;
+    }
+
+    await db.analytics.clear();
   }
 
   /**
@@ -84,6 +116,10 @@ class OfflineAnalytics {
       console.warn(
         "Analytics instance has been destroyed, ignoring track call"
       );
+      return;
+    }
+
+    if (!this.trackingEnabled) {
       return;
     }
 
@@ -288,7 +324,7 @@ class OfflineAnalytics {
    * an analytics endpoint. See README for current limitations.
    */
   async syncEvents(): Promise<void> {
-    if (!this.isOnline || this.isDestroyed) return;
+    if (!this.isOnline || this.isDestroyed || !this.trackingEnabled) return;
 
     // Clear any pending debounced sync to prevent duplicate sync attempts
     // This ensures manual sync (e.g., from handleOnline) cancels debounced sync

--- a/src/services/authApi.test.ts
+++ b/src/services/authApi.test.ts
@@ -284,6 +284,7 @@ describe("authApi", () => {
         expect.objectContaining({
           method: "POST",
           credentials: "include",
+          cache: "no-store",
         })
       );
 
@@ -335,6 +336,7 @@ describe("authApi", () => {
         expect.objectContaining({
           method: "POST",
           credentials: "include",
+          cache: "no-store",
         })
       );
 
@@ -394,6 +396,7 @@ describe("authApi", () => {
         expect.objectContaining({
           method: "GET",
           credentials: "include",
+          cache: "no-store",
         })
       );
 

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -51,6 +51,7 @@ export async function login(
   // Use SPA login endpoint (session-based, not token-based)
   const response = await apiFetch(`${getApiBaseUrl()}/v1/auth/login`, {
     method: "POST",
+    cache: "no-store",
     headers: {
       "Content-Type": "application/json",
       Accept: "application/json",
@@ -84,6 +85,7 @@ export async function login(
 export async function logout(): Promise<void> {
   const response = await apiFetch(`${getApiBaseUrl()}/v1/auth/logout`, {
     method: "POST",
+    cache: "no-store",
     headers: {
       Accept: "application/json",
     },
@@ -107,6 +109,7 @@ export async function logout(): Promise<void> {
 export async function logoutAll(): Promise<void> {
   const response = await apiFetch(`${getApiBaseUrl()}/v1/auth/logout-all`, {
     method: "POST",
+    cache: "no-store",
     headers: {
       Accept: "application/json",
     },
@@ -135,6 +138,7 @@ export async function getCurrentUser(): Promise<LoginResponse["user"]> {
   try {
     response = await apiFetch(`${getApiBaseUrl()}/v1/me`, {
       method: "GET",
+      cache: "no-store",
       headers: {
         Accept: "application/json",
       },

--- a/tests/e2e/offline-logout.spec.ts
+++ b/tests/e2e/offline-logout.spec.ts
@@ -170,6 +170,13 @@ test.describe("Offline Logout Privacy", () => {
       page.getByText(offlineLogoutMockUser.email).first()
     ).not.toBeVisible();
 
+    await page.goto("/settings").catch(() => undefined);
+    await page.waitForLoadState("networkidle");
+
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.locator("#email")).toBeVisible();
+    await expect(page.locator("#password")).toBeVisible();
+
     await context.setOffline(false);
   });
 });

--- a/tests/e2e/offline-logout.spec.ts
+++ b/tests/e2e/offline-logout.spec.ts
@@ -171,9 +171,8 @@ test.describe("Offline Logout Privacy", () => {
     ).not.toBeVisible();
 
     await page.goto("/settings").catch(() => undefined);
-    await page.waitForLoadState("networkidle");
+    await page.waitForURL(/\/login/);
 
-    await expect(page).toHaveURL(/\/login/);
     await expect(page.locator("#email")).toBeVisible();
     await expect(page.locator("#password")).toBeVisible();
 


### PR DESCRIPTION
## Description
- harden post-logout cleanup so authenticated analytics state is disabled and cleared when the client session ends
- force `POST /v1/auth/login`, `POST /v1/auth/logout`, `POST /v1/auth/logout-all`, and `GET /v1/me` to bypass browser caches
- extend logout regressions to cover stale-auth bootstrap blocking and offline `/settings` access after logout

## Testing
- npm run typecheck
- npx vitest run src/lib/analytics.test.ts src/services/authApi.test.ts src/hooks/useAuth.test.ts
- npx eslint src/lib/analytics.ts src/lib/analytics.test.ts src/contexts/AuthContext.tsx src/services/authApi.ts src/services/authApi.test.ts src/hooks/useAuth.test.ts tests/e2e/offline-logout.spec.ts
- npx prettier --check CHANGELOG.md src/lib/analytics.ts src/lib/analytics.test.ts src/contexts/AuthContext.tsx src/services/authApi.ts src/services/authApi.test.ts src/hooks/useAuth.test.ts tests/e2e/offline-logout.spec.ts
- npm run test:e2e:offline-logout