### PR TITLE
fix(pwa): harden nginx response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Added a versioned `deploy/nginx/app.secpal.dev.conf` production baseline plus a `test:live:pwa-headers` smoke check so the live PWA host can enforce CSP, Permissions-Policy, HSTS, Referrer-Policy, framing protection, and correct `sw.js` / `manifest.webmanifest` header delivery under Nginx instead of relying on Apache-only `.htaccess` rules.
 - Blocked the shipped Apache SPA fallback from answering `/v1/*`, `/sanctum/*`, and `/health*` with `index.html`, and documented the matching Nginx guard so API paths on `app.secpal.dev` now fail clearly instead of returning a misleading `200 text/html` shell.
 - Added a live frontend smoke script for auth-route separation so deployments can automatically fail when `app.secpal.dev/v1/me` regresses to the SPA shell or `api.secpal.dev/v1/me` stops returning JSON.
 - Hardened the browser/PWA response baseline by enforcing a production CSP without inline scripts, expanding `Permissions-Policy` and modern cross-origin headers, and serving `index.html`, `sw.js`, and `manifest.webmanifest` with update-safe cache rules so PWA security fixes propagate promptly.

--- a/deploy/nginx/app.secpal.dev.conf
+++ b/deploy/nginx/app.secpal.dev.conf
@@ -117,9 +117,6 @@ server {
     expires 1y;
     try_files $uri =404;
   }
