### PR TITLE
feat: add MFA auth client support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Replaced the remaining hand-written frontend auth response shapes with contract-aligned auth and MFA types under `@/types/api`, and extended the auth API client to cover login MFA challenges plus the backend self-service MFA endpoints needed by the upcoming UI slices.
 - Reduced the repo-local Copilot always-on context by replacing the long runtime baseline and removing the auto-loaded overlay fallback, which lowers request size in large VS Code workspaces without dropping the frontend-specific governance rules
 
 - Aligned the frontend browser-session auth contract with the backend UUID-based user payload so successful login, current-user bootstrap, persisted auth state, and onboarding handoff now accept valid string user IDs instead of incorrectly rejecting them as unsafe.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Replaced the remaining hand-written frontend auth response shapes with contract-aligned auth and MFA types under `@/types/api`, and extended the auth API client to cover login MFA challenges plus the backend self-service MFA endpoints needed by the upcoming UI slices.
+- Replaced the remaining hand-written frontend auth response shapes with contract-aligned auth and MFA types under `@/types/api`, extended the auth API client to cover login MFA challenges plus the backend self-service MFA endpoints needed by the upcoming UI slices, updated the browser-session auth transport to surface the discriminated `authenticated | mfa_required` result, and added full unit coverage for all new API client methods and transport branches.
 - Reduced the repo-local Copilot always-on context by replacing the long runtime baseline and removing the auto-loaded overlay fallback, which lowers request size in large VS Code workspaces without dropping the frontend-specific governance rules
 
 - Aligned the frontend browser-session auth contract with the backend UUID-based user payload so successful login, current-user bootstrap, persisted auth state, and onboarding handoff now accept valid string user IDs instead of incorrectly rejecting them as unsafe.

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -113,8 +113,16 @@ describe("Login", () => {
   it("submits login form with email and password", async () => {
     const mockLogin = vi.mocked(authApi.login);
     const mockResponse = {
-      token: "test-token",
-      user: { id: "1", name: "Test User", email: "test@secpal.dev" },
+      user: {
+        id: "1",
+        name: "Test User",
+        email: "test@secpal.dev",
+        roles: [],
+        permissions: [],
+        hasOrganizationalScopes: false,
+        hasCustomerAccess: false,
+        hasSiteAccess: false,
+      },
     };
     mockLogin.mockResolvedValueOnce(mockResponse);
 
@@ -304,7 +312,16 @@ describe("Login", () => {
 
     // Second call: success
     mockLogin.mockResolvedValueOnce({
-      user: { id: "1", name: "Test", email: "test@secpal.dev" },
+      user: {
+        id: "1",
+        name: "Test",
+        email: "test@secpal.dev",
+        roles: [],
+        permissions: [],
+        hasOrganizationalScopes: false,
+        hasCustomerAccess: false,
+        hasSiteAccess: false,
+      },
     });
 
     // Second submission should clear error
@@ -669,7 +686,16 @@ describe("Login", () => {
 
       const mockLogin = vi.mocked(authApi.login);
       mockLogin.mockResolvedValueOnce({
-        user: { id: "1", name: "Test", email: "test@secpal.dev" },
+        user: {
+          id: "1",
+          name: "Test",
+          email: "test@secpal.dev",
+          roles: [],
+          permissions: [],
+          hasOrganizationalScopes: false,
+          hasCustomerAccess: false,
+          hasSiteAccess: false,
+        },
       });
 
       renderLogin();

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -136,6 +136,16 @@ export function Login() {
     try {
       const response = await authTransport.login({ email, password });
       resetAttempts(); // Clear rate limit state on successful login
+
+      if (response.status === "mfa_required") {
+        // MFA challenge UI is handled in an upcoming feature slice.
+        // Reaching this branch means the account has MFA enabled.
+        setError(
+          "Multi-factor authentication is required. Please use the MFA-enabled login flow."
+        );
+        return;
+      }
+
       login(response.user);
       navigate("/");
     } catch (err) {

--- a/src/services/authApi.test.ts
+++ b/src/services/authApi.test.ts
@@ -8,6 +8,10 @@ import {
   logoutAll,
   getCurrentUser,
   getMfaStatus,
+  startTotpEnrollment,
+  confirmTotpEnrollment,
+  regenerateRecoveryCodes,
+  disableMfa,
   AuthApiError,
   verifyMfaChallenge,
 } from "./authApi";
@@ -598,6 +602,228 @@ describe("authApi", () => {
           cache: "no-store",
         })
       );
+    });
+  });
+
+  describe("startTotpEnrollment", () => {
+    it("posts to /v1/me/mfa/totp/enrollment and returns enrollment data", async () => {
+      const mockResponse = {
+        data: {
+          issuer: "SecPal",
+          account_name: "test@secpal.dev",
+          manual_entry_key: "JBSWY3DPEHPK3PXP",
+          otpauth_uri:
+            "otpauth://totp/SecPal:test@secpal.dev?secret=JBSWY3DPEHPK3PXP&issuer=SecPal",
+          expires_at: "2026-04-01T09:25:00Z",
+        },
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => mockResponse,
+      } as Response);
+
+      await expect(startTotpEnrollment()).resolves.toEqual(mockResponse);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/v1/me/mfa/totp/enrollment"),
+        expect.objectContaining({
+          method: "POST",
+          credentials: "include",
+          cache: "no-store",
+        })
+      );
+    });
+
+    it("throws AuthApiError with status and code on JSON error response", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        json: async () => ({
+          message: "MFA is already enabled.",
+          code: "CONFLICT",
+        }),
+      } as Response);
+
+      try {
+        await startTotpEnrollment();
+        expect.fail("Expected startTotpEnrollment to throw");
+      } catch (error) {
+        expect(error).toBeInstanceOf(AuthApiError);
+        expect((error as AuthApiError).status).toBe(409);
+        expect((error as AuthApiError).code).toBe("CONFLICT");
+      }
+    });
+  });
+
+  describe("confirmTotpEnrollment", () => {
+    it("posts TOTP code to /v1/me/mfa/totp/enrollment/confirm and returns recovery codes", async () => {
+      const mockResponse = {
+        data: {
+          status: {
+            enabled: true,
+            method: "totp",
+            recovery_codes_remaining: 8,
+            recovery_codes_generated_at: "2026-04-01T09:12:00Z",
+            enrolled_at: "2026-04-01T09:10:00Z",
+          },
+          recovery_codes: {
+            codes: ["B6F4-2Q8P", "F9LM-7N2R"],
+            generated_at: "2026-04-01T09:12:00Z",
+          },
+        },
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockResponse,
+      } as Response);
+
+      const result = await confirmTotpEnrollment({ code: "123456" });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/v1/me/mfa/totp/enrollment/confirm"),
+        expect.objectContaining({
+          method: "POST",
+          credentials: "include",
+          body: JSON.stringify({ code: "123456" }),
+        })
+      );
+      expect(result).toEqual(mockResponse);
+    });
+
+    it("throws AuthApiError with status and code on JSON error response", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        json: async () => ({
+          message: "The provided code is invalid.",
+          code: "VALIDATION_ERROR",
+        }),
+      } as Response);
+
+      try {
+        await confirmTotpEnrollment({ code: "000000" });
+        expect.fail("Expected confirmTotpEnrollment to throw");
+      } catch (error) {
+        expect(error).toBeInstanceOf(AuthApiError);
+        expect((error as AuthApiError).status).toBe(422);
+        expect((error as AuthApiError).code).toBe("VALIDATION_ERROR");
+      }
+    });
+  });
+
+  describe("regenerateRecoveryCodes", () => {
+    it("posts to /v1/me/mfa/recovery-codes/regenerate and returns new codes", async () => {
+      const mockResponse = {
+        data: {
+          status: {
+            enabled: true,
+            method: "totp",
+            recovery_codes_remaining: 8,
+            recovery_codes_generated_at: "2026-04-01T10:00:00Z",
+            enrolled_at: "2026-04-01T09:10:00Z",
+          },
+          recovery_codes: {
+            codes: ["X3CE-1RM6", "V7NK-5HF9"],
+            generated_at: "2026-04-01T10:00:00Z",
+          },
+        },
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockResponse,
+      } as Response);
+
+      const result = await regenerateRecoveryCodes({
+        method: "totp",
+        code: "654321",
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/v1/me/mfa/recovery-codes/regenerate"),
+        expect.objectContaining({
+          method: "POST",
+          credentials: "include",
+          body: JSON.stringify({ method: "totp", code: "654321" }),
+        })
+      );
+      expect(result).toEqual(mockResponse);
+    });
+
+    it("throws AuthApiError with status and code on JSON error response", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        json: async () => ({
+          message: "The login challenge has expired.",
+          code: "CONFLICT",
+        }),
+      } as Response);
+
+      try {
+        await regenerateRecoveryCodes({ method: "totp", code: "000000" });
+        expect.fail("Expected regenerateRecoveryCodes to throw");
+      } catch (error) {
+        expect(error).toBeInstanceOf(AuthApiError);
+        expect((error as AuthApiError).status).toBe(409);
+        expect((error as AuthApiError).code).toBe("CONFLICT");
+      }
+    });
+  });
+
+  describe("disableMfa", () => {
+    it("sends DELETE to /v1/me/mfa with verification code and returns updated status", async () => {
+      const mockResponse = {
+        data: {
+          enabled: false,
+          method: null,
+          recovery_codes_remaining: 0,
+          recovery_codes_generated_at: null,
+          enrolled_at: null,
+        },
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockResponse,
+      } as Response);
+
+      const result = await disableMfa({ method: "totp", code: "123456" });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/v1/me/mfa"),
+        expect.objectContaining({
+          method: "DELETE",
+          credentials: "include",
+          body: JSON.stringify({ method: "totp", code: "123456" }),
+        })
+      );
+      expect(result).toEqual(mockResponse);
+    });
+
+    it("throws AuthApiError with status and code on JSON error response", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        json: async () => ({
+          message: "The provided code is invalid.",
+          code: "VALIDATION_ERROR",
+        }),
+      } as Response);
+
+      try {
+        await disableMfa({ method: "totp", code: "000000" });
+        expect.fail("Expected disableMfa to throw");
+      } catch (error) {
+        expect(error).toBeInstanceOf(AuthApiError);
+        expect((error as AuthApiError).status).toBe(422);
+        expect((error as AuthApiError).code).toBe("VALIDATION_ERROR");
+      }
     });
   });
 

