### PR TITLE
fix(pwa): harden browser response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Hardened the browser/PWA response baseline by enforcing a production CSP without inline scripts, expanding `Permissions-Policy` and modern cross-origin headers, and serving `index.html`, `sw.js`, and `manifest.webmanifest` with update-safe cache rules so PWA security fixes propagate promptly.
+
 - Reduced shared-device post-logout bleed further by clearing stored notification preferences during logout cleanup, and added regression coverage for the IndexedDB table-clearing fallback when deleting `SecPalDB` is blocked.
 
 - Minimized post-logout PWA persistence further by deleting `SecPalDB` instead of leaving cleared IndexedDB stores behind, reducing the service-worker offline auth cache to a bare `isAuthenticated` boolean, and preventing the logged-out sync-status UI from recreating offline session storage on the login screen.

--- a/docs/deployment-spa-routing.md
+++ b/docs/deployment-spa-routing.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2025-2026 SecPal
 SPDX-License-Identifier: CC0-1.0
 -->
 
@@ -24,6 +24,13 @@ When deploying a React SPA, users get 404 errors when refreshing the page on any
 ## Apache Configuration (Uberspace, Shared Hosting)
 
 The `.htaccess` file in `public/` handles SPA routing for Apache servers.
+
+It also now carries the baseline browser hardening for the shipped PWA:
+
+- enforcing a production CSP without inline scripts
+- explicitly denying unused browser capabilities via `Permissions-Policy`
+- setting `COOP` / `CORP` and related response headers consistently
+- keeping `index.html`, `sw.js`, and `manifest.webmanifest` on short cache rules so security and PWA updates land quickly
 
 **File:** `public/.htaccess`
 
@@ -95,12 +102,32 @@ server {
     add_header Cache-Control "public, immutable";
   }
 
-  # Security headers
+   # Security headers
+   add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self'; style-src-attr 'unsafe-inline'; worker-src 'self'; upgrade-insecure-requests" always;
+   add_header Permissions-Policy "accelerometer=(), autoplay=(), camera=(), clipboard-read=(), clipboard-write=(), display-capture=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;
+   add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
   add_header X-Content-Type-Options "nosniff" always;
   add_header X-Frame-Options "DENY" always;
-  add_header X-XSS-Protection "1; mode=block" always;
+   add_header X-XSS-Protection "0" always;
   add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-  add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+   add_header Cross-Origin-Opener-Policy "same-origin" always;
