### PR TITLE
fix(ui): remove stacked layout inset frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Removed the inset desktop content frame beneath the top navigation so the page surface now spans edge to edge without the previous side and bottom border effect.
 - Clarified the repo-local branch-start and post-merge readiness workflow so new frontend work must start from a clean, updated local `main`, and post-merge cleanup now explicitly returns the repo to `main`, refreshes dependencies with `npm ci` where applicable, runs `npm run build` when available, and confirms a clean working tree
 - Added a dedicated email-verification gate for protected routes, wired it to the backend resend-verification endpoint, and stopped surfacing the raw backend `Your email address is not verified.` error inside arbitrary app pages after login.
 - Restored explicit repo-local Copilot governance by making TDD-first, quality-first, one-topic-per-PR, immediate issue creation for out-of-scope findings, and EPIC-plus-sub-issue requirements always-on again; the frontend runtime overlay now auto-loads repo-wide so these rules remain present while working

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -22,9 +22,9 @@ const QUERY_TIMEOUT = 15000;
 // Mock ResizeObserver for HeadlessUI Menu component
 beforeAll(() => {
   global.ResizeObserver = class ResizeObserver {
-    observe() { }
-    unobserve() { }
-    disconnect() { }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
   };
 });
 
@@ -337,7 +337,7 @@ describe("ApplicationLayout", () => {
 
       const consoleSpy = vi
         .spyOn(console, "error")
-        .mockImplementation(() => { });
+        .mockImplementation(() => {});
 
       renderWithProviders(
         <ApplicationLayout>

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -22,9 +22,9 @@ const QUERY_TIMEOUT = 15000;
 // Mock ResizeObserver for HeadlessUI Menu component
 beforeAll(() => {
   global.ResizeObserver = class ResizeObserver {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
+    observe() { }
+    unobserve() { }
+    disconnect() { }
   };
 });
 
@@ -104,6 +104,25 @@ describe("ApplicationLayout", () => {
 
       expect(screen.getByTestId("test-content")).toBeInTheDocument();
       expect(screen.getByText("Test Content")).toBeInTheDocument();
+    });
+
+    it("renders the desktop content surface without an inset frame", () => {
+      renderWithProviders(
+        <ApplicationLayout>
+          <div>Content</div>
+        </ApplicationLayout>
+      );
+
+      const main = screen.getByRole("main");
+      expect(main).not.toHaveClass("pb-2");
+      expect(main.className).not.toContain("lg:px-2");
+
+      const contentSurface = main.firstElementChild as HTMLDivElement | null;
+
+      expect(contentSurface).not.toBeNull();
+      expect(contentSurface?.className).not.toContain("lg:rounded-lg");
+      expect(contentSurface?.className).not.toContain("lg:shadow-xs");
+      expect(contentSurface?.className).not.toContain("lg:ring-1");
     });
 
     it("renders navigation links", () => {
@@ -318,7 +337,7 @@ describe("ApplicationLayout", () => {
 
       const consoleSpy = vi
         .spyOn(console, "error")
-        .mockImplementation(() => {});
+        .mockImplementation(() => { });
 
       renderWithProviders(
         <ApplicationLayout>

--- a/src/components/stacked-layout.tsx
+++ b/src/components/stacked-layout.tsx
@@ -83,8 +83,8 @@ export function StackedLayout({
       </header>
 
       {/* Content */}
-      <main className="flex flex-1 flex-col pb-2 lg:px-2">
-        <div className="flex flex-col flex-1 bg-white lg:rounded-lg lg:shadow-xs lg:ring-1 lg:ring-zinc-950/5 dark:bg-zinc-900 dark:lg:ring-white/10">
+      <main className="flex flex-1 flex-col">
+        <div className="flex flex-col flex-1 bg-white dark:bg-zinc-900">
           <div className="grow p-6 lg:p-10">
             <div className="mx-auto max-w-6xl">{children}</div>
           </div>


### PR DESCRIPTION
## Summary
- remove the inset desktop content frame from the stacked layout so the surface flows directly below the top navigation
- add a regression test that prevents the stacked layout from reintroducing the desktop inset card classes
- document the UI change in the frontend changelog

## Validation
- npx vitest run src/components/application-layout.test.tsx
- npm run typecheck
- npx eslint src/components/application-layout.test.tsx src/components/stacked-layout.tsx

## Review
- local 4-pass self-review completed with no findings
- no out-of-scope follow-up issues were identified for this change