--- a/src/services/authApi.test.ts
+++ b/src/services/authApi.test.ts
@@ -7,10 +7,24 @@ import {
   logout,
   logoutAll,
   getCurrentUser,
+  getMfaStatus,
   AuthApiError,
+  verifyMfaChallenge,
 } from "./authApi";
 
 const mockFetch = vi.fn();
+
+const createAuthenticatedUser = (overrides?: Record<string, unknown>) => ({
+  id: 1,
+  name: "Test User",
+  email: "test@secpal.dev",
+  roles: [],
+  permissions: [],
+  hasOrganizationalScopes: false,
+  hasCustomerAccess: false,
+  hasSiteAccess: false,
+  ...overrides,
+});
 
 describe("authApi", () => {
   beforeEach(() => {
@@ -29,7 +43,7 @@ describe("authApi", () => {
   describe("login", () => {
     it("sends POST request to /v1/auth/login with credentials", async () => {
       const mockResponse = {
-        user: { id: 1, name: "Test User", email: "test@secpal.dev" },
+        user: createAuthenticatedUser(),
       };
 
       // Mock CSRF token fetch
@@ -115,16 +129,43 @@ describe("authApi", () => {
         password: "password123",
       });
 
-      expect(result.user.roles).toEqual(["Admin"]);
-      expect(result.user.permissions).toEqual(["users.read", "customers.*"]);
-      expect(result.user.hasOrganizationalScopes).toBe(true);
-      expect(result.user.hasCustomerAccess).toBe(true);
-      expect(result.user.hasSiteAccess).toBe(true);
+      expect("user" in result).toBe(true);
+      if ("user" in result) {
+        expect(result.user.roles).toEqual(["Admin"]);
+        expect(result.user.permissions).toEqual(["users.read", "customers.*"]);
+        expect(result.user.hasOrganizationalScopes).toBe(true);
+        expect(result.user.hasCustomerAccess).toBe(true);
+        expect(result.user.hasSiteAccess).toBe(true);
+      }
+    });
+
+    it("returns an MFA challenge when the backend requires a second factor", async () => {
+      const mockResponse = {
+        challenge: {
+          id: "550e8400-e29b-41d4-a716-446655440099",
+          purpose: "login",
+          login_context: "session",
+          primary_method: "totp",
+          available_methods: ["totp", "recovery_code"],
+          expires_at: "2026-04-01T09:30:00Z",
+        },
+      };
+
+      mockFetch.mockResolvedValueOnce({ ok: true } as Response);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 202,
+        json: async () => mockResponse,
+      } as Response);
+
+      await expect(
+        login({ email: "test@secpal.dev", password: "password123" })
+      ).resolves.toEqual(mockResponse);
     });
 
     it("sends login request with email and password only (no device_name for SPA)", async () => {
       const mockResponse = {
-        user: { id: 1, name: "Test", email: "test@secpal.dev" },
+        user: createAuthenticatedUser({ name: "Test" }),
       };
 
       // Mock CSRF token fetch
@@ -463,6 +504,103 @@ describe("authApi", () => {
     });
   });
 
+  describe("verifyMfaChallenge", () => {
+    it("posts the verification code to the MFA challenge endpoint", async () => {
+      const mockResponse = {
+        user: createAuthenticatedUser(),
+        authentication: {
+          mode: "session",
+          mfa_completed: true,
+        },
+      };
+
+      mockFetch.mockResolvedValueOnce({ ok: true } as Response);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockResponse,
+      } as Response);
+
+      const result = await verifyMfaChallenge(
+        "550e8400-e29b-41d4-a716-446655440099",
+        {
+          method: "totp",
+          code: "123456",
+        }
+      );
+
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining(
+          "/v1/auth/mfa-challenges/550e8400-e29b-41d4-a716-446655440099/verify"
+        ),
+        expect.objectContaining({
+          method: "POST",
+          credentials: "include",
+          body: JSON.stringify({
+            method: "totp",
+            code: "123456",
+          }),
+        })
+      );
+      expect(result).toEqual(mockResponse);
+    });
+
+    it("surfaces JSON verification errors with status metadata", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true } as Response);
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        json: async () => ({
+          message: "The login challenge has expired.",
+          code: "CONFLICT",
+        }),
+      } as Response);
+
+      try {
+        await verifyMfaChallenge("550e8400-e29b-41d4-a716-446655440099", {
+          method: "totp",
+          code: "123456",
+        });
+        expect.fail("Expected verifyMfaChallenge to throw");
+      } catch (error) {
+        expect(error).toBeInstanceOf(AuthApiError);
+        expect((error as AuthApiError).status).toBe(409);
+        expect((error as AuthApiError).code).toBe("CONFLICT");
+      }
+    });
+  });
+
+  describe("getMfaStatus", () => {
+    it("fetches MFA status from /v1/me/mfa", async () => {
+      const mockResponse = {
+        data: {
+          enabled: true,
+          method: "totp",
+          recovery_codes_remaining: 8,
+          recovery_codes_generated_at: "2026-04-01T09:12:00Z",
+          enrolled_at: "2026-04-01T09:10:00Z",
+        },
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockResponse,
+      } as Response);
+
+      await expect(getMfaStatus()).resolves.toEqual(mockResponse);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/v1/me/mfa"),
+        expect.objectContaining({
+          method: "GET",
+          credentials: "include",
+          cache: "no-store",
+        })
+      );
+    });
+  });
+
   describe("AuthApiError", () => {
     it("creates error with message and errors", () => {
       const errors = { email: ["Invalid email"] };
@@ -478,6 +616,13 @@ describe("authApi", () => {
 
       expect(error.message).toBe("Test error");
       expect(error.errors).toBeUndefined();
+    });
+
+    it("stores optional status and code metadata", () => {
+      const error = new AuthApiError("Conflict", undefined, 409, "CONFLICT");
+
+      expect(error.status).toBe(409);
+      expect(error.code).toBe("CONFLICT");
     });
   });
 });

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -1,6 +1,16 @@
 // SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import type {
