### PR TITLE
fix(auth): minimize post-logout persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Minimized post-logout PWA persistence further by deleting `SecPalDB` instead of leaving cleared IndexedDB stores behind, reducing the service-worker offline auth cache to a bare `isAuthenticated` boolean, and preventing the logged-out sync-status UI from recreating offline session storage on the login screen.
+
 - Tightened the PWA post-logout cleanup path so authenticated analytics state is disabled and cleared on logout, `/v1/auth/*` and `/v1/me` requests explicitly bypass browser caches, and offline logout regressions now cover both `/profile` and `/settings` to prevent stale protected content from reappearing.
 
 - Tightened the PWA logout/offline privacy hardening by persisting an explicit logout barrier in local storage, scrubbing any stale `auth_user` payload that reappears after logout, and rejecting BFCache or cross-tab restoration paths until a fresh login writes a new authenticated state.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { OfflineIndicator } from "./components/OfflineIndicator";
 import { SyncStatusIndicator } from "./components/SyncStatusIndicator";
 import { UpdatePrompt } from "./components/UpdatePrompt";
 import { AuthProvider } from "./contexts/AuthContext";
+import { useAuth } from "./hooks/useAuth";
 import { ProtectedRoute } from "./components/ProtectedRoute";
 import { FeatureRoute } from "./components/FeatureRoute";
 import { RouteLoader } from "./components/RouteLoader";