+   add_header Cross-Origin-Resource-Policy "same-origin" always;
+   add_header Origin-Agent-Cluster "?1" always;
+   add_header X-Permitted-Cross-Domain-Policies "none" always;
+
+   location = /index.html {
+      add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+   }
+
+   location = /sw.js {
+      add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+      add_header Service-Worker-Allowed "/" always;
+   }
+
+   location = /manifest.webmanifest {
+      default_type application/manifest+json;
+      add_header Cache-Control "no-cache, must-revalidate" always;
+   }
 }
 ```
 
@@ -225,7 +252,8 @@ Before deploying to production:
 - ✅ `VITE_API_URL` points to the canonical `api.secpal.dev` production API
 - ✅ No `.env` files committed to Git
 - ✅ Service Worker registered (PWA functionality)
-- ✅ CSP headers if needed (restrict script sources)
+- ✅ CSP, permissions, and modern cross-origin headers enabled
+- ✅ `index.html`, `sw.js`, and `manifest.webmanifest` use short cache rules
 
 ---
 
@@ -251,7 +279,12 @@ After deployment, test these scenarios:
    - JS/CSS files should load with `200` status ✅
    - Images should load ✅
 
-5. **API connectivity:**
+5. **Security headers:**
+   - Check `Content-Security-Policy`, `Permissions-Policy`, and `Cross-Origin-*` headers on `/` ✅
+   - Check `Cache-Control` and `Service-Worker-Allowed` on `/sw.js` ✅
+   - Check `Content-Type: application/manifest+json` and `Cache-Control` on `/manifest.webmanifest` ✅
+
+6. **API connectivity:**
    - Login should work ✅
    - API requests should succeed ✅
    - Check CORS headers in Network tab ✅
@@ -293,6 +326,8 @@ export default defineConfig({
 
 1. Hard refresh: `Ctrl+Shift+R` (Windows) or `Cmd+Shift+R` (Mac)
 2. Or unregister SW in DevTools: Application → Service Workers → Unregister
+
+The shipped config now sets `Cache-Control: no-cache, no-store, must-revalidate` on `sw.js` and `no-cache, must-revalidate` on `manifest.webmanifest`; if updates still lag, check your CDN or reverse proxy for overrides.
 
 ### Issue: `.htaccess` Rules Not Applied
 

--- a/index.html
+++ b/index.html
@@ -1,77 +1,28 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2025-2026 SecPal
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="32x32"
-      href="/favicon-32x32.png"
-      media="(prefers-color-scheme: light)"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="32x32"
-      href="/logo-dark-32.png"
-      media="(prefers-color-scheme: dark)"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="16x16"
-      href="/favicon-16x16.png"
-      media="(prefers-color-scheme: light)"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="16x16"
-      href="/logo-dark-16.png"
-      media="(prefers-color-scheme: dark)"
-    />
-    <link
-      rel="icon"
-      type="image/x-icon"
-      href="/favicon-light.ico"
-      media="(prefers-color-scheme: light)"
-    />
-    <link
-      rel="icon"
-      type="image/x-icon"
-      href="/favicon-dark.ico"
-      media="(prefers-color-scheme: dark)"
-    />
-    <link
-      rel="apple-touch-icon"
-      sizes="180x180"
-      href="/apple-touch-icon-v7.png"
-    />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#ffffff" />
-    <title>SecPal</title>
-    <script>
-      // Android PWAs don't reliably support media queries in theme-color
-      // Update theme-color dynamically to match app background
-      (function () {
-        const updateThemeColor = (isDark) => {
-          const color = isDark ? "#18181b" : "#ffffff";
-          document
-            .querySelector('meta[name="theme-color"]')
-            .setAttribute("content", color);
-        };
-        const mq = window.matchMedia("(prefers-color-scheme: dark)");
-        updateThemeColor(mq.matches);
-        mq.addEventListener("change", (e) => updateThemeColor(e.matches));
-      })();
-    </script>
-  </head>
-  <body class="bg-white text-zinc-950 dark:bg-zinc-900 dark:text-white">
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" media="(prefers-color-scheme: light)" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/logo-dark-32.png" media="(prefers-color-scheme: dark)" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" media="(prefers-color-scheme: light)" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/logo-dark-16.png" media="(prefers-color-scheme: dark)" />
+  <link rel="icon" type="image/x-icon" href="/favicon-light.ico" media="(prefers-color-scheme: light)" />
+  <link rel="icon" type="image/x-icon" href="/favicon-dark.ico" media="(prefers-color-scheme: dark)" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-v7.png" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#ffffff" />
+  <script src="/theme-color.js"></script>
+  <title>SecPal</title>
+</head>
+
+<body class="bg-white text-zinc-950 dark:bg-zinc-900 dark:text-white">
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+
 </html>

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: CC0-1.0
 
 # Apache configuration for SPA routing
@@ -15,8 +15,19 @@
   RewriteRule . /index.html [L]
 </IfModule>
 
+<IfModule mod_mime.c>
+  AddType application/manifest+json .webmanifest
+</IfModule>
+
 # Security headers
 <IfModule mod_headers.c>
+  # Restrict script execution to same-origin assets. connect-src stays HTTPS-only
+  # because deployments may point at customer-specific API origins.
+  Header always set Content-Security-Policy "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self'; style-src-attr 'unsafe-inline'; worker-src 'self'; upgrade-insecure-requests"
+
+  # Explicitly deny browser capabilities the app does not require.
+  Header always set Permissions-Policy "accelerometer=(), autoplay=(), camera=(), clipboard-read=(), clipboard-write=(), display-capture=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()"
+
   # Enable HSTS (HTTP Strict Transport Security)
   # NOTE: The 'preload' directive requires manual submission to hstspreload.org
   # and only has effect if the domain is accepted into the preload list.
@@ -26,8 +37,8 @@
   # Prevent MIME type sniffing
   Header always set X-Content-Type-Options "nosniff"
 
-  # XSS Protection (legacy browsers)
-  Header always set X-XSS-Protection "1; mode=block"
+  # Disable the legacy XSS auditor. Modern browsers rely on CSP instead.
+  Header always set X-XSS-Protection "0"
 
   # Prevent clickjacking
   Header always set X-Frame-Options "DENY"
@@ -35,8 +46,26 @@
   # Referrer Policy
   Header always set Referrer-Policy "strict-origin-when-cross-origin"
 
-  # Permissions Policy (limit browser features)
-  Header always set Permissions-Policy "geolocation=(), microphone=(), camera=()"
+  # Modern cross-origin isolation defaults for the app shell and static assets.
+  Header always set Cross-Origin-Opener-Policy "same-origin"
+  Header always set Cross-Origin-Resource-Policy "same-origin"
+  Header always set Origin-Agent-Cluster "?1"
+  Header always set X-Permitted-Cross-Domain-Policies "none"
+
+  # Keep the HTML shell, service worker, and manifest fresh so security and PWA
+  # updates activate quickly instead of sitting behind intermediary caches.
+  <Files "index.html">
+    Header always set Cache-Control "no-cache, no-store, must-revalidate"
+  </Files>
+
+  <Files "sw.js">
+    Header always set Cache-Control "no-cache, no-store, must-revalidate"
+    Header always set Service-Worker-Allowed "/"
+  </Files>
+
+  <Files "manifest.webmanifest">
+    Header always set Cache-Control "no-cache, must-revalidate"
+  </Files>
 </IfModule>
 
 # Enable compression for better performance
@@ -58,6 +87,7 @@
   ExpiresByType text/css "access plus 1 year"
   ExpiresByType text/javascript "access plus 1 year"
   ExpiresByType application/javascript "access plus 1 year"
+  ExpiresByType application/manifest+json "access plus 0 seconds"
 
   # Fonts
   ExpiresByType font/woff "access plus 1 year"

--- a/public/theme-color.js
+++ b/public/theme-color.js
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+(function () {
+  const themeColorMeta = document.querySelector('meta[name="theme-color"]');
+
+  if (!themeColorMeta) {
+    return;
+  }
+
+  const updateThemeColor = function (isDark) {
+    themeColorMeta.setAttribute("content", isDark ? "#18181b" : "#ffffff");
+  };
+
+  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+  const handleChange = function (event) {
+    updateThemeColor(event.matches);
+  };
+
+  updateThemeColor(mediaQuery.matches);
+
+  if (typeof mediaQuery.addEventListener === "function") {
+    mediaQuery.addEventListener("change", handleChange);
+    return;
+  }
+
+  if (typeof mediaQuery.addListener === "function") {
+    mediaQuery.addListener(handleChange);
+  }
+})();

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -1,7 +1,17 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
 
 /**
  * Build Output Tests
@@ -12,46 +22,67 @@ import { describe, it, expect } from "vitest";
  * Note: These tests require a successful build (npm run build) to pass.
  */
 describe("Build Output Verification", () => {
-  it("should document that .htaccess must be present in dist/", () => {
-    // This is a documentation test to ensure developers know about the requirement
-    const requiredFiles = {
-      ".htaccess": "Apache SPA routing configuration",
-      "index.html": "Entry point for React app",
-    };
-
-    expect(requiredFiles[".htaccess"]).toBe("Apache SPA routing configuration");
-    expect(requiredFiles["index.html"]).toBe("Entry point for React app");
+  it("keeps the Apache SPA routing file in the build inputs", () => {
+    expect(existsSync(path.join(repoRoot, "public/.htaccess"))).toBe(true);
+    expect(existsSync(path.join(repoRoot, "index.html"))).toBe(true);
   });
 
-  it("should verify vite-plugin-static-copy is configured", () => {
-    // This test documents that vite-plugin-static-copy MUST be configured
-    // in vite.config.ts to copy .htaccess from public/ to dist/
-    const pluginConfig = {
-      name: "vite-plugin-static-copy",
-      purpose: "Copy .htaccess from public/ to dist/ during build",
-      requiredTarget: {
-        src: "public/.htaccess",
-        dest: ".",
-      },
-    };
+  it("keeps vite-plugin-static-copy configured for .htaccess", () => {
+    const viteConfig = readRepoFile("vite.config.ts");
 
-    expect(pluginConfig.name).toBe("vite-plugin-static-copy");
-    expect(pluginConfig.requiredTarget.src).toBe("public/.htaccess");
+    expect(viteConfig).toContain("vite-plugin-static-copy");
+    expect(viteConfig).toContain('src: "public/.htaccess"');
+    expect(viteConfig).toContain('dest: "."');
   });
 
-  it("should document required .htaccess directives", () => {
-    // Document the essential directives that MUST be in .htaccess
-    const requiredDirectives = [
-      "RewriteEngine On",
-      "RewriteCond %{REQUEST_FILENAME} !-f",
-      "RewriteCond %{REQUEST_FILENAME} !-d",
-      "RewriteRule . /index.html [L]",
+  it("hardens browser responses with the required security headers", () => {
+    const htaccess = readRepoFile("public/.htaccess");
+
+    const requiredHeaders = [
+      "Content-Security-Policy",
+      "Permissions-Policy",
+      "Strict-Transport-Security",
+      "Referrer-Policy",
+      "X-Frame-Options",
+      "X-Content-Type-Options",
+      "Cross-Origin-Opener-Policy",
+      "Cross-Origin-Resource-Policy",
+      "Origin-Agent-Cluster",
+      "X-Permitted-Cross-Domain-Policies",
     ];
 
-    // Verify we're documenting all essential directives
-    expect(requiredDirectives).toHaveLength(4);
-    expect(requiredDirectives[0]).toBe("RewriteEngine On");
-    expect(requiredDirectives[3]).toContain("index.html");
+    for (const header of requiredHeaders) {
+      expect(htaccess).toContain(header);
+    }
+  });
+
+  it("ships an enforceable CSP that fits the PWA runtime", () => {
+    const htaccess = readRepoFile("public/.htaccess");
+
+    expect(htaccess).toContain("default-src 'self'");
+    expect(htaccess).toContain("script-src 'self'");
+    expect(htaccess).toContain("object-src 'none'");
+    expect(htaccess).toContain("frame-ancestors 'none'");
+    expect(htaccess).toContain("worker-src 'self'");
+    expect(htaccess).toContain("manifest-src 'self'");
+    expect(htaccess).toContain("connect-src 'self'");
+  });
+
+  it("uses an external theme-color bootstrap so CSP can block inline scripts", () => {
+    const indexHtml = readRepoFile("index.html");
+
+    expect(indexHtml).toContain('<script src="/theme-color.js"></script>');
+    expect(indexHtml).not.toContain("(function () {");
+    expect(existsSync(path.join(repoRoot, "public/theme-color.js"))).toBe(true);
+  });
+
+  it("adds dedicated delivery rules for service worker and manifest files", () => {
+    const htaccess = readRepoFile("public/.htaccess");
+
+    expect(htaccess).toContain('Files "sw.js"');
+    expect(htaccess).toContain("Service-Worker-Allowed");
+    expect(htaccess).toContain("application/manifest+json");
+    expect(htaccess).toContain("manifest.webmanifest");
   });
 });
 

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -14,12 +14,11 @@ function readRepoFile(relativePath: string): string {
 }
 
 /**
- * Build Output Tests
+ * Build Configuration and Source Verification Tests
  *
- * These tests verify that the build process produces the expected output,
- * including SPA routing configuration files.
- *
- * Note: These tests require a successful build (npm run build) to pass.
+ * These tests verify that the required source files and build configuration
+ * are present and contain the expected directives. They read repo source
+ * files directly and do not require a prior build step to pass.
  */
 describe("Build Output Verification", () => {
   it("keeps the Apache SPA routing file in the build inputs", () => {


### PR DESCRIPTION
## Summary
- enforce a production browser/PWA hardening baseline in the Apache SPA delivery layer
- replace the inline theme-color bootstrap with a same-origin script so CSP can block inline scripts
- add regression coverage and deployment guidance for CSP, permissions, cross-origin headers, and PWA asset delivery

## Validation
- npm run lint
- npm run format:check
- npm run test -- tests/build.test.ts
- npm run build
- reuse lint

## Review
- local self-review completed with no blocking findings