-
-  listen 443 ssl; # managed by Certbot
-  listen [::]:443 ssl; # managed by Certbot
 }
 
 server {

--- a/deploy/nginx/app.secpal.dev.conf
+++ b/deploy/nginx/app.secpal.dev.conf
@@ -12,6 +12,10 @@ server {
   access_log /var/log/nginx/app.secpal.dev.access.log;
   error_log /var/log/nginx/app.secpal.dev.error.log;
 
+  # The live VPS uses a single SAN/wildcard certificate managed under the
+  # api.secpal.dev Certbot entry that also covers app.secpal.dev.  If you
+  # deploy on a server with a dedicated app.secpal.dev cert, update these
+  # paths to /etc/letsencrypt/live/app.secpal.dev/.
   ssl_certificate /etc/letsencrypt/live/api.secpal.dev/fullchain.pem;
   ssl_certificate_key /etc/letsencrypt/live/api.secpal.dev/privkey.pem;
   include /etc/letsencrypt/options-ssl-nginx.conf;

--- a/deploy/nginx/app.secpal.dev.conf
+++ b/deploy/nginx/app.secpal.dev.conf
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: CC0-1.0
+
+server {
+  listen 443 ssl http2;
+  listen [::]:443 ssl http2;
+  server_name app.secpal.dev;
+
+  root /home/secpal/code/SecPal/frontend/dist;
+  index index.html;
+
+  access_log /var/log/nginx/app.secpal.dev.access.log;
+  error_log /var/log/nginx/app.secpal.dev.error.log;
+
+  ssl_certificate /etc/letsencrypt/live/api.secpal.dev/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/api.secpal.dev/privkey.pem;
+  include /etc/letsencrypt/options-ssl-nginx.conf;
+  ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+  set $secpal_csp "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self'; style-src-attr 'unsafe-inline'; worker-src 'self'; upgrade-insecure-requests";
+  set $secpal_permissions_policy "accelerometer=(), autoplay=(), camera=(), clipboard-read=(), clipboard-write=(), display-capture=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
+  set $secpal_hsts "max-age=63072000; includeSubDomains";
+
+  add_header Content-Security-Policy $secpal_csp always;
+  add_header Permissions-Policy $secpal_permissions_policy always;
+  add_header Strict-Transport-Security $secpal_hsts always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header X-XSS-Protection "0" always;
+  add_header X-Frame-Options "DENY" always;
+  add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+  add_header Cross-Origin-Opener-Policy "same-origin" always;
+  add_header Cross-Origin-Resource-Policy "same-origin" always;
+  add_header Origin-Agent-Cluster "?1" always;
+  add_header X-Permitted-Cross-Domain-Policies "none" always;
+
+  location ~ ^/(v1|sanctum)(/|$) {
+    return 404;
+  }
+
+  location ~ ^/health(/|$) {
+    return 404;
+  }
+
+  # Nginx does not inherit add_header directives into locations that declare
+  # their own headers, so the PWA-critical exact matches repeat the baseline.
+  location = / {
+    add_header Content-Security-Policy $secpal_csp always;
+    add_header Permissions-Policy $secpal_permissions_policy always;
+    add_header Strict-Transport-Security $secpal_hsts always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "0" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    add_header Cross-Origin-Resource-Policy "same-origin" always;
+    add_header Origin-Agent-Cluster "?1" always;
+    add_header X-Permitted-Cross-Domain-Policies "none" always;
+    add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+    try_files /index.html =404;
+  }
+
+  location = /index.html {
+    add_header Content-Security-Policy $secpal_csp always;
+    add_header Permissions-Policy $secpal_permissions_policy always;
+    add_header Strict-Transport-Security $secpal_hsts always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "0" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    add_header Cross-Origin-Resource-Policy "same-origin" always;
+    add_header Origin-Agent-Cluster "?1" always;
+    add_header X-Permitted-Cross-Domain-Policies "none" always;
+    add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+    try_files $uri =404;
+  }
+
+  location = /sw.js {
+    add_header Content-Security-Policy $secpal_csp always;
+    add_header Permissions-Policy $secpal_permissions_policy always;
+    add_header Strict-Transport-Security $secpal_hsts always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "0" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    add_header Cross-Origin-Resource-Policy "same-origin" always;
+    add_header Origin-Agent-Cluster "?1" always;
+    add_header X-Permitted-Cross-Domain-Policies "none" always;
+    add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+    add_header Service-Worker-Allowed "/" always;
+    try_files $uri =404;
+  }
+
+  location = /manifest.webmanifest {
+    default_type application/manifest+json;
+    add_header Content-Security-Policy $secpal_csp always;
+    add_header Permissions-Policy $secpal_permissions_policy always;
+    add_header Strict-Transport-Security $secpal_hsts always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "0" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    add_header Cross-Origin-Resource-Policy "same-origin" always;
+    add_header Origin-Agent-Cluster "?1" always;
+    add_header X-Permitted-Cross-Domain-Policies "none" always;
+    add_header Cache-Control "no-cache, must-revalidate" always;
+    try_files $uri =404;
+  }
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
+  location ~* \.(?:js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2)$ {
+    expires 1y;
+    try_files $uri =404;
+  }
+
+  listen 443 ssl; # managed by Certbot
+  listen [::]:443 ssl; # managed by Certbot
+}
+
+server {
+  if ($host = app.secpal.dev) {
+    return 301 https://$host$request_uri;
+  }
+
+  listen 80;
+  listen [::]:80;
+  server_name app.secpal.dev;
+  return 404;
+}

--- a/docs/deployment-spa-routing.md
+++ b/docs/deployment-spa-routing.md
@@ -86,62 +86,25 @@ It also now carries the baseline browser hardening for the shipped PWA:
 
 ## Nginx Configuration
 
-For Nginx servers, add this to your server block:
+`app.secpal.dev` currently runs behind Nginx, so treat the versioned config in
+`deploy/nginx/app.secpal.dev.conf` as the source of truth for production header
+hardening and keep it aligned with the live VPS site file.
 
-```nginx
-server {
-  listen 80;
-  server_name app.secpal.dev;
-  root /var/www/app.secpal.dev;
-  index index.html;
+The file already covers:
 
-   # Never serve API/framework endpoints as the SPA shell.
-   location ~ ^/(v1|sanctum)(/|$) {
-      return 404;
-   }
+- the production CSP and `Permissions-Policy`
+- `Strict-Transport-Security`, `Referrer-Policy`, and framing protection
+- explicit `404` handling for `/v1/*`, `/sanctum/*`, and `/health*`
+- exact-match delivery rules for `/`, `/index.html`, `/sw.js`, and `/manifest.webmanifest`
+- the manifest MIME fix (`application/manifest+json`) and update-safe cache headers
 
-   location ~ ^/health(/|$) {
-      return 404;
-   }
+Use this file as your site config or merge its contents into the live server block:
 
-   # SPA routing: Serve index.html for all frontend routes only
-  location / {
-    try_files $uri $uri/ /index.html;
-  }
-
-  # Cache static assets
-  location ~* \.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2)$ {
-    expires 1y;
-    add_header Cache-Control "public, immutable";
-  }
-
-   # Security headers
-   add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self'; style-src-attr 'unsafe-inline'; worker-src 'self'; upgrade-insecure-requests" always;
-   add_header Permissions-Policy "accelerometer=(), autoplay=(), camera=(), clipboard-read=(), clipboard-write=(), display-capture=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;
-   add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
-  add_header X-Content-Type-Options "nosniff" always;
-  add_header X-Frame-Options "DENY" always;
-   add_header X-XSS-Protection "0" always;
-  add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-   add_header Cross-Origin-Opener-Policy "same-origin" always;
-   add_header Cross-Origin-Resource-Policy "same-origin" always;
-   add_header Origin-Agent-Cluster "?1" always;
-   add_header X-Permitted-Cross-Domain-Policies "none" always;
-
-   location = /index.html {
-      add_header Cache-Control "no-cache, no-store, must-revalidate" always;
-   }
-
-   location = /sw.js {
-      add_header Cache-Control "no-cache, no-store, must-revalidate" always;
-      add_header Service-Worker-Allowed "/" always;
-   }
-
-   location = /manifest.webmanifest {
-      default_type application/manifest+json;
-      add_header Cache-Control "no-cache, must-revalidate" always;
-   }
-}
+```bash
+sudo install -D -m 0644 deploy/nginx/app.secpal.dev.conf /etc/nginx/sites-available/app.secpal.dev.conf
+sudo ln -sf /etc/nginx/sites-available/app.secpal.dev.conf /etc/nginx/sites-enabled/app.secpal.dev.conf
+sudo nginx -t
+sudo systemctl reload nginx
 ```
 
 **Deployment Steps:**
@@ -152,17 +115,30 @@ server {
    npm run build
    ```
 
-2. Copy files to server:
+2. Build or update the live document root used by the current VPS config:
 
    ```bash
-   scp -r dist/* user@server:/var/www/app.secpal.dev/
+   npm run build
    ```
 
-3. Reload Nginx:
+3. Install or update the versioned Nginx site config:
+
+   ```bash
+   sudo install -D -m 0644 deploy/nginx/app.secpal.dev.conf /etc/nginx/sites-available/app.secpal.dev
+   sudo ln -sf /etc/nginx/sites-available/app.secpal.dev /etc/nginx/sites-enabled/app.secpal.dev
+   ```
+
+4. Reload Nginx:
 
    ```bash
    sudo nginx -t  # Test config
    sudo systemctl reload nginx
+   ```
+
+5. Verify the deployed headers:
+
+   ```bash
+   npm run test:live:pwa-headers
    ```
 
 ---

--- a/docs/deployment-spa-routing.md
+++ b/docs/deployment-spa-routing.md
@@ -115,17 +115,18 @@ sudo systemctl reload nginx
    npm run build
    ```
 
-2. Build or update the live document root used by the current VPS config:
+2. Deploy the built assets to the Nginx document root configured in
+   `deploy/nginx/app.secpal.dev.conf` (adjust the path to match your server):
 
    ```bash
-   npm run build
+   rsync -av --delete dist/ /home/secpal/code/SecPal/frontend/dist/
    ```
 
 3. Install or update the versioned Nginx site config:
 
    ```bash
-   sudo install -D -m 0644 deploy/nginx/app.secpal.dev.conf /etc/nginx/sites-available/app.secpal.dev
-   sudo ln -sf /etc/nginx/sites-available/app.secpal.dev /etc/nginx/sites-enabled/app.secpal.dev
+   sudo install -D -m 0644 deploy/nginx/app.secpal.dev.conf /etc/nginx/sites-available/app.secpal.dev.conf
+   sudo ln -sf /etc/nginx/sites-available/app.secpal.dev.conf /etc/nginx/sites-enabled/app.secpal.dev.conf
    ```
 
 4. Reload Nginx:

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "test:e2e:offline-logout": "cross-env CI=true PLAYWRIGHT_SKIP_GLOBAL_LOGIN=1 playwright test tests/e2e/offline-logout.spec.ts --project=chromium --project=mobile-chrome",
     "test:e2e:offline-logout:staging": "cross-env PLAYWRIGHT_BASE_URL=https://app.secpal.dev PLAYWRIGHT_SKIP_GLOBAL_LOGIN=1 playwright test tests/e2e/offline-logout.spec.ts --project=chromium --project=mobile-chrome",
     "test:live:auth-routes": "bash ./scripts/check-live-auth-route-separation.sh",
+    "test:live:pwa-headers": "bash ./scripts/check-live-pwa-headers.sh",
     "format": "prettier --write --cache '**/*.{md,yml,yaml,json,ts,tsx,js,jsx}'",
     "format:check": "prettier --check '**/*.{md,yml,yaml,json,ts,tsx,js,jsx}'",
     "lingui:extract": "lingui extract",

--- a/scripts/check-live-pwa-headers.sh
+++ b/scripts/check-live-pwa-headers.sh
@@ -9,6 +9,18 @@ APP_ROOT_URL="${APP_URL%/}/"
 SERVICE_WORKER_URL="${APP_URL%/}/sw.js"
 MANIFEST_URL="${APP_URL%/}/manifest.webmanifest"
 
+# Extract headers from the last HTTP response block in a dump-header file.
+# When curl --location follows redirects, the file contains one block per
+# response; only the final block carries the headers we want to assert.
+last_response_headers() {
+    local raw="$1"
+    printf '%s\n' "$raw" | awk '
+        /^HTTP\/[0-9.]+ / { block = "" }
+        { block = block "\n" $0 }
+        END { print block }
+    '
+}
+
 get_header_value() {
     local headers="$1"
     local header_name="$2"
@@ -23,6 +35,11 @@ get_header_value() {
             exit
         }
     '
+}
+
+get_status_code() {
+    local headers="$1"
+    printf '%s\n' "$headers" | awk '/^HTTP\/[0-9.]+ / { code = $2 } END { if (code != "") print code }'
 }
 
 request_headers() {
@@ -65,6 +82,20 @@ assert_header_contains() {
     fi
 }
 
+assert_status_ok() {
+    local headers="$1"
+    local url="$2"
+    local status
+
+    status="$(get_status_code "$headers")"
+
+    if [[ "$status" != "200" ]]; then
+        echo "ERROR: expected HTTP 200 for ${url}"
+        echo "  actual status: ${status}"
+        exit 1
+    fi
+}
+
 assert_common_hardening() {
     local headers="$1"
     local label="$2"
@@ -81,20 +112,26 @@ assert_common_hardening() {
 
 echo "Checking live PWA hardening on ${APP_URL}"
 
-app_headers="$(request_headers "$APP_ROOT_URL")"
+app_raw="$(request_headers "$APP_ROOT_URL")"
+app_headers="$(last_response_headers "$app_raw")"
+assert_status_ok "$app_raw" "$APP_ROOT_URL"
 assert_common_hardening "$app_headers" "$APP_ROOT_URL"
 assert_header_contains "$app_headers" "Cache-Control" "no-cache"
 assert_header_contains "$app_headers" "Cache-Control" "no-store"
 assert_header_contains "$app_headers" "Cache-Control" "must-revalidate"
 
-sw_headers="$(request_headers "$SERVICE_WORKER_URL")"
+sw_raw="$(request_headers "$SERVICE_WORKER_URL")"
+sw_headers="$(last_response_headers "$sw_raw")"
+assert_status_ok "$sw_raw" "$SERVICE_WORKER_URL"
 assert_common_hardening "$sw_headers" "$SERVICE_WORKER_URL"
 assert_header_contains "$sw_headers" "Cache-Control" "no-cache"
 assert_header_contains "$sw_headers" "Cache-Control" "no-store"
 assert_header_contains "$sw_headers" "Cache-Control" "must-revalidate"
 assert_header_contains "$sw_headers" "Service-Worker-Allowed" "/"
 
-manifest_headers="$(request_headers "$MANIFEST_URL")"
+manifest_raw="$(request_headers "$MANIFEST_URL")"
+manifest_headers="$(last_response_headers "$manifest_raw")"
+assert_status_ok "$manifest_raw" "$MANIFEST_URL"
 assert_common_hardening "$manifest_headers" "$MANIFEST_URL"
 assert_header_contains "$manifest_headers" "Content-Type" "application/manifest+json"
 assert_header_contains "$manifest_headers" "Cache-Control" "no-cache"

--- a/scripts/check-live-pwa-headers.sh
+++ b/scripts/check-live-pwa-headers.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+APP_URL="${APP_URL:-https://app.secpal.dev}"
+APP_ROOT_URL="${APP_URL%/}/"
+SERVICE_WORKER_URL="${APP_URL%/}/sw.js"
+MANIFEST_URL="${APP_URL%/}/manifest.webmanifest"
+
+get_header_value() {
+    local headers="$1"
+    local header_name="$2"
+
+    printf '%s\n' "$headers" | awk -v target="$header_name" '
+        BEGIN {
+            FS = ": "
+        }
+        tolower($1) == tolower(target) {
+            gsub(/\r/, "", $2)
+            print $2
+            exit
+        }
+    '
+}
+
+request_headers() {
+    local url="$1"
+    local tmp_headers
+
+    tmp_headers="$(mktemp)"
+
+    if ! curl --silent --show-error --location --retry 2 --retry-delay 2 \
+        --dump-header "$tmp_headers" \
+        --output /dev/null \
+        "$url"; then
+        echo "ERROR: request failed for ${url}"
+        rm -f "$tmp_headers"
+        exit 1
+    fi
+
+    cat "$tmp_headers"
+    rm -f "$tmp_headers"
+}
+
+assert_header_contains() {
+    local headers="$1"
+    local header_name="$2"
+    local expected_value="$3"
+    local actual_value
+
+    actual_value="$(get_header_value "$headers" "$header_name")"
+
+    if [[ -z "$actual_value" ]]; then
+        echo "ERROR: missing header ${header_name}"
+        exit 1
+    fi
+
+    if [[ "$actual_value" != *"$expected_value"* ]]; then
+        echo "ERROR: unexpected ${header_name} header"
+        echo "  expected to contain: ${expected_value}"
+        echo "  actual:              ${actual_value}"
+        exit 1
+    fi
+}
+
+assert_common_hardening() {
+    local headers="$1"
+    local label="$2"
+
+    echo "Checking hardening headers on ${label}"
+
+    assert_header_contains "$headers" "Content-Security-Policy" "default-src 'self'"
+    assert_header_contains "$headers" "Permissions-Policy" "camera=()"
+    assert_header_contains "$headers" "Strict-Transport-Security" "max-age=63072000"
+    assert_header_contains "$headers" "Referrer-Policy" "strict-origin-when-cross-origin"
+    assert_header_contains "$headers" "X-Frame-Options" "DENY"
+    assert_header_contains "$headers" "X-Content-Type-Options" "nosniff"
+}
+
+echo "Checking live PWA hardening on ${APP_URL}"
+
+app_headers="$(request_headers "$APP_ROOT_URL")"
+assert_common_hardening "$app_headers" "$APP_ROOT_URL"
+assert_header_contains "$app_headers" "Cache-Control" "no-cache"
+assert_header_contains "$app_headers" "Cache-Control" "no-store"
+assert_header_contains "$app_headers" "Cache-Control" "must-revalidate"
+
+sw_headers="$(request_headers "$SERVICE_WORKER_URL")"
+assert_common_hardening "$sw_headers" "$SERVICE_WORKER_URL"
+assert_header_contains "$sw_headers" "Cache-Control" "no-cache"
+assert_header_contains "$sw_headers" "Cache-Control" "no-store"
+assert_header_contains "$sw_headers" "Cache-Control" "must-revalidate"
+assert_header_contains "$sw_headers" "Service-Worker-Allowed" "/"
+
+manifest_headers="$(request_headers "$MANIFEST_URL")"
+assert_common_hardening "$manifest_headers" "$MANIFEST_URL"
+assert_header_contains "$manifest_headers" "Content-Type" "application/manifest+json"
+assert_header_contains "$manifest_headers" "Cache-Control" "no-cache"
+assert_header_contains "$manifest_headers" "Cache-Control" "must-revalidate"
+
+echo "Live PWA hardening smoke test passed"

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -26,6 +26,19 @@ describe("Build Output Verification", () => {
     expect(existsSync(path.join(repoRoot, "index.html"))).toBe(true);
   });
 
+  it("ships a versioned Nginx config for app.secpal.dev", () => {
+    expect(
+      existsSync(path.join(repoRoot, "deploy/nginx/app.secpal.dev.conf"))
+    ).toBe(true);
+
+    const nginxConfig = readRepoFile("deploy/nginx/app.secpal.dev.conf");
+
+    expect(nginxConfig).toContain("server_name app.secpal.dev;");
+    expect(nginxConfig).toContain("try_files $uri $uri/ /index.html;");
+    expect(nginxConfig).toContain("location ~ ^/(v1|sanctum)(/|$)");
+    expect(nginxConfig).toContain("location ~ ^/health(/|$)");
+  });
+
   it("keeps vite-plugin-static-copy configured for .htaccess", () => {
     const viteConfig = readRepoFile("vite.config.ts");
 
@@ -36,6 +49,7 @@ describe("Build Output Verification", () => {
 
   it("hardens browser responses with the required security headers", () => {
     const htaccess = readRepoFile("public/.htaccess");
+    const nginxConfig = readRepoFile("deploy/nginx/app.secpal.dev.conf");
 
     const requiredHeaders = [
       "Content-Security-Policy",
@@ -52,11 +66,13 @@ describe("Build Output Verification", () => {
 
     for (const header of requiredHeaders) {
       expect(htaccess).toContain(header);
+      expect(nginxConfig).toContain(header);
     }
   });
 
   it("ships an enforceable CSP that fits the PWA runtime", () => {
     const htaccess = readRepoFile("public/.htaccess");
+    const nginxConfig = readRepoFile("deploy/nginx/app.secpal.dev.conf");
 
     expect(htaccess).toContain("default-src 'self'");
     expect(htaccess).toContain("script-src 'self'");
@@ -65,6 +81,14 @@ describe("Build Output Verification", () => {
     expect(htaccess).toContain("worker-src 'self'");
     expect(htaccess).toContain("manifest-src 'self'");
     expect(htaccess).toContain("connect-src 'self'");
+
+    expect(nginxConfig).toContain("default-src 'self'");
+    expect(nginxConfig).toContain("script-src 'self'");
+    expect(nginxConfig).toContain("object-src 'none'");
+    expect(nginxConfig).toContain("frame-ancestors 'none'");
+    expect(nginxConfig).toContain("worker-src 'self'");
+    expect(nginxConfig).toContain("manifest-src 'self'");
+    expect(nginxConfig).toContain("connect-src 'self'");
   });
 
   it("uses an external theme-color bootstrap so CSP can block inline scripts", () => {
@@ -77,11 +101,29 @@ describe("Build Output Verification", () => {
 
   it("adds dedicated delivery rules for service worker and manifest files", () => {
     const htaccess = readRepoFile("public/.htaccess");
+    const nginxConfig = readRepoFile("deploy/nginx/app.secpal.dev.conf");
 
     expect(htaccess).toContain('Files "sw.js"');
     expect(htaccess).toContain("Service-Worker-Allowed");
     expect(htaccess).toContain("application/manifest+json");
     expect(htaccess).toContain("manifest.webmanifest");
+
+    expect(nginxConfig).toContain("location = /sw.js");
+    expect(nginxConfig).toContain("Service-Worker-Allowed");
+    expect(nginxConfig).toContain("default_type application/manifest+json");
+    expect(nginxConfig).toContain("location = /manifest.webmanifest");
+  });
+
+  it("ships a live smoke check for deployed PWA security headers", () => {
+    expect(
+      existsSync(path.join(repoRoot, "scripts/check-live-pwa-headers.sh"))
+    ).toBe(true);
+
+    const packageJson = readRepoFile("package.json");
+
+    expect(packageJson).toContain(
+      '"test:live:pwa-headers": "bash ./scripts/check-live-pwa-headers.sh"'
+    );
   });
 
   it("keeps PWA shortcuts limited to live routes", () => {


### PR DESCRIPTION
## Summary
- version the live `app.secpal.dev` nginx hardening baseline in `deploy/nginx/app.secpal.dev.conf`
- add a live smoke check for PWA/browser hardening headers and wire it into `package.json`
- extend regression coverage and deployment docs so manifest/service-worker delivery rules stay enforced

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test -- --run tests/build.test.ts`
- `npm run test:live:pwa-headers`
- `bash scripts/preflight.sh`

## Notes
- The recurring `@typescript-eslint` TypeScript 6 support warning remains tracked separately in #666.
