### PR TITLE
fix: accept uuid auth user ids in browser sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Aligned the frontend browser-session auth contract with the backend UUID-based user payload so successful login, current-user bootstrap, persisted auth state, and onboarding handoff now accept valid string user IDs instead of incorrectly rejecting them as unsafe.
 - Hardened the browser-session auth endpoint wiring so login, logout, CSRF bootstrapping, and `GET /v1/me` all build URLs from the same production-safe API resolver, which now requires an explicit absolute `VITE_API_URL` for every production deployment and fails fast on missing or relative API bases instead of guessing a host.
 - Aligned repo-local domain governance and validation with the current split of `secpal.app` for the public homepage and real email addresses, `api.secpal.dev` for the API, and `app.secpal.dev` for the PWA, while keeping `app.secpal.app` identifier-only for Android
 - Corrected the frontend production API fallback and related examples to use the canonical `https://api.secpal.dev` host.

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -335,7 +335,7 @@ describe("AuthContext", () => {
             <button
               onClick={() =>
                 auth.login({
-                  id: 1,
+                  id: "1",
                   name: "Test",
                   email: "test@test.com",
                   hasOrganizationalScopes: true,

--- a/src/contexts/auth-context.ts
+++ b/src/contexts/auth-context.ts
@@ -4,8 +4,10 @@
 import { createContext } from "react";
 import type { Employee } from "@/types/api";
 
+export type AuthUserId = string;
+
 export interface User {
-  id: number;
+  id: AuthUserId;
   name: string;
   email: string;
   roles?: string[];

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -74,7 +74,11 @@ describe("useAuth", () => {
   });
 
   it("revalidates a stored user before completing bootstrap", async () => {
-    const mockUser = { id: 1, name: "Test User", email: "test@secpal.dev" };
+    const mockUser = {
+      id: "1",
+      name: "Test User",
+      email: "test@secpal.dev",
+    };
     const revalidatedUser = {
       ...mockUser,
       roles: ["Admin"],
@@ -106,7 +110,11 @@ describe("useAuth", () => {
   });
 
   it("does not restore auth state when bootstrap revalidation resolves after logout", async () => {
-    const mockUser = { id: 1, name: "Test User", email: "test@secpal.dev" };
+    const mockUser = {
+      id: "1",
+      name: "Test User",
+      email: "test@secpal.dev",
+    };
     const revalidatedUser = {
       ...mockUser,
       roles: ["Admin"],
@@ -142,7 +150,11 @@ describe("useAuth", () => {
   });
 
   it("clears stale stored auth data when revalidation fails", async () => {
-    const mockUser = { id: 1, name: "Test User", email: "test@secpal.dev" };
+    const mockUser = {
+      id: "1",
+      name: "Test User",
+      email: "test@secpal.dev",
+    };
 
     localStorage.setItem("auth_user", JSON.stringify(mockUser));
     mockGetCurrentUser.mockRejectedValueOnce(new Error("Unauthorized"));
@@ -164,7 +176,11 @@ describe("useAuth", () => {
   });
 
   it("keeps stored auth when offline without revalidation", () => {
-    const mockUser = { id: 1, name: "Test User", email: "test@secpal.dev" };
+    const mockUser = {
+      id: "1",
+      name: "Test User",
+      email: "test@secpal.dev",
+    };
 
     localStorage.setItem("auth_user", JSON.stringify(mockUser));
 
@@ -200,7 +216,11 @@ describe("useAuth", () => {
       wrapper: AuthProvider,
     });
 
-    const mockUser = { id: 1, name: "Test User", email: "test@secpal.dev" };
+    const mockUser = {
+      id: "1",
+      name: "Test User",
+      email: "test@secpal.dev",
+    };
 
     act(() => {
       result.current.login(mockUser);
@@ -263,7 +283,7 @@ describe("useAuth", () => {
     expect(result.current.isAuthenticated).toBe(false);
 
     act(() => {
-      result.current.login({ id: 1, name: "User", email: "u@e.com" });
+      result.current.login({ id: "1", name: "User", email: "u@e.com" });
     });
 
     expect(result.current.isAuthenticated).toBe(true);
@@ -498,7 +518,7 @@ describe("useAuth", () => {
     expect(result.current.isAuthenticated).toBe(false);
 
     const newUser = {
-      id: 2,
+      id: "2",
       name: "Cross-Tab User",
       email: "cross@secpal.dev",
     };

--- a/src/lib/capabilities.test.ts
+++ b/src/lib/capabilities.test.ts
@@ -7,7 +7,7 @@ import { getUserCapabilities } from "./capabilities";
 describe("getUserCapabilities", () => {
   it("keeps scope-only users in self-service areas", () => {
     const capabilities = getUserCapabilities({
-      id: 1,
+      id: "1",
       name: "Scope User",
       email: "scope.user@secpal.dev",
       hasOrganizationalScopes: true,
@@ -30,7 +30,7 @@ describe("getUserCapabilities", () => {
 
   it("enables management areas for elevated organization roles", () => {
     const capabilities = getUserCapabilities({
-      id: 1,
+      id: "1",
       name: "Manager User",
       email: "manager.user@secpal.dev",
       hasOrganizationalScopes: true,
@@ -49,7 +49,7 @@ describe("getUserCapabilities", () => {
 
   it("enables customer and site features from explicit permissions", () => {
     const capabilities = getUserCapabilities({
-      id: 1,
+      id: "1",
       name: "Customer User",
       email: "customer.user@secpal.dev",
       roles: [],
@@ -66,7 +66,7 @@ describe("getUserCapabilities", () => {
 
   it("does not leak the site feature from customer-only read access", () => {
     const capabilities = getUserCapabilities({
-      id: 1,
+      id: "1",
       name: "Customer Reader",
       email: "customer.reader@secpal.dev",
       roles: [],
@@ -79,7 +79,7 @@ describe("getUserCapabilities", () => {
 
   it("does not unlock customer or site features from assignment mutation permissions alone", () => {
     const capabilities = getUserCapabilities({
-      id: 1,
+      id: "1",
       name: "Assignment Operator",
       email: "assignment.operator@secpal.dev",
       roles: [],
@@ -92,7 +92,7 @@ describe("getUserCapabilities", () => {
 
   it("enables customer and site features from backend scoped-access flags", () => {
     const capabilities = getUserCapabilities({
-      id: 1,
+      id: "1",
       name: "Scoped Access User",
       email: "scoped.access@secpal.dev",
       roles: [],
@@ -109,7 +109,7 @@ describe("getUserCapabilities", () => {
 
   it("grants action capabilities from explicit action permissions", () => {
     const capabilities = getUserCapabilities({
-      id: 1,
+      id: "1",
       name: "Action User",
       email: "action.user@secpal.dev",
       roles: [],
@@ -126,7 +126,7 @@ describe("getUserCapabilities", () => {
 
   it("grants employee action capabilities from explicit permissions with org scopes", () => {
     const capabilities = getUserCapabilities({
-      id: 1,
+      id: "1",
       name: "Employee Manager",
       email: "emp.manager@secpal.dev",
       hasOrganizationalScopes: true,
@@ -141,7 +141,7 @@ describe("getUserCapabilities", () => {
 
   it("blocks employee action capabilities without org scopes even with matching permissions", () => {
     const capabilities = getUserCapabilities({
-      id: 1,
+      id: "1",
       name: "External User",
       email: "external.user@secpal.dev",
       hasOrganizationalScopes: false,

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -104,7 +104,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const mockResponse = {
       token: "test-token",
-      user: { id: 1, name: "Test User", email: "test@secpal.dev" },
+      user: { id: "1", name: "Test User", email: "test@secpal.dev" },
     };
     mockLogin.mockResolvedValueOnce(mockResponse);
 
@@ -294,7 +294,7 @@ describe("Login", () => {
 
     // Second call: success
     mockLogin.mockResolvedValueOnce({
-      user: { id: 1, name: "Test", email: "test@secpal.dev" },
+      user: { id: "1", name: "Test", email: "test@secpal.dev" },
     });
 
     // Second submission should clear error
@@ -632,7 +632,7 @@ describe("Login", () => {
 
       const mockLogin = vi.mocked(authApi.login);
       mockLogin.mockResolvedValueOnce({
-        user: { id: 1, name: "Test", email: "test@secpal.dev" },
+        user: { id: "1", name: "Test", email: "test@secpal.dev" },
       });
 
       renderLogin();

--- a/src/pages/Onboarding/OnboardingComplete.tsx
+++ b/src/pages/Onboarding/OnboardingComplete.tsx
@@ -434,7 +434,7 @@ export function OnboardingComplete() {
 
       // Store authentication token and user data
       login({
-        id: response.data.user.id,
+        id: String(response.data.user.id),
         email: response.data.user.email,
         name: response.data.user.name,
       });

--- a/src/pages/Onboarding/OnboardingComplete.tsx
+++ b/src/pages/Onboarding/OnboardingComplete.tsx
@@ -434,7 +434,7 @@ export function OnboardingComplete() {
 
       // Store authentication token and user data
       login({
-        id: String(response.data.user.id),
+        id: response.data.user.id,
         email: response.data.user.email,
         name: response.data.user.name,
       });

--- a/src/pages/Profile/ProfilePage.test.tsx
+++ b/src/pages/Profile/ProfilePage.test.tsx
@@ -16,7 +16,7 @@ const renderWithProviders = (
 ) => {
   const defaultAuthValue: AuthContextType = {
     user: {
-      id: 1,
+      id: "1",
       name: "John Doe",
       email: "john.doe@secpal.dev",
       roles: ["user"],
@@ -102,7 +102,7 @@ describe("ProfilePage", () => {
   it("handles user with single name", () => {
     renderWithProviders(<ProfilePage />, {
       user: {
-        id: 2,
+        id: "2",
         name: "Alice",
         email: "alice@secpal.dev",
       },
@@ -131,7 +131,7 @@ describe("ProfilePage", () => {
   it("handles user with empty name", () => {
     renderWithProviders(<ProfilePage />, {
       user: {
-        id: 3,
+        id: "3",
         name: "",
         email: "empty@secpal.dev",
       },
@@ -144,7 +144,7 @@ describe("ProfilePage", () => {
   it("handles user with whitespace-only name", () => {
     renderWithProviders(<ProfilePage />, {
       user: {
-        id: 4,
+        id: "4",
         name: "   ",
         email: "whitespace@secpal.dev",
       },

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -12,7 +12,7 @@ interface LoginCredentials {
 
 interface LoginResponse {
   user: {
-    id: number;
+    id: string;
     name: string;
     email: string;
     roles?: string[];

--- a/src/services/authState.test.ts
+++ b/src/services/authState.test.ts
@@ -5,6 +5,28 @@ import { describe, expect, it } from "vitest";
 import { sanitizeAuthUser, sanitizePersistedAuthUser } from "./authState";
 
 describe("authState", () => {
+  it("accepts UUID-style string ids from the auth API", () => {
+    const sanitizedUser = sanitizeAuthUser({
+      id: "019d30f1-767e-7210-bc31-2b8c1985bb61",
+      name: "Test User",
+      email: "test@secpal.app",
+      roles: [],
+      permissions: [],
+      hasOrganizationalScopes: false,
+      hasCustomerAccess: false,
+      hasSiteAccess: false,
+    });
+
+    expect(sanitizedUser).toEqual({
+      id: "019d30f1-767e-7210-bc31-2b8c1985bb61",
+      name: "Test User",
+      email: "test@secpal.app",
+      hasOrganizationalScopes: false,
+      hasCustomerAccess: false,
+      hasSiteAccess: false,
+    });
+  });
+
   it("keeps employee data in ephemeral auth state by default", () => {
     const sanitizedUser = sanitizeAuthUser({
       id: 1,
@@ -16,7 +38,7 @@ describe("authState", () => {
     });
 
     expect(sanitizedUser).toEqual({
-      id: 1,
+      id: "1",
       name: "Test User",
       email: "test@secpal.app",
       employee: {
@@ -37,10 +59,24 @@ describe("authState", () => {
     });
 
     expect(sanitizedUser).toEqual({
-      id: 1,
+      id: "1",
       name: "Test User",
       email: "test@secpal.app",
     });
     expect(sanitizedUser).not.toHaveProperty("employee");
+  });
+
+  it("persists UUID-style string ids without dropping a valid auth user", () => {
+    const sanitizedUser = sanitizePersistedAuthUser({
+      id: "019d30f1-767e-7210-bc31-2b8c1985bb61",
+      name: "Persisted User",
+      email: "persisted@secpal.app",
+    });
+
+    expect(sanitizedUser).toEqual({
+      id: "019d30f1-767e-7210-bc31-2b8c1985bb61",
+      name: "Persisted User",
+      email: "persisted@secpal.app",
+    });
   });
 });

--- a/src/services/authState.test.ts
+++ b/src/services/authState.test.ts
@@ -9,7 +9,7 @@ describe("authState", () => {
     const sanitizedUser = sanitizeAuthUser({
       id: "019d30f1-767e-7210-bc31-2b8c1985bb61",
       name: "Test User",
-      email: "test@secpal.app",
+      email: "test@secpal.dev",
       roles: [],
       permissions: [],
       hasOrganizationalScopes: false,
@@ -20,7 +20,7 @@ describe("authState", () => {
     expect(sanitizedUser).toEqual({
       id: "019d30f1-767e-7210-bc31-2b8c1985bb61",
       name: "Test User",
-      email: "test@secpal.app",
+      email: "test@secpal.dev",
       hasOrganizationalScopes: false,
       hasCustomerAccess: false,
       hasSiteAccess: false,
@@ -70,13 +70,13 @@ describe("authState", () => {
     const sanitizedUser = sanitizePersistedAuthUser({
       id: "019d30f1-767e-7210-bc31-2b8c1985bb61",
       name: "Persisted User",
-      email: "persisted@secpal.app",
+      email: "persisted@secpal.dev",
     });
 
     expect(sanitizedUser).toEqual({
       id: "019d30f1-767e-7210-bc31-2b8c1985bb61",
       name: "Persisted User",
-      email: "persisted@secpal.app",
+      email: "persisted@secpal.dev",
     });
   });
 });

--- a/src/services/authState.ts
+++ b/src/services/authState.ts
@@ -25,6 +25,18 @@ function sanitizeBoolean(value: unknown): boolean | undefined {
   return typeof value === "boolean" ? value : undefined;
 }
 
+function sanitizeAuthUserId(value: unknown): User["id"] | null {
+  if (typeof value === "string") {
+    return value.trim().length > 0 ? value : null;
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return null;
+}
+
 export function sanitizeAuthUser(
   value: unknown,
   options: SanitizeAuthUserOptions = {}
@@ -36,10 +48,10 @@ export function sanitizeAuthUser(
   const includeEmployee = options.includeEmployee ?? true;
 
   const candidate = value as Record<string, unknown>;
+  const sanitizedId = sanitizeAuthUserId(candidate.id);
 
   if (
-    typeof candidate.id !== "number" ||
-    !Number.isFinite(candidate.id) ||
+    sanitizedId === null ||
     typeof candidate.name !== "string" ||
     typeof candidate.email !== "string"
   ) {
@@ -47,7 +59,7 @@ export function sanitizeAuthUser(
   }
 
   const sanitizedUser: User = {
-    id: candidate.id,
+    id: sanitizedId,
     name: candidate.name,
     email: candidate.email,
   };

--- a/src/services/authState.ts
+++ b/src/services/authState.ts
@@ -27,7 +27,8 @@ function sanitizeBoolean(value: unknown): boolean | undefined {
 
 function sanitizeAuthUserId(value: unknown): User["id"] | null {
   if (typeof value === "string") {
-    return value.trim().length > 0 ? value : null;
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
   }
 
   if (typeof value === "number" && Number.isFinite(value)) {

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -71,13 +71,45 @@ describe("authTransport", () => {
     });
     expect(result).toEqual({
       user: {
-        id: 1,
+        id: "1",
         name: "Browser User",
         email: "browser@secpal.app",
         roles: ["Admin"],
       },
     });
     expect(result.user).not.toHaveProperty("token");
+  });
+
+  it("accepts a browser-session login payload with a UUID string id", async () => {
+    mockBrowserLogin.mockResolvedValueOnce({
+      user: {
+        id: "019d30f1-767e-7210-bc31-2b8c1985bb61",
+        name: "Browser User",
+        email: "browser@secpal.app",
+        roles: [],
+        permissions: [],
+        hasOrganizationalScopes: false,
+        hasCustomerAccess: false,
+        hasSiteAccess: false,
+      },
+    });
+
+    const transport = getAuthTransport();
+    const result = await transport.login({
+      email: "browser@secpal.app",
+      password: "password123",
+    });
+
+    expect(result).toEqual({
+      user: {
+        id: "019d30f1-767e-7210-bc31-2b8c1985bb61",
+        name: "Browser User",
+        email: "browser@secpal.app",
+        hasOrganizationalScopes: false,
+        hasCustomerAccess: false,
+        hasSiteAccess: false,
+      },
+    });
   });
 
   it("uses a native bridge transport and strips raw token fields from auth state", async () => {
@@ -118,7 +150,7 @@ describe("authTransport", () => {
     expect(mockBrowserLogin).not.toHaveBeenCalled();
     expect(loginResult).toEqual({
       user: {
-        id: 7,
+        id: "7",
         name: "Native User",
         email: "native@secpal.app",
         permissions: ["profile.read"],
@@ -126,7 +158,7 @@ describe("authTransport", () => {
     });
     expect(loginResult.user).not.toHaveProperty("token");
     expect(currentUser).toEqual({
-      id: 7,
+      id: "7",
       name: "Native User",
       email: "native@secpal.app",
       permissions: ["profile.read"],
@@ -200,12 +232,37 @@ describe("authTransport", () => {
 
     expect(mockBrowserGetCurrentUser).toHaveBeenCalledOnce();
     expect(user).toEqual({
-      id: 2,
+      id: "2",
       name: "Session User",
       email: "session@secpal.app",
       roles: ["Viewer"],
     });
     expect(user).not.toHaveProperty("token");
+  });
+
+  it("accepts a browser-session current-user payload with a UUID string id", async () => {
+    mockBrowserGetCurrentUser.mockResolvedValueOnce({
+      id: "019d30f1-767e-7210-bc31-2b8c1985bb61",
+      name: "Session User",
+      email: "session@secpal.app",
+      roles: [],
+      permissions: [],
+      hasOrganizationalScopes: false,
+      hasCustomerAccess: false,
+      hasSiteAccess: false,
+    });
+
+    const transport = getAuthTransport();
+    const user = await transport.getCurrentUser();
+
+    expect(user).toEqual({
+      id: "019d30f1-767e-7210-bc31-2b8c1985bb61",
+      name: "Session User",
+      email: "session@secpal.app",
+      hasOrganizationalScopes: false,
+      hasCustomerAccess: false,
+      hasSiteAccess: false,
+    });
   });
 
   it("delegates native bridge logout to the bridge", async () => {

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -85,7 +85,7 @@ describe("authTransport", () => {
       user: {
         id: "019d30f1-767e-7210-bc31-2b8c1985bb61",
         name: "Browser User",
-        email: "browser@secpal.app",
+        email: "uuid.browser@secpal.dev",
         roles: [],
         permissions: [],
         hasOrganizationalScopes: false,
@@ -96,7 +96,7 @@ describe("authTransport", () => {
 
     const transport = getAuthTransport();
     const result = await transport.login({
-      email: "browser@secpal.app",
+      email: "uuid.browser@secpal.dev",
       password: "password123",
     });
 
@@ -104,7 +104,7 @@ describe("authTransport", () => {
       user: {
         id: "019d30f1-767e-7210-bc31-2b8c1985bb61",
         name: "Browser User",
-        email: "browser@secpal.app",
+        email: "uuid.browser@secpal.dev",
         hasOrganizationalScopes: false,
         hasCustomerAccess: false,
         hasSiteAccess: false,
@@ -244,7 +244,7 @@ describe("authTransport", () => {
     mockBrowserGetCurrentUser.mockResolvedValueOnce({
       id: "019d30f1-767e-7210-bc31-2b8c1985bb61",
       name: "Session User",
-      email: "session@secpal.app",
+      email: "uuid.session@secpal.dev",
       roles: [],
       permissions: [],
       hasOrganizationalScopes: false,
@@ -258,7 +258,7 @@ describe("authTransport", () => {
     expect(user).toEqual({
       id: "019d30f1-767e-7210-bc31-2b8c1985bb61",
       name: "Session User",
-      email: "session@secpal.app",
+      email: "uuid.session@secpal.dev",
       hasOrganizationalScopes: false,
       hasCustomerAccess: false,
       hasSiteAccess: false,

--- a/src/services/onboardingApi.ts
+++ b/src/services/onboardingApi.ts
@@ -89,7 +89,7 @@ export interface OnboardingCompleteResponse {
   data: {
     token: string;
     user: {
-      id: number;
+      id: string;
       email: string;
       name: string;
     };

--- a/tests/unit/pages/Onboarding/OnboardingComplete.test.tsx
+++ b/tests/unit/pages/Onboarding/OnboardingComplete.test.tsx
@@ -289,7 +289,7 @@ describe("OnboardingComplete", () => {
       data: {
         token: "test-sanctum-token",
         user: {
-          id: 1,
+          id: "1",
           email: "john@secpal.dev",
           name: "John Doe",
         },
@@ -340,7 +340,7 @@ describe("OnboardingComplete", () => {
 
     await waitFor(() => {
       expect(mockLogin).toHaveBeenCalledWith({
-        id: 1,
+        id: "1",
         email: "john@secpal.dev",
         name: "John Doe",
       });


### PR DESCRIPTION
## Summary
- align the frontend auth user contract with the backend by accepting UUID string user IDs for browser-session login, current-user bootstrap, persisted auth state, and onboarding handoff
- normalize legacy numeric auth IDs to strings in the sanitization layer instead of rejecting valid authenticated users as unsafe
- add regression coverage for auth sanitization, auth transport, login, useAuth, capability checks, profile rendering, and related context flows

## Testing
- npm --prefix /home/secpal/code/SecPal/frontend test -- src/services/authState.test.ts src/services/authTransport.test.ts src/pages/Login.test.tsx src/contexts/AuthContext.test.tsx src/hooks/useAuth.test.ts src/lib/capabilities.test.ts src/pages/Profile/ProfilePage.test.tsx
- npm --prefix /home/secpal/code/SecPal/frontend run typecheck
- npm --prefix /home/secpal/code/SecPal/frontend run lint
- npm --prefix /home/secpal/code/SecPal/frontend run format:check

## Notes
- The remaining TypeScript 6 / `@typescript-eslint` support warning during lint is already tracked in #666.