### PR TITLE
fix(pwa): minimize offline organizational unit cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Hardened the browser/PWA response baseline by enforcing a production CSP without inline scripts, expanding `Permissions-Policy` and modern cross-origin headers, and serving `index.html`, `sw.js`, and `manifest.webmanifest` with update-safe cache rules so PWA security fixes propagate promptly.
 
-- Reduced the shipped PWA client surface further by stripping offline organizational-unit cache entries down to route/tree fields, removing dead manifest shortcuts that pointed to non-existent routes, and deleting the dormant generic browser sync/cache layer so the frontend no longer ships unused plaintext queue state.
+- Reduced the shipped PWA client surface further by stripping offline organizational-unit cache entries down to route/tree fields and removing dead manifest shortcuts that pointed to non-existent routes.
 
 - Reduced shared-device post-logout bleed further by clearing stored notification preferences during logout cleanup, and added regression coverage for the IndexedDB table-clearing fallback when deleting `SecPalDB` is blocked.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Hardened the browser/PWA response baseline by enforcing a production CSP without inline scripts, expanding `Permissions-Policy` and modern cross-origin headers, and serving `index.html`, `sw.js`, and `manifest.webmanifest` with update-safe cache rules so PWA security fixes propagate promptly.
 
+- Reduced the shipped PWA client surface further by stripping offline organizational-unit cache entries down to route/tree fields, removing dead manifest shortcuts that pointed to non-existent routes, and deleting the dormant generic browser sync/cache layer so the frontend no longer ships unused plaintext queue state.
+
 - Reduced shared-device post-logout bleed further by clearing stored notification preferences during logout cleanup, and added regression coverage for the IndexedDB table-clearing fallback when deleting `SecPalDB` is blocked.
 
 - Minimized post-logout PWA persistence further by deleting `SecPalDB` instead of leaving cleared IndexedDB stores behind, reducing the service-worker offline auth cache to a bare `isAuthenticated` boolean, and preventing the logged-out sync-status UI from recreating offline session storage on the login screen.

