### PR TITLE
docs: correct HKDF info parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Corrected the HKDF key-derivation documentation so `CRYPTO_ARCHITECTURE.md` matches the shipped frontend crypto code, which uses an empty HKDF `info` parameter for attachment file keys.
 - Replaced the remaining `@secpal.app` auth-service test fixture emails in `authState.test.ts` and `authTransport.test.ts` with `@secpal.dev` so those tests follow the repository domain policy for non-production addresses.
 - Aligned repo-local domain governance and validation with the renamed Android application identifier `app.secpal`, removing the old identifier-only exception from current policy text.
 - Replaced the raw backend `Server Error` text on login failures with a controlled temporary-unavailable message when the login API returns a `5xx`, so browser and PWA users no longer see the uncaught backend error string on the live login screen.

--- a/docs/CRYPTO_ARCHITECTURE.md
+++ b/docs/CRYPTO_ARCHITECTURE.md
@@ -509,6 +509,7 @@ const checksum = await calculateChecksum(fileData);
 For security issues or vulnerabilities, please report to:
 
 **Email:** <security@secpal.app>
+
 **PGP Key:** TBD (will be published on keys.openpgp.org)
 
 **Please DO NOT open public GitHub issues for security vulnerabilities.**---

--- a/docs/CRYPTO_ARCHITECTURE.md
+++ b/docs/CRYPTO_ARCHITECTURE.md
@@ -512,7 +512,9 @@ For security issues or vulnerabilities, please report to:
 
 **PGP Key:** TBD (will be published on keys.openpgp.org)
 
-**Please DO NOT open public GitHub issues for security vulnerabilities.**---
+**Please DO NOT open public GitHub issues for security vulnerabilities.**
+
+---
 
 **Document Version:** 1.0
 **Last Updated:** 2025-11-21

--- a/docs/CRYPTO_ARCHITECTURE.md
+++ b/docs/CRYPTO_ARCHITECTURE.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2026 SecPal
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
@@ -31,7 +31,7 @@ Encrypted File Blob
 2. **File Encryption Key**: Derived using HKDF-SHA-256:
    - Input: Secret's master key (32 bytes)
    - Salt: Filename as UTF-8 bytes
-   - Info: "file-encryption" string
+   - Info: Empty byte string (`new Uint8Array(0)`)
    - Output: 256-bit key for AES-GCM
 
 **Why HKDF?**
@@ -508,7 +508,7 @@ const checksum = await calculateChecksum(fileData);
 
 For security issues or vulnerabilities, please report to:
 
-**Email:** <security@secpal.app>  
+**Email:** <security@secpal.app>
 **PGP Key:** TBD (will be published on keys.openpgp.org)
 
 **Please DO NOT open public GitHub issues for security vulnerabilities.**---


### PR DESCRIPTION
## Summary
- correct the HKDF key-derivation documentation to match the shipped frontend crypto implementation
- update the edited document's SPDX year while touching the file
- record the documentation fix in the changelog

Closes #684