### PR TITLE
fix: harden browser-session API routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,7 @@ TRANSLATION_IO_API_KEY=
 
 # Example: API endpoints, feature flags, etc.
 # VITE_API_URL=http://localhost:8000
+
+# Production/static deployments MUST set VITE_API_URL to an absolute API origin.
+# Example:
+# VITE_API_URL=https://api.customer.example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Hardened the browser-session auth endpoint wiring so login, logout, CSRF bootstrapping, and `GET /v1/me` all build URLs from the same production-safe API resolver, which now requires an explicit absolute `VITE_API_URL` for every production deployment and fails fast on missing or relative API bases instead of guessing a host.
 - Aligned repo-local domain governance and validation with the current split of `secpal.app` for the public homepage and real email addresses, `api.secpal.dev` for the API, and `app.secpal.dev` for the PWA, while keeping `app.secpal.app` identifier-only for Android
 - Corrected the frontend production API fallback and related examples to use the canonical `https://api.secpal.dev` host.
 - Separated customer and site feature visibility from assignment-mutation and cross-resource permissions, so only explicit collection access (`hasCustomerAccess` / `hasSiteAccess` or the matching read permission) unlocks those frontend areas and future custom roles cannot drift into implicit half-authorized states.
@@ -48,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Blocked the shipped Apache SPA fallback from answering `/v1/*`, `/sanctum/*`, and `/health*` with `index.html`, and documented the matching Nginx guard so API paths on `app.secpal.dev` now fail clearly instead of returning a misleading `200 text/html` shell.
+- Added a live frontend smoke script for auth-route separation so deployments can automatically fail when `app.secpal.dev/v1/me` regresses to the SPA shell or `api.secpal.dev/v1/me` stops returning JSON.
 - Hardened the browser/PWA response baseline by enforcing a production CSP without inline scripts, expanding `Permissions-Policy` and modern cross-origin headers, and serving `index.html`, `sw.js`, and `manifest.webmanifest` with update-safe cache rules so PWA security fixes propagate promptly.
 
 - Reduced the shipped PWA client surface further by removing the dormant sync-status path from the runtime app shell and narrowing `SecPalDB` plus logout fallback cleanup to the currently supported offline tables so the frontend no longer ships the unused generic queue/cache runtime.

--- a/docs/deployment-spa-routing.md
+++ b/docs/deployment-spa-routing.md
@@ -38,6 +38,10 @@ It also now carries the baseline browser hardening for the shipped PWA:
 <IfModule mod_rewrite.c>
   RewriteEngine On
 
+   # Never rewrite API/framework endpoints into the SPA shell.
+   RewriteRule ^(?:v1|sanctum)(?:/|$) - [R=404,L]
+   RewriteRule ^health(?:/|$) - [R=404,L]
+
   # Don't rewrite files or directories that actually exist
   RewriteCond %{REQUEST_FILENAME} !-f
   RewriteCond %{REQUEST_FILENAME} !-d
