### PR TITLE
fix(pwa): remove stale pending sync schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Removed the stale `pendingSync` field and index from the offline organizational-unit schema so the reduced IndexedDB surface no longer carries leftover generic sync metadata.
+
 - Removed the stale `getPendingSyncUnits` helper and its dead organizational-unit store tests so the frontend no longer advertises an unused pending-sync browser path.
 
 - Removed the unused `StorageQuotaIndicator` component and its dead test coverage so the frontend no longer ships that dormant browser-storage UI surface.

--- a/docs/IMPLEMENTATION_SUMMARY_OFFLINE_ORGANIZATION.md
+++ b/docs/IMPLEMENTATION_SUMMARY_OFFLINE_ORGANIZATION.md
@@ -31,12 +31,12 @@ SPDX-License-Identifier: CC0-1.0
 4. **OrganizationalUnitTree** (`src/components/OrganizationalUnitTree.tsx`)
    - Replaced direct API calls with offline hook
    - Tree building works even without API metadata
-   - Optimistic UI preserved
+   - Cached read-only viewing stays available without API metadata
 
 5. **OrganizationPage** (`src/pages/Organization/OrganizationPage.tsx`)
    - Offline banner (yellow): "You're offline..."
    - Stale data banner (blue): "Viewing cached data..."
-   - Full functionality in offline mode
+   - Offline mode supports cached viewing; create, edit, and delete remain online-only
 
 6. **Documentation** (`frontend/docs/OFFLINE_ORGANIZATIONAL_UNITS.md`)
    - Complete implementation documentation

--- a/docs/IMPLEMENTATION_SUMMARY_OFFLINE_ORGANIZATION.md
+++ b/docs/IMPLEMENTATION_SUMMARY_OFFLINE_ORGANIZATION.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2025-2026 SecPal
 SPDX-License-Identifier: CC0-1.0
 -->
 
@@ -11,8 +11,9 @@ SPDX-License-Identifier: CC0-1.0
 
 1. **IndexedDB Schema v5** (`src/lib/db.ts`)
    - New table `organizationalUnitCache` with all necessary fields
-   - Indexes for performant queries (type, parent_id, pendingSync)
+   - Indexes for performant queries (type, parent_id)
    - DB_VERSION 4 → 5 (automatic migration)
+   - The current live schema later removed the unused `pendingSync` field and index
 
 2. **Store Functions** (`src/lib/organizationalUnitStore.ts`)
    - All CRUD operations for IndexedDB

--- a/docs/OFFLINE_ORGANIZATIONAL_UNITS.md
+++ b/docs/OFFLINE_ORGANIZATIONAL_UNITS.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2025-2026 SecPal
 SPDX-License-Identifier: CC0-1.0
 -->
 
@@ -11,14 +11,14 @@ The `/organization` page is now fully offline-capable. Organizational units are 
 
 ## Implemented Changes
 
-### 1. IndexedDB Schema (v5)
+### 1. IndexedDB Schema
 
 **File:** `src/lib/db.ts`
 
 - New table: `organizationalUnitCache`
-- Schema version: 4 → 5
-- Fields: id, type, name, parent_id, created_at, updated_at, cachedAt, lastSynced, pendingSync
-- Indexes: `id, type, parent_id, updated_at, cachedAt, pendingSync`
+- Introduced in schema version 5; current live schema is version 10
+- Fields: id, type, name, parent_id, created_at, updated_at, cachedAt, lastSynced
+- Indexes: `id, type, parent_id, updated_at, cachedAt`
 
 ```typescript
 export interface OrganizationalUnitCacheEntry {
@@ -42,7 +42,6 @@ export interface OrganizationalUnitCacheEntry {
   // Offline-specific fields
   cachedAt: Date;
   lastSynced: Date;
-  pendingSync?: boolean;
 }
 ```
 
