### PR TITLE
feat: add MFA settings management actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a reusable MFA QR-code component with browser-safe fallback messaging and focused component coverage so upcoming enrollment UI slices can render authenticator setup material without duplicating QR generation logic.
 - Added PWA offline persistence security and privacy [audit document](PWA_OFFLINE_PERSISTENCE_AUDIT.md) covering all client-side storage mechanisms (localStorage, sessionStorage, IndexedDB, Cache API, Service Worker state) with 10 findings, issue overlap analysis, and prioritized remediation recommendations.
 - Added a platform-aware frontend auth transport boundary that keeps browser/PWA flows on Sanctum session auth, sanitizes auth state before it enters React or local storage, and creates the explicit seam Android can later wire to a native bearer-token bridge without exposing raw tokens to JavaScript.
+- Added the first MFA settings management slice with live status loading plus self-service recovery-code regeneration and MFA disablement flows for accounts that already have MFA enabled.
 
 ### Changed
 

--- a/src/pages/Settings/SettingsPage.test.tsx
+++ b/src/pages/Settings/SettingsPage.test.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -8,6 +8,7 @@ import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
 import { SettingsPage } from "./SettingsPage";
 import * as i18nModule from "../../i18n";
+import * as authApi from "../../services/authApi";
 
 // Mock the i18n module
 vi.mock("../../i18n", async () => {
@@ -20,6 +21,16 @@ vi.mock("../../i18n", async () => {
   };
 });
 
+vi.mock("../../services/authApi", async () => {
+  const actual = await vi.importActual("../../services/authApi");
+  return {
+    ...actual,
+    getMfaStatus: vi.fn(),
+    regenerateRecoveryCodes: vi.fn(),
+    disableMfa: vi.fn(),
+  };
+});
+
 // Helper to render with all required providers
 const renderWithProviders = (component: React.ReactNode) => {
   return render(
@@ -29,24 +40,77 @@ const renderWithProviders = (component: React.ReactNode) => {
   );
 };
 
+async function renderSettingsPage() {
+  renderWithProviders(<SettingsPage />);
+  await screen.findByText(/not enabled/i);
+}
+
+function createDisabledMfaStatusResponse() {
+  return {
+    data: {
+      enabled: false,
+      method: null,
+      recovery_codes_remaining: 0,
+      recovery_codes_generated_at: null,
+      enrolled_at: null,
+    },
+  };
+}
+
+function createEnabledMfaStatusResponse() {
+  return {
+    data: {
+      enabled: true,
+      method: "totp" as const,
+      recovery_codes_remaining: 10,
+      recovery_codes_generated_at: "2026-04-01T09:12:00Z",
+      enrolled_at: "2026-04-01T09:10:00Z",
+    },
+  };
+}
+
+function createRecoveryRevealResponse() {
+  return {
+    data: {
+      status: createEnabledMfaStatusResponse().data,
+      recovery_codes: {
+        codes: [
+          "B6F4-2Q8P",
+          "F9LM-7N2R",
+          "HT4V-3KQ1",
+          "J8PW-6CX5",
+          "M2TR-9DZ7",
+          "Q4YS-8LB2",
+          "V7NK-5HF9",
+          "X3CE-1RM6",
+        ],
+        generated_at: "2026-04-01T09:12:00Z",
+      },
+    },
+  };
+}
+
 describe("SettingsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Setup i18n with English locale
     i18n.load("en", {});
     i18n.activate("en");
+    vi.mocked(authApi.getMfaStatus).mockResolvedValue(
+      createDisabledMfaStatusResponse()
+    );
   });
 
-  it("renders the settings page with heading", () => {
-    renderWithProviders(<SettingsPage />);
+  it("renders the settings page with heading", async () => {
+    await renderSettingsPage();
 
     expect(
       screen.getByRole("heading", { name: /settings/i })
     ).toBeInTheDocument();
   });
 
-  it("displays language selection section", () => {
-    renderWithProviders(<SettingsPage />);
+  it("displays language selection section", async () => {
+    await renderSettingsPage();
 
     // Language heading should exist
     expect(
@@ -57,8 +121,8 @@ describe("SettingsPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows current language as selected", () => {
-    renderWithProviders(<SettingsPage />);
+  it("shows current language as selected", async () => {
+    await renderSettingsPage();
 
     const select = screen.getByRole("combobox", { name: /select language/i });
     expect(select).toHaveValue("en");
@@ -69,7 +133,7 @@ describe("SettingsPage", () => {
     const mockSetLocalePreference = vi.mocked(i18nModule.setLocalePreference);
     mockActivateLocale.mockResolvedValueOnce(undefined);
 
-    renderWithProviders(<SettingsPage />);
+    await renderSettingsPage();
 
     const select = screen.getByRole("combobox", { name: /select language/i });
     fireEvent.change(select, { target: { value: "de" } });
@@ -80,16 +144,16 @@ describe("SettingsPage", () => {
     });
   });
 
-  it("displays description text for language setting", () => {
-    renderWithProviders(<SettingsPage />);
+  it("displays description text for language setting", async () => {
+    await renderSettingsPage();
 
     expect(
       screen.getByText(/choose.*preferred.*language/i)
     ).toBeInTheDocument();
   });
 
-  it("has proper heading hierarchy", () => {
-    renderWithProviders(<SettingsPage />);
+  it("has proper heading hierarchy", async () => {
+    await renderSettingsPage();
 
     // Main heading should be h1 (via Heading component)
     const mainHeading = screen.getByRole("heading", { name: /settings/i });
@@ -98,5 +162,79 @@ describe("SettingsPage", () => {
     // Language section heading should be h2
     const languageHeading = screen.getByRole("heading", { name: /language/i });
     expect(languageHeading.tagName).toBe("H2");
+  });
+
+  it("regenerates recovery codes for an enabled MFA account", async () => {
+    vi.mocked(authApi.getMfaStatus).mockResolvedValueOnce(
+      createEnabledMfaStatusResponse()
+    );
+    vi.mocked(authApi.regenerateRecoveryCodes).mockResolvedValueOnce(
+      createRecoveryRevealResponse()
+    );
+
+    renderWithProviders(<SettingsPage />);
+
+    await screen.findByText(/authenticator app/i);
+    fireEvent.click(
+      screen.getByRole("button", { name: /regenerate recovery codes/i })
+    );
+
+    await screen.findByRole("heading", {
+      name: /regenerate recovery codes/i,
+    });
+
+    fireEvent.change(
+      screen.getByRole("textbox", { name: /^authenticator code$/i }),
+      {
+        target: { value: "123456" },
+      }
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /^regenerate codes$/i })
+    );
+
+    await waitFor(() => {
+      expect(authApi.regenerateRecoveryCodes).toHaveBeenCalledWith({
+        method: "totp",
+        code: "123456",
+      });
+    });
+    expect(
+      await screen.findByRole("heading", {
+        name: /store your recovery codes now/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("disables MFA after code confirmation", async () => {
+    vi.mocked(authApi.getMfaStatus).mockResolvedValueOnce(
+      createEnabledMfaStatusResponse()
+    );
+    vi.mocked(authApi.disableMfa).mockResolvedValueOnce(
+      createDisabledMfaStatusResponse()
+    );
+
+    renderWithProviders(<SettingsPage />);
+
+    await screen.findByText(/authenticator app/i);
+    fireEvent.click(screen.getByRole("button", { name: /disable mfa/i }));
+
+    await screen.findByRole("heading", { name: /disable mfa/i });
+
+    fireEvent.change(
+      screen.getByRole("textbox", { name: /^authenticator code$/i }),
+      {
+        target: { value: "123456" },
+      }
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^disable mfa$/i }));
+
+    await waitFor(() => {
+      expect(authApi.disableMfa).toHaveBeenCalledWith({
+        method: "totp",
+        code: "123456",
+      });
+    });
+    expect(await screen.findByText(/not enabled/i)).toBeInTheDocument();
   });
 });

--- a/src/pages/Settings/SettingsPage.test.tsx
+++ b/src/pages/Settings/SettingsPage.test.tsx
@@ -237,4 +237,147 @@ describe("SettingsPage", () => {
     });
     expect(await screen.findByText(/not enabled/i)).toBeInTheDocument();
   });
+
+  it("shows error message when MFA status fails to load", async () => {
+    vi.mocked(authApi.getMfaStatus).mockRejectedValueOnce(
+      new Error("Network error")
+    );
+
+    renderWithProviders(<SettingsPage />);
+
+    expect(await screen.findByText(/network error/i)).toBeInTheDocument();
+  });
+
+  it("shows API error in dialog when disabling MFA fails", async () => {
+    vi.mocked(authApi.getMfaStatus).mockResolvedValueOnce(
+      createEnabledMfaStatusResponse()
+    );
+    vi.mocked(authApi.disableMfa).mockRejectedValueOnce(
+      new Error("Invalid authenticator code")
+    );
+
+    renderWithProviders(<SettingsPage />);
+
+    await screen.findByText(/authenticator app/i);
+    fireEvent.click(screen.getByRole("button", { name: /disable mfa/i }));
+
+    await screen.findByRole("heading", { name: /disable mfa/i });
+
+    fireEvent.change(
+      screen.getByRole("textbox", { name: /^authenticator code$/i }),
+      { target: { value: "000000" } }
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^disable mfa$/i }));
+
+    expect(
+      await screen.findByText(/invalid authenticator code/i)
+    ).toBeInTheDocument();
+  });
+
+  it("requires acknowledgment before closing recovery codes dialog", async () => {
+    vi.mocked(authApi.getMfaStatus).mockResolvedValueOnce(
+      createEnabledMfaStatusResponse()
+    );
+    vi.mocked(authApi.regenerateRecoveryCodes).mockResolvedValueOnce(
+      createRecoveryRevealResponse()
+    );
+
+    renderWithProviders(<SettingsPage />);
+
+    await screen.findByText(/authenticator app/i);
+    fireEvent.click(
+      screen.getByRole("button", { name: /regenerate recovery codes/i })
+    );
+
+    await screen.findByRole("heading", { name: /regenerate recovery codes/i });
+
+    fireEvent.change(
+      screen.getByRole("textbox", { name: /^authenticator code$/i }),
+      { target: { value: "123456" } }
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /^regenerate codes$/i })
+    );
+
+    await screen.findByRole("heading", {
+      name: /store your recovery codes now/i,
+    });
+
+    const doneButton = screen.getByRole("button", { name: /^done$/i });
+    expect(doneButton).toBeDisabled();
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: /i stored these recovery codes/i,
+    });
+    fireEvent.click(checkbox);
+
+    expect(doneButton).not.toBeDisabled();
+
+    fireEvent.click(doneButton);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("heading", {
+          name: /store your recovery codes now/i,
+        })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("cancels the sensitive action dialog without submitting", async () => {
+    vi.mocked(authApi.getMfaStatus).mockResolvedValueOnce(
+      createEnabledMfaStatusResponse()
+    );
+
+    renderWithProviders(<SettingsPage />);
+
+    await screen.findByText(/authenticator app/i);
+    fireEvent.click(screen.getByRole("button", { name: /disable mfa/i }));
+
+    await screen.findByRole("heading", { name: /disable mfa/i });
+
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("heading", { name: /disable mfa/i })
+      ).not.toBeInTheDocument();
+    });
+    expect(authApi.disableMfa).not.toHaveBeenCalled();
+  });
+
+  it("shows processing state while a sensitive action is submitting", async () => {
+    vi.mocked(authApi.getMfaStatus).mockResolvedValueOnce(
+      createEnabledMfaStatusResponse()
+    );
+    let resolveDisable!: (
+      value: ReturnType<typeof createDisabledMfaStatusResponse>
+    ) => void;
+    vi.mocked(authApi.disableMfa).mockReturnValueOnce(
+      new Promise<ReturnType<typeof createDisabledMfaStatusResponse>>((res) => {
+        resolveDisable = res;
+      })
+    );
+
+    renderWithProviders(<SettingsPage />);
+
+    await screen.findByText(/authenticator app/i);
+    fireEvent.click(screen.getByRole("button", { name: /disable mfa/i }));
+
+    await screen.findByRole("heading", { name: /disable mfa/i });
+
+    fireEvent.change(
+      screen.getByRole("textbox", { name: /^authenticator code$/i }),
+      { target: { value: "123456" } }
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^disable mfa$/i }));
+
+    expect(await screen.findByText(/processing\.\.\./i)).toBeInTheDocument();
+
+    resolveDisable(createDisabledMfaStatusResponse());
+
+    await waitFor(() => {
+      expect(screen.queryByText(/processing\.\.\./i)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/pages/Settings/SettingsPage.tsx
+++ b/src/pages/Settings/SettingsPage.tsx
@@ -1,7 +1,14 @@
 // SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { useEffect, useMemo, useState, type FormEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type FormEvent,
+  type ReactNode,
+} from "react";
 import { Trans } from "@lingui/macro";
 import type {
   MfaRecoveryCodeReveal,
@@ -36,33 +43,45 @@ import {
 
 type SensitiveMfaAction = "disable" | "regenerate";
 
-function getStatusLabel(status: MfaStatus | null): string {
+function getStatusLabel(status: MfaStatus | null): ReactNode {
   if (!status?.enabled) {
-    return "Not enabled";
+    return <Trans>Not enabled</Trans>;
   }
 
-  return status.method === "totp" ? "Authenticator app" : "Enabled";
+  return status.method === "totp" ? (
+    <Trans>Authenticator app</Trans>
+  ) : (
+    <Trans>Enabled</Trans>
+  );
 }
 
 function getSensitiveActionLabels(action: SensitiveMfaAction | null): {
-  title: string;
-  description: string;
-  submit: string;
+  title: ReactNode;
+  description: ReactNode;
+  submit: ReactNode;
 } {
   if (action === "disable") {
     return {
-      title: "Disable MFA",
-      description:
-        "Confirm with your authenticator app or one recovery code to disable MFA for this account.",
-      submit: "Disable MFA",
+      title: <Trans>Disable MFA</Trans>,
+      description: (
+        <Trans>
+          Confirm with your authenticator app or one recovery code to disable
+          MFA for this account.
+        </Trans>
+      ),
+      submit: <Trans>Disable MFA</Trans>,
     };
   }
 
   return {
-    title: "Regenerate recovery codes",
-    description:
-      "Confirm with your authenticator app or one recovery code to replace every existing recovery code.",
-    submit: "Regenerate codes",
+    title: <Trans>Regenerate recovery codes</Trans>,
+    description: (
+      <Trans>
+        Confirm with your authenticator app or one recovery code to replace
+        every existing recovery code.
+      </Trans>
+    ),
+    submit: <Trans>Regenerate codes</Trans>,
   };
 }
 
@@ -88,7 +107,7 @@ export function SettingsPage() {
     [sensitiveAction]
   );
 
-  const loadMfaStatus = async () => {
+  const loadMfaStatus = useCallback(async () => {
     setIsLoadingMfaStatus(true);
     setMfaStatusError(null);
 
@@ -106,11 +125,11 @@ export function SettingsPage() {
     } finally {
       setIsLoadingMfaStatus(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     void loadMfaStatus();
-  }, []);
+  }, [loadMfaStatus]);
 
   const handleSensitiveActionSubmit = async (event: FormEvent) => {
     event.preventDefault();
@@ -207,6 +226,10 @@ export function SettingsPage() {
           {isLoadingMfaStatus ? (
             <Text className="text-sm text-zinc-500 dark:text-zinc-400">
               <Trans>Loading MFA status...</Trans>
+            </Text>
+          ) : mfaStatusError ? (
+            <Text className="text-sm text-zinc-500 dark:text-zinc-400">
+              <Trans>MFA status could not be loaded.</Trans>
             </Text>
           ) : (
             <div className="space-y-6">

--- a/src/pages/Settings/SettingsPage.tsx
+++ b/src/pages/Settings/SettingsPage.tsx
@@ -1,19 +1,178 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import { useEffect, useMemo, useState, type FormEvent } from "react";
 import { Trans } from "@lingui/macro";
+import type {
+  MfaRecoveryCodeReveal,
+  MfaStatus,
+  MfaVerificationMethod,
+} from "@/types/api";
 import { Heading } from "../../components/heading";
 import { Text } from "../../components/text";
 import { LanguageSwitcher } from "../../components/LanguageSwitcher";
 import { Divider } from "../../components/divider";
+import { Button } from "../../components/button";
+import { ErrorMessage, Field, Label } from "../../components/fieldset";
+import { Input } from "../../components/input";
+import {
+  Dialog,
+  DialogActions,
+  DialogBody,
+  DialogDescription,
+  DialogTitle,
+} from "../../components/dialog";
+import {
+  DescriptionDetails,
+  DescriptionList,
+  DescriptionTerm,
+} from "../../components/description-list";
+import {
+  AuthApiError,
+  disableMfa,
+  getMfaStatus,
+  regenerateRecoveryCodes,
+} from "../../services/authApi";
 
-/**
- * Settings Page
- *
- * Allows users to configure their preferences including language selection.
- * Part of Issue #261 - Create Settings page with language selection.
- */
+type SensitiveMfaAction = "disable" | "regenerate";
+
+function getStatusLabel(status: MfaStatus | null): string {
+  if (!status?.enabled) {
+    return "Not enabled";
+  }
+
+  return status.method === "totp" ? "Authenticator app" : "Enabled";
+}
+
+function getSensitiveActionLabels(action: SensitiveMfaAction | null): {
+  title: string;
+  description: string;
+  submit: string;
+} {
+  if (action === "disable") {
+    return {
+      title: "Disable MFA",
+      description:
+        "Confirm with your authenticator app or one recovery code to disable MFA for this account.",
+      submit: "Disable MFA",
+    };
+  }
+
+  return {
+    title: "Regenerate recovery codes",
+    description:
+      "Confirm with your authenticator app or one recovery code to replace every existing recovery code.",
+    submit: "Regenerate codes",
+  };
+}
+
 export function SettingsPage() {
+  const [mfaStatus, setMfaStatus] = useState<MfaStatus | null>(null);
+  const [isLoadingMfaStatus, setIsLoadingMfaStatus] = useState(true);
+  const [mfaStatusError, setMfaStatusError] = useState<string | null>(null);
+  const [revealedRecoveryCodes, setRevealedRecoveryCodes] =
+    useState<MfaRecoveryCodeReveal | null>(null);
+  const [hasAcknowledgedRecoveryCodes, setHasAcknowledgedRecoveryCodes] =
+    useState(false);
+  const [sensitiveAction, setSensitiveAction] =
+    useState<SensitiveMfaAction | null>(null);
+  const [sensitiveMethod, setSensitiveMethod] =
+    useState<MfaVerificationMethod>("totp");
+  const [sensitiveCode, setSensitiveCode] = useState("");
+  const [sensitiveError, setSensitiveError] = useState<string | null>(null);
+  const [isSubmittingSensitiveAction, setIsSubmittingSensitiveAction] =
+    useState(false);
+
+  const sensitiveActionLabels = useMemo(
+    () => getSensitiveActionLabels(sensitiveAction),
+    [sensitiveAction]
+  );
+
+  const loadMfaStatus = async () => {
+    setIsLoadingMfaStatus(true);
+    setMfaStatusError(null);
+
+    try {
+      const response = await getMfaStatus();
+      setMfaStatus(response.data);
+    } catch (error) {
+      if (error instanceof AuthApiError) {
+        setMfaStatusError(error.message);
+      } else if (error instanceof Error) {
+        setMfaStatusError(error.message);
+      } else {
+        setMfaStatusError("Failed to load MFA status.");
+      }
+    } finally {
+      setIsLoadingMfaStatus(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadMfaStatus();
+  }, []);
+
+  const handleSensitiveActionSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+
+    if (!sensitiveAction) {
+      return;
+    }
+
+    setSensitiveError(null);
+    setIsSubmittingSensitiveAction(true);
+
+    try {
+      if (sensitiveAction === "disable") {
+        const response = await disableMfa({
+          method: sensitiveMethod,
+          code: sensitiveCode.trim(),
+        });
+
+        setMfaStatus(response.data);
+        setSensitiveAction(null);
+        setSensitiveCode("");
+        return;
+      }
+
+      const response = await regenerateRecoveryCodes({
+        method: sensitiveMethod,
+        code: sensitiveCode.trim(),
+      });
+
+      setMfaStatus(response.data.status);
+      setSensitiveAction(null);
+      setSensitiveCode("");
+      setRevealedRecoveryCodes(response.data.recovery_codes);
+      setHasAcknowledgedRecoveryCodes(false);
+    } catch (error) {
+      if (error instanceof AuthApiError) {
+        setSensitiveError(error.message);
+      } else if (error instanceof Error) {
+        setSensitiveError(error.message);
+      } else {
+        setSensitiveError("Failed to complete MFA action.");
+      }
+    } finally {
+      setIsSubmittingSensitiveAction(false);
+    }
+  };
+
+  const handleOpenSensitiveAction = (action: SensitiveMfaAction) => {
+    setSensitiveAction(action);
+    setSensitiveMethod("totp");
+    setSensitiveCode("");
+    setSensitiveError(null);
+  };
+
+  const handleCloseRecoveryCodes = () => {
+    if (!hasAcknowledgedRecoveryCodes) {
+      return;
+    }
+
+    setRevealedRecoveryCodes(null);
+  };
+
   return (
     <div className="space-y-10">
       <div>
@@ -24,6 +183,76 @@ export function SettingsPage() {
           <Trans>Manage your application preferences.</Trans>
         </Text>
       </div>
+
+      <Divider />
+
+      <section className="space-y-6">
+        <div>
+          <div>
+            <Heading level={2}>
+              <Trans>Multi-factor authentication</Trans>
+            </Heading>
+          </div>
+        </div>
+
+        {mfaStatusError ? (
+          <div className="rounded-2xl border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">
+            <Text className="text-sm text-red-800 dark:text-red-200">
+              {mfaStatusError}
+            </Text>
+          </div>
+        ) : null}
+
+        <div className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900/60">
+          {isLoadingMfaStatus ? (
+            <Text className="text-sm text-zinc-500 dark:text-zinc-400">
+              <Trans>Loading MFA status...</Trans>
+            </Text>
+          ) : (
+            <div className="space-y-6">
+              <DescriptionList>
+                <DescriptionTerm>
+                  <Trans>Status</Trans>
+                </DescriptionTerm>
+                <DescriptionDetails>
+                  {getStatusLabel(mfaStatus)}
+                </DescriptionDetails>
+
+                <DescriptionTerm>
+                  <Trans>Recovery codes remaining</Trans>
+                </DescriptionTerm>
+                <DescriptionDetails>
+                  {mfaStatus?.recovery_codes_remaining ?? 0}
+                </DescriptionDetails>
+              </DescriptionList>
+
+              {mfaStatus?.enabled ? (
+                <div className="flex flex-col gap-3 sm:flex-row">
+                  <Button
+                    color="blue"
+                    onClick={() => handleOpenSensitiveAction("regenerate")}
+                  >
+                    <Trans>Regenerate recovery codes</Trans>
+                  </Button>
+                  <Button
+                    color="red"
+                    onClick={() => handleOpenSensitiveAction("disable")}
+                  >
+                    <Trans>Disable MFA</Trans>
+                  </Button>
+                </div>
+              ) : (
+                <Text className="text-sm text-zinc-600 dark:text-zinc-300">
+                  <Trans>
+                    MFA is currently off for this account. Enrollment support
+                    follows in the next rollout slice.
+                  </Trans>
+                </Text>
+              )}
+            </div>
+          )}
+        </div>
+      </section>
 
       <Divider />
 
@@ -42,6 +271,184 @@ export function SettingsPage() {
           <LanguageSwitcher />
         </div>
       </section>
+
+      <Dialog
+        open={revealedRecoveryCodes !== null}
+        onClose={handleCloseRecoveryCodes}
+        size="2xl"
+      >
+        <DialogTitle>
+          <Trans>Store your recovery codes now</Trans>
+        </DialogTitle>
+        <DialogDescription>
+          <Trans>
+            These codes are shown only once. Store them securely before closing
+            this dialog.
+          </Trans>
+        </DialogDescription>
+
+        <DialogBody>
+          {revealedRecoveryCodes ? (
+            <div className="space-y-6">
+              <div className="rounded-2xl border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-900/20">
+                <Text className="text-sm text-amber-800 dark:text-amber-200">
+                  <Trans>
+                    Anyone with one of these recovery codes can bypass your
+                    authenticator app once. Do not store them in chat, email, or
+                    screenshots.
+                  </Trans>
+                </Text>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2">
+                {revealedRecoveryCodes.codes.map((code) => (
+                  <code
+                    key={code}
+                    className="rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm tracking-[0.18em] text-zinc-900 dark:border-zinc-800 dark:bg-zinc-900/60 dark:text-white"
+                  >
+                    {code}
+                  </code>
+                ))}
+              </div>
+
+              <label className="flex items-start gap-3 rounded-2xl border border-zinc-200 bg-white px-4 py-3 text-sm text-zinc-900 dark:border-zinc-800 dark:bg-zinc-900/60 dark:text-white">
+                <input
+                  type="checkbox"
+                  checked={hasAcknowledgedRecoveryCodes}
+                  onChange={(event) =>
+                    setHasAcknowledgedRecoveryCodes(event.target.checked)
+                  }
+                  className="mt-1"
+                />
+                <span>
+                  <Trans>
+                    I stored these recovery codes securely and understand they
+                    will not be shown again.
+                  </Trans>
+                </span>
+              </label>
+
+              <DialogActions>
+                <Button
+                  color="blue"
+                  onClick={handleCloseRecoveryCodes}
+                  disabled={!hasAcknowledgedRecoveryCodes}
+                >
+                  <Trans>Done</Trans>
+                </Button>
+              </DialogActions>
+            </div>
+          ) : null}
+        </DialogBody>
+      </Dialog>
+
+      <Dialog
+        open={sensitiveAction !== null}
+        onClose={() => {
+          if (!isSubmittingSensitiveAction) {
+            setSensitiveAction(null);
+            setSensitiveCode("");
+            setSensitiveError(null);
+          }
+        }}
+      >
+        <DialogTitle>{sensitiveActionLabels.title}</DialogTitle>
+        <DialogDescription>
+          {sensitiveActionLabels.description}
+        </DialogDescription>
+
+        <DialogBody>
+          {sensitiveAction ? (
+            <form className="space-y-6" onSubmit={handleSensitiveActionSubmit}>
+              <fieldset className="space-y-3">
+                <legend className="text-sm font-medium text-zinc-950 dark:text-white">
+                  <Trans>Verification method</Trans>
+                </legend>
+
+                {(["totp", "recovery_code"] as const).map((method) => (
+                  <label
+                    key={method}
+                    className="flex cursor-default items-start gap-3 rounded-2xl border border-zinc-200 bg-white px-4 py-3 text-sm text-zinc-900 dark:border-zinc-800 dark:bg-zinc-900/60 dark:text-white"
+                  >
+                    <input
+                      type="radio"
+                      name="sensitive-mfa-method"
+                      value={method}
+                      checked={sensitiveMethod === method}
+                      onChange={() => setSensitiveMethod(method)}
+                      disabled={isSubmittingSensitiveAction}
+                      className="mt-1"
+                    />
+                    <span>
+                      {method === "totp" ? (
+                        <Trans>Authenticator code</Trans>
+                      ) : (
+                        <Trans>Recovery code</Trans>
+                      )}
+                    </span>
+                  </label>
+                ))}
+              </fieldset>
+
+              <Field>
+                <Label htmlFor="sensitive-mfa-code">
+                  {sensitiveMethod === "totp" ? (
+                    <Trans>Authenticator code</Trans>
+                  ) : (
+                    <Trans>Recovery code</Trans>
+                  )}
+                </Label>
+                <Input
+                  id="sensitive-mfa-code"
+                  name="sensitive-mfa-code"
+                  type="text"
+                  autoComplete="one-time-code"
+                  required
+                  value={sensitiveCode}
+                  onChange={(event) => setSensitiveCode(event.target.value)}
+                  placeholder={
+                    sensitiveMethod === "totp" ? "123456" : "B6F4-2Q8P"
+                  }
+                  disabled={isSubmittingSensitiveAction}
+                />
+                {sensitiveError ? (
+                  <ErrorMessage>{sensitiveError}</ErrorMessage>
+                ) : null}
+              </Field>
+
+              <DialogActions>
+                <Button
+                  type="button"
+                  outline
+                  onClick={() => {
+                    setSensitiveAction(null);
+                    setSensitiveCode("");
+                    setSensitiveError(null);
+                  }}
+                  disabled={isSubmittingSensitiveAction}
+                >
+                  <Trans>Cancel</Trans>
+                </Button>
+                <Button
+                  type="submit"
+                  color={sensitiveAction === "disable" ? "red" : "blue"}
+                  disabled={
+                    isSubmittingSensitiveAction ||
+                    sensitiveCode.trim().length === 0
+                  }
+                  aria-busy={isSubmittingSensitiveAction}
+                >
+                  {isSubmittingSensitiveAction ? (
+                    <Trans>Processing...</Trans>
+                  ) : (
+                    sensitiveActionLabels.submit
+                  )}
+                </Button>
+              </DialogActions>
+            </form>
+          ) : null}
+        </DialogBody>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show the current MFA status on the settings page
- add recovery-code regeneration and MFA disable flows with verification dialogs
- cover the new settings actions with focused page tests

## Testing
- npx prettier --check CHANGELOG.md src/pages/Settings/SettingsPage.tsx src/pages/Settings/SettingsPage.test.tsx
- npx eslint src/pages/Settings/SettingsPage.tsx src/pages/Settings/SettingsPage.test.tsx
- npx tsc --noEmit -p tsconfig.json
- npx vitest run src/pages/Settings/SettingsPage.test.tsx