### PR TITLE
fix: align frontend domain policy guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,9 +19,11 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
 - Before any commit, PR, or merge, announce and verify the required checklist. Stop on the first failed check.
 - Update `CHANGELOG.md` in the same change set for real fixes, features, or breaking changes.
 - Keep GitHub-facing communication in English.
-- Domain policy is strict: use `secpal.app` for production services and all
-  email addresses, and `secpal.dev` only for dev, staging, testing, and
-  examples.
+- Domain policy is strict: use `secpal.app` only for the public homepage and
+  real email addresses, `api.secpal.dev` for the API, `app.secpal.dev` for the
+  PWA/frontend, and `secpal.dev` for dev, staging, testing, and examples.
+  Treat `api.secpal.app` and `app.secpal.app` as deprecated web hosts;
+  `app.secpal.app` remains valid only as the Android application identifier.
 - Never reply to Copilot review comments with GitHub comment tools. Fix the
   code, push, and resolve review threads through the approved non-comment
   workflow.

--- a/.github/instructions/org-shared.instructions.md
+++ b/.github/instructions/org-shared.instructions.md
@@ -17,8 +17,11 @@ At runtime, this file now acts as the repo-local overlay for the `frontend` repo
   applicable, no bypass, fail fast, one topic per change, immediate issue
   creation for out-of-scope findings, and `CHANGELOG.md` updates for real
   changes.
-- Use `secpal.app` for production services and all email addresses, and
-  `secpal.dev` only for dev, staging, testing, and examples.
+- Use `secpal.app` only for the public homepage and real email addresses,
+  `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, and
+  `secpal.dev` for dev, staging, testing, and examples. Treat
+  `api.secpal.app` and `app.secpal.app` as deprecated web hosts;
+  `app.secpal.app` remains valid only as the Android application identifier.
 - Never reply to Copilot review comments with GitHub comment tools; use the
   approved non-comment review workflow instead.
 - Keep commits GPG-signed, use file and line references instead of verbatim code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- aligned repo-local domain governance and validation with the current split of `secpal.app` for the public homepage and real email addresses, `api.secpal.dev` for the API, and `app.secpal.dev` for the PWA, while keeping `app.secpal.app` identifier-only for Android
 - Corrected the frontend production API fallback and related examples to use the canonical `https://api.secpal.dev` host; `api.secpal.app` is deprecated and not deployed.
 - Separated customer and site feature visibility from assignment-mutation and cross-resource permissions, so only explicit collection access (`hasCustomerAccess` / `hasSiteAccess` or the matching read permission) unlocks those frontend areas and future custom roles cannot drift into implicit half-authorized states.
 - Aligned customer and site feature gating with the backend collection policy by honoring explicit `hasCustomerAccess` and `hasSiteAccess` auth-context flags, so scoped-assignment users can enter the same areas the API intentionally exposes while users without any effective access continue to see the shared access-denied state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Aligned repo-local domain governance and validation with the current split of `secpal.app` for the public homepage and real email addresses, `api.secpal.dev` for the API, and `app.secpal.dev` for the PWA, while keeping `app.secpal.app` identifier-only for Android
-- Corrected the frontend production API fallback and related examples to use the canonical `https://api.secpal.dev` host; `api.secpal.app` is deprecated and not deployed.
+- Corrected the frontend production API fallback and related examples to use the canonical `https://api.secpal.dev` host.
 - Separated customer and site feature visibility from assignment-mutation and cross-resource permissions, so only explicit collection access (`hasCustomerAccess` / `hasSiteAccess` or the matching read permission) unlocks those frontend areas and future custom roles cannot drift into implicit half-authorized states.
 - Aligned customer and site feature gating with the backend collection policy by honoring explicit `hasCustomerAccess` and `hasSiteAccess` auth-context flags, so scoped-assignment users can enter the same areas the API intentionally exposes while users without any effective access continue to see the shared access-denied state.
 - Clarified the employee status rules in the create and edit UI by showing the full valid status set (`Applicant`, `Pre-Contract`, `Active`, `On Leave`, `Terminated`) and by explaining inline that onboarding invitations are only available in `Pre-Contract`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- aligned repo-local domain governance and validation with the current split of `secpal.app` for the public homepage and real email addresses, `api.secpal.dev` for the API, and `app.secpal.dev` for the PWA, while keeping `app.secpal.app` identifier-only for Android