@@ -115,8 +114,8 @@ export interface UseOrganizationalUnitsWithOfflineResult {
 1. Open page → Cache loads data
 2. **Yellow Banner:** "You're offline. Viewing cached organizational units..."
 3. All data is loaded from cache
-4. Changes (Create/Edit/Delete) are saved locally
-5. Sync when connection is restored
+4. Cached read access remains available while offline
+5. Mutations stay online-only and are blocked by the UI until connectivity returns
 
 ### API Error (Online)
 
@@ -155,10 +154,10 @@ export interface UseOrganizationalUnitsWithOfflineResult {
 
 **Automatic:**
 
-- Dexie.js detects schema version 5
-- Automatically migrates from v4 → v5
-- Existing tables are preserved
-- New table `organizationalUnitCache` is created
+- Dexie.js migrates the IndexedDB schema automatically as `DB_VERSION` changes
+- The organizational-unit cache was introduced in v5
+- The current live schema is v10 and no longer keeps the stale `pendingSync` field or index
+- Existing cached records are preserved while the store definition is updated
 
 **No user action required!**
 
@@ -184,36 +183,12 @@ Implementation follows the exact pattern of `/secrets`:
 5. ✅ OrganizationPage with banners
 6. ✅ Tests for store and hook
 7. ⚠️ OrganizationalUnitTree tests need updating (mock adjustments)
-8. 📝 Service Worker: Cache strategy for `/v1/organizational-units`
+8. ✅ Authenticated organizational-unit HTTP responses remain uncached; offline reads rely on IndexedDB only
 
 ## Service Worker Integration
 
-**TODO:** Add cache strategy in `src/sw.ts`:
-
-```typescript
-// Cache organizational units list with NetworkFirst strategy
-registerRoute(
-  ({ url }) =>
-    url.origin === self.location.origin &&
-    url.pathname === "/v1/organizational-units" &&
-    url.search === "",
-  new NetworkFirst({
-    cacheName: "organizational-units-list-cache",
-    networkTimeoutSeconds: 5,
-  })
-);
-
-// Cache organizational unit details with NetworkFirst strategy
-registerRoute(
-  ({ url }) =>
-    url.origin === self.location.origin &&
-    url.pathname.match(/^\/v1\/organizational-units\/[a-f0-9-]+$/),
-  new NetworkFirst({
-    cacheName: "organizational-units-detail-cache",
-    networkTimeoutSeconds: 5,
-  })
-);
-```
+Authenticated organizational-unit API responses are intentionally not cached in the service worker.
+The supported offline path is the explicit IndexedDB cache populated from successful online reads.
 
 ## Maintenance
 
@@ -222,7 +197,7 @@ registerRoute(
 For future schema changes:
 
 1. Increment `DB_VERSION` in `db-constants.ts`
-2. Add new `db.version(X).stores({...})` in `db.ts`
+2. Update the current `db.version(DB_VERSION).stores({...})` block in `db.ts`
 3. Re-declare all existing tables
 4. Update tests
 

--- a/docs/OFFLINE_ORGANIZATIONAL_UNITS.md
+++ b/docs/OFFLINE_ORGANIZATIONAL_UNITS.md
@@ -99,7 +99,7 @@ export interface UseOrganizationalUnitsWithOfflineResult {
 
 - **Offline Banner:** Displayed when user is offline
 - **Stale Data Banner:** Displayed when using cached data
-- **Functionality:** All CRUD operations work (optimistic UI)
+- **Functionality:** Cached organizational-unit reads remain available offline; create, edit, and delete flows stay online-only
 
 ## User Behavior
 
@@ -231,7 +231,7 @@ Follows **ADR-003: Offline-First Architecture**:
 - Service Worker for HTTP caching
 - NetworkFirst strategy for fresh data
 - Cache fallback when offline/error
-- Optimistic UI for fast feedback
+- Cache-backed read access for fast offline feedback
 
 ## Support
 

--- a/src/lib/db-constants.ts
+++ b/src/lib/db-constants.ts
@@ -24,4 +24,4 @@ export const DB_NAME = "SecPalDB";
  * 1. Update this constant
  * 2. Update the single version() block in db.ts
  */
-export const DB_VERSION = 9;
+export const DB_VERSION = 10;

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect, beforeEach } from "vitest";
 import { db } from "./db";
+import { DB_VERSION } from "./db-constants";
 
 describe("IndexedDB Database", () => {
   beforeEach(async () => {
@@ -16,8 +17,8 @@ describe("IndexedDB Database", () => {
       expect(db.name).toBe("SecPalDB");
     });
 
-    it("should have version 10", () => {
-      expect(db.verno).toBe(10);
+    it(`should have version ${DB_VERSION}`, () => {
+      expect(db.verno).toBe(DB_VERSION);
     });
 
     it("keeps only the currently supported offline tables in the live schema", () => {

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -16,8 +16,8 @@ describe("IndexedDB Database", () => {
       expect(db.name).toBe("SecPalDB");
     });
 
-    it("should have version 9", () => {
-      expect(db.verno).toBe(9);
+    it("should have version 10", () => {
+      expect(db.verno).toBe(10);
     });
 
     it("keeps only the currently supported offline tables in the live schema", () => {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -58,7 +58,6 @@ export interface OrganizationalUnitCacheEntry {
   // Offline-specific fields
   cachedAt: Date;
   lastSynced: Date;
-  pendingSync?: boolean; // True if local changes haven't been synced
 }
 
 /**
@@ -73,10 +72,9 @@ export const db = new Dexie(DB_NAME) as Dexie & {
   organizationalUnitCache: EntityTable<OrganizationalUnitCacheEntry, "id">;
 };
 
-// Schema version 9 - Current offline storage only
+// Schema version 10 - Current offline storage only
 // 0.x keeps the IndexedDB schema focused on the currently supported offline data.
 db.version(DB_VERSION).stores({
   analytics: "++id, synced, timestamp, sessionId, type",
-  organizationalUnitCache:
-    "id, type, parent_id, updated_at, cachedAt, pendingSync",
+  organizationalUnitCache: "id, type, parent_id, updated_at, cachedAt",
 });


### PR DESCRIPTION
## Summary
- remove the stale pendingSync field from the offline organizational-unit cache type
- drop the unused pendingSync index from the Dexie schema and bump the DB version
- update focused schema coverage and changelog

## Validation
- npm run test -- src/lib/db.test.ts src/lib/organizationalUnitStore.test.ts src/hooks/useOrganizationalUnitsWithOffline.test.ts src/services/organizationalUnitApi.test.ts
- npm run lint
- npm run build

## Links
- Fixes #664
- Parent issue: #642
- Root issue: #641