@@ -114,6 +115,20 @@ function AppFeatureRoute(props: React.ComponentProps<typeof FeatureRoute>) {
   return (
     <FeatureRoute {...props} missingFeatureElement={<HiddenAppRouteState />} />
   );
+}
+
+function AuthenticatedSyncStatusIndicator({
+  apiBaseUrl,
+}: {
+  apiBaseUrl: string;
+}) {
+  const { isAuthenticated } = useAuth();
+
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  return <SyncStatusIndicator apiBaseUrl={apiBaseUrl} />;
 }
 
 function App() {
@@ -401,7 +416,7 @@ function App() {
           </Routes>
         </Suspense>
         <OfflineIndicator />
-        <SyncStatusIndicator apiBaseUrl={getApiBaseUrl()} />
+        <AuthenticatedSyncStatusIndicator apiBaseUrl={getApiBaseUrl()} />
       </BrowserRouter>
     </AuthProvider>
   );

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -234,6 +234,27 @@ describe("useAuth", () => {
     expect(clearSensitiveClientState).toHaveBeenCalledTimes(1);
   });
 
+  it("logout stores only the minimal logout barrier flag", async () => {
+    const mockUser = { id: 1, name: "Test User", email: "test@secpal.dev" };
+
+    localStorage.setItem("auth_user", JSON.stringify(mockUser));
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    act(() => {
+      result.current.logout();
+    });
+
+    expect(localStorage.getItem("auth_user")).toBeNull();
+    expect(localStorage.getItem("auth_logout_barrier")).toBe("1");
+  });
+
   it("updates isAuthenticated when user changes", () => {
     const { result } = renderHook(() => useAuth(), {
       wrapper: AuthProvider,
@@ -435,7 +456,7 @@ describe("useAuth", () => {
     const staleUser = { id: 1, name: "Stale User", email: "stale@secpal.dev" };
 
     localStorage.setItem("auth_user", JSON.stringify(staleUser));
-    localStorage.setItem("auth_logout_barrier", String(Date.now()));
+    localStorage.setItem("auth_logout_barrier", "1");
 
     const { result } = renderHook(() => useAuth(), {
       wrapper: AuthProvider,

--- a/src/lib/clientStateCleanup.test.ts
+++ b/src/lib/clientStateCleanup.test.ts
@@ -26,7 +26,7 @@ describe("clearSensitiveClientState", () => {
     globalThis.caches = mockCaches;
   });
 
-  it("clears auth storage, sensitive caches, and IndexedDB tables", async () => {
+  it("clears auth storage, sensitive caches, and deletes the IndexedDB database", async () => {
     const deleteSpy = vi.spyOn(db, "delete");
 
     localStorage.setItem("auth_user", JSON.stringify({ id: 1 }));

--- a/src/lib/clientStateCleanup.test.ts
+++ b/src/lib/clientStateCleanup.test.ts
@@ -27,6 +27,8 @@ describe("clearSensitiveClientState", () => {
   });
 
   it("clears auth storage, sensitive caches, and IndexedDB tables", async () => {
+    const deleteSpy = vi.spyOn(db, "delete");
+
     localStorage.setItem("auth_user", JSON.stringify({ id: 1 }));
     localStorage.setItem("auth_token", "legacy-token");
     localStorage.setItem("locale", "de");
@@ -80,10 +82,20 @@ describe("clearSensitiveClientState", () => {
 
     await clearSensitiveClientState();
 
+    expect(deleteSpy).toHaveBeenCalledTimes(1);
+
     expect(localStorage.getItem("auth_user")).toBeNull();
     expect(localStorage.getItem("auth_token")).toBeNull();
     expect(localStorage.getItem("locale")).toBe("de");
     expect(sessionStorage.length).toBe(0);
+
+    if (typeof indexedDB.databases === "function") {
+      const databases = await indexedDB.databases();
+
+      expect(databases.map((database) => database.name)).not.toContain(db.name);
+    }
+
+    await db.open();
 
     expect(await db.guards.count()).toBe(0);
     expect(await db.syncQueue.count()).toBe(0);

--- a/src/lib/clientStateCleanup.ts
+++ b/src/lib/clientStateCleanup.ts
@@ -27,13 +27,25 @@ async function clearSensitiveCaches(): Promise<void> {
 }
 
 async function clearSensitiveIndexedDbState(): Promise<void> {
-  await Promise.all([
-    db.guards.clear(),
-    db.syncQueue.clear(),
-    db.apiCache.clear(),
-    db.analytics.clear(),
-    db.organizationalUnitCache.clear(),
-  ]);
+  try {
+    // Logout policy: remove the entire local session database because all
+    // stores in SecPalDB are session- or user-adjacent and unnecessary once
+    // the authenticated client state is cleared.
+    await db.delete();
+  } catch (error) {
+    console.warn(
+      "Failed to delete SecPalDB during logout, falling back to table clearing:",
+      error
+    );
+
+    await Promise.all([
+      db.guards.clear(),
+      db.syncQueue.clear(),
+      db.apiCache.clear(),
+      db.analytics.clear(),
+      db.organizationalUnitCache.clear(),
+    ]);
+  }
 }
 
 export async function clearSensitiveClientState(): Promise<void> {

--- a/src/lib/offlineSessionState.test.ts
+++ b/src/lib/offlineSessionState.test.ts
@@ -55,7 +55,7 @@ describe("offlineSessionState", () => {
       });
 
       it("returns the parsed session state on a cache hit", async () => {
-        const state = { isAuthenticated: true, updatedAt: 1_000_000 };
+        const state = { isAuthenticated: true };
         mockMatch.mockResolvedValue(new Response(JSON.stringify(state)));
 
         const result = await readOfflineSessionState();
@@ -98,9 +98,7 @@ describe("offlineSessionState", () => {
       });
 
       it("writes the correct URL and authenticated=false payload", async () => {
-        const before = Date.now();
         await writeOfflineSessionState(false);
-        const after = Date.now();
 
         const [urlArg, responseArg] = mockPut.mock.calls[0] as unknown as [
           string,
@@ -110,11 +108,8 @@ describe("offlineSessionState", () => {
 
         const written = (await responseArg.json()) as {
           isAuthenticated: boolean;
-          updatedAt: number;
         };
-        expect(written.isAuthenticated).toBe(false);
-        expect(written.updatedAt).toBeGreaterThanOrEqual(before);
-        expect(written.updatedAt).toBeLessThanOrEqual(after);
+        expect(written).toEqual({ isAuthenticated: false });
       });
 
       it("writes authenticated=true when the user is logged in", async () => {

--- a/src/lib/offlineSessionState.ts
+++ b/src/lib/offlineSessionState.ts
@@ -6,7 +6,6 @@ export const OFFLINE_SESSION_STATE_PATH = "/__session-state__";
 
 export interface OfflineSessionState {
   isAuthenticated: boolean;
-  updatedAt: number;
 }
 
 export interface AuthSessionChangedMessage {
@@ -52,15 +51,16 @@ export async function readOfflineSessionState(): Promise<OfflineSessionState | n
     if (
       typeof parsed !== "object" ||
       parsed === null ||
-      typeof (parsed as Record<string, unknown>).isAuthenticated !==
-        "boolean" ||
-      typeof (parsed as Record<string, unknown>).updatedAt !== "number"
+      typeof (parsed as Record<string, unknown>).isAuthenticated !== "boolean"
     ) {
       await cache.delete(getOfflineSessionStateUrl());
       return null;
     }
 
-    return parsed as OfflineSessionState;
+    return {
+      isAuthenticated: (parsed as Record<string, unknown>)
+        .isAuthenticated as boolean,
+    };
   } catch {
     await cache.delete(getOfflineSessionStateUrl());
     return null;
@@ -76,10 +76,9 @@ export async function writeOfflineSessionState(
     return;
   }
 
-  const state: OfflineSessionState = {
-    isAuthenticated,
-    updatedAt: Date.now(),
-  };
+  // Logout policy: keep only the minimum boolean auth state required for the
+  // service worker to gate offline navigation after logout.
+  const state: OfflineSessionState = { isAuthenticated };
 
   await cache.put(
     getOfflineSessionStateUrl(),

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -45,7 +45,7 @@ class LocalStorageAuthStorage implements AuthStorage {
   }
 
   private setLogoutBarrier(): void {
-    localStorage.setItem(this.LOGOUT_BARRIER_KEY, String(Date.now()));
+    localStorage.setItem(this.LOGOUT_BARRIER_KEY, "1");
   }
 
   hasLogoutBarrier(): boolean {

--- a/tests/e2e/offline-logout.spec.ts
+++ b/tests/e2e/offline-logout.spec.ts
@@ -163,7 +163,10 @@ test.describe("Offline Logout Privacy", () => {
         const cacheNames = "caches" in globalThis ? await caches.keys() : [];
         let offlineSessionState: unknown = null;
 
-        if ("caches" in globalThis) {
+        if (
+          "caches" in globalThis &&
+          cacheNames.includes("auth-session-state")
+        ) {
           const cache = await caches.open("auth-session-state");
           const response = await cache.match(
             new URL(offlineSessionStatePath, window.location.origin).toString()

--- a/tests/e2e/offline-logout.spec.ts
+++ b/tests/e2e/offline-logout.spec.ts
@@ -18,6 +18,8 @@ const offlineLogoutMockUser = {
   hasSiteAccess: false,
 };
 
+const OFFLINE_SESSION_STATE_PATH = "/__session-state__";
+
 async function installMockAuthRoutes(context: BrowserContext): Promise<void> {
   await context.route("**/health/ready", async (route) => {
     await route.fulfill({
@@ -155,6 +157,47 @@ test.describe("Offline Logout Privacy", () => {
         return localStorage.getItem("auth_user");
       })
     ).toBeNull();
+
+    const persistedState = await page.evaluate(
+      async (offlineSessionStatePath) => {
+        const cacheNames = "caches" in globalThis ? await caches.keys() : [];
+        let offlineSessionState: unknown = null;
+
+        if ("caches" in globalThis) {
+          const cache = await caches.open("auth-session-state");
+          const response = await cache.match(
+            new URL(offlineSessionStatePath, window.location.origin).toString()
+          );
+
+          offlineSessionState = response ? await response.json() : null;
+        }
+
+        const indexedDbNames =
+          typeof indexedDB.databases === "function"
+            ? (await indexedDB.databases()).map((database) => database.name)
+            : null;
+
+        return {
+          cacheNames,
+          indexedDbNames,
+          localStorageKeys: Object.keys(localStorage).sort(),
+          offlineSessionState,
+          sessionStorageKeys: Object.keys(sessionStorage).sort(),
+        };
+      },
+      OFFLINE_SESSION_STATE_PATH
+    );
+
+    expect(persistedState.localStorageKeys).toEqual(["auth_logout_barrier"]);
+    expect(persistedState.sessionStorageKeys).toEqual([]);
+    expect(persistedState.offlineSessionState).toEqual({
+      isAuthenticated: false,
+    });
+    expect(persistedState.cacheNames).toContain("auth-session-state");
+
+    if (persistedState.indexedDbNames !== null) {
+      expect(persistedState.indexedDbNames).not.toContain("SecPalDB");
+    }
 
     await context.setOffline(true);
     await page.goto("/profile").catch(() => undefined);


### PR DESCRIPTION
## Description
- delete `SecPalDB` on logout instead of leaving cleared session-adjacent stores behind
- minimize the remaining service-worker auth cache to `{ isAuthenticated: false }` and reduce the logout barrier to a minimal local flag
- prevent the logged-out sync status indicator from reopening IndexedDB and add direct regressions for the minimized logout policy

## Testing
- npm run typecheck
- npx vitest run src/hooks/useAuth.test.ts src/lib/clientStateCleanup.test.ts src/lib/offlineSessionState.test.ts src/lib/analytics.test.ts src/components/SyncStatusIndicator.test.tsx
- npx eslint src/App.tsx src/hooks/useAuth.test.ts src/lib/clientStateCleanup.ts src/lib/clientStateCleanup.test.ts src/lib/offlineSessionState.ts src/lib/offlineSessionState.test.ts src/services/storage.ts tests/e2e/offline-logout.spec.ts
- npx prettier --check CHANGELOG.md src/App.tsx src/hooks/useAuth.test.ts src/lib/clientStateCleanup.ts src/lib/clientStateCleanup.test.ts src/lib/offlineSessionState.ts src/lib/offlineSessionState.test.ts src/services/storage.ts tests/e2e/offline-logout.spec.ts
- PLAYWRIGHT_SKIP_GLOBAL_LOGIN=1 npm run test:e2e:offline-logout