### PR TITLE
feat: add login MFA challenge flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added PWA offline persistence security and privacy [audit document](PWA_OFFLINE_PERSISTENCE_AUDIT.md) covering all client-side storage mechanisms (localStorage, sessionStorage, IndexedDB, Cache API, Service Worker state) with 10 findings, issue overlap analysis, and prioritized remediation recommendations.
 - Added a platform-aware frontend auth transport boundary that keeps browser/PWA flows on Sanctum session auth, sanitizes auth state before it enters React or local storage, and creates the explicit seam Android can later wire to a native bearer-token bridge without exposing raw tokens to JavaScript.
 - Added the first MFA settings management slice with live status loading plus self-service recovery-code regeneration and MFA disablement flows for accounts that already have MFA enabled.
+- Added the phase-1 browser-session MFA login challenge flow so the login page can pause after primary credentials, collect the second factor, and complete the session only after the backend challenge verification succeeds.
 
 ### Changed
 

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -12,7 +12,7 @@ import {
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
 import { MemoryRouter } from "react-router-dom";
-import type { AuthenticatedUser } from "@/types/api";
+import type { AuthenticatedUser, MfaVerificationMethod } from "@/types/api";
 import { Login } from "./Login";
 import { AuthProvider } from "../contexts/AuthContext";
 import * as authApi from "../services/authApi";
@@ -90,6 +90,31 @@ const createAuthUser = (overrides?: Partial<AuthenticatedUser>) => ({
   hasSiteAccess: false,
   ...overrides,
 });
+
+const mfaChallengeFixture = {
+  id: "550e8400-e29b-41d4-a716-446655440099",
+  purpose: "login" as const,
+  login_context: "session" as const,
+  primary_method: "totp" as const,
+  available_methods: ["totp", "recovery_code"] as MfaVerificationMethod[],
+  expires_at: "2026-04-01T09:30:00Z",
+};
+
+async function openMfaDialog() {
+  vi.mocked(authApi.login).mockResolvedValueOnce({
+    challenge: mfaChallengeFixture,
+  });
+  renderLogin();
+  await screen.findByRole("button", { name: /log in/i });
+  fireEvent.change(screen.getByLabelText(/email/i), {
+    target: { value: "test@secpal.dev" },
+  });
+  fireEvent.change(screen.getByLabelText(/password/i), {
+    target: { value: "password123" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /log in/i }));
+  await screen.findByRole("heading", { name: /second factor required/i });
+}
 
 describe("Login", () => {
   beforeEach(() => {
@@ -321,6 +346,55 @@ describe("Login", () => {
       await screen.findByText(/the login challenge has expired/i)
     ).toBeInTheDocument();
 
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("closes the MFA dialog when the cancel button is clicked", async () => {
+    await openMfaDialog();
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("heading", { name: /second factor required/i })
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /log in/i })).toBeInTheDocument();
+  });
+
+  it("switches to the recovery code input when the recovery code method is selected", async () => {
+    await openMfaDialog();
+    fireEvent.click(screen.getByRole("radio", { name: /recovery code/i }));
+    expect(
+      screen.getByRole("textbox", { name: /recovery code/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("textbox", { name: /authenticator code/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows an error when MFA challenge response has an unexpected mode", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    vi.mocked(authApi.verifyMfaChallenge).mockResolvedValueOnce({
+      user: createAuthUser(),
+      authentication: {
+        mode: "token" as unknown as "session",
+        mfa_completed: true,
+      },
+    });
+    await openMfaDialog();
+    fireEvent.change(
+      screen.getByRole("textbox", { name: /authenticator code/i }),
+      { target: { value: "123456" } }
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /verify and continue/i })
+    );
+    expect(
+      await screen.findByText(
+        /the mfa challenge completed with an unsupported login mode/i
+      )
+    ).toBeInTheDocument();
     consoleErrorSpy.mockRestore();
   });
 

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -12,6 +12,7 @@ import {
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
 import { MemoryRouter } from "react-router-dom";
+import type { AuthenticatedUser } from "@/types/api";
 import { Login } from "./Login";
 import { AuthProvider } from "../contexts/AuthContext";
 import * as authApi from "../services/authApi";
@@ -24,6 +25,7 @@ vi.mock("../services/authApi", async () => {
   return {
     ...actual,
     login: vi.fn(),
+    verifyMfaChallenge: vi.fn(),
     logout: vi.fn(),
     logoutAll: vi.fn(),
   };
@@ -77,6 +79,18 @@ const createUnhealthyResponse = (): healthApi.HealthStatus => ({
   timestamp: "2025-11-29T10:00:00Z",
 });
 
+const createAuthUser = (overrides?: Partial<AuthenticatedUser>) => ({
+  id: "1",
+  name: "Test User",
+  email: "test@secpal.dev",
+  roles: [],
+  permissions: [],
+  hasOrganizationalScopes: false,
+  hasCustomerAccess: false,
+  hasSiteAccess: false,
+  ...overrides,
+});
+
 describe("Login", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -114,16 +128,7 @@ describe("Login", () => {
   it("submits login form with email and password", async () => {
     const mockLogin = vi.mocked(authApi.login);
     const mockResponse = {
-      user: {
-        id: "1",
-        name: "Test User",
-        email: "test@secpal.dev",
-        roles: [],
-        permissions: [],
-        hasOrganizationalScopes: false,
-        hasCustomerAccess: false,
-        hasSiteAccess: false,
-      },
+      user: createAuthUser(),
     };
     mockLogin.mockResolvedValueOnce(mockResponse);
 
@@ -154,6 +159,169 @@ describe("Login", () => {
         password: "password123",
       });
     });
+  });
+
+  it("shows an MFA challenge dialog when the backend requires a second factor", async () => {
+    const mockLogin = vi.mocked(authApi.login);
+    mockLogin.mockResolvedValueOnce({
+      challenge: {
+        id: "550e8400-e29b-41d4-a716-446655440099",
+        purpose: "login",
+        login_context: "session",
+        primary_method: "totp",
+        available_methods: ["totp", "recovery_code"],
+        expires_at: "2026-04-01T09:30:00Z",
+      },
+    });
+
+    renderLogin();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /log in/i })
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "test@secpal.dev" },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: "password123" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /log in/i }));
+
+    expect(
+      await screen.findByRole("heading", { name: /second factor required/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("textbox", { name: /authenticator code/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("radio", { name: /recovery code/i })
+    ).toBeInTheDocument();
+  });
+
+  it("verifies an MFA challenge and continues the session login flow", async () => {
+    const mockLogin = vi.mocked(authApi.login);
+    const mockVerifyMfaChallenge = vi.mocked(authApi.verifyMfaChallenge);
+
+    mockLogin.mockResolvedValueOnce({
+      challenge: {
+        id: "550e8400-e29b-41d4-a716-446655440099",
+        purpose: "login",
+        login_context: "session",
+        primary_method: "totp",
+        available_methods: ["totp", "recovery_code"],
+        expires_at: "2026-04-01T09:30:00Z",
+      },
+    });
+    mockVerifyMfaChallenge.mockResolvedValueOnce({
+      user: createAuthUser(),
+      authentication: {
+        mode: "session",
+        mfa_completed: true,
+      },
+    });
+
+    renderLogin();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /log in/i })
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "test@secpal.dev" },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: "password123" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /log in/i }));
+
+    await screen.findByRole("heading", { name: /second factor required/i });
+
+    fireEvent.change(
+      screen.getByRole("textbox", { name: /authenticator code/i }),
+      {
+        target: { value: "123456" },
+      }
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /verify and continue/i })
+    );
+
+    await waitFor(() => {
+      expect(mockVerifyMfaChallenge).toHaveBeenCalledWith(
+        "550e8400-e29b-41d4-a716-446655440099",
+        {
+          method: "totp",
+          code: "123456",
+        }
+      );
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("heading", { name: /second factor required/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows MFA verification errors inline inside the challenge dialog", async () => {
+    const mockLogin = vi.mocked(authApi.login);
+    const mockVerifyMfaChallenge = vi.mocked(authApi.verifyMfaChallenge);
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    mockLogin.mockResolvedValueOnce({
+      challenge: {
+        id: "550e8400-e29b-41d4-a716-446655440099",
+        purpose: "login",
+        login_context: "session",
+        primary_method: "totp",
+        available_methods: ["totp", "recovery_code"],
+        expires_at: "2026-04-01T09:30:00Z",
+      },
+    });
+    mockVerifyMfaChallenge.mockRejectedValueOnce(
+      new authApi.AuthApiError("The login challenge has expired.")
+    );
+
+    renderLogin();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /log in/i })
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "test@secpal.dev" },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: "password123" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /log in/i }));
+
+    await screen.findByRole("heading", { name: /second factor required/i });
+
+    fireEvent.change(
+      screen.getByRole("textbox", { name: /authenticator code/i }),
+      {
+        target: { value: "123456" },
+      }
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /verify and continue/i })
+    );
+
+    expect(
+      await screen.findByText(/the login challenge has expired/i)
+    ).toBeInTheDocument();
+
+    consoleErrorSpy.mockRestore();
   });
 
   it("displays error message on login failure", async () => {
@@ -353,16 +521,7 @@ describe("Login", () => {
 
     // Second call: success
     mockLogin.mockResolvedValueOnce({
-      user: {
-        id: "1",
-        name: "Test",
-        email: "test@secpal.dev",
-        roles: [],
-        permissions: [],
-        hasOrganizationalScopes: false,
-        hasCustomerAccess: false,
-        hasSiteAccess: false,
-      },
+      user: createAuthUser({ name: "Test" }),
     });
 
     // Second submission should clear error
@@ -727,16 +886,7 @@ describe("Login", () => {
 
       const mockLogin = vi.mocked(authApi.login);
       mockLogin.mockResolvedValueOnce({
-        user: {
-          id: "1",
-          name: "Test",
-          email: "test@secpal.dev",
-          roles: [],
-          permissions: [],
-          hasOrganizationalScopes: false,
-          hasCustomerAccess: false,
-          hasSiteAccess: false,
-        },
+        user: createAuthUser({ name: "Test" }),
       });
 
       renderLogin();

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -4,22 +4,48 @@
 import { useState, useEffect, useMemo, FormEvent } from "react";
 import { useNavigate } from "react-router-dom";
 import { Trans } from "@lingui/macro";
+import type { MfaChallenge, MfaVerificationMethod } from "@/types/api";
 import { useAuth } from "../hooks/useAuth";
 import { useLoginRateLimiter } from "../hooks/useLoginRateLimiter";
 import { useOnlineStatus } from "../hooks/useOnlineStatus";
 import { getAuthTransport, AuthApiError } from "../services/authTransport";
+import { verifyMfaChallenge } from "../services/authApi";
+import { sanitizeAuthUser } from "../services/authState";
 import { checkHealth, HealthStatus } from "../services/healthApi";
 import { AuthLayout } from "../components/auth-layout";
 import { Footer } from "../components/Footer";
 import { LanguageSwitcher } from "../components/LanguageSwitcher";
 import { Logo } from "../components/Logo";
 import { Button } from "../components/button";
-import { Field, Label } from "../components/fieldset";
+import {
+  Description,
+  ErrorMessage,
+  Field,
+  Label,
+} from "../components/fieldset";
+import {
+  Dialog,
+  DialogActions,
+  DialogBody,
+  DialogDescription,
+  DialogTitle,
+} from "../components/dialog";
 import { Input } from "../components/input";
 
 const HEALTH_CHECK_RETRY_DELAYS_MS = [0, 1500, 5000];
 const TEMPORARY_LOGIN_UNAVAILABLE_MESSAGE =
   "Login is temporarily unavailable. Please try again later.";
+
+function formatDateTime(value: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function getMfaMethodLabel(method: MfaVerificationMethod): string {
+  return method === "recovery_code" ? "Recovery code" : "Authenticator code";
+}
 
 export function Login() {
   const navigate = useNavigate();
@@ -38,6 +64,12 @@ export function Login() {
   const [password, setPassword] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [pendingMfaChallenge, setPendingMfaChallenge] =
+    useState<MfaChallenge | null>(null);
+  const [mfaMethod, setMfaMethod] = useState<MfaVerificationMethod>("totp");
+  const [mfaCode, setMfaCode] = useState("");
+  const [mfaError, setMfaError] = useState<string | null>(null);
+  const [isVerifyingMfa, setIsVerifyingMfa] = useState(false);
   const [healthStatus, setHealthStatus] = useState<HealthStatus | null>(null);
   const [isHealthCheckLoading, setIsHealthCheckLoading] = useState(true);
   const [healthCheckError, setHealthCheckError] = useState(false);
@@ -138,13 +170,12 @@ export function Login() {
     try {
       const response = await authTransport.login({ email, password });
       resetAttempts(); // Clear rate limit state on successful login
-
       if (response.status === "mfa_required") {
-        // MFA challenge UI is handled in an upcoming feature slice.
-        // Reaching this branch means the account has MFA enabled.
-        setError(
-          "Multi-factor authentication is required. Please use the MFA-enabled login flow."
-        );
+        setPendingMfaChallenge(response.challenge);
+        setMfaMethod(response.challenge.primary_method);
+        setMfaCode("");
+        setMfaError(null);
+        setPassword("");
         return;
       }
 
@@ -171,6 +202,67 @@ export function Login() {
       }
     } finally {
       setIsSubmitting(false);
+    }
+  };
+
+  const handleCloseMfaDialog = () => {
+    if (isVerifyingMfa) {
+      return;
+    }
+
+    setPendingMfaChallenge(null);
+    setMfaCode("");
+    setMfaError(null);
+  };
+
+  const handleVerifyMfa = async (e: FormEvent) => {
+    e.preventDefault();
+
+    if (!pendingMfaChallenge) {
+      return;
+    }
+
+    setMfaError(null);
+    setIsVerifyingMfa(true);
+
+    try {
+      const response = await verifyMfaChallenge(pendingMfaChallenge.id, {
+        method: mfaMethod,
+        code: mfaCode.trim(),
+      });
+
+      if (response.authentication.mode !== "session") {
+        throw new Error(
+          "The MFA challenge completed with an unsupported login mode."
+        );
+      }
+
+      const sanitizedUser = sanitizeAuthUser(response.user);
+
+      if (!sanitizedUser) {
+        throw new Error(
+          "The MFA challenge completed with an invalid user payload."
+        );
+      }
+
+      setPendingMfaChallenge(null);
+      setMfaCode("");
+      login(sanitizedUser);
+      navigate("/");
+    } catch (err) {
+      console.error("MFA verification error:", err);
+
+      if (err instanceof AuthApiError) {
+        setMfaError(err.message);
+      } else if (err instanceof Error) {
+        setMfaError(err.message);
+      } else {
+        setMfaError(
+          "An unexpected MFA verification error occurred. Please try logging in again."
+        );
+      }
+    } finally {
+      setIsVerifyingMfa(false);
     }
   };
 
@@ -313,7 +405,12 @@ export function Login() {
             onChange={(e) => setEmail(e.target.value)}
             placeholder="you@secpal.app"
             aria-describedby={ariaDescribedBy}
-            disabled={!isOnline || isSystemNotReady || isLocked}
+            disabled={
+              !isOnline ||
+              isSystemNotReady ||
+              isLocked ||
+              pendingMfaChallenge !== null
+            }
           />
         </Field>
 
@@ -331,7 +428,12 @@ export function Login() {
             onChange={(e) => setPassword(e.target.value)}
             placeholder="••••••••"
             aria-describedby={ariaDescribedBy}
-            disabled={!isOnline || isSystemNotReady || isLocked}
+            disabled={
+              !isOnline ||
+              isSystemNotReady ||
+              isLocked ||
+              pendingMfaChallenge !== null
+            }
           />
         </Field>
 
@@ -342,12 +444,17 @@ export function Login() {
             isSubmitting ||
             isSystemNotReady ||
             isHealthCheckLoading ||
-            isLocked
+            isLocked ||
+            pendingMfaChallenge !== null
           }
           className="w-full"
           aria-busy={isSubmitting}
           aria-disabled={
-            !isOnline || isSystemNotReady || isHealthCheckLoading || isLocked
+            !isOnline ||
+            isSystemNotReady ||
+            isHealthCheckLoading ||
+            isLocked ||
+            pendingMfaChallenge !== null
           }
         >
           {isHealthCheckLoading ? (
@@ -363,6 +470,127 @@ export function Login() {
           )}
         </Button>
       </form>
+
+      <Dialog
+        open={pendingMfaChallenge !== null}
+        onClose={handleCloseMfaDialog}
+      >
+        <DialogTitle>
+          <Trans id="login.mfa.title">Second factor required</Trans>
+        </DialogTitle>
+        <DialogDescription>
+          <Trans id="login.mfa.description">
+            Your password was accepted. Complete MFA to finish signing in.
+          </Trans>
+        </DialogDescription>
+
+        <DialogBody>
+          {pendingMfaChallenge && (
+            <form className="space-y-6" onSubmit={handleVerifyMfa}>
+              <div className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-800 dark:bg-zinc-900/60">
+                <p className="text-sm text-zinc-700 dark:text-zinc-300">
+                  <Trans id="login.mfa.expiry">
+                    This verification step expires at{" "}
+                    {formatDateTime(pendingMfaChallenge.expires_at)}.
+                  </Trans>
+                </p>
+              </div>
+
+              <fieldset className="space-y-3">
+                <legend className="text-sm font-medium text-zinc-950 dark:text-white">
+                  <Trans id="login.mfa.method">Verification method</Trans>
+                </legend>
+
+                {pendingMfaChallenge.available_methods.map((method) => (
+                  <label
+                    key={method}
+                    className="flex cursor-default items-start gap-3 rounded-2xl border border-zinc-200 bg-white px-4 py-3 text-sm text-zinc-900 dark:border-zinc-800 dark:bg-zinc-900/60 dark:text-white"
+                  >
+                    <input
+                      type="radio"
+                      name="mfa-method"
+                      value={method}
+                      checked={mfaMethod === method}
+                      onChange={() => setMfaMethod(method)}
+                      disabled={isVerifyingMfa}
+                      className="mt-1"
+                    />
+                    <span>
+                      {getMfaMethodLabel(method)}
+                      {method === pendingMfaChallenge.primary_method ? (
+                        <span className="ml-2 text-xs text-zinc-500 dark:text-zinc-400">
+                          <Trans id="login.mfa.preferred">recommended</Trans>
+                        </span>
+                      ) : null}
+                    </span>
+                  </label>
+                ))}
+              </fieldset>
+
+              <Field>
+                <Label htmlFor="mfa-code">
+                  {mfaMethod === "recovery_code" ? (
+                    <Trans id="login.mfa.recoveryCode">Recovery code</Trans>
+                  ) : (
+                    <Trans id="login.mfa.authenticatorCode">
+                      Authenticator code
+                    </Trans>
+                  )}
+                </Label>
+                <Description>
+                  {mfaMethod === "recovery_code" ? (
+                    <Trans id="login.mfa.recoveryHelp">
+                      Enter one unused recovery code exactly as stored.
+                    </Trans>
+                  ) : (
+                    <Trans id="login.mfa.totpHelp">
+                      Enter the current 6-digit code from your authenticator
+                      app.
+                    </Trans>
+                  )}
+                </Description>
+                <Input
+                  id="mfa-code"
+                  name="mfa-code"
+                  type="text"
+                  autoComplete="one-time-code"
+                  required
+                  value={mfaCode}
+                  onChange={(event) => setMfaCode(event.target.value)}
+                  placeholder={
+                    mfaMethod === "recovery_code" ? "B6F4-2Q8P" : "123456"
+                  }
+                  disabled={isVerifyingMfa}
+                />
+                {mfaError ? <ErrorMessage>{mfaError}</ErrorMessage> : null}
+              </Field>
+
+              <DialogActions>
+                <Button
+                  type="button"
+                  outline
+                  onClick={handleCloseMfaDialog}
+                  disabled={isVerifyingMfa}
+                >
+                  <Trans id="login.mfa.cancel">Cancel</Trans>
+                </Button>
+                <Button
+                  type="submit"
+                  color="blue"
+                  disabled={isVerifyingMfa || mfaCode.trim().length === 0}
+                  aria-busy={isVerifyingMfa}
+                >
+                  {isVerifyingMfa ? (
+                    <Trans id="login.mfa.verifying">Verifying...</Trans>
+                  ) : (
+                    <Trans id="login.mfa.submit">Verify and continue</Trans>
+                  )}
+                </Button>
+              </DialogActions>
+            </form>
+          )}
+        </DialogBody>
+      </Dialog>
 
       <div className="flex-1" />
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -37,14 +37,20 @@ const TEMPORARY_LOGIN_UNAVAILABLE_MESSAGE =
   "Login is temporarily unavailable. Please try again later.";
 
 function formatDateTime(value: string): string {
+  if (!value) {
+    return "—";
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return "—";
+  }
+
   return new Intl.DateTimeFormat(undefined, {
     dateStyle: "medium",
     timeStyle: "short",
-  }).format(new Date(value));
-}
-
-function getMfaMethodLabel(method: MfaVerificationMethod): string {
-  return method === "recovery_code" ? "Recovery code" : "Authenticator code";
+  }).format(date);
 }
 
 export function Login() {
@@ -516,7 +522,15 @@ export function Login() {
                       className="mt-1"
                     />
                     <span>
-                      {getMfaMethodLabel(method)}
+                      {method === "recovery_code" ? (
+                        <Trans id="login.mfa.method.recovery_code">
+                          Recovery code
+                        </Trans>
+                      ) : (
+                        <Trans id="login.mfa.method.totp">
+                          Authenticator code
+                        </Trans>
+                      )}
                       {method === pendingMfaChallenge.primary_method ? (
                         <span className="ml-2 text-xs text-zinc-500 dark:text-zinc-400">
                           <Trans id="login.mfa.preferred">recommended</Trans>
@@ -561,8 +575,13 @@ export function Login() {
                     mfaMethod === "recovery_code" ? "B6F4-2Q8P" : "123456"
                   }
                   disabled={isVerifyingMfa}
+                  aria-invalid={mfaError ? true : undefined}
+                  data-invalid={mfaError ? true : undefined}
+                  aria-describedby={mfaError ? "mfa-code-error" : undefined}
                 />
-                {mfaError ? <ErrorMessage>{mfaError}</ErrorMessage> : null}
+                {mfaError ? (
+                  <ErrorMessage id="mfa-code-error">{mfaError}</ErrorMessage>
+                ) : null}
               </Field>
 
               <DialogActions>

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -213,6 +213,37 @@ describe("authTransport", () => {
     expect(nativeBridge.isNetworkAvailable).toHaveBeenCalledOnce();
   });
 
+  it("passes browser-session MFA challenges through without sanitizing them as users", async () => {
+    mockBrowserLogin.mockResolvedValueOnce({
+      challenge: {
+        id: "550e8400-e29b-41d4-a716-446655440099",
+        purpose: "login",
+        login_context: "session",
+        primary_method: "totp",
+        available_methods: ["totp", "recovery_code"],
+        expires_at: "2026-04-01T09:30:00Z",
+      },
+    });
+
+    const transport = getAuthTransport();
+    const result = await transport.login({
+      email: "mfa@secpal.dev",
+      password: "password123",
+    });
+
+    expect(result).toEqual({
+      status: "mfa_required",
+      challenge: {
+        id: "550e8400-e29b-41d4-a716-446655440099",
+        purpose: "login",
+        login_context: "session",
+        primary_method: "totp",
+        available_methods: ["totp", "recovery_code"],
+        expires_at: "2026-04-01T09:30:00Z",
+      },
+    });
+  });
+
   it("rejects invalid native payloads before they can become auth state", async () => {
     const nativeBridge: NativeAuthBridge = {
       login: vi.fn().mockResolvedValue({ token: "native-secret" }),


### PR DESCRIPTION
## Summary
- extend the browser-session auth transport to surface MFA challenge responses
- update the login page to pause after primary credentials and verify a second factor before completing the session
- cover the MFA login challenge flow in focused login and auth-transport tests

## Validation
- `npx prettier --check src/pages/Login.tsx src/pages/Login.test.tsx src/services/authTransport.ts src/services/authTransport.test.ts CHANGELOG.md`
- `npx eslint src/pages/Login.tsx src/pages/Login.test.tsx src/services/authTransport.ts src/services/authTransport.test.ts`
- `npx tsc --noEmit -p tsconfig.json`
- `npx vitest run src/services/authTransport.test.ts src/pages/Login.test.tsx`

Part of #690