### PR TITLE
chore(governance): reduce Copilot instruction context bloat

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,16 +10,21 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
 
 ## Always-On Rules
 
-- Run `git status --short --branch` before any write action. Never start implementation on local `main`, and stop if a dirty non-`main` branch contains unrelated work.
+- Run `git status --short --branch` before any write action. Never start implementation on local `main`,
+  and stop if a dirty non-`main` branch contains unrelated work.
 - Keep one topic per change, fail fast, and never use bypasses such as `--no-verify` or force-push.
 - Update `CHANGELOG.md` in the same change set for real fixes, features, and breaking changes.
-- Create a GitHub issue immediately for out-of-scope bugs, technical debt, missing tests, documentation gaps, and actionable warnings you cannot fix now.
+- Create a GitHub issue immediately for out-of-scope bugs, technical debt, missing tests,
+  documentation gaps, and actionable warnings you cannot fix now.
 - Keep GitHub-facing communication in English and reference files and lines instead of pasting large code blocks.
 - Treat warnings, audit findings, and deprecations as actionable. Fix them in scope or track them immediately.
-- Never reply to Copilot review comments with GitHub comment tools. Fix the code, push, and resolve threads through the approved non-comment workflow.
+- Never reply to Copilot review comments with GitHub comment tools. Fix the code, push,
+  and resolve threads through the approved non-comment workflow.
 - Use EPIC plus sub-issues before starting work that will span more than one PR.
 - Keep `SPDX-FileCopyrightText` years current in edited files or companion `.license` sidecars.
-- Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, and `app.secpal.app` only as the Android application identifier.
+- Domain policy is strict: `secpal.app` for the public homepage and real email addresses,
+  `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev,
+  staging, testing, and examples, and `app.secpal.app` only as the Android application identifier.
 
 ## Required Validation
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,86 +10,37 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
 
 ## Always-On Rules
 
-- Apply SecPal core rules on every task: TDD first, fail fast, no bypass,
-  one topic per change, and create a GitHub issue immediately for findings
-  that cannot be fixed in the current scope.
-- Apply branch hygiene from the first local change: inspect branch state before
-  work, never start on local `main`, and do not mix unrelated uncommitted
-  changes into the current task.
-- Before any commit, PR, or merge, announce and verify the required checklist. Stop on the first failed check.
-- Update `CHANGELOG.md` in the same change set for real fixes, features, or breaking changes.
-- Keep GitHub-facing communication in English.
-- Domain policy is strict: use `secpal.app` only for the public homepage and
-  real email addresses, `api.secpal.dev` for the API, `app.secpal.dev` for the
-  PWA/frontend, and `secpal.dev` for dev, staging, testing, and examples.
-  Treat `api.secpal.app` and `app.secpal.app` as deprecated web hosts;
-  `app.secpal.app` remains valid only as the Android application identifier.
-- Never reply to Copilot review comments with GitHub comment tools. Fix the
-  code, push, and resolve review threads through the approved non-comment
-  workflow.
-- For work that needs more than one PR, create an EPIC with linked sub-issues
-  before implementation.
-- Do not paste large verbatim code blocks into GitHub comments, issues, or PR
-  descriptions. Reference file paths and line numbers instead.
-- Treat warnings, audit findings, deprecation notices, and similar non-fatal
-  diagnostics from scripts, `composer`, `npm`, and related tooling as
-  actionable: review them, fix them in scope, or create a GitHub issue
-  immediately if they are real but out of scope.
-- Prefer small, user-visible fixes that match existing patterns. Avoid speculative abstractions.
-- When editing a file or license sidecar that contains
-  `SPDX-FileCopyrightText`, keep the year current: use a single year such as
-  `2026` if it is already the current year, otherwise extend it to a no-spaces
-  range ending in the current year such as `2025-2026`. If the edited file has
-  no inline header but a companion `.license` file exists, check and update
-  that `.license` file instead.
+- Run `git status --short --branch` before any write action. Never start implementation on local `main`, and stop if a dirty non-`main` branch contains unrelated work.
+- Keep one topic per change, fail fast, and never use bypasses such as `--no-verify` or force-push.
+- Update `CHANGELOG.md` in the same change set for real fixes, features, and breaking changes.
+- Create a GitHub issue immediately for out-of-scope bugs, technical debt, missing tests, documentation gaps, and actionable warnings you cannot fix now.
+- Keep GitHub-facing communication in English and reference files and lines instead of pasting large code blocks.
+- Treat warnings, audit findings, and deprecations as actionable. Fix them in scope or track them immediately.
+- Never reply to Copilot review comments with GitHub comment tools. Fix the code, push, and resolve threads through the approved non-comment workflow.
+- Use EPIC plus sub-issues before starting work that will span more than one PR.
+- Keep `SPDX-FileCopyrightText` years current in edited files or companion `.license` sidecars.
+- Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, and `app.secpal.app` only as the Android application identifier.
 
-## Branch Hygiene
+## Required Validation
 
-- Before any edit or other write action, run `git status --short --branch` and
-  understand the current branch plus local changes.
-- Never start implementation on local `main`. Create or switch to a dedicated topic branch first.
-- If a non-`main` branch already contains uncommitted changes, continue only
-  when they belong to the same task.
-- If existing changes are unrelated or unclear, stop and ask whether they
-  should be committed, stashed, or split before proceeding.
-- Never create mixed commits by reusing a dirty branch for a new topic.
+Before any commit, PR, or merge, announce the checklist you are executing and stop on the first failed item.
+At minimum verify:
 
-## Required Checklist
-
-Before any commit, PR, or merge, announce and verify at least:
-
-- the smallest relevant validation passed for the affected area: tests, typecheck, and lint when applicable
-- `CHANGELOG.md` was updated in the same change set for real changes
+- the smallest relevant validation for the touched area passed: tests, typecheck, and lint when applicable
+- `CHANGELOG.md` was updated for real changes
 - commits are GPG-signed
-- REUSE compliance was checked when the changed files require it
-- the local 4-pass review was completed before creating a PR
-- tooling warnings and audit/deprecation notices were reviewed and either fixed
-  or tracked immediately
-- no bypass was used, including `--no-verify` or force-push
-- repo-local instructions remain self-contained and do not rely on cross-repo inheritance
-- out-of-scope findings were turned into GitHub issues immediately
+- REUSE compliance was checked when changed files require it
+- the local 4-pass review was completed
+- no bypass was used
 
-## Repository Stack
+## Repository Conventions
 
-- Node 22, React, TypeScript strict mode, Vite, Vitest, React Testing Library.
-- All API types come from generated OpenAPI types. Use `@/types/api` and do not hand-write API response types.
-
-## Architecture
-
-- Keep presentation in components and logic in hooks or API clients.
-- Prefer functional components, named exports, and one component per file.
-- Use React built-ins first. Introduce extra state libraries only when the
-  existing codebase already uses them or the task truly requires them.
-
-## Frontend Rules
-
-- Preserve strict TypeScript. Do not introduce `any` without a concrete, justified boundary.
-- Test user-visible behavior with Testing Library and MSW where applicable.
-- Run the smallest relevant validation for every change: tests, typecheck, and lint for affected areas.
-- Keep accessibility, semantic HTML, focus behavior, and responsive layouts intact.
-- Prefer generated API types, container-presenter separation, and existing design system patterns.
+- Stack: Node 22, React, TypeScript strict mode, Vite, Vitest, and React Testing Library.
+- All API types come from generated OpenAPI types in `@/types/api`; do not hand-write response types.
+- Keep presentation in components and reusable logic in hooks or API clients.
+- Prefer functional components, named exports, and existing design-system patterns before new abstractions.
+- Preserve strict TypeScript, accessibility, semantic HTML, focus behavior, and responsive layouts.
 
 ## Scope Notes
 
-- Do not add dependencies or create documentation files unless the task requires it.
-- Treat this file as the runtime baseline for the repo. Repo-specific `.instructions.md` files add detail for matching files.
+- Do not add dependencies or create documentation files unless the task requires them.

--- a/.github/instructions/org-shared.instructions.md
+++ b/.github/instructions/org-shared.instructions.md
@@ -2,32 +2,13 @@
 # SPDX-FileCopyrightText: 2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
 name: Frontend Runtime Overlay
-description: Reinforces the frontend repository baseline when working on files in this repo.
-applyTo: "**"
+description: Provides additional frontend governance context when a task needs more than the repo baseline.
 ---
 
 # Frontend Runtime Overlay
 
-The historical filename `org-shared.instructions.md` is retained for continuity.
-At runtime, this file now acts as the repo-local overlay for the `frontend` repository.
+Use this file only when a task needs additional repo-wide governance context beyond `.github/copilot-instructions.md`.
 
-- Treat `.github/copilot-instructions.md` in this repo as the authoritative runtime baseline.
-- Do not rely on cross-repo inheritance, comments, or external config files being loaded.
-- Enforce SecPal core rules while editing any file: tests first where
-  applicable, no bypass, fail fast, one topic per change, immediate issue
-  creation for out-of-scope findings, and `CHANGELOG.md` updates for real
-  changes.
-- Use `secpal.app` only for the public homepage and real email addresses,
-  `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, and
-  `secpal.dev` for dev, staging, testing, and examples. Treat
-  `api.secpal.app` and `app.secpal.app` as deprecated web hosts;
-  `app.secpal.app` remains valid only as the Android application identifier.
-- Never reply to Copilot review comments with GitHub comment tools; use the
-  approved non-comment review workflow instead.
-- Keep commits GPG-signed, use file and line references instead of verbatim code
-  quotes in GitHub communication, and require EPIC + sub-issues for work that
-  spans more than one PR.
-- Treat warnings, audit findings, deprecation notices, and similar non-fatal
-  diagnostics as actionable; fix them in scope or create a GitHub issue
-  immediately when they are real but out of scope.
+- `.github/copilot-instructions.md` is the authoritative runtime baseline for this repo.
 - Keep changes repo-local, minimal, and consistent with React, strict TypeScript, and generated API type conventions.