+  CompletedLoginResponse,
+  LoginMfaChallengeResponse,
+  MfaRecoveryCodeRevealResponse,
+  MfaStatusResponse,
+  MfaTotpEnrollmentResponse,
+  MfaVerificationCodeRequest,
+  SessionLoginResponse,
+  TotpCodeRequest,
+} from "@/types/api";
 import { buildApiUrl } from "../config";
 import { fetchCsrfToken, apiFetch } from "./csrf";
 
@@ -10,22 +20,14 @@ interface LoginCredentials {
   device_name?: string;
 }
 
-interface LoginResponse {
-  user: {
-    id: string;
-    name: string;
-    email: string;
-    roles?: string[];
-    permissions?: string[];
-    hasOrganizationalScopes?: boolean;
-    hasCustomerAccess?: boolean;
-    hasSiteAccess?: boolean;
-  };
-}
+export type BrowserLoginResponse =
+  | SessionLoginResponse
+  | LoginMfaChallengeResponse;
 
 interface ApiError {
   message: string;
   errors?: Record<string, string[]>;
+  code?: string;
 }
 
 function hasJsonContentType(response: Response): boolean {
@@ -74,11 +76,32 @@ async function parseJsonError(response: Response): Promise<ApiError | null> {
 export class AuthApiError extends Error {
   constructor(
     message: string,
-    public errors?: Record<string, string[]>
+    public errors?: Record<string, string[]>,
+    public status?: number,
+    public code?: string
   ) {
     super(message);
     this.name = "AuthApiError";
   }
+}
+
+async function createAuthApiError(
+  response: Response,
+  defaultMessage: string,
+  nonJsonMessage = `${defaultMessage}: ${response.status} ${response.statusText}`
+): Promise<AuthApiError> {
+  const error = await parseJsonError(response);
+
+  if (!error) {
+    return new AuthApiError(nonJsonMessage, undefined, response.status);
+  }
+
+  return new AuthApiError(
+    error.message || defaultMessage,
+    error.errors,
+    response.status,
+    error.code
+  );
 }
 
 /**
@@ -87,7 +110,7 @@ export class AuthApiError extends Error {
  */
 export async function login(
   credentials: LoginCredentials
-): Promise<LoginResponse> {
+): Promise<BrowserLoginResponse> {
   // Fetch CSRF token before login
   await fetchCsrfToken();
 
@@ -106,19 +129,39 @@ export async function login(
   });
 
   if (!response.ok) {
-    const error = await parseJsonError(response);
-
-    if (!error) {
-      // Fallback if response is not JSON (e.g., HTML error page)
-      throw new AuthApiError(
-        `Login failed: ${response.status} ${response.statusText}`
-      );
-    }
-
-    throw new AuthApiError(error?.message || "Login failed", error?.errors);
+    throw await createAuthApiError(response, "Login failed");
   }
 
-  return parseJsonResponse<LoginResponse>(response, "Login failed");
+  return parseJsonResponse<BrowserLoginResponse>(response, "Login failed");
+}
+
+export async function verifyMfaChallenge(
+  challengeId: string,
+  payload: MfaVerificationCodeRequest
+): Promise<CompletedLoginResponse> {
+  await fetchCsrfToken();
+
+  const response = await apiFetch(
+    buildApiUrl(`/v1/auth/mfa-challenges/${challengeId}/verify`),
+    {
+      method: "POST",
+      cache: "no-store",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(payload),
+    }
+  );
+
+  if (!response.ok) {
+    throw await createAuthApiError(response, "MFA verification failed");
+  }
+
+  return parseJsonResponse<CompletedLoginResponse>(
+    response,
+    "MFA verification failed"
+  );
 }
 
 /**
@@ -135,13 +178,7 @@ export async function logout(): Promise<void> {
   });
 
   if (!response.ok) {
-    const error = await parseJsonError(response);
-
-    if (!error) {
-      throw new AuthApiError("Logout failed");
-    }
-
-    throw new AuthApiError(error?.message || "Logout failed", error?.errors);
+    throw await createAuthApiError(response, "Logout failed", "Logout failed");
   }
 }
 
@@ -159,15 +196,10 @@ export async function logoutAll(): Promise<void> {
   });
 
   if (!response.ok) {
-    const error = await parseJsonError(response);
-
-    if (!error) {
-      throw new AuthApiError("Logout all devices failed");
-    }
-
-    throw new AuthApiError(
-      error?.message || "Logout all devices failed",
-      error?.errors
+    throw await createAuthApiError(
+      response,
+      "Logout all devices failed",
+      "Logout all devices failed"
     );
   }
 }
@@ -176,7 +208,7 @@ export async function logoutAll(): Promise<void> {
  * Fetch the currently authenticated user for bootstrap revalidation.
  * @throws {AuthApiError} If the session is invalid or the request fails
  */
-export async function getCurrentUser(): Promise<LoginResponse["user"]> {
+export async function getCurrentUser(): Promise<SessionLoginResponse["user"]> {
   let response: Response;
   try {
     response = await apiFetch(buildApiUrl("/v1/me"), {
@@ -195,22 +227,127 @@ export async function getCurrentUser(): Promise<LoginResponse["user"]> {
   }
 
   if (!response.ok) {
-    const error = await parseJsonError(response);
-
-    if (!error) {
-      throw new AuthApiError(
-        `Current user fetch failed: ${response.status} ${response.statusText}`
-      );
-    }
-
-    throw new AuthApiError(
-      error?.message || "Current user fetch failed",
-      error?.errors
-    );
+    throw await createAuthApiError(response, "Current user fetch failed");
   }
 
-  return parseJsonResponse<LoginResponse["user"]>(
+  return parseJsonResponse<SessionLoginResponse["user"]>(
     response,
     "Current user fetch failed"
   );
+}
+
+export async function getMfaStatus(): Promise<MfaStatusResponse> {
+  const response = await apiFetch(buildApiUrl("/v1/me/mfa"), {
+    method: "GET",
+    cache: "no-store",
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw await createAuthApiError(response, "MFA status fetch failed");
+  }
+
+  return parseJsonResponse<MfaStatusResponse>(
+    response,
+    "MFA status fetch failed"
+  );
+}
+
+export async function startTotpEnrollment(): Promise<MfaTotpEnrollmentResponse> {
+  const response = await apiFetch(buildApiUrl("/v1/me/mfa/totp/enrollment"), {
+    method: "POST",
+    cache: "no-store",
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw await createAuthApiError(response, "TOTP enrollment start failed");
+  }
+
+  return parseJsonResponse<MfaTotpEnrollmentResponse>(
+    response,
+    "TOTP enrollment start failed"
+  );
+}
+
+export async function confirmTotpEnrollment(
+  payload: TotpCodeRequest
+): Promise<MfaRecoveryCodeRevealResponse> {
+  const response = await apiFetch(
+    buildApiUrl("/v1/me/mfa/totp/enrollment/confirm"),
+    {
+      method: "POST",
+      cache: "no-store",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(payload),
+    }
+  );
+
+  if (!response.ok) {
+    throw await createAuthApiError(
+      response,
+      "TOTP enrollment confirmation failed"
+    );
+  }
+
+  return parseJsonResponse<MfaRecoveryCodeRevealResponse>(
+    response,
+    "TOTP enrollment confirmation failed"
+  );
+}
+
+export async function regenerateRecoveryCodes(
+  payload: MfaVerificationCodeRequest
+): Promise<MfaRecoveryCodeRevealResponse> {
+  const response = await apiFetch(
+    buildApiUrl("/v1/me/mfa/recovery-codes/regenerate"),
+    {
+      method: "POST",
+      cache: "no-store",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(payload),
+    }
+  );
+
+  if (!response.ok) {
+    throw await createAuthApiError(
+      response,
+      "Recovery code regeneration failed"
+    );
+  }
+
+  return parseJsonResponse<MfaRecoveryCodeRevealResponse>(
+    response,
+    "Recovery code regeneration failed"
+  );
+}
+
+export async function disableMfa(
+  payload: MfaVerificationCodeRequest
+): Promise<MfaStatusResponse> {
+  const response = await apiFetch(buildApiUrl("/v1/me/mfa"), {
+    method: "DELETE",
+    cache: "no-store",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw await createAuthApiError(response, "MFA disable failed");
+  }
+
+  return parseJsonResponse<MfaStatusResponse>(response, "MFA disable failed");
 }

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -70,6 +70,7 @@ describe("authTransport", () => {
       password: "password123",
     });
     expect(result).toEqual({
+      status: "authenticated",
       user: {
         id: "1",
         name: "Browser User",
@@ -77,7 +78,10 @@ describe("authTransport", () => {
         roles: ["Admin"],
       },
     });
-    expect(result.user).not.toHaveProperty("token");
+    expect(result.status).toBe("authenticated");
+    if (result.status === "authenticated") {
+      expect(result.user).not.toHaveProperty("token");
+    }
   });
 
   it("reports browser network availability from navigator.onLine", async () => {
@@ -92,6 +96,27 @@ describe("authTransport", () => {
     } finally {
       onLineSpy.mockRestore();
     }
+  });
+
+  it("surfaces an MFA challenge from the browser-session transport", async () => {
+    const mfaChallenge = {
+      id: "550e8400-e29b-41d4-a716-446655440099",
+      purpose: "login",
+      login_context: "session",
+      primary_method: "totp",
+      available_methods: ["totp", "recovery_code"],
+      expires_at: "2026-04-01T09:30:00Z",
+    };
+
+    mockBrowserLogin.mockResolvedValueOnce({ challenge: mfaChallenge });
+
+    const transport = getAuthTransport();
+    const result = await transport.login({
+      email: "mfa@secpal.dev",
+      password: "password123",
+    });
+
+    expect(result).toEqual({ status: "mfa_required", challenge: mfaChallenge });
   });
 
   it("accepts a browser-session login payload with a UUID string id", async () => {
@@ -115,6 +140,7 @@ describe("authTransport", () => {
     });
 
     expect(result).toEqual({
+      status: "authenticated",
       user: {
         id: "019d30f1-767e-7210-bc31-2b8c1985bb61",
         name: "Browser User",
@@ -164,6 +190,7 @@ describe("authTransport", () => {
     });
     expect(mockBrowserLogin).not.toHaveBeenCalled();
     expect(loginResult).toEqual({
+      status: "authenticated",
       user: {
         id: "7",
         name: "Native User",
@@ -171,7 +198,10 @@ describe("authTransport", () => {
         permissions: ["profile.read"],
       },
     });
-    expect(loginResult.user).not.toHaveProperty("token");
+    expect(loginResult.status).toBe("authenticated");
+    if (loginResult.status === "authenticated") {
+      expect(loginResult.user).not.toHaveProperty("token");
+    }
     expect(currentUser).toEqual({
       id: "7",
       name: "Native User",

--- a/src/services/authTransport.ts
+++ b/src/services/authTransport.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import type { LoginMfaChallengeResponse, MfaChallenge } from "@/types/api";
 import type { User } from "../contexts/auth-context";
 import {
   AuthApiError,
@@ -19,9 +20,17 @@ export interface AuthCredentials {
   password: string;
 }
 
-export interface AuthLoginResult {
+export interface AuthenticatedLoginResult {
+  status: "authenticated";
   user: User;
 }
+
+export interface MfaRequiredLoginResult {
+  status: "mfa_required";
+  challenge: MfaChallenge;
+}
+
+export type AuthLoginResult = AuthenticatedLoginResult | MfaRequiredLoginResult;
 
 export type AuthTransportKind = "browser-session" | "native-bridge";
 
@@ -40,6 +49,18 @@ export interface AuthTransport {
   logoutAll(): Promise<void>;
   getCurrentUser(): Promise<User>;
   isNetworkAvailable(): Promise<boolean>;
+}
+
+function isMfaChallengeResponse(
+  payload: unknown
+): payload is LoginMfaChallengeResponse {
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    "challenge" in payload &&
+    typeof (payload as { challenge?: unknown }).challenge === "object" &&
+    (payload as { challenge?: unknown }).challenge !== null
+  );
 }
 
 function sanitizeAuthPayload(payload: unknown, operation: string): User {
@@ -64,7 +85,15 @@ const browserSessionAuthTransport: AuthTransport = {
   async login(credentials): Promise<AuthLoginResult> {
     const result = await loginWithBrowserSession(credentials);
 
+    if (isMfaChallengeResponse(result)) {
+      return {
+        status: "mfa_required",
+        challenge: result.challenge,
+      };
+    }
+
     return {
+      status: "authenticated",
       user: sanitizeAuthPayload(result, "Browser-session login"),
     };
   },
@@ -93,6 +122,7 @@ function createNativeBridgeAuthTransport(
       const result = await nativeAuthBridge.login(credentials);
 
       return {
+        status: "authenticated",
         user: sanitizeAuthPayload(result, "Native auth login"),
       };
     },

--- a/src/types/api/auth.ts
+++ b/src/types/api/auth.ts
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * Authentication and MFA API types.
+ *
+ * Derived from the shared API contract in `contracts/docs/openapi.yaml` and
+ * aligned with the current backend/runtime behavior for frontend session flows.
+ */
+
+export type AuthenticatedUserId = number | string;
+
+export interface AuthenticatedUser {
+  id: AuthenticatedUserId;
+  name: string;
+  email: string;
+  roles: string[];
+  permissions: string[];
+  hasOrganizationalScopes: boolean;
+  hasCustomerAccess: boolean;
+  hasSiteAccess: boolean;
+}
+
+export interface SessionLoginResponse {
+  user: AuthenticatedUser;
+}
+
+export interface TokenLoginResponse {
+  token: string;
+  user: AuthenticatedUser;
+}
+
+export type MfaLoginPurpose = "login";
+export type MfaLoginContext = "session" | "token";
+export type MfaPrimaryMethod = "totp";
+export type MfaVerificationMethod = "totp" | "recovery_code";
+
+export interface MfaChallenge {
+  id: string;
+  purpose: MfaLoginPurpose;
+  login_context: MfaLoginContext;
+  primary_method: MfaPrimaryMethod;
+  available_methods: MfaVerificationMethod[];
+  expires_at: string;
+}
+
+export interface LoginMfaChallengeResponse {
+  challenge: MfaChallenge;
+}
+
+export interface SessionAuthenticationResult {
+  mode: "session";
+  mfa_completed: true;
+}
+
+export interface TokenAuthenticationResult {
+  mode: "token";
+  mfa_completed: true;
+}
+
+export type CompletedLoginResponse =
+  | {
+      user: AuthenticatedUser;
+      authentication: SessionAuthenticationResult;
+    }
+  | {
+      token: string;
+      user: AuthenticatedUser;
+      authentication: TokenAuthenticationResult;
+    };
+
+export interface MfaStatus {
+  enabled: boolean;
+  method: "totp" | null;
+  recovery_codes_remaining: number;
+  recovery_codes_generated_at: string | null;
+  enrolled_at: string | null;
+}
+
+export interface MfaStatusResponse {
+  data: MfaStatus;
+}
+
+export interface TotpCodeRequest {
+  code: string;
+}
+
+export interface MfaVerificationCodeRequest {
+  method: MfaVerificationMethod;
+  code: string;
+}
+
+export interface TotpEnrollmentPreparation {
+  issuer: string;
+  account_name: string;
+  manual_entry_key: string;
+  otpauth_uri: string;
+  expires_at: string;
+}
+
+export interface MfaTotpEnrollmentResponse {
+  data: TotpEnrollmentPreparation;
+}
+
+export interface MfaRecoveryCodeReveal {
+  codes: string[];
+  generated_at: string;
+}
+
+export interface MfaRecoveryCodeRevealPayload {
+  status: MfaStatus;
+  recovery_codes: MfaRecoveryCodeReveal;
+}
+
+export interface MfaRecoveryCodeRevealResponse {
+  data: MfaRecoveryCodeRevealPayload;
+}

--- a/src/types/api/index.ts
+++ b/src/types/api/index.ts
@@ -2,4 +2,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 export * from "../customers";
+export * from "./auth";
 export * from "./employees";


### PR DESCRIPTION
## Summary
- add contract-aligned frontend auth and MFA types under `@/types/api`
- extend the auth API client for login MFA challenges and self-service MFA endpoints
- align existing login test fixtures with the stricter authenticated-user shape

## Validation
- `npx prettier --check CHANGELOG.md src/types/api/auth.ts src/types/api/index.ts src/services/authApi.ts src/services/authApi.test.ts src/pages/Login.test.tsx`
- `npx eslint src/types/api/auth.ts src/types/api/index.ts src/services/authApi.ts src/services/authApi.test.ts src/pages/Login.test.tsx`
- `npx tsc --noEmit -p tsconfig.json`
- `npx vitest run src/services/authApi.test.ts src/pages/Login.test.tsx`

Part of #690