@@ -91,7 +95,16 @@ server {
   root /var/www/app.secpal.dev;
   index index.html;
 
-  # SPA routing: Serve index.html for all routes
+   # Never serve API/framework endpoints as the SPA shell.
+   location ~ ^/(v1|sanctum)(/|$) {
+      return 404;
+   }
+
+   location ~ ^/health(/|$) {
+      return 404;
+   }
+
+   # SPA routing: Serve index.html for all frontend routes only
   location / {
     try_files $uri $uri/ /index.html;
   }
@@ -222,13 +235,15 @@ server {
 
 **Build-time variables** (set before `npm run build`):
 
-- `VITE_API_URL` - Backend API URL (e.g., `https://api.secpal.dev`)
+- `VITE_API_URL` - Backend API URL as an absolute origin (for example `https://api.secpal.dev` or `https://api.customer.example`)
 
 **Example (.env.production):**
 
 ```env
 VITE_API_URL=https://api.secpal.dev
 ```
+
+`VITE_API_URL` is mandatory for production builds. Do not use `/`, `/api`, or any other relative value in production, because that allows `/v1/*` and `/sanctum/*` requests to fall back to the SPA host when the web server is misrouted.
 
 **Load environment:**
 
@@ -249,7 +264,7 @@ Before deploying to production:
 - ✅ HTTPS enabled (Let's Encrypt, Certbot)
 - ✅ Security headers configured (`.htaccess` includes them)
 - ✅ CORS configured on backend (API must allow frontend domain)
-- ✅ `VITE_API_URL` points to the canonical `api.secpal.dev` production API
+- ✅ `VITE_API_URL` is an absolute API origin for the current deployment (never a relative path)
 - ✅ No `.env` files committed to Git
 - ✅ Service Worker registered (PWA functionality)
 - ✅ CSP, permissions, and modern cross-origin headers enabled
@@ -288,6 +303,7 @@ After deployment, test these scenarios:
    - Login should work ✅
    - API requests should succeed ✅
    - Check CORS headers in Network tab ✅
+   - Check `https://app.secpal.dev/v1/me` no longer returns `200 text/html`; it must fail clearly on the app host and succeed only on `https://api.secpal.dev/v1/me` ✅
 
 ---
 
@@ -316,6 +332,44 @@ export default defineConfig({
 'allowed_origins' => [
     'https://app.secpal.dev',
 ],
+```
+
+### Issue: Production Build Uses the Wrong API Host
+
+**Cause:** `VITE_API_URL` is missing, relative, or points at the wrong origin.
+
+**Solution:** Set `VITE_API_URL` to the absolute API origin for that deployment before building. Examples:
+
+```bash
+VITE_API_URL=https://api.secpal.dev npm run build
+VITE_API_URL=https://api.customer.example npm run build
+```
+
+The frontend now fails fast on invalid production values instead of silently falling back to the SPA host.
+
+### Issue: API Routes Return the SPA HTML Shell
+
+**Cause:** Frontend rewrites catch `/v1/*`, `/sanctum/*`, or `/health*` and serve `index.html` instead of failing or proxying.
+
+**Solution:** Keep explicit guards ahead of the SPA fallback so API/framework paths never hit the app shell.
+
+For Apache/Uberspace:
+
+```apache
+RewriteRule ^(?:v1|sanctum)(?:/|$) - [R=404,L]
+RewriteRule ^health(?:/|$) - [R=404,L]
+```
+
+For Nginx:
+
+```nginx
+location ~ ^/(v1|sanctum)(/|$) {
+   return 404;
+}
+
+location ~ ^/health(/|$) {
+   return 404;
+}
 ```
 
 ### Issue: Service Worker Not Updating

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test:e2e:staging": "cross-env PLAYWRIGHT_BASE_URL=https://app.secpal.dev playwright test",
     "test:e2e:offline-logout": "cross-env CI=true PLAYWRIGHT_SKIP_GLOBAL_LOGIN=1 playwright test tests/e2e/offline-logout.spec.ts --project=chromium --project=mobile-chrome",
     "test:e2e:offline-logout:staging": "cross-env PLAYWRIGHT_BASE_URL=https://app.secpal.dev PLAYWRIGHT_SKIP_GLOBAL_LOGIN=1 playwright test tests/e2e/offline-logout.spec.ts --project=chromium --project=mobile-chrome",
+    "test:live:auth-routes": "bash ./scripts/check-live-auth-route-separation.sh",
     "format": "prettier --write --cache '**/*.{md,yml,yaml,json,ts,tsx,js,jsx}'",
     "format:check": "prettier --check '**/*.{md,yml,yaml,json,ts,tsx,js,jsx}'",
     "lingui:extract": "lingui extract",

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -7,6 +7,11 @@
 <IfModule mod_rewrite.c>
   RewriteEngine On
 
+  # Never serve API/framework paths as the SPA shell. These routes must be
+  # handled by the canonical API host or fail clearly instead of returning HTML.
+  RewriteRule ^(?:v1|sanctum)(?:/|$) - [R=404,L]
+  RewriteRule ^health(?:/|$) - [R=404,L]
+
   # Don't rewrite files or directories that actually exist
   RewriteCond %{REQUEST_FILENAME} !-f
   RewriteCond %{REQUEST_FILENAME} !-d

--- a/scripts/check-live-auth-route-separation.sh
+++ b/scripts/check-live-auth-route-separation.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+APP_URL="${APP_URL:-https://app.secpal.dev}"
+API_URL="${API_URL:-https://api.secpal.dev}"
+APP_ME_URL="${APP_URL%/}/v1/me"
+API_ME_URL="${API_URL%/}/v1/me"
+
+get_header_value() {
+    local headers="$1"
+    local header_name="$2"
+
+    printf '%s\n' "$headers" | awk -v target="$header_name" '
+        BEGIN {
+            FS = ": "
+        }
+        tolower($1) == tolower(target) {
+            gsub(/\r/, "", $2)
+            print $2
+            exit
+        }
+    '
+}
+
+get_status_code() {
+    local headers="$1"
+
+    printf '%s\n' "$headers" | awk '/^HTTP\/[0-9.]+/ { code = $2 } END { if (code != "") print code }'
+}
+
+request_headers() {
+    local method="$1"
+    local url="$2"
+    local tmp_headers
+
+    tmp_headers="$(mktemp)"
+
+    if ! curl --silent --show-error --retry 2 --retry-delay 2 \
+        --request "$method" \
+        --dump-header "$tmp_headers" \
+        --output /dev/null \
+        --header 'Accept: application/json' \
+        "$url"; then
+        echo "ERROR: ${method} ${url} request failed"
+        rm -f "$tmp_headers"
+        exit 1
+    fi
+
+    cat "$tmp_headers"
+    rm -f "$tmp_headers"
+}
+
+assert_not_html_shell() {
+    local status="$1"
+    local content_type="$2"
+    local url="$3"
+
+    if [[ "$status" == "200" && "$content_type" == text/html* ]]; then
+        echo "ERROR: ${url} still resolves to the SPA HTML shell"
+        echo "  status:       ${status}"
+        echo "  content-type: ${content_type}"
+        exit 1
+    fi
+}
+
+assert_json_api_response() {
+    local status="$1"
+    local content_type="$2"
+    local url="$3"
+
+    if [[ "$status" != "200" && "$status" != "401" ]]; then
+        echo "ERROR: ${url} returned an unexpected status"
+        echo "  expected: 200 or 401"
+        echo "  actual:   ${status}"
+        exit 1
+    fi
+
+    if [[ "$content_type" != application/json* ]]; then
+        echo "ERROR: ${url} did not return JSON"
+        echo "  expected: application/json"
+        echo "  actual:   ${content_type:-<missing>}"
+        exit 1
+    fi
+}
+
+echo "Checking live auth route separation"
+echo "  app host: ${APP_ME_URL}"
+echo "  api host: ${API_ME_URL}"
+
+app_headers="$(request_headers GET "$APP_ME_URL")"
+app_status="$(get_status_code "$app_headers")"
+app_content_type="$(get_header_value "$app_headers" 'Content-Type')"
+
+assert_not_html_shell "$app_status" "$app_content_type" "$APP_ME_URL"
+
+echo "App host no longer serves /v1/me as SPA HTML"
+
+api_headers="$(request_headers GET "$API_ME_URL")"
+api_status="$(get_status_code "$api_headers")"
+api_content_type="$(get_header_value "$api_headers" 'Content-Type')"
+
+assert_json_api_response "$api_status" "$api_content_type" "$API_ME_URL"
+
+echo "API host serves /v1/me as JSON"
+echo "Live auth route separation smoke test passed"

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -9,13 +9,15 @@ describe("config", () => {
     vi.resetModules();
   });
 
-  it("uses secpal.dev as the production API fallback", async () => {
+  it("requires an explicit absolute API URL in production", async () => {
     vi.stubEnv("MODE", "production");
     vi.stubEnv("VITE_API_URL", "");
 
     const { getApiBaseUrl } = await import("./config");
 
-    expect(getApiBaseUrl()).toBe("https://api.secpal.dev");
+    expect(() => getApiBaseUrl()).toThrow(
+      "VITE_API_URL must be set to an absolute https:// or http:// API origin in production"
+    );
   });
 
   it("prefers VITE_API_URL when explicitly configured", async () => {
@@ -25,5 +27,31 @@ describe("config", () => {
     const { getApiBaseUrl } = await import("./config");
 
     expect(getApiBaseUrl()).toBe("https://tenant.secpal.dev");
+  });
+
+  it("does not allow production auth/API traffic to fall back to relative routing", async () => {
+    vi.stubEnv("MODE", "production");
+    vi.stubEnv("VITE_API_URL", "/api");
+
+    const { buildApiUrl, getApiBaseUrl } = await import("./config");
+
+    expect(() => getApiBaseUrl()).toThrow(
+      "VITE_API_URL must be an absolute https:// or http:// API origin in production"
+    );
+    expect(() => buildApiUrl("/v1/me")).toThrow(
+      "VITE_API_URL must be an absolute https:// or http:// API origin in production"
+    );
+  });
+
+  it("accepts deployment-specific absolute production API URLs", async () => {
+    vi.stubEnv("MODE", "production");
+    vi.stubEnv("VITE_API_URL", "https://portal.customer.example");
+
+    const { buildApiUrl, getApiBaseUrl } = await import("./config");
+
+    expect(getApiBaseUrl()).toBe("https://portal.customer.example");
+    expect(buildApiUrl("/v1/auth/logout")).toBe(
+      "https://portal.customer.example/v1/auth/logout"
+    );
   });
 });

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -54,4 +54,14 @@ describe("config", () => {
       "https://portal.customer.example/v1/auth/logout"
     );
   });
+
+  it("normalizes VITE_API_URL to its origin, stripping accidental path segments", async () => {
+    vi.stubEnv("MODE", "production");
+    vi.stubEnv("VITE_API_URL", "https://api.customer.example/api");
+
+    const { buildApiUrl, getApiBaseUrl } = await import("./config");
+
+    expect(getApiBaseUrl()).toBe("https://api.customer.example");
+    expect(buildApiUrl("/v1/me")).toBe("https://api.customer.example/v1/me");
+  });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,17 +11,78 @@
 /**
  * API Configuration
  */
+export class ApiBaseUrlConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ApiBaseUrlConfigurationError";
+  }
+}
+
+function stripTrailingSlashes(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function isAbsoluteHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function normalizeConfiguredApiBaseUrl(value: string): string {
+  return stripTrailingSlashes(value.trim());
+}
+
+export function resolveApiBaseUrl(options?: {
+  configuredBaseUrl?: string;
+  mode?: string;
+}): string {
+  const configuredBaseUrl =
+    options?.configuredBaseUrl ?? import.meta.env.VITE_API_URL ?? "";
+  const mode = options?.mode ?? import.meta.env.MODE;
+  const normalizedConfiguredBaseUrl =
+    normalizeConfiguredApiBaseUrl(configuredBaseUrl);
+
+  if (!normalizedConfiguredBaseUrl) {
+    if (mode === "production") {
+      throw new ApiBaseUrlConfigurationError(
+        "VITE_API_URL must be set to an absolute https:// or http:// API origin in production. Relative or missing API base URLs are unsafe because they can route /v1/* and /sanctum/* back to the SPA host."
+      );
+    }
+
+    return "";
+  }
+
+  if (mode !== "production") {
+    return normalizedConfiguredBaseUrl;
+  }
+
+  if (!isAbsoluteHttpUrl(normalizedConfiguredBaseUrl)) {
+    throw new ApiBaseUrlConfigurationError(
+      "VITE_API_URL must be an absolute https:// or http:// API origin in production. Relative API base URLs are unsafe because they can route /v1/* and /sanctum/* back to the SPA host."
+    );
+  }
+
+  return normalizedConfiguredBaseUrl;
+}
+
 export const apiConfig = {
   /**
    * Base URL for API requests (without /api prefix - backend routes are at /v1/*)
-   * Can be overridden via VITE_API_URL environment variable
+   * Can be overridden via VITE_API_URL environment variable.
+   * Production builds require an absolute API base URL; missing or relative
+   * values fail fast so `/v1/*` and `/sanctum/*` never fall back to the SPA
+   * origin by accident.
    *
    * Examples:
    * - Development with DDEV: (empty string, Vite proxy handles routing)
    * - Development without proxy: http://localhost:8000
    * - Demo/Testing: https://api.secpal.dev
-   * - Production: https://api.secpal.dev (canonical production endpoint)
-   * - Customer On-Premise: tenant-specific SecPal domain provided during deployment
+   * - Production: deployment-specific absolute API origin provided during deployment
+   * - Customer On-Premise: customer-specific absolute API origin provided during deployment
    *
    * Note: The backend uses apiPrefix: '' in Laravel's bootstrap/app.php,
    * so routes are accessible at /v1/* NOT /api/v1/*
@@ -30,9 +91,9 @@ export const apiConfig = {
    * When VITE_API_URL is not set, we use empty string for same-origin requests.
    * Vite's proxy (see vite.config.ts) forwards /v1/* and /sanctum/* to DDEV.
    */
-  baseUrl:
-    import.meta.env.VITE_API_URL ||
-    (import.meta.env.MODE === "production" ? "https://api.secpal.dev" : ""),
+  get baseUrl(): string {
+    return resolveApiBaseUrl();
+  },
 
   /**
    * API timeout in milliseconds
@@ -75,4 +136,17 @@ export const appConfig = {
  */
 export function getApiBaseUrl(): string {
   return apiConfig.baseUrl;
+}
+
+export function buildApiUrl(
+  path: string,
+  options?: {
+    configuredBaseUrl?: string;
+    mode?: string;
+  }
+): string {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  const baseUrl = resolveApiBaseUrl(options);
+
+  return baseUrl ? `${baseUrl}${normalizedPath}` : normalizedPath;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -66,7 +66,7 @@ export function resolveApiBaseUrl(options?: {
     );
   }
 
-  return normalizedConfiguredBaseUrl;
+  return new URL(normalizedConfiguredBaseUrl).origin;
 }
 
 export const apiConfig = {

--- a/src/services/authApi.test.ts
+++ b/src/services/authApi.test.ts
@@ -454,10 +454,12 @@ describe("authApi", () => {
         }),
       } as Partial<Response> as Response);
 
-      await expect(getCurrentUser()).rejects.toThrow(
+      const currentUserPromise = getCurrentUser();
+
+      await expect(currentUserPromise).rejects.toThrow(
         "Current user fetch failed: expected application/json response from API"
       );
-      await expect(getCurrentUser()).rejects.toBeInstanceOf(AuthApiError);
+      await expect(currentUserPromise).rejects.toBeInstanceOf(AuthApiError);
     });
   });
 

--- a/src/services/authApi.test.ts
+++ b/src/services/authApi.test.ts
@@ -444,6 +444,21 @@ describe("authApi", () => {
       );
       await expect(getCurrentUser()).rejects.toBeInstanceOf(AuthApiError);
     });
+
+    it("fails fast when the current-user endpoint returns HTML instead of JSON", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({
+          "Content-Type": "text/html; charset=utf-8",
+        }),
+      } as Partial<Response> as Response);
+
+      await expect(getCurrentUser()).rejects.toThrow(
+        "Current user fetch failed: expected application/json response from API"
+      );
+      await expect(getCurrentUser()).rejects.toBeInstanceOf(AuthApiError);
+    });
   });
 
   describe("AuthApiError", () => {

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { getApiBaseUrl } from "../config";
+import { buildApiUrl } from "../config";
 import { fetchCsrfToken, apiFetch } from "./csrf";
 
 interface LoginCredentials {
@@ -28,6 +28,49 @@ interface ApiError {
   errors?: Record<string, string[]>;
 }
 
+function hasJsonContentType(response: Response): boolean {
+  if (
+    !("headers" in response) ||
+    !response.headers ||
+    typeof response.headers.get !== "function"
+  ) {
+    return typeof response.json === "function";
+  }
+
+  const contentType = response.headers.get("Content-Type");
+
+  return contentType?.toLowerCase().includes("application/json") ?? false;
+}
+
+async function parseJsonResponse<T>(
+  response: Response,
+  operation: string
+): Promise<T> {
+  if (!hasJsonContentType(response)) {
+    throw new AuthApiError(
+      `${operation}: expected application/json response from API`
+    );
+  }
+
+  try {
+    return (await response.json()) as T;
+  } catch {
+    throw new AuthApiError(`${operation}: received malformed JSON from API`);
+  }
+}
+
+async function parseJsonError(response: Response): Promise<ApiError | null> {
+  if (!hasJsonContentType(response)) {
+    return null;
+  }
+
+  try {
+    return (await response.json()) as ApiError;
+  } catch {
+    return null;
+  }
+}
+
 export class AuthApiError extends Error {
   constructor(
     message: string,
@@ -49,7 +92,7 @@ export async function login(
   await fetchCsrfToken();
 
   // Use SPA login endpoint (session-based, not token-based)
-  const response = await apiFetch(`${getApiBaseUrl()}/v1/auth/login`, {
+  const response = await apiFetch(buildApiUrl("/v1/auth/login"), {
     method: "POST",
     cache: "no-store",
     headers: {
@@ -63,19 +106,19 @@ export async function login(
   });
 
   if (!response.ok) {
-    let error: ApiError | null;
-    try {
-      error = await response.json();
-    } catch {
+    const error = await parseJsonError(response);
+
+    if (!error) {
       // Fallback if response is not JSON (e.g., HTML error page)
       throw new AuthApiError(
         `Login failed: ${response.status} ${response.statusText}`
       );
     }
+
     throw new AuthApiError(error?.message || "Login failed", error?.errors);
   }
 
-  return response.json();
+  return parseJsonResponse<LoginResponse>(response, "Login failed");
 }
 
 /**
@@ -83,7 +126,7 @@ export async function login(
  * @throws {AuthApiError} If logout fails
  */
 export async function logout(): Promise<void> {
-  const response = await apiFetch(`${getApiBaseUrl()}/v1/auth/logout`, {
+  const response = await apiFetch(buildApiUrl("/v1/auth/logout"), {
     method: "POST",
     cache: "no-store",
     headers: {
@@ -92,12 +135,12 @@ export async function logout(): Promise<void> {
   });
 
   if (!response.ok) {
-    let error: ApiError | null;
-    try {
-      error = await response.json();
-    } catch {
+    const error = await parseJsonError(response);
+
+    if (!error) {
       throw new AuthApiError("Logout failed");
     }
+
     throw new AuthApiError(error?.message || "Logout failed", error?.errors);
   }
 }
@@ -107,7 +150,7 @@ export async function logout(): Promise<void> {
  * @throws {AuthApiError} If logout fails
  */
 export async function logoutAll(): Promise<void> {
-  const response = await apiFetch(`${getApiBaseUrl()}/v1/auth/logout-all`, {
+  const response = await apiFetch(buildApiUrl("/v1/auth/logout-all"), {
     method: "POST",
     cache: "no-store",
     headers: {
@@ -116,12 +159,12 @@ export async function logoutAll(): Promise<void> {
   });
 
   if (!response.ok) {
-    let error: ApiError | null;
-    try {
-      error = await response.json();
-    } catch {
+    const error = await parseJsonError(response);
+
+    if (!error) {
       throw new AuthApiError("Logout all devices failed");
     }
+
     throw new AuthApiError(
       error?.message || "Logout all devices failed",
       error?.errors
@@ -136,7 +179,7 @@ export async function logoutAll(): Promise<void> {
 export async function getCurrentUser(): Promise<LoginResponse["user"]> {
   let response: Response;
   try {
-    response = await apiFetch(`${getApiBaseUrl()}/v1/me`, {
+    response = await apiFetch(buildApiUrl("/v1/me"), {
       method: "GET",
       cache: "no-store",
       headers: {
@@ -152,10 +195,9 @@ export async function getCurrentUser(): Promise<LoginResponse["user"]> {
   }
 
   if (!response.ok) {
-    let error: ApiError | null;
-    try {
-      error = await response.json();
-    } catch {
+    const error = await parseJsonError(response);
+
+    if (!error) {
       throw new AuthApiError(
         `Current user fetch failed: ${response.status} ${response.statusText}`
       );
@@ -167,5 +209,8 @@ export async function getCurrentUser(): Promise<LoginResponse["user"]> {
     );
   }
 
-  return response.json();
+  return parseJsonResponse<LoginResponse["user"]>(
+    response,
+    "Current user fetch failed"
+  );
 }

--- a/src/services/csrf.ts
+++ b/src/services/csrf.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { getApiBaseUrl } from "../config";
+import { buildApiUrl } from "../config";
 import { sessionEvents, isOnline } from "./sessionEvents";
 
 /**
@@ -28,7 +28,7 @@ export class CsrfError extends Error {
  */
 export async function fetchCsrfToken(): Promise<void> {
   try {
-    const response = await fetch(`${getApiBaseUrl()}/sanctum/csrf-cookie`, {
+    const response = await fetch(buildApiUrl("/sanctum/csrf-cookie"), {
       credentials: "include",
     });
 
@@ -102,10 +102,10 @@ const CSRF_REQUIRED_METHODS = ["POST", "PUT", "PATCH", "DELETE"];
  * @example
  * ```ts
  * // GET request (no CSRF token needed)
- * const response = await apiFetch(`${apiConfig.baseUrl}/v1/me`);
+ * const response = await apiFetch(buildApiUrl("/v1/me"));
  *
  * // POST request (CSRF token added automatically)
- * const response = await apiFetch(`${apiConfig.baseUrl}/v1/organizational-units`, {
+ * const response = await apiFetch(buildApiUrl("/v1/organizational-units"), {
  *   method: "POST",
  *   headers: { "Content-Type": "application/json" },
  *   body: JSON.stringify(data),

--- a/tests/htaccess-routing.test.ts
+++ b/tests/htaccess-routing.test.ts
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const htaccessPath = path.resolve(import.meta.dirname, "../public/.htaccess");
+const htaccess = readFileSync(htaccessPath, "utf8");
+
+describe("frontend public/.htaccess", () => {
+  it("fails API and Sanctum paths explicitly before the SPA fallback", () => {
+    const apiGuard = "RewriteRule ^(?:v1|sanctum)(?:/|$) - [R=404,L]";
+    const healthGuard = "RewriteRule ^health(?:/|$) - [R=404,L]";
+    const spaFallback = "RewriteRule . /index.html [L]";
+
+    expect(htaccess).toContain(apiGuard);
+    expect(htaccess).toContain(healthGuard);
+    expect(htaccess.indexOf(apiGuard)).toBeGreaterThan(-1);
+    expect(htaccess.indexOf(healthGuard)).toBeGreaterThan(-1);
+    expect(htaccess.indexOf(apiGuard)).toBeLessThan(
+      htaccess.indexOf(spaFallback)
+    );
+    expect(htaccess.indexOf(healthGuard)).toBeLessThan(
+      htaccess.indexOf(spaFallback)
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- build browser-session auth, logout, CSRF, and current-user URLs through one shared API URL resolver
- fail fast in production when `VITE_API_URL` is missing or relative, and reject HTML success payloads from `/v1/me`
- ship Apache route guards, a matching regression test, deployment guidance, and a live auth-route smoke script

## Testing
- npm --prefix /home/secpal/code/SecPal/frontend test -- src/config.test.ts src/services/authApi.test.ts tests/htaccess-routing.test.ts
- npm --prefix /home/secpal/code/SecPal/frontend run typecheck
- npm --prefix /home/secpal/code/SecPal/frontend run lint
- npm --prefix /home/secpal/code/SecPal/frontend run format:check
- VITE_API_URL=https://api.secpal.dev npm --prefix /home/secpal/code/SecPal/frontend run build

## Follow-up
- Live deployment route-separation rollout is tracked in #669
- Existing TypeScript 6 / `@typescript-eslint` support warning remains tracked in #666