### PR TITLE
docs: scope zero-knowledge claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Scoped the frontend zero-knowledge documentation to attachment contents only, clarifying in `README.md` and `CRYPTO_ARCHITECTURE.md` that broader application data uses server-side encryption at rest and that file metadata is still visible to the server.
 - Corrected the HKDF key-derivation documentation so `CRYPTO_ARCHITECTURE.md` matches the shipped frontend crypto code, which uses an empty HKDF `info` parameter for attachment file keys.
 - Replaced the remaining `@secpal.app` auth-service test fixture emails in `authState.test.ts` and `authTransport.test.ts` with `@secpal.dev` so those tests follow the repository domain policy for non-production addresses.
 - Aligned repo-local domain governance and validation with the renamed Android application identifier `app.secpal`, removing the old identifier-only exception from current policy text.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Scoped the frontend zero-knowledge documentation to attachment contents only, clarifying in `README.md` and `CRYPTO_ARCHITECTURE.md` that broader application data uses server-side encryption at rest and that file metadata is still visible to the server.
+- Scoped the frontend zero-knowledge documentation to attachment contents only, clarifying in `README.md` and `docs/CRYPTO_ARCHITECTURE.md` that broader application data uses server-side encryption at rest and that file metadata is still visible to the server.
 - Corrected the HKDF key-derivation documentation so `CRYPTO_ARCHITECTURE.md` matches the shipped frontend crypto code, which uses an empty HKDF `info` parameter for attachment file keys.
 - Replaced the remaining `@secpal.app` auth-service test fixture emails in `authState.test.ts` and `authTransport.test.ts` with `@secpal.dev` so those tests follow the repository domain policy for non-production addresses.
 - Aligned repo-local domain governance and validation with the renamed Android application identifier `app.secpal`, removing the old identifier-only exception from current policy text.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Employee and tenant data outside attachment contents use server-side encryption 
 
 **Key Features:**
 
-- 🔒 **Zero-Knowledge Architecture**: Backend cannot decrypt files
 - 🔒 **Zero-Knowledge File Contents**: Backend cannot decrypt attachment contents
 - 🔑 **AES-GCM-256**: Industry-standard authenticated encryption
 - 🧬 **HKDF-SHA-256**: Secure key derivation per file

--- a/README.md
+++ b/README.md
@@ -62,11 +62,14 @@ See [PWA_PHASE3_TESTING.md](PWA_PHASE3_TESTING.md) for comprehensive testing gui
 
 ## 🔐 Client-Side File Encryption
 
-SecPal implements **end-to-end client-side file encryption** using the Web Crypto API with **AES-GCM-256**. Files are encrypted on the client before upload, ensuring a **zero-knowledge architecture** where the backend cannot decrypt file contents.
+SecPal implements **end-to-end client-side file encryption** for file attachments using the Web Crypto API with **AES-GCM-256**. Attachment contents are encrypted on the client before upload, giving those files a **zero-knowledge** path where the backend cannot decrypt file contents.
+
+Employee and tenant data outside attachment contents use server-side encryption at rest, not zero-knowledge encryption, and attachment metadata such as filenames and sizes remains visible to the server.
 
 **Key Features:**
 
 - 🔒 **Zero-Knowledge Architecture**: Backend cannot decrypt files
+- 🔒 **Zero-Knowledge File Contents**: Backend cannot decrypt attachment contents
 - 🔑 **AES-GCM-256**: Industry-standard authenticated encryption
 - 🧬 **HKDF-SHA-256**: Secure key derivation per file
 - ✅ **Integrity Verification**: SHA-256 checksums detect tampering

--- a/docs/CRYPTO_ARCHITECTURE.md
+++ b/docs/CRYPTO_ARCHITECTURE.md
@@ -7,7 +7,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 ## 📋 Overview
 
-SecPal implements **end-to-end client-side file encryption** for attachments using the Web Crypto API with **AES-GCM-256**. This ensures a **zero-knowledge architecture** where the backend server cannot decrypt file contents.
+SecPal implements **end-to-end client-side file encryption** for attachments using the Web Crypto API with **AES-GCM-256**. Attachment contents follow a **zero-knowledge** path where the backend server cannot decrypt file contents.
+
+This zero-knowledge property applies only to attachment contents. Other application data is encrypted at rest on the server with server-held keys, and attachment metadata such as filenames and sizes is not encrypted.
 
 **Key Principle:** Files are encrypted on the client before upload and can only be decrypted by authorized users with access to the Secret's master key.
 


### PR DESCRIPTION
## Summary
- scope the zero-knowledge wording in the frontend docs to attachment contents only
- clarify that broader application data uses server-side encryption at rest and that file metadata remains visible to the server
- record the documentation clarification in the changelog

Closes #685