+- Aligned repo-local domain governance and validation with the current split of `secpal.app` for the public homepage and real email addresses, `api.secpal.dev` for the API, and `app.secpal.dev` for the PWA, while keeping `app.secpal.app` identifier-only for Android
 - Corrected the frontend production API fallback and related examples to use the canonical `https://api.secpal.dev` host; `api.secpal.app` is deprecated and not deployed.
 - Separated customer and site feature visibility from assignment-mutation and cross-resource permissions, so only explicit collection access (`hasCustomerAccess` / `hasSiteAccess` or the matching read permission) unlocks those frontend areas and future custom roles cannot drift into implicit half-authorized states.
 - Aligned customer and site feature gating with the backend collection policy by honoring explicit `hasCustomerAccess` and `hasSiteAccess` auth-context flags, so scoped-assignment users can enter the same areas the API intentionally exposes while users without any effective access continue to see the shared access-denied state.

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -45,7 +45,12 @@ matches=$(grep -r -n -E "secpal\.[A-Za-z0-9.-]+" \
     grep -v -- '- "secpal\.' | \
     grep -v -- '^[[:space:]]*- \[' || true)
 
-violations=$(printf '%s\n' "$matches" | grep -E "secpal\.(com|org|net|io|example)" || true)
+# Allowlist approach: flag any secpal.* domain not matching an approved pattern.
+# Approved: secpal.app, secpal.dev, api.secpal.dev, app.secpal.dev, app.secpal.app (identifier context).
+# This catches unknown domains (e.g. secpal.xyz) that a denylist-only check would miss.
+violations=$(printf '%s\n' "$matches" | \
+    grep -Ev 'secpal\.(app|dev)([^a-zA-Z0-9.-]|$)|api\.secpal\.(dev|app)|app\.secpal\.(dev|app)' | \
+    grep -E 'secpal\.' || true)
 
 deprecated_web_hosts=$(printf '%s\n' "$matches" | \
     grep -E 'api\.secpal\.app|app\.secpal\.app' | \
@@ -65,17 +70,14 @@ deprecated_web_hosts=$(printf '%s\n' "$matches" | \
     grep -v -- "validation_rule" | \
     grep -v -- './.github/copilot-instructions.md:' | \
     grep -v -- './.github/copilot-config.yaml:' | \
+    grep -v -- './.github/instructions/' | \
     grep -v -- 'namespace "app\.secpal\.app"' | \
     grep -v -- 'package app\.secpal\.app;' | \
     grep -v -- 'package_name' | \
     grep -v -- 'custom_url_scheme' | \
     grep -v -- 'getPackageName()' | \
     grep -v -- 'adb shell monkey -p app\.secpal\.app' | \
-    grep -v -- 'deprecated' | \
-    grep -v -- 'mistaken' | \
-    grep -v -- 'before deployment' | \
     grep -v -- 'must not appear as active web hosts' | \
-    grep -v -- 'not deployed' | \
     grep -v -- 'not treated as a deployable web domain' || true)
 
 if [[ -z "$violations" && -z "$deprecated_web_hosts" ]]; then

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: MIT
 
 # Domain Policy Enforcement Script
-# Validates that ONLY secpal.app and secpal.dev are used
-# ZERO TOLERANCE for other domains
+# Validates that only approved SecPal domains and identifiers are used
+# ZERO TOLERANCE for other domains or deprecated .app web hosts
 
 set -euo pipefail
 
@@ -17,17 +17,13 @@ NC='\033[0m' # No Color
 
 echo -e "${BLUE}=== Domain Policy Check ===${NC}"
 echo "Allowed: secpal.app, secpal.dev"
+echo "Active web hosts: api.secpal.dev, app.secpal.dev"
+echo "Identifier-only: app.secpal.app (Android application ID)"
+echo "Deprecated web hosts: api.secpal.app, app.secpal.app"
 echo "Forbidden: secpal.com, secpal.org, secpal.net, secpal.io, secpal.example, ANY other"
 echo ""
 
-# Search for secpal domains
-# Includes common file types: md, yaml, json, sh, ts, tsx, js, jsx, php, html
-# Excludes:
-#   - This script itself
-#   - Lines documenting forbidden domains (with "Forbidden:" or "FORBIDDEN:" label)
-#   - YAML arrays of forbidden domains (lines with "- "secpal.")
-#   - Checklist items mentioning forbidden domains (lines with "[ ]")
-violations=$(grep -r "secpal\." \
+matches=$(grep -r -n -E "secpal\.[A-Za-z0-9.-]+" \
     --include="*.md" \
     --include="*.yaml" \
     --include="*.yml" \
@@ -44,25 +40,68 @@ violations=$(grep -r "secpal\." \
     --exclude-dir="vendor" \
     . 2>/dev/null | \
     grep -v -- "check-domains.sh" | \
-    grep -v -- "secpal\.app\|secpal\.dev" | \
     grep -v -- "Forbidden:" | \
     grep -v -- "FORBIDDEN:" | \
     grep -v -- '- "secpal\.' | \
     grep -v -- '^[[:space:]]*- \[' || true)
 
-if [[ -z "$violations" ]]; then
+violations=$(printf '%s\n' "$matches" | grep -E "secpal\.(com|org|net|io|example)" || true)
+
+deprecated_web_hosts=$(printf '%s\n' "$matches" | \
+    grep -E 'api\.secpal\.app|app\.secpal\.app' | \
+    grep -v -- "appId" | \
+    grep -v -- "applicationId" | \
+    grep -v -- "package name" | \
+    grep -v -- "package/application ID" | \
+    grep -v -- "application ID" | \
+    grep -v -- "Android application identifier" | \
+    grep -v -- "Android identifier" | \
+    grep -v -- "Android package ID" | \
+    grep -v -- "identifier-only" | \
+    grep -v -- "active web hosts" | \
+    grep -v -- "Deprecated Web Hosts" | \
+    grep -v -- "deprecated_web_hosts" | \
+    grep -v -- "android_application_identifier" | \
+    grep -v -- "validation_rule" | \
+    grep -v -- './.github/copilot-instructions.md:' | \
+    grep -v -- './.github/copilot-config.yaml:' | \
+    grep -v -- 'namespace "app\.secpal\.app"' | \
+    grep -v -- 'package app\.secpal\.app;' | \
+    grep -v -- 'package_name' | \
+    grep -v -- 'custom_url_scheme' | \
+    grep -v -- 'getPackageName()' | \
+    grep -v -- 'adb shell monkey -p app\.secpal\.app' | \
+    grep -v -- 'deprecated' | \
+    grep -v -- 'mistaken' | \
+    grep -v -- 'before deployment' | \
+    grep -v -- 'must not appear as active web hosts' | \
+    grep -v -- 'not deployed' | \
+    grep -v -- 'not treated as a deployable web domain' || true)
+
+if [[ -z "$violations" && -z "$deprecated_web_hosts" ]]; then
     echo -e "${GREEN}✅ Domain Policy Check PASSED${NC}"
-    echo "All domains use secpal.app or secpal.dev"
+    echo "All domain usage matches the approved SecPal split"
     exit 0
 else
     echo -e "${RED}❌ Domain Policy Check FAILED${NC}"
     echo ""
-    echo "Found forbidden domains:"
-    echo "$violations"
-    echo ""
+    if [[ -n "$violations" ]]; then
+        echo "Found forbidden domains:"
+        echo "$violations"
+        echo ""
+    fi
+    if [[ -n "$deprecated_web_hosts" ]]; then
+        echo "Found deprecated .app web-host usage:"
+        echo "$deprecated_web_hosts"
+        echo ""
+    fi
     echo -e "${YELLOW}Policy:${NC}"
-    echo "  - secpal.app: Production services, ALL emails"
-    echo "  - secpal.dev: Development, testing, examples, docs"
+    echo "  - secpal.app: public homepage and real email addresses"
+    echo "  - api.secpal.dev: live API host"
+    echo "  - app.secpal.dev: live PWA/frontend host"
+    echo "  - secpal.dev: development, staging, testing, examples"
+    echo "  - app.secpal.app: Android application identifier only"
+    echo "  - DEPRECATED as web hosts: api.secpal.app, app.secpal.app"
     echo "  - FORBIDDEN: secpal.com, secpal.org, secpal.net, secpal.io, secpal.example"
     echo ""
     echo "Fix these violations before committing."

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,8 +20,7 @@ export const apiConfig = {
    * - Development with DDEV: (empty string, Vite proxy handles routing)
    * - Development without proxy: http://localhost:8000
    * - Demo/Testing: https://api.secpal.dev
-   * - Production: https://api.secpal.dev (canonical production endpoint;
-   *   api.secpal.app was deprecated before deployment — see PR #632)
+   * - Production: https://api.secpal.dev (canonical production endpoint)
    * - Customer On-Premise: tenant-specific SecPal domain provided during deployment
    *
    * Note: The backend uses apiPrefix: '' in Laravel's bootstrap/app.php,


### PR DESCRIPTION
Fixes SecPal/.github#270

## Summary

- align repo-local frontend guidance with the approved SecPal domain split
- update the frontend domain validation script for deprecated `.app` host handling
- add the changelog entry for the governance correction

## Validation

- `./scripts/check-domains.sh`
- `npm run format:check`
- repo pre-push hook passed during push
