### PR TITLE
fix(auth): clear logout preference leftovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Reduced shared-device post-logout bleed further by clearing stored notification preferences during logout cleanup, and added regression coverage for the IndexedDB table-clearing fallback when deleting `SecPalDB` is blocked.
+
 - Minimized post-logout PWA persistence further by deleting `SecPalDB` instead of leaving cleared IndexedDB stores behind, reducing the service-worker offline auth cache to a bare `isAuthenticated` boolean, and preventing the logged-out sync-status UI from recreating offline session storage on the login screen.
 
 - Tightened the PWA post-logout cleanup path so authenticated analytics state is disabled and cleared on logout, `/v1/auth/*` and `/v1/me` requests explicitly bypass browser caches, and offline logout regressions now cover both `/profile` and `/settings` to prevent stale protected content from reappearing.

--- a/src/lib/clientStateCleanup.test.ts
+++ b/src/lib/clientStateCleanup.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "./db";
 import {
   clearSensitiveClientState,
@@ -15,6 +15,7 @@ const mockCaches = {
 
 describe("clearSensitiveClientState", () => {
   beforeEach(async () => {
+    vi.restoreAllMocks();
     vi.clearAllMocks();
     await db.delete();
     await db.open();
@@ -26,11 +27,19 @@ describe("clearSensitiveClientState", () => {
     globalThis.caches = mockCaches;
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("clears auth storage, sensitive caches, and deletes the IndexedDB database", async () => {
     const deleteSpy = vi.spyOn(db, "delete");
 
     localStorage.setItem("auth_user", JSON.stringify({ id: 1 }));
     localStorage.setItem("auth_token", "legacy-token");
+    localStorage.setItem(
+      "secpal-notification-preferences",
+      JSON.stringify([{ category: "alerts", enabled: false }])
+    );
     localStorage.setItem("locale", "de");
     sessionStorage.setItem("share-draft", "pending");
 
@@ -86,6 +95,9 @@ describe("clearSensitiveClientState", () => {
 
     expect(localStorage.getItem("auth_user")).toBeNull();
     expect(localStorage.getItem("auth_token")).toBeNull();
+    expect(
+      localStorage.getItem("secpal-notification-preferences")
+    ).toBeNull();
     expect(localStorage.getItem("locale")).toBe("de");
     expect(sessionStorage.length).toBe(0);
 
@@ -106,6 +118,80 @@ describe("clearSensitiveClientState", () => {
     expect(mockCaches.delete).toHaveBeenCalledWith(SENSITIVE_CACHE_NAMES[0]);
     expect(mockCaches.delete).toHaveBeenCalledWith(SENSITIVE_CACHE_NAMES[2]);
     expect(mockCaches.delete).not.toHaveBeenCalledWith("static-assets");
+  });
+
+  it("falls back to clearing IndexedDB tables when deleting the database fails", async () => {
+    const deleteError = new Error("Delete blocked by another connection");
+    const deleteSpy = vi
+      .spyOn(db, "delete")
+      .mockRejectedValueOnce(deleteError);
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    localStorage.setItem("auth_user", JSON.stringify({ id: 1 }));
+    localStorage.setItem(
+      "secpal-notification-preferences",
+      JSON.stringify([{ category: "alerts", enabled: true }])
+    );
+    sessionStorage.setItem("share-draft", "pending");
+
+    await db.guards.add({
+      id: "guard-1",
+      name: "Guard",
+      email: "guard@secpal.dev",
+      lastSynced: new Date(),
+    });
+    await db.syncQueue.add({
+      id: "sync-1",
+      type: "create",
+      entity: "organizational-unit",
+      data: { id: "org-1" },
+      status: "pending",
+      createdAt: new Date(),
+      attempts: 0,
+    });
+    await db.apiCache.put({
+      url: "/v1/organizational-units",
+      data: [{ id: "org-1" }],
+      cachedAt: new Date(),
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    await db.analytics.add({
+      type: "page_view",
+      category: "navigation",
+      action: "open",
+      timestamp: Date.now(),
+      synced: false,
+      sessionId: "session-1",
+    });
+    await db.organizationalUnitCache.add({
+      id: "org-1",
+      type: "company",
+      name: "SecPal GmbH",
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      cachedAt: new Date(),
+      lastSynced: new Date(),
+    });
+
+    mockCaches.keys.mockResolvedValue([]);
+
+    await clearSensitiveClientState();
+
+    expect(deleteSpy).toHaveBeenCalled();
+    expect(consoleWarn).toHaveBeenCalledWith(
+      "Failed to delete SecPalDB during logout, falling back to table clearing:",
+      deleteError
+    );
+    expect(localStorage.getItem("auth_user")).toBeNull();
+    expect(
+      localStorage.getItem("secpal-notification-preferences")
+    ).toBeNull();
+    expect(sessionStorage.length).toBe(0);
+    expect(await db.guards.count()).toBe(0);
+    expect(await db.syncQueue.count()).toBe(0);
+    expect(await db.apiCache.count()).toBe(0);
+    expect(await db.analytics.count()).toBe(0);
+    expect(await db.organizationalUnitCache.count()).toBe(0);
   });
 
   it("does not fail when Cache API is unavailable", async () => {

--- a/src/lib/clientStateCleanup.test.ts
+++ b/src/lib/clientStateCleanup.test.ts
@@ -95,9 +95,7 @@ describe("clearSensitiveClientState", () => {
 
     expect(localStorage.getItem("auth_user")).toBeNull();
     expect(localStorage.getItem("auth_token")).toBeNull();
-    expect(
-      localStorage.getItem("secpal-notification-preferences")
-    ).toBeNull();
+    expect(localStorage.getItem("secpal-notification-preferences")).toBeNull();
     expect(localStorage.getItem("locale")).toBe("de");
     expect(sessionStorage.length).toBe(0);
 
@@ -122,9 +120,7 @@ describe("clearSensitiveClientState", () => {
 
   it("falls back to clearing IndexedDB tables when deleting the database fails", async () => {
     const deleteError = new Error("Delete blocked by another connection");
-    const deleteSpy = vi
-      .spyOn(db, "delete")
-      .mockRejectedValueOnce(deleteError);
+    const deleteSpy = vi.spyOn(db, "delete").mockRejectedValueOnce(deleteError);
     const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     localStorage.setItem("auth_user", JSON.stringify({ id: 1 }));
@@ -183,9 +179,7 @@ describe("clearSensitiveClientState", () => {
       deleteError
     );
     expect(localStorage.getItem("auth_user")).toBeNull();
-    expect(
-      localStorage.getItem("secpal-notification-preferences")
-    ).toBeNull();
+    expect(localStorage.getItem("secpal-notification-preferences")).toBeNull();
     expect(sessionStorage.length).toBe(0);
     expect(await db.guards.count()).toBe(0);
     expect(await db.syncQueue.count()).toBe(0);

--- a/src/lib/clientStateCleanup.ts
+++ b/src/lib/clientStateCleanup.ts
@@ -9,6 +9,12 @@ export const SENSITIVE_CACHE_NAMES = [
   "api-general",
 ] as const;
 
+const USER_SCOPED_LOCAL_STORAGE_KEYS = [
+  "auth_user",
+  "auth_token",
+  "secpal-notification-preferences",
+] as const;
+
 async function clearSensitiveCaches(): Promise<void> {
   if (!("caches" in globalThis)) {
     return;
@@ -49,8 +55,10 @@ async function clearSensitiveIndexedDbState(): Promise<void> {
 }
 
 export async function clearSensitiveClientState(): Promise<void> {
-  localStorage.removeItem("auth_user");
-  localStorage.removeItem("auth_token");
+  for (const key of USER_SCOPED_LOCAL_STORAGE_KEYS) {
+    localStorage.removeItem(key);
+  }
+
   sessionStorage.clear();
 
   await Promise.all([clearSensitiveCaches(), clearSensitiveIndexedDbState()]);

--- a/tests/e2e/offline-logout.spec.ts
+++ b/tests/e2e/offline-logout.spec.ts
@@ -145,6 +145,13 @@ test.describe("Offline Logout Privacy", () => {
       page.getByText(offlineLogoutMockUser.email).first()
     ).toBeVisible();
 
+    await page.evaluate(() => {
+      localStorage.setItem(
+        "secpal-notification-preferences",
+        JSON.stringify([{ category: "alerts", enabled: false }])
+      );
+    });
+
     await context.setOffline(false);
     await page.getByRole("button", { name: /user menu/i }).click();
     await page.getByRole("menuitem", { name: /sign out|abmelden/i }).click();


### PR DESCRIPTION
## Summary\n- clear stored notification preferences as part of logout-sensitive client cleanup\n- cover the IndexedDB table-clearing fallback when deleting SecPalDB is blocked\n- extend the offline logout regression to verify the stricter post-logout local state\n\n## Validation\n- npm exec vitest run src/lib/clientStateCleanup.test.ts\n- PLAYWRIGHT_SKIP_GLOBAL_LOGIN=1 npm run test:e2e:offline-logout\n- npm run typecheck\n- npm exec eslint src/lib/clientStateCleanup.ts src/lib/clientStateCleanup.test.ts tests/e2e/offline-logout.spec.ts\n- npx --yes prettier --check src/lib/clientStateCleanup.test.ts\n- reuse lint