### PR TITLE
fix(pwa): remove stale pending sync helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Removed the stale `getPendingSyncUnits` helper and its dead organizational-unit store tests so the frontend no longer advertises an unused pending-sync browser path.
+
 - Removed the unused `StorageQuotaIndicator` component and its dead test coverage so the frontend no longer ships that dormant browser-storage UI surface.
 
 - Removed the deleted legacy product module from the frontend, including its obsolete routes, navigation entries, offline caches, background sync wiring, and associated documentation so the repository no longer ships or documents that retired area in 0.x

--- a/docs/OFFLINE_ORGANIZATIONAL_UNITS.md
+++ b/docs/OFFLINE_ORGANIZATIONAL_UNITS.md
@@ -60,7 +60,6 @@ Similar to `secretStore.ts`:
 - `getOrganizationalUnitsByParent(parentId)` - Filters by parent
 - `searchOrganizationalUnits(query)` - Full-text search in names
 - `clearOrganizationalUnitCache()` - Clears entire cache
-- `getPendingSyncUnits()` - Units with unsynced changes
 
 ### 3. Offline Hook
 

--- a/src/lib/organizationalUnitStore.test.ts
+++ b/src/lib/organizationalUnitStore.test.ts
@@ -13,7 +13,6 @@ import {
   getOrganizationalUnitsByParent,
   searchOrganizationalUnits,
   clearOrganizationalUnitCache,
-  getPendingSyncUnits,
 } from "./organizationalUnitStore";
 
 /**
@@ -397,57 +396,6 @@ describe("OrganizationalUnitStore", () => {
 
       await clearOrganizationalUnitCache();
       expect(await db.organizationalUnitCache.count()).toBe(0);
-    });
-  });
-
-  describe("getPendingSyncUnits", () => {
-    it("should return units with pendingSync flag", async () => {
-      const units: OrganizationalUnitCacheEntry[] = [
-        {
-          id: "unit-1",
-          type: "branch",
-          name: "Berlin Branch",
-          created_at: "2025-01-01T00:00:00Z",
-          updated_at: "2025-01-01T00:00:00Z",
-          cachedAt: new Date("2025-01-10T00:00:00Z"),
-          lastSynced: new Date("2025-01-10T00:00:00Z"),
-          pendingSync: true,
-        },
-        {
-          id: "unit-2",
-          type: "company",
-          name: "SecPal GmbH",
-          created_at: "2025-01-01T00:00:00Z",
-          updated_at: "2025-01-01T00:00:00Z",
-          cachedAt: new Date("2025-01-10T00:00:00Z"),
-          lastSynced: new Date("2025-01-10T00:00:00Z"),
-          pendingSync: false,
-        },
-        {
-          id: "unit-3",
-          type: "branch",
-          name: "Hamburg Branch",
-          created_at: "2025-01-01T00:00:00Z",
-          updated_at: "2025-01-01T00:00:00Z",
-          cachedAt: new Date("2025-01-10T00:00:00Z"),
-          lastSynced: new Date("2025-01-10T00:00:00Z"),
-          pendingSync: true,
-        },
-      ];
-
-      await Promise.all(
-        units.map((unit) => db.organizationalUnitCache.put(unit))
-      );
-
-      const pending = await getPendingSyncUnits();
-      expect(pending).toHaveLength(2);
-      expect(pending[0]!.name).toBe("Berlin Branch");
-      expect(pending[1]!.name).toBe("Hamburg Branch");
-    });
-
-    it("should return empty array when no pending units", async () => {
-      const pending = await getPendingSyncUnits();
-      expect(pending).toEqual([]);
     });
   });
 });

--- a/src/lib/organizationalUnitStore.ts
+++ b/src/lib/organizationalUnitStore.ts
@@ -170,24 +170,3 @@ export async function searchOrganizationalUnits(
 export async function clearOrganizationalUnitCache(): Promise<void> {
   await db.organizationalUnitCache.clear();
 }
-
-/**
- * Get organizational units with pending sync
- *
- * @returns Array of organizational units that have local changes not yet synced
- *
- * @example
- * ```ts
- * const pendingUnits = await getPendingSyncUnits();
- * console.log(`${pendingUnits.length} units need to be synced`);
- * ```
- */
-export async function getPendingSyncUnits(): Promise<
-  OrganizationalUnitCacheEntry[]
-> {
-  // Filter units where pendingSync is explicitly true
-  const allUnits = await db.organizationalUnitCache.toArray();
-  const units = allUnits.filter((unit) => unit.pendingSync === true);
-
-  return units.sort((a, b) => a.name.localeCompare(b.name));
-}


### PR DESCRIPTION
## Summary
- delete the stale getPendingSyncUnits helper from the organizational-unit store
- remove the dead matching test coverage
- document the cleanup in the changelog

## Validation
- npm run test -- src/lib/organizationalUnitStore.test.ts
- npm run lint
- npm run build

## Links
- Fixes #649
- Parent issue: #642
- Root issue: #641