### PR TITLE
fix: harden native Android runtime login bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Disabled PWA service-worker registration inside the native Capacitor runtime and added native-runtime cleanup of stale browser service workers and cache storage so Android app updates no longer stay pinned to an outdated cached app shell that misses the injected native auth bridge.
+- Retried transient login health-check failures before surfacing the "System not ready" blocker so Android startup races no longer leave the login screen latched in a false offline/configuration error state.
 - Split frontend translation catalog maintenance into a local-only `npm run sync` flow and explicit `sync:translationio` commands, so contributors without a Translation.io API key no longer get noisy sync warnings while maintainers still have a fail-fast remote sync path.
 - Replaced the remaining frontend documentation-only placeholder-domain references with `secpal.dev` / `app.secpal.dev` host examples and `secpal.app` email examples so the repo stays aligned with the SecPal domain policy outside runtime and test fixtures as well.
 - Replaced the remaining non-SecPal frontend test fixtures with `secpal.dev` addresses and updated the login email placeholder to a SecPal domain. This keeps the repository aligned with the `secpal.app` / `secpal.dev` domain policy consistently.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { lazy, Suspense } from "react";
 import { BrowserRouter, Navigate, Routes, Route } from "react-router-dom";
 import { Trans } from "@lingui/macro";
 import { ApplicationLayout } from "./components/application-layout";
+import { NativeRuntimePwaGuard } from "./components/NativeRuntimePwaGuard";
 import { OfflineIndicator } from "./components/OfflineIndicator";
 import { UpdatePrompt } from "./components/UpdatePrompt";
 import { AuthProvider } from "./contexts/AuthContext";