+- Apply the SecPal domain policy and immediate warning and issue triage rules from the repo baseline.

--- a/.github/instructions/org-shared.instructions.md
+++ b/.github/instructions/org-shared.instructions.md
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 name: Frontend Runtime Overlay
 description: Provides additional frontend governance context when a task needs more than the repo baseline.
+# applyTo is intentionally omitted — this file is NOT auto-loaded.
+# Reference it explicitly in a prompt or task description when extra governance context is needed.
 ---
 
 # Frontend Runtime Overlay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- reduced the repo-local Copilot always-on context by replacing the long runtime baseline and removing the auto-loaded overlay fallback, which lowers request size in large VS Code workspaces without dropping the frontend-specific governance rules
+- Reduced the repo-local Copilot always-on context by replacing the long runtime baseline and removing the auto-loaded overlay fallback, which lowers request size in large VS Code workspaces without dropping the frontend-specific governance rules
 
 - Aligned the frontend browser-session auth contract with the backend UUID-based user payload so successful login, current-user bootstrap, persisted auth state, and onboarding handoff now accept valid string user IDs instead of incorrectly rejecting them as unsafe.
 - Hardened the browser-session auth endpoint wiring so login, logout, CSRF bootstrapping, and `GET /v1/me` all build URLs from the same production-safe API resolver, which now requires an explicit absolute `VITE_API_URL` for every production deployment and fails fast on missing or relative API bases instead of guessing a host.
@@ -134,7 +134,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sync status UI now surfaces the next scheduled offline retry time and hides the manual sync trigger while pending operations are still in their backoff window
 - `.github/instructions/react-typescript.instructions.md` - targeted React and strict TypeScript guidance for frontend source and test files
 - `.github/instructions/github-workflows.instructions.md` - targeted workflow and Dependabot guidance for GitHub automation files in this repo
-- `.github/instructions/org-shared.instructions.md` — org-wide Copilot principles (TDD, quality gates, PR protocol) auto-loaded for all files via `applyTo: "**"`
+- `.github/instructions/org-shared.instructions.md` — org-wide Copilot principles (TDD, quality gates, PR protocol); `applyTo: "**"` auto-loading was later removed during governance context cleanup
 - `docs/OFFLINE_DATA_PROTECTION_ROADMAP.md` - deferred Phase 2 design notes for future encrypted offline data protection with device-bound key options
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- reduced the repo-local Copilot always-on context by replacing the long runtime baseline and removing the auto-loaded overlay fallback, which lowers request size in large VS Code workspaces without dropping the frontend-specific governance rules
+
 - Aligned the frontend browser-session auth contract with the backend UUID-based user payload so successful login, current-user bootstrap, persisted auth state, and onboarding handoff now accept valid string user IDs instead of incorrectly rejecting them as unsafe.
 - Hardened the browser-session auth endpoint wiring so login, logout, CSRF bootstrapping, and `GET /v1/me` all build URLs from the same production-safe API resolver, which now requires an explicit absolute `VITE_API_URL` for every production deployment and fails fast on missing or relative API bases instead of guessing a host.
 - Aligned repo-local domain governance and validation with the current split of `secpal.app` for the public homepage and real email addresses, `api.secpal.dev` for the API, and `app.secpal.dev` for the PWA, while keeping `app.secpal.app` identifier-only for Android


### PR DESCRIPTION
Fixes SecPal/.github#279

## Summary
- reduce the repo-local Copilot runtime baseline to the rules that need to stay always-on
- remove the `applyTo: "**"` auto-loading path from the repo-wide overlay
- document the governance cleanup in `CHANGELOG.md`

## Validation
- `git diff --check`
- `reuse lint`