--- a/src/hooks/useOrganizationalUnitsWithOffline.test.ts
+++ b/src/hooks/useOrganizationalUnitsWithOffline.test.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -29,6 +29,8 @@ describe("useOrganizationalUnitsWithOffline", () => {
       id: "unit-1",
       type: "branch",
       name: "Berlin Branch",
+      description: "Main branch in Berlin",
+      metadata: { timezone: "Europe/Berlin" },
       created_at: "2025-01-01T00:00:00Z",
       updated_at: "2025-01-01T00:00:00Z",
     },
@@ -58,6 +60,27 @@ describe("useOrganizationalUnitsWithOffline", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+
+    vi.mocked(
+      organizationalUnitStore.buildOrganizationalUnitCacheEntry
+    ).mockImplementation((unit) => ({
+      id: unit.id,
+      type: unit.type,
+      name: unit.name,
+      custom_type_name: unit.custom_type_name ?? undefined,
+      parent_id: unit.parent?.id ?? null,
+      parent: unit.parent
+        ? {
+            id: unit.parent.id,
+            type: unit.parent.type,
+            name: unit.parent.name,
+          }
+        : null,
+      created_at: unit.created_at,
+      updated_at: unit.updated_at,
+      cachedAt: new Date("2025-01-10T00:00:00Z"),
+      lastSynced: new Date("2025-01-10T00:00:00Z"),
+    }));
 
     // Store original value
     originalOnLine = navigator.onLine;
@@ -96,6 +119,8 @@ describe("useOrganizationalUnitsWithOffline", () => {
     });
 
     it("should fetch organizational units from API and cache them", async () => {
+      const cachedUnits: OrganizationalUnitCacheEntry[] = [];
+
       vi.mocked(
         organizationalUnitApi.listOrganizationalUnits
       ).mockResolvedValue({
@@ -113,7 +138,9 @@ describe("useOrganizationalUnitsWithOffline", () => {
       ).mockResolvedValue([]);
       vi.mocked(
         organizationalUnitStore.saveOrganizationalUnit
-      ).mockResolvedValue();
+      ).mockImplementation(async (unit) => {
+        cachedUnits.push(unit);
+      });
 
       const { result } = renderHook(() => useOrganizationalUnitsWithOffline());
 
@@ -134,6 +161,9 @@ describe("useOrganizationalUnitsWithOffline", () => {
       expect(
         organizationalUnitStore.saveOrganizationalUnit
       ).toHaveBeenCalledTimes(2);
+      expect(cachedUnits[0]).toBeDefined();
+      expect(cachedUnits[0]).not.toHaveProperty("description");
+      expect(cachedUnits[0]).not.toHaveProperty("metadata");
     });
 
     it("should fall back to cache when API fails", async () => {

--- a/src/hooks/useOrganizationalUnitsWithOffline.ts
+++ b/src/hooks/useOrganizationalUnitsWithOffline.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { useState, useEffect, useCallback, useRef } from "react";
@@ -8,6 +8,7 @@ import {
   saveOrganizationalUnit,
   listOrganizationalUnits as listCachedOrganizationalUnits,
   clearOrganizationalUnitCache,
+  buildOrganizationalUnitCacheEntry,
 } from "../lib/organizationalUnitStore";
 import type { OrganizationalUnitCacheEntry } from "../lib/db";
 import { useOnlineStatus } from "./useOnlineStatus";
@@ -45,8 +46,6 @@ function cacheEntryToOrganizationalUnit(
     type: entry.type,
     name: entry.name,
     custom_type_name: entry.custom_type_name ?? undefined,
-    description: entry.description ?? undefined,
-    metadata: entry.metadata,
     parent: entry.parent
       ? {
           id: entry.parent.id,
@@ -58,35 +57,6 @@ function cacheEntryToOrganizationalUnit(
       : undefined,
     created_at: entry.created_at,
     updated_at: entry.updated_at,
-  };
-}
-
-/**
- * Convert OrganizationalUnit to OrganizationalUnitCacheEntry for storage
- */
-function organizationalUnitToCacheEntry(
-  unit: OrganizationalUnit
-): OrganizationalUnitCacheEntry {
-  const now = new Date();
-  return {
-    id: unit.id,
-    type: unit.type,
-    name: unit.name,
-    custom_type_name: unit.custom_type_name ?? undefined,
-    description: unit.description ?? undefined,
-    metadata: unit.metadata,
-    parent_id: unit.parent?.id ?? null,
-    parent: unit.parent
-      ? {
-          id: unit.parent.id,
-          type: unit.parent.type,
-          name: unit.parent.name,
-        }
-      : null,
-    created_at: unit.created_at,
-    updated_at: unit.updated_at,
-    cachedAt: now,
-    lastSynced: now,
   };
 }
 
@@ -169,7 +139,7 @@ export function useOrganizationalUnitsWithOffline(): UseOrganizationalUnitsWithO
     // Cache all units for offline access
     await Promise.all(
       response.data.map((unit) =>
-        saveOrganizationalUnit(organizationalUnitToCacheEntry(unit))
+        saveOrganizationalUnit(buildOrganizationalUnitCacheEntry(unit))
       )
     );
 

--- a/src/lib/organizationalUnitStore.test.ts
+++ b/src/lib/organizationalUnitStore.test.ts
@@ -4,7 +4,9 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { db } from "./db";
 import type { OrganizationalUnitCacheEntry } from "./db";
+import type { OrganizationalUnit } from "../types/organizational";
 import {
+  buildOrganizationalUnitCacheEntry,
   saveOrganizationalUnit,
   getOrganizationalUnit,
   listOrganizationalUnits,
@@ -14,6 +16,73 @@ import {
   searchOrganizationalUnits,
   clearOrganizationalUnitCache,
 } from "./organizationalUnitStore";
+
+describe("buildOrganizationalUnitCacheEntry", () => {
+  const baseUnit: OrganizationalUnit = {
+    id: "unit-1",
+    type: "branch",
+    name: "Berlin Branch",
+    custom_type_name: null,
+    description: "A description that must not be cached",
+    metadata: { key: "value" },
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-02T00:00:00Z",
+  };
+
+  it("maps route/tree fields correctly", () => {
+    const entry = buildOrganizationalUnitCacheEntry(baseUnit);
+
+    expect(entry.id).toBe("unit-1");
+    expect(entry.type).toBe("branch");
+    expect(entry.name).toBe("Berlin Branch");
+    expect(entry.created_at).toBe("2025-01-01T00:00:00Z");
+    expect(entry.updated_at).toBe("2025-01-02T00:00:00Z");
+  });
+
+  it("omits description and metadata fields from the cache entry", () => {
+    const entry = buildOrganizationalUnitCacheEntry(baseUnit);
+
+    expect(entry).not.toHaveProperty("description");
+    expect(entry).not.toHaveProperty("metadata");
+  });
+
+  it("derives parent_id from unit.parent.id when parent is present", () => {
+    const unitWithParent: OrganizationalUnit = {
+      ...baseUnit,
+      parent: { id: "parent-1", type: "company", name: "HQ", created_at: "2024-01-01T00:00:00Z", updated_at: "2024-01-01T00:00:00Z" },
+    };
+
+    const entry = buildOrganizationalUnitCacheEntry(unitWithParent);
+
+    expect(entry.parent_id).toBe("parent-1");
+    expect(entry.parent).toEqual({ id: "parent-1", type: "company", name: "HQ" });
+  });
+
+  it("sets parent_id to null when unit has no parent", () => {
+    const entry = buildOrganizationalUnitCacheEntry(baseUnit);
+
+    expect(entry.parent_id).toBeNull();
+    expect(entry.parent).toBeNull();
+  });
+
+  it("defaults cachedAt and lastSynced to current time when syncedAt is omitted", () => {
+    const before = new Date();
+    const entry = buildOrganizationalUnitCacheEntry(baseUnit);
+    const after = new Date();
+
+    expect(entry.cachedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    expect(entry.cachedAt.getTime()).toBeLessThanOrEqual(after.getTime());
+    expect(entry.lastSynced).toEqual(entry.cachedAt);
+  });
+
+  it("uses explicit syncedAt when provided", () => {
+    const syncedAt = new Date("2026-01-15T10:00:00Z");
+    const entry = buildOrganizationalUnitCacheEntry(baseUnit, syncedAt);
+
+    expect(entry.cachedAt).toBe(syncedAt);
+    expect(entry.lastSynced).toBe(syncedAt);
+  });
+});
 
 /**
  * Test suite for OrganizationalUnitStore (IndexedDB organizational unit caching)

--- a/src/lib/organizationalUnitStore.test.ts
+++ b/src/lib/organizationalUnitStore.test.ts
@@ -49,13 +49,23 @@ describe("buildOrganizationalUnitCacheEntry", () => {
   it("derives parent_id from unit.parent.id when parent is present", () => {
     const unitWithParent: OrganizationalUnit = {
       ...baseUnit,
-      parent: { id: "parent-1", type: "company", name: "HQ", created_at: "2024-01-01T00:00:00Z", updated_at: "2024-01-01T00:00:00Z" },
+      parent: {
+        id: "parent-1",
+        type: "company",
+        name: "HQ",
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
+      },
     };
 
     const entry = buildOrganizationalUnitCacheEntry(unitWithParent);
 
     expect(entry.parent_id).toBe("parent-1");
-    expect(entry.parent).toEqual({ id: "parent-1", type: "company", name: "HQ" });
+    expect(entry.parent).toEqual({
+      id: "parent-1",
+      type: "company",
+      name: "HQ",
+    });
   });
 
   it("sets parent_id to null when unit has no parent", () => {

--- a/src/lib/organizationalUnitStore.test.ts
+++ b/src/lib/organizationalUnitStore.test.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, beforeEach } from "vitest";
@@ -36,7 +36,6 @@ describe("OrganizationalUnitStore", () => {
         id: "unit-1",
         type: "branch",
         name: "Berlin Branch",
-        description: "Main branch in Berlin",
         created_at: "2025-01-01T00:00:00Z",
         updated_at: "2025-01-01T00:00:00Z",
         cachedAt: new Date("2025-01-10T00:00:00Z"),

--- a/src/lib/organizationalUnitStore.ts
+++ b/src/lib/organizationalUnitStore.ts
@@ -1,8 +1,33 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { db } from "./db";
 import type { OrganizationalUnitCacheEntry } from "./db";
+import type { OrganizationalUnit } from "../types/organizational";
+
+export function buildOrganizationalUnitCacheEntry(
+  unit: OrganizationalUnit,
+  syncedAt: Date = new Date()
+): OrganizationalUnitCacheEntry {
+  return {
+    id: unit.id,
+    type: unit.type,
+    name: unit.name,
+    custom_type_name: unit.custom_type_name ?? undefined,
+    parent_id: unit.parent?.id ?? null,
+    parent: unit.parent
+      ? {
+          id: unit.parent.id,
+          type: unit.parent.type,
+          name: unit.parent.name,
+        }
+      : null,
+    created_at: unit.created_at,
+    updated_at: unit.updated_at,
+    cachedAt: syncedAt,
+    lastSynced: syncedAt,
+  };
+}
 
 /**
  * Save an organizational unit to IndexedDB cache

--- a/src/services/organizationalUnitApi.ts
+++ b/src/services/organizationalUnitApi.ts
@@ -7,6 +7,7 @@ import { ApiError } from "./ApiError";
 import {
   saveOrganizationalUnit as saveToCache,
   deleteOrganizationalUnit as deleteFromCache,
+  buildOrganizationalUnitCacheEntry,
 } from "../lib/organizationalUnitStore";
 import type {
   OrganizationalUnit,
@@ -29,6 +30,12 @@ import type {
  *
  * @see ADR-007: Organizational Structure Hierarchy
  */
+
+async function cacheOrganizationalUnit(
+  unit: OrganizationalUnit
+): Promise<void> {
+  await saveToCache(buildOrganizationalUnitCacheEntry(unit));
+}
 
 /**
  * List organizational units with optional filters
@@ -143,27 +150,7 @@ export async function createOrganizationalUnit(
   const unit = result.data;
 
   // Update cache immediately
-  const now = new Date();
-  await saveToCache({
-    id: unit.id,
-    type: unit.type,
-    name: unit.name,
-    custom_type_name: unit.custom_type_name ?? undefined,
-    description: unit.description ?? undefined,
-    metadata: unit.metadata,
-    parent_id: unit.parent?.id ?? null,
-    parent: unit.parent
-      ? {
-          id: unit.parent.id,
-          type: unit.parent.type,
-          name: unit.parent.name,
-        }
-      : null,
-    created_at: unit.created_at,
-    updated_at: unit.updated_at,
-    cachedAt: now,
-    lastSynced: now,
-  });
+  await cacheOrganizationalUnit(unit);
 
   return unit;
 }
@@ -202,27 +189,7 @@ export async function updateOrganizationalUnit(
   const unit = result.data;
 
   // Update cache immediately
-  const now = new Date();
-  await saveToCache({
-    id: unit.id,
-    type: unit.type,
-    name: unit.name,
-    custom_type_name: unit.custom_type_name ?? undefined,
-    description: unit.description ?? undefined,
-    metadata: unit.metadata,
-    parent_id: unit.parent?.id ?? null,
-    parent: unit.parent
-      ? {
-          id: unit.parent.id,
-          type: unit.parent.type,
-          name: unit.parent.name,
-        }
-      : null,
-    created_at: unit.created_at,
-    updated_at: unit.updated_at,
-    cachedAt: now,
-    lastSynced: now,
-  });
+  await cacheOrganizationalUnit(unit);
 
   return unit;
 }
@@ -351,27 +318,7 @@ export async function attachOrganizationalUnitParent(
   const unit = result.data;
 
   // Update cache immediately
-  const now = new Date();
-  await saveToCache({
-    id: unit.id,
-    type: unit.type,
-    name: unit.name,
-    custom_type_name: unit.custom_type_name ?? undefined,
-    description: unit.description ?? undefined,
-    metadata: unit.metadata,
-    parent_id: unit.parent?.id ?? null,
-    parent: unit.parent
-      ? {
-          id: unit.parent.id,
-          type: unit.parent.type,
-          name: unit.parent.name,
-        }
-      : null,
-    created_at: unit.created_at,
-    updated_at: unit.updated_at,
-    cachedAt: now,
-    lastSynced: now,
-  });
+  await cacheOrganizationalUnit(unit);
 
   return unit;
 }
@@ -406,27 +353,7 @@ export async function detachOrganizationalUnitParent(
 
   // Fetch updated unit and update cache
   const unit = await getOrganizationalUnit(id);
-  const now = new Date();
-  await saveToCache({
-    id: unit.id,
-    type: unit.type,
-    name: unit.name,
-    custom_type_name: unit.custom_type_name ?? undefined,
-    description: unit.description ?? undefined,
-    metadata: unit.metadata,
-    parent_id: unit.parent?.id ?? null,
-    parent: unit.parent
-      ? {
-          id: unit.parent.id,
-          type: unit.parent.type,
-          name: unit.parent.name,
-        }
-      : null,
-    created_at: unit.created_at,
-    updated_at: unit.updated_at,
-    cachedAt: now,
-    lastSynced: now,
-  });
+  await cacheOrganizationalUnit(unit);
 }
 
 /**

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -83,6 +83,15 @@ describe("Build Output Verification", () => {
     expect(htaccess).toContain("application/manifest+json");
     expect(htaccess).toContain("manifest.webmanifest");
   });
+
+  it("keeps PWA shortcuts limited to live routes", () => {
+    const viteConfig = readRepoFile("vite.config.ts");
+
+    expect(viteConfig).toContain('url: "/profile"');
+    expect(viteConfig).not.toContain('url: "/schedule"');
+    expect(viteConfig).not.toContain('url: "/reports/new"');
+    expect(viteConfig).not.toContain('url: "/emergency"');
+  });
 });
 
 /**

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -107,49 +107,10 @@ export default defineConfig(({ mode }) => {
           ],
           shortcuts: [
             {
-              name: "View Schedule",
-              short_name: "Schedule",
-              description: "View your current work schedule",
-              url: "/schedule",
-              icons: [
-                {
-                  src: "pwa-192x192.png",
-                  sizes: "192x192",
-                  type: "image/png",
-                },
-              ],
-            },
-            {
-              name: "Quick Report",
-              short_name: "Report",
-              description: "Create a new incident report",
-              url: "/reports/new",
-              icons: [
-                {
-                  src: "pwa-192x192.png",
-                  sizes: "192x192",
-                  type: "image/png",
-                },
-              ],
-            },
-            {
               name: "My Profile",
               short_name: "Profile",
               description: "View and edit your profile",
               url: "/profile",
-              icons: [
-                {
-                  src: "pwa-192x192.png",
-                  sizes: "192x192",
-                  type: "image/png",
-                },
-              ],
-            },
-            {
-              name: "Emergency Contact",
-              short_name: "Emergency",
-              description: "Quick access to emergency contacts",
-              url: "/emergency",
               icons: [
                 {
                   src: "pwa-192x192.png",


### PR DESCRIPTION
## Summary
- minimize offline organizational-unit cache entries to route and tree fields only
- remove dead manifest shortcuts for routes the app does not actually ship
- add focused regression coverage for the reduced offline payload and manifest surface

## Validation
- `npm run test -- tests/build.test.ts src/hooks/useOrganizationalUnitsWithOffline.test.ts src/lib/organizationalUnitStore.test.ts src/services/organizationalUnitApi.test.ts`
- `npm run lint`
- `npm run build`

## Links
- Fixes #643
- Parent issue: #641