### PR TITLE
test: align auth fixture domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Replaced the remaining `@secpal.app` auth-service test fixture emails in `authState.test.ts` and `authTransport.test.ts` with `@secpal.dev` so those tests follow the repository domain policy for non-production addresses.
 - Aligned repo-local domain governance and validation with the renamed Android application identifier `app.secpal`, removing the old identifier-only exception from current policy text.
 - Replaced the raw backend `Server Error` text on login failures with a controlled temporary-unavailable message when the login API returns a `5xx`, so browser and PWA users no longer see the uncaught backend error string on the live login screen.
 - Replaced the remaining hand-written frontend auth response shapes with contract-aligned auth and MFA types under `@/types/api`, extended the auth API client to cover login MFA challenges plus the backend self-service MFA endpoints needed by the upcoming UI slices, updated the browser-session auth transport to surface the discriminated `authenticated | mfa_required` result, and added full unit coverage for all new API client methods and transport branches.

--- a/src/services/authState.test.ts
+++ b/src/services/authState.test.ts
@@ -31,7 +31,7 @@ describe("authState", () => {
     const sanitizedUser = sanitizeAuthUser({
       id: 1,
       name: "Test User",
-      email: "test@secpal.app",
+      email: "test@secpal.dev",
       employee: {
         management_level: 7,
       },
@@ -40,7 +40,7 @@ describe("authState", () => {
     expect(sanitizedUser).toEqual({
       id: "1",
       name: "Test User",
-      email: "test@secpal.app",
+      email: "test@secpal.dev",
       employee: {
         management_level: 7,
       },
@@ -51,7 +51,7 @@ describe("authState", () => {
     const sanitizedUser = sanitizePersistedAuthUser({
       id: 1,
       name: "Test User",
-      email: "test@secpal.app",
+      email: "test@secpal.dev",
       employee: {
         management_level: 7,
         personnel_number: "EMP-12345",
@@ -61,7 +61,7 @@ describe("authState", () => {
     expect(sanitizedUser).toEqual({
       id: "1",
       name: "Test User",
-      email: "test@secpal.app",
+      email: "test@secpal.dev",
     });
     expect(sanitizedUser).not.toHaveProperty("employee");
   });

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -52,7 +52,7 @@ describe("authTransport", () => {
       user: {
         id: 1,
         name: "Browser User",
-        email: "browser@secpal.app",
+        email: "browser@secpal.dev",
         roles: ["Admin"],
         token: "should-not-leak",
       },
@@ -60,13 +60,13 @@ describe("authTransport", () => {
 
     const transport = getAuthTransport();
     const result = await transport.login({
-      email: "browser@secpal.app",
+      email: "browser@secpal.dev",
       password: "password123",
     });
 
     expect(transport.kind).toBe("browser-session");
     expect(mockBrowserLogin).toHaveBeenCalledWith({
-      email: "browser@secpal.app",
+      email: "browser@secpal.dev",
       password: "password123",
     });
     expect(result).toEqual({
@@ -74,7 +74,7 @@ describe("authTransport", () => {
       user: {
         id: "1",
         name: "Browser User",
-        email: "browser@secpal.app",
+        email: "browser@secpal.dev",
         roles: ["Admin"],
       },
     });
@@ -158,7 +158,7 @@ describe("authTransport", () => {
         user: {
           id: 7,
           name: "Native User",
-          email: "native@secpal.app",
+          email: "native@secpal.dev",
           permissions: ["profile.read"],
           token: "native-secret",
           refreshToken: "native-refresh-secret",
@@ -169,7 +169,7 @@ describe("authTransport", () => {
       getCurrentUser: vi.fn().mockResolvedValue({
         id: 7,
         name: "Native User",
-        email: "native@secpal.app",
+        email: "native@secpal.dev",
         permissions: ["profile.read"],
         token: "native-secret",
       }),
@@ -178,14 +178,14 @@ describe("authTransport", () => {
 
     const transport = resolveAuthTransport({ nativeBridge });
     const loginResult = await transport.login({
-      email: "native@secpal.app",
+      email: "native@secpal.dev",
       password: "password123",
     });
     const currentUser = await transport.getCurrentUser();
 
     expect(transport.kind).toBe("native-bridge");
     expect(nativeBridge.login).toHaveBeenCalledWith({
-      email: "native@secpal.app",
+      email: "native@secpal.dev",
       password: "password123",
     });
     expect(mockBrowserLogin).not.toHaveBeenCalled();
@@ -194,7 +194,7 @@ describe("authTransport", () => {
       user: {
         id: "7",
         name: "Native User",
-        email: "native@secpal.app",
+        email: "native@secpal.dev",
         permissions: ["profile.read"],
       },
     });
@@ -205,7 +205,7 @@ describe("authTransport", () => {
     expect(currentUser).toEqual({
       id: "7",
       name: "Native User",
-      email: "native@secpal.app",
+      email: "native@secpal.dev",
       permissions: ["profile.read"],
     });
     expect(currentUser).not.toHaveProperty("token");
@@ -257,7 +257,7 @@ describe("authTransport", () => {
 
     await expect(
       transport.login({
-        email: "native@secpal.app",
+        email: "native@secpal.dev",
         password: "password123",
       })
     ).rejects.toThrow(
@@ -302,7 +302,7 @@ describe("authTransport", () => {
     mockBrowserGetCurrentUser.mockResolvedValueOnce({
       id: 2,
       name: "Session User",
-      email: "session@secpal.app",
+      email: "session@secpal.dev",
       roles: ["Viewer"],
       token: "should-not-leak",
     });
@@ -314,7 +314,7 @@ describe("authTransport", () => {
     expect(user).toEqual({
       id: "2",
       name: "Session User",
-      email: "session@secpal.app",
+      email: "session@secpal.dev",
       roles: ["Viewer"],
     });
     expect(user).not.toHaveProperty("token");


### PR DESCRIPTION
## Summary
- replace the remaining @secpal.app auth-service test fixture emails with @secpal.dev
- keep the change scoped to authState and authTransport service tests
- record the domain-policy cleanup in the changelog

Closes #672