@@ -118,6 +119,7 @@ function App() {
   return (
     <AuthProvider>
       <BrowserRouter>
+        <NativeRuntimePwaGuard />
         <UpdatePrompt />
         <Suspense fallback={<RouteLoader />}>
           <Routes>

--- a/src/components/NativeRuntimePwaGuard.tsx
+++ b/src/components/NativeRuntimePwaGuard.tsx
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { useEffect } from "react";
+import {
+  disableBrowserPwaStateForNativeRuntime,
+  isCapacitorNativeRuntime,
+  shouldReloadAfterNativePwaCleanup,
+} from "../lib/nativeRuntime";
+
+export function NativeRuntimePwaGuard() {
+  useEffect(() => {
+    if (!isCapacitorNativeRuntime()) {
+      return;
+    }
+
+    let isActive = true;
+
+    void disableBrowserPwaStateForNativeRuntime().then((didCleanup) => {
+      if (!isActive || !didCleanup || !shouldReloadAfterNativePwaCleanup()) {
+        return;
+      }
+
+      window.location.reload();
+    });
+
+    return () => {
+      isActive = false;
+    };
+  }, []);
+
+  return null;
+}

--- a/src/components/UpdatePrompt.test.tsx
+++ b/src/components/UpdatePrompt.test.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -8,9 +8,13 @@ import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
 import { UpdatePrompt } from "./UpdatePrompt";
 import { useServiceWorkerUpdate } from "../hooks/useServiceWorkerUpdate";
+import { isCapacitorNativeRuntime } from "../lib/nativeRuntime";
 
 // Mock useServiceWorkerUpdate hook
 vi.mock("../hooks/useServiceWorkerUpdate");
+vi.mock("../lib/nativeRuntime", () => ({
+  isCapacitorNativeRuntime: vi.fn(() => false),
+}));
 
 describe("UpdatePrompt", () => {
   const mockUpdateServiceWorker = vi.fn();
@@ -28,6 +32,7 @@ describe("UpdatePrompt", () => {
       offlineReady: false,
       updateServiceWorker: mockUpdateServiceWorker,
     });
+    vi.mocked(isCapacitorNativeRuntime).mockReturnValue(false);
   });
 
   function renderWithI18n(component: React.ReactElement) {
@@ -35,6 +40,15 @@ describe("UpdatePrompt", () => {
   }
 
   describe("Visibility", () => {
+    it("should not render or register PWA updates in native runtime", () => {
+      vi.mocked(isCapacitorNativeRuntime).mockReturnValue(true);
+
+      const { container } = renderWithI18n(<UpdatePrompt />);
+
+      expect(container.firstChild).toBeNull();
+      expect(useServiceWorkerUpdate).not.toHaveBeenCalled();
+    });
+
     it("should not render when needRefresh is false", () => {
       const { container } = renderWithI18n(<UpdatePrompt />);
       expect(container.firstChild).toBeNull();

--- a/src/components/UpdatePrompt.tsx
+++ b/src/components/UpdatePrompt.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { useState } from "react";
@@ -7,6 +7,7 @@ import { useLingui } from "@lingui/react";
 import { Button } from "./button";
 import { Spinner } from "./spinner";
 import { useServiceWorkerUpdate } from "../hooks/useServiceWorkerUpdate";
+import { isCapacitorNativeRuntime } from "../lib/nativeRuntime";
 
 /**
  * UpdatePrompt Component
@@ -32,7 +33,7 @@ import { useServiceWorkerUpdate } from "../hooks/useServiceWorkerUpdate";
  * }
  * ```
  */
-export function UpdatePrompt() {
+function BrowserUpdatePrompt() {
   const { _ } = useLingui();
   const { needRefresh, updateServiceWorker } = useServiceWorkerUpdate();
   const [isUpdating, setIsUpdating] = useState(false);
@@ -83,4 +84,12 @@ export function UpdatePrompt() {
       </div>
     </div>
   );
+}
+
+export function UpdatePrompt() {
+  if (isCapacitorNativeRuntime()) {
+    return null;
+  }
+
+  return <BrowserUpdatePrompt />;
 }

--- a/src/lib/nativeRuntime.test.ts
+++ b/src/lib/nativeRuntime.test.ts
@@ -46,6 +46,7 @@ describe("nativeRuntime", () => {
     clearServiceWorker();
     sessionStorage.clear();
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   afterEach(() => {
@@ -53,6 +54,7 @@ describe("nativeRuntime", () => {
     clearServiceWorker();
     sessionStorage.clear();
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   describe("isCapacitorNativeRuntime", () => {

--- a/src/lib/nativeRuntime.test.ts
+++ b/src/lib/nativeRuntime.test.ts
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  disableBrowserPwaStateForNativeRuntime,
+  isCapacitorNativeRuntime,
+  shouldReloadAfterNativePwaCleanup,
+} from "./nativeRuntime";
+
+interface MockServiceWorkerRegistration {
+  unregister: ReturnType<typeof vi.fn>;
+}
+
+function setCapacitorRuntime(value: unknown): void {
+  Object.defineProperty(globalThis, "Capacitor", {
+    configurable: true,
+    value,
+  });
+}
+
+function clearCapacitorRuntime(): void {
+  delete (globalThis as Record<string, unknown>).Capacitor;
+}
+
+function setServiceWorker(
+  registrations: MockServiceWorkerRegistration[],
+  controller: object | null = null
+): void {
+  Object.defineProperty(navigator, "serviceWorker", {
+    configurable: true,
+    value: {
+      controller,
+      getRegistrations: vi.fn().mockResolvedValue(registrations),
+    },
+  });
+}
+
+function clearServiceWorker(): void {
+  delete (navigator as unknown as Record<string, unknown>).serviceWorker;
+}
+
+describe("nativeRuntime", () => {
+  beforeEach(() => {
+    clearCapacitorRuntime();
+    clearServiceWorker();
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    clearCapacitorRuntime();
+    clearServiceWorker();
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  describe("isCapacitorNativeRuntime", () => {
+    it("returns false when Capacitor is unavailable", () => {
+      expect(isCapacitorNativeRuntime()).toBe(false);
+    });
+
+    it("uses Capacitor.isNativePlatform when available", () => {
+      setCapacitorRuntime({
+        isNativePlatform: () => true,
+      });
+
+      expect(isCapacitorNativeRuntime()).toBe(true);
+    });
+
+    it("falls back to Capacitor.getPlatform when needed", () => {
+      setCapacitorRuntime({
+        getPlatform: () => "android",
+      });
+
+      expect(isCapacitorNativeRuntime()).toBe(true);
+    });
+  });
+
+  describe("disableBrowserPwaStateForNativeRuntime", () => {
+    it("does nothing outside a native runtime", async () => {
+      const unregister = vi.fn().mockResolvedValue(true);
+      setServiceWorker([{ unregister }]);
+
+      await expect(disableBrowserPwaStateForNativeRuntime()).resolves.toBe(
+        false
+      );
+      expect(unregister).not.toHaveBeenCalled();
+    });
+
+    it("unregisters service workers and clears cache storage in native runtime", async () => {
+      const unregister = vi.fn().mockResolvedValue(true);
+      const cacheDelete = vi.fn().mockResolvedValue(true);
+      const cacheKeys = vi.fn().mockResolvedValue(["shell-cache"]);
+
+      setCapacitorRuntime({
+        isNativePlatform: () => true,
+      });
+      setServiceWorker([{ unregister }], { active: true });
+      vi.stubGlobal("caches", {
+        keys: cacheKeys,
+        delete: cacheDelete,
+      });
+
+      await expect(disableBrowserPwaStateForNativeRuntime()).resolves.toBe(
+        true
+      );
+      expect(unregister).toHaveBeenCalledTimes(1);
+      expect(cacheKeys).toHaveBeenCalledTimes(1);
+      expect(cacheDelete).toHaveBeenCalledWith("shell-cache");
+    });
+
+    it("returns controller state even when Cache Storage is unavailable", async () => {
+      const unregister = vi.fn().mockResolvedValue(true);
+
+      setCapacitorRuntime({
+        isNativePlatform: () => true,
+      });
+      setServiceWorker([{ unregister }], { active: true });
+      vi.unstubAllGlobals();
+
+      await expect(disableBrowserPwaStateForNativeRuntime()).resolves.toBe(
+        true
+      );
+      expect(unregister).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("shouldReloadAfterNativePwaCleanup", () => {
+    it("reloads only once per cleanup cycle", () => {
+      expect(shouldReloadAfterNativePwaCleanup()).toBe(true);
+      expect(shouldReloadAfterNativePwaCleanup()).toBe(false);
+      expect(shouldReloadAfterNativePwaCleanup()).toBe(true);
+    });
+  });
+});

--- a/src/lib/nativeRuntime.ts
+++ b/src/lib/nativeRuntime.ts
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+interface CapacitorRuntime {
+  isNativePlatform?: () => boolean;
+  getPlatform?: () => string;
+}
+
+const NATIVE_PWA_RELOAD_MARKER = "secpal.native-pwa-cleanup-reload";
+
+function getCapacitorRuntime(): CapacitorRuntime | undefined {
+  return (globalThis as { Capacitor?: CapacitorRuntime }).Capacitor;
+}
+
+export function isCapacitorNativeRuntime(): boolean {
+  const capacitor = getCapacitorRuntime();
+
+  if (capacitor === undefined) {
+    return false;
+  }
+
+  if (typeof capacitor.isNativePlatform === "function") {
+    return capacitor.isNativePlatform();
+  }
+
+  if (typeof capacitor.getPlatform === "function") {
+    return capacitor.getPlatform() !== "web";
+  }
+
+  return false;
+}
+
+export async function disableBrowserPwaStateForNativeRuntime(): Promise<boolean> {
+  if (
+    !isCapacitorNativeRuntime() ||
+    typeof navigator === "undefined" ||
+    navigator.serviceWorker === undefined
+  ) {
+    return false;
+  }
+
+  let didCleanup = navigator.serviceWorker.controller !== null;
+
+  try {
+    const registrations = await navigator.serviceWorker.getRegistrations();
+
+    if (registrations.length > 0) {
+      didCleanup = true;
+    }
+
+    await Promise.all(registrations.map((registration) => registration.unregister()));
+  } catch (error) {
+    console.warn("[Native Runtime] Failed to unregister service workers:", error);
+  }
+
+  if (typeof caches === "undefined") {
+    return didCleanup;
+  }
+
+  try {
+    const cacheKeys = await caches.keys();
+
+    if (cacheKeys.length > 0) {
+      didCleanup = true;
+    }
+
+    await Promise.all(cacheKeys.map((cacheKey) => caches.delete(cacheKey)));
+  } catch (error) {
+    console.warn("[Native Runtime] Failed to clear browser caches:", error);
+  }
+
+  return didCleanup;
+}
+
+export function shouldReloadAfterNativePwaCleanup(): boolean {
+  if (typeof sessionStorage === "undefined") {
+    return true;
+  }
+
+  const reloadAlreadyTriggered =
+    sessionStorage.getItem(NATIVE_PWA_RELOAD_MARKER) === "1";
+
+  if (reloadAlreadyTriggered) {
+    sessionStorage.removeItem(NATIVE_PWA_RELOAD_MARKER);
+    return false;
+  }
+
+  sessionStorage.setItem(NATIVE_PWA_RELOAD_MARKER, "1");
+  return true;
+}

--- a/src/lib/nativeRuntime.ts
+++ b/src/lib/nativeRuntime.ts
@@ -6,7 +6,7 @@ interface CapacitorRuntime {
   getPlatform?: () => string;
 }
 
-const NATIVE_PWA_RELOAD_MARKER = "secpal.native-pwa-cleanup-reload";
+const NATIVE_PWA_RELOAD_MARKER = "secpal-native-pwa-cleanup-reload";
 
 function getCapacitorRuntime(): CapacitorRuntime | undefined {
   return (globalThis as { Capacitor?: CapacitorRuntime }).Capacitor;
@@ -79,17 +79,25 @@ export async function disableBrowserPwaStateForNativeRuntime(): Promise<boolean>
 
 export function shouldReloadAfterNativePwaCleanup(): boolean {
   if (typeof sessionStorage === "undefined") {
-    return true;
-  }
-
-  const reloadAlreadyTriggered =
-    sessionStorage.getItem(NATIVE_PWA_RELOAD_MARKER) === "1";
-
-  if (reloadAlreadyTriggered) {
-    sessionStorage.removeItem(NATIVE_PWA_RELOAD_MARKER);
     return false;
   }
 
-  sessionStorage.setItem(NATIVE_PWA_RELOAD_MARKER, "1");
-  return true;
+  try {
+    const reloadAlreadyTriggered =
+      sessionStorage.getItem(NATIVE_PWA_RELOAD_MARKER) === "1";
+
+    if (reloadAlreadyTriggered) {
+      sessionStorage.removeItem(NATIVE_PWA_RELOAD_MARKER);
+      return false;
+    }
+
+    sessionStorage.setItem(NATIVE_PWA_RELOAD_MARKER, "1");
+    return true;
+  } catch (error) {
+    console.warn(
+      "[Native Runtime] Failed to access sessionStorage for reload guard:",
+      error
+    );
+    return false;
+  }
 }

--- a/src/lib/nativeRuntime.ts
+++ b/src/lib/nativeRuntime.ts
@@ -48,9 +48,14 @@ export async function disableBrowserPwaStateForNativeRuntime(): Promise<boolean>
       didCleanup = true;
     }
 
-    await Promise.all(registrations.map((registration) => registration.unregister()));
+    await Promise.all(
+      registrations.map((registration) => registration.unregister())
+    );
   } catch (error) {
-    console.warn("[Native Runtime] Failed to unregister service workers:", error);
+    console.warn(
+      "[Native Runtime] Failed to unregister service workers:",
+      error
+    );
   }
 
   if (typeof caches === "undefined") {

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
@@ -81,6 +81,10 @@ describe("Login", () => {
     vi.mocked(healthApi.checkHealth).mockResolvedValue(createHealthyResponse());
     // Default: user is online
     vi.mocked(useOnlineStatus).mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("renders login form", async () => {
@@ -401,9 +405,12 @@ describe("Login", () => {
       renderLogin();
 
       // Wait for health check to complete and warning to appear
-      await waitFor(() => {
-        expect(screen.getByText(/system not ready/i)).toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(screen.getByText(/system not ready/i)).toBeInTheDocument();
+        },
+        { timeout: 8000 }
+      );
 
       // Button should be disabled
       const submitButton = screen.getByRole("button", { name: /log in/i });
@@ -460,6 +467,29 @@ describe("Login", () => {
       await waitFor(() => {
         const warning = screen.getByRole("alert");
         expect(warning).toHaveAttribute("aria-live", "polite");
+      });
+    });
+
+    it("retries transient health-check failures before showing the warning", async () => {
+      vi.mocked(healthApi.checkHealth)
+        .mockRejectedValueOnce(new healthApi.HealthCheckError("Network error"))
+        .mockResolvedValueOnce(createHealthyResponse());
+
+      renderLogin();
+
+      await waitFor(
+        () => {
+          expect(vi.mocked(healthApi.checkHealth)).toHaveBeenCalledTimes(2);
+        },
+        { timeout: 4000 }
+      );
+
+      expect(screen.queryByText(/system not ready/i)).not.toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /log in/i })
+        ).toBeEnabled();
       });
     });
   });
@@ -891,9 +921,12 @@ describe("Login", () => {
       });
 
       // Should now show system not ready warning
-      await waitFor(() => {
-        expect(screen.getByText(/system not ready/i)).toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(screen.getByText(/system not ready/i)).toBeInTheDocument();
+        },
+        { timeout: 8000 }
+      );
 
       // Offline warning should be gone
       expect(

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -487,9 +487,7 @@ describe("Login", () => {
       expect(screen.queryByText(/system not ready/i)).not.toBeInTheDocument();
 
       await waitFor(() => {
-        expect(
-          screen.getByRole("button", { name: /log in/i })
-        ).toBeEnabled();
+        expect(screen.getByRole("button", { name: /log in/i })).toBeEnabled();
       });
     });
   });

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  act,
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
 import { MemoryRouter } from "react-router-dom";
@@ -471,24 +477,27 @@ describe("Login", () => {
     });
 
     it("retries transient health-check failures before showing the warning", async () => {
-      vi.mocked(healthApi.checkHealth)
-        .mockRejectedValueOnce(new healthApi.HealthCheckError("Network error"))
-        .mockResolvedValueOnce(createHealthyResponse());
+      vi.useFakeTimers();
+      try {
+        vi.mocked(healthApi.checkHealth)
+          .mockRejectedValueOnce(
+            new healthApi.HealthCheckError("Network error")
+          )
+          .mockResolvedValueOnce(createHealthyResponse());
 
-      renderLogin();
+        renderLogin();
 
-      await waitFor(
-        () => {
-          expect(vi.mocked(healthApi.checkHealth)).toHaveBeenCalledTimes(2);
-        },
-        { timeout: 4000 }
-      );
+        // Flush the retry backoff timer(s) and React updates without waiting in real time.
+        await act(async () => {
+          await vi.runAllTimersAsync();
+        });
 
-      expect(screen.queryByText(/system not ready/i)).not.toBeInTheDocument();
-
-      await waitFor(() => {
+        expect(vi.mocked(healthApi.checkHealth)).toHaveBeenCalledTimes(2);
+        expect(screen.queryByText(/system not ready/i)).not.toBeInTheDocument();
         expect(screen.getByRole("button", { name: /log in/i })).toBeEnabled();
-      });
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -17,6 +17,8 @@ import { Button } from "../components/button";
 import { Field, Label } from "../components/fieldset";
 import { Input } from "../components/input";
 
+const HEALTH_CHECK_RETRY_DELAYS_MS = [0, 1500, 5000];
+
 export function Login() {
   const navigate = useNavigate();
   const { login } = useAuth();
@@ -58,14 +60,33 @@ export function Login() {
       }
 
       try {
-        const status = await checkHealth();
-        if (isMounted) {
-          setHealthStatus(status);
-          setHealthCheckError(false);
-        }
-      } catch {
-        if (isMounted) {
-          setHealthCheckError(true);
+        for (const [attempt, retryDelay] of HEALTH_CHECK_RETRY_DELAYS_MS.entries()) {
+          if (retryDelay > 0) {
+            await new Promise((resolve) => setTimeout(resolve, retryDelay));
+          }
+
+          if (!isMounted) {
+            return;
+          }
+
+          try {
+            const status = await checkHealth();
+
+            if (isMounted) {
+              setHealthStatus(status);
+              setHealthCheckError(false);
+            }
+
+            return;
+          } catch {
+            const isLastAttempt =
+              attempt === HEALTH_CHECK_RETRY_DELAYS_MS.length - 1;
+
+            if (isMounted && isLastAttempt) {
+              setHealthStatus(null);
+              setHealthCheckError(true);
+            }
+          }
         }
       } finally {
         if (isMounted) {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -60,7 +60,10 @@ export function Login() {
       }
 
       try {
-        for (const [attempt, retryDelay] of HEALTH_CHECK_RETRY_DELAYS_MS.entries()) {
+        for (const [
+          attempt,
+          retryDelay,
+        ] of HEALTH_CHECK_RETRY_DELAYS_MS.entries()) {
           if (retryDelay > 0) {
             await new Promise((resolve) => setTimeout(resolve, retryDelay));
           }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -54,9 +54,11 @@ export function Login() {
         return;
       }
 
-      // Reset loading state when checking
+      // Reset loading state and stale results before (re)trying
       if (isMounted) {
         setIsHealthCheckLoading(true);
+        setHealthStatus(null);
+        setHealthCheckError(false);
       }
 
       try {


### PR DESCRIPTION
## Summary
- disable browser PWA update flows inside the native Capacitor runtime and clear stale browser-side service worker/cache state before the Android shell boots
- retry transient login health-check failures so Android startup races do not leave the login screen stuck behind a false "System not ready" blocker
- add focused regression coverage for native runtime cleanup, update prompt suppression, and the login health-check retry path

## Validation
- `npm run typecheck`
- `npx vitest run /home/holger/code/SecPal/frontend/src/lib/nativeRuntime.test.ts /home/holger/code/SecPal/frontend/src/components/UpdatePrompt.test.tsx /home/holger/code/SecPal/frontend/src/pages/Login.test.tsx`

## Notes
- Pairs with the Android wrapper changes on branch `fix/android-native-auth-bridge-runtime`
- Keeps the native runtime aligned with `app.secpal.dev` and `api.secpal.dev` host policy