### PR TITLE
feat: finish MFA enrollment settings flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the missing MFA enrollment slice to the settings page so disabled accounts can start TOTP setup, scan a QR code or use the manual setup key, confirm the authenticator code, and immediately receive one-time recovery codes.
 - Added a reusable MFA QR-code component with browser-safe fallback messaging and focused component coverage so upcoming enrollment UI slices can render authenticator setup material without duplicating QR generation logic.
 - Added PWA offline persistence security and privacy [audit document](PWA_OFFLINE_PERSISTENCE_AUDIT.md) covering all client-side storage mechanisms (localStorage, sessionStorage, IndexedDB, Cache API, Service Worker state) with 10 findings, issue overlap analysis, and prioritized remediation recommendations.
 - Added a platform-aware frontend auth transport boundary that keeps browser/PWA flows on Sanctum session auth, sanitizes auth state before it enters React or local storage, and creates the explicit seam Android can later wire to a native bearer-token bridge without exposing raw tokens to JavaScript.

--- a/src/pages/Settings/SettingsPage.test.tsx
+++ b/src/pages/Settings/SettingsPage.test.tsx
@@ -321,6 +321,50 @@ describe("SettingsPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows enrollment preparation error and retries on demand", async () => {
+    vi.mocked(authApi.startTotpEnrollment)
+      .mockRejectedValueOnce(new Error("Service unavailable"))
+      .mockResolvedValueOnce(createTotpEnrollmentPreparationResponse());
+
+    renderWithProviders(<SettingsPage />);
+
+    await screen.findByText(/not enabled/i);
+    fireEvent.click(screen.getByRole("button", { name: /set up mfa/i }));
+
+    expect(
+      await screen.findByText(/service unavailable/i)
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(
+      await screen.findByRole("heading", { name: /set up mfa/i })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("mfa-qr-code")).toBeInTheDocument();
+  });
+
+  it("cancels the enrollment dialog without submitting", async () => {
+    vi.mocked(authApi.startTotpEnrollment).mockResolvedValueOnce(
+      createTotpEnrollmentPreparationResponse()
+    );
+
+    renderWithProviders(<SettingsPage />);
+
+    await screen.findByText(/not enabled/i);
+    fireEvent.click(screen.getByRole("button", { name: /set up mfa/i }));
+
+    await screen.findByRole("heading", { name: /set up mfa/i });
+
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("heading", { name: /set up mfa/i })
+      ).not.toBeInTheDocument();
+    });
+    expect(authApi.confirmTotpEnrollment).not.toHaveBeenCalled();
+  });
+
   it("disables MFA after code confirmation", async () => {
     vi.mocked(authApi.getMfaStatus).mockResolvedValueOnce(
       createEnabledMfaStatusResponse()

--- a/src/pages/Settings/SettingsPage.test.tsx
+++ b/src/pages/Settings/SettingsPage.test.tsx
@@ -331,9 +331,7 @@ describe("SettingsPage", () => {
     await screen.findByText(/not enabled/i);
     fireEvent.click(screen.getByRole("button", { name: /set up mfa/i }));
 
-    expect(
-      await screen.findByText(/service unavailable/i)
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/service unavailable/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /try again/i }));
 

--- a/src/pages/Settings/SettingsPage.test.tsx
+++ b/src/pages/Settings/SettingsPage.test.tsx
@@ -10,6 +10,14 @@ import { SettingsPage } from "./SettingsPage";
 import * as i18nModule from "../../i18n";
 import * as authApi from "../../services/authApi";
 
+vi.mock("../../components/MfaQrCode", () => ({
+  MfaQrCode: ({ value, alt }: { value: string; alt: string }) => (
+    <div data-testid="mfa-qr-code" aria-label={alt}>
+      {value}
+    </div>
+  ),
+}));
+
 // Mock the i18n module
 vi.mock("../../i18n", async () => {
   const actual = await vi.importActual("../../i18n");
@@ -26,6 +34,8 @@ vi.mock("../../services/authApi", async () => {
   return {
     ...actual,
     getMfaStatus: vi.fn(),
+    startTotpEnrollment: vi.fn(),
+    confirmTotpEnrollment: vi.fn(),
     regenerateRecoveryCodes: vi.fn(),
     disableMfa: vi.fn(),
   };
@@ -86,6 +96,19 @@ function createRecoveryRevealResponse() {
         ],
         generated_at: "2026-04-01T09:12:00Z",
       },
+    },
+  };
+}
+
+function createTotpEnrollmentPreparationResponse() {
+  return {
+    data: {
+      issuer: "SecPal",
+      account_name: "mfa@secpal.dev",
+      manual_entry_key: "JBSWY3DPEHPK3PXP",
+      otpauth_uri:
+        "otpauth://totp/SecPal:mfa@secpal.dev?secret=JBSWY3DPEHPK3PXP&issuer=SecPal",
+      expires_at: "2026-04-05T12:30:00Z",
     },
   };
 }
@@ -203,6 +226,98 @@ describe("SettingsPage", () => {
       await screen.findByRole("heading", {
         name: /store your recovery codes now/i,
       })
+    ).toBeInTheDocument();
+  });
+
+  it("starts MFA enrollment for a disabled account and shows QR plus manual setup details", async () => {
+    vi.mocked(authApi.startTotpEnrollment).mockResolvedValueOnce(
+      createTotpEnrollmentPreparationResponse()
+    );
+
+    renderWithProviders(<SettingsPage />);
+
+    await screen.findByText(/not enabled/i);
+    fireEvent.click(screen.getByRole("button", { name: /set up mfa/i }));
+
+    await waitFor(() => {
+      expect(authApi.startTotpEnrollment).toHaveBeenCalledTimes(1);
+    });
+
+    expect(
+      await screen.findByRole("heading", { name: /set up mfa/i })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("mfa-qr-code")).toHaveTextContent(
+      /otpauth:\/\/totp/i
+    );
+    expect(screen.getByText(/manual setup key/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/jbswy3dpehpk3pxp/i)).toHaveLength(2);
+  });
+
+  it("confirms MFA enrollment and reveals recovery codes", async () => {
+    vi.mocked(authApi.startTotpEnrollment).mockResolvedValueOnce(
+      createTotpEnrollmentPreparationResponse()
+    );
+    vi.mocked(authApi.confirmTotpEnrollment).mockResolvedValueOnce(
+      createRecoveryRevealResponse()
+    );
+
+    renderWithProviders(<SettingsPage />);
+
+    await screen.findByText(/not enabled/i);
+    fireEvent.click(screen.getByRole("button", { name: /set up mfa/i }));
+
+    await screen.findByRole("heading", { name: /set up mfa/i });
+
+    fireEvent.change(
+      screen.getByRole("textbox", { name: /authenticator code/i }),
+      {
+        target: { value: "123456" },
+      }
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /confirm and enable mfa/i })
+    );
+
+    await waitFor(() => {
+      expect(authApi.confirmTotpEnrollment).toHaveBeenCalledWith({
+        code: "123456",
+      });
+    });
+
+    expect(
+      await screen.findByRole("heading", {
+        name: /store your recovery codes now/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("shows inline error when MFA enrollment confirmation fails", async () => {
+    vi.mocked(authApi.startTotpEnrollment).mockResolvedValueOnce(
+      createTotpEnrollmentPreparationResponse()
+    );
+    vi.mocked(authApi.confirmTotpEnrollment).mockRejectedValueOnce(
+      new Error("Invalid authenticator code")
+    );
+
+    renderWithProviders(<SettingsPage />);
+
+    await screen.findByText(/not enabled/i);
+    fireEvent.click(screen.getByRole("button", { name: /set up mfa/i }));
+
+    await screen.findByRole("heading", { name: /set up mfa/i });
+
+    fireEvent.change(
+      screen.getByRole("textbox", { name: /authenticator code/i }),
+      {
+        target: { value: "000000" },
+      }
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /confirm and enable mfa/i })
+    );
+
+    expect(
+      await screen.findByText(/invalid authenticator code/i)
     ).toBeInTheDocument();
   });
 

--- a/src/pages/Settings/SettingsPage.tsx
+++ b/src/pages/Settings/SettingsPage.tsx
@@ -13,6 +13,7 @@ import { Trans } from "@lingui/macro";
 import type {
   MfaRecoveryCodeReveal,
   MfaStatus,
+  TotpEnrollmentPreparation,
   MfaVerificationMethod,
 } from "@/types/api";
 import { Heading } from "../../components/heading";
@@ -36,10 +37,13 @@ import {
 } from "../../components/description-list";
 import {
   AuthApiError,
+  confirmTotpEnrollment,
   disableMfa,
   getMfaStatus,
   regenerateRecoveryCodes,
+  startTotpEnrollment,
 } from "../../services/authApi";
+import { MfaQrCode } from "../../components/MfaQrCode";
 
 type SensitiveMfaAction = "disable" | "regenerate";
 
@@ -89,6 +93,15 @@ export function SettingsPage() {
   const [mfaStatus, setMfaStatus] = useState<MfaStatus | null>(null);
   const [isLoadingMfaStatus, setIsLoadingMfaStatus] = useState(true);
   const [mfaStatusError, setMfaStatusError] = useState<string | null>(null);
+  const [isEnrollmentDialogOpen, setIsEnrollmentDialogOpen] = useState(false);
+  const [isPreparingEnrollment, setIsPreparingEnrollment] = useState(false);
+  const [enrollmentPreparation, setEnrollmentPreparation] =
+    useState<TotpEnrollmentPreparation | null>(null);
+  const [enrollmentPreparationError, setEnrollmentPreparationError] =
+    useState<string | null>(null);
+  const [enrollmentCode, setEnrollmentCode] = useState("");
+  const [enrollmentCodeError, setEnrollmentCodeError] = useState<string | null>(null);
+  const [isSubmittingEnrollment, setIsSubmittingEnrollment] = useState(false);
   const [revealedRecoveryCodes, setRevealedRecoveryCodes] =
     useState<MfaRecoveryCodeReveal | null>(null);
   const [hasAcknowledgedRecoveryCodes, setHasAcknowledgedRecoveryCodes] =
@@ -130,6 +143,80 @@ export function SettingsPage() {
   useEffect(() => {
     void loadMfaStatus();
   }, [loadMfaStatus]);
+
+  const loadEnrollmentPreparation = useCallback(async () => {
+    setIsPreparingEnrollment(true);
+    setEnrollmentPreparationError(null);
+    setEnrollmentCodeError(null);
+
+    try {
+      const response = await startTotpEnrollment();
+      setEnrollmentPreparation(response.data);
+    } catch (error) {
+      setEnrollmentPreparation(null);
+
+      if (error instanceof AuthApiError) {
+        setEnrollmentPreparationError(error.message);
+      } else if (error instanceof Error) {
+        setEnrollmentPreparationError(error.message);
+      } else {
+        setEnrollmentPreparationError("Failed to prepare MFA enrollment.");
+      }
+    } finally {
+      setIsPreparingEnrollment(false);
+    }
+  }, []);
+
+  const handleOpenEnrollment = () => {
+    setIsEnrollmentDialogOpen(true);
+    setEnrollmentPreparation(null);
+    setEnrollmentPreparationError(null);
+    setEnrollmentCode("");
+    setEnrollmentCodeError(null);
+    void loadEnrollmentPreparation();
+  };
+
+  const handleCloseEnrollment = () => {
+    if (isPreparingEnrollment || isSubmittingEnrollment) {
+      return;
+    }
+
+    setIsEnrollmentDialogOpen(false);
+    setEnrollmentPreparation(null);
+    setEnrollmentPreparationError(null);
+    setEnrollmentCode("");
+    setEnrollmentCodeError(null);
+  };
+
+  const handleEnrollmentSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+
+    setEnrollmentCodeError(null);
+    setIsSubmittingEnrollment(true);
+
+    try {
+      const response = await confirmTotpEnrollment({
+        code: enrollmentCode.trim(),
+      });
+
+      setMfaStatus(response.data.status);
+      setIsEnrollmentDialogOpen(false);
+      setEnrollmentPreparation(null);
+      setEnrollmentCode("");
+      setRevealedRecoveryCodes(response.data.recovery_codes);
+      setHasAcknowledgedRecoveryCodes(false);
+    } catch (error) {
+      if (error instanceof AuthApiError) {
+        setEnrollmentCodeError(error.message);
+      } else if (error instanceof Error) {
+        setEnrollmentCodeError(error.message);
+      } else {
+        setEnrollmentCodeError("Failed to confirm MFA enrollment.");
+      }
+    } finally {
+      setIsSubmittingEnrollment(false);
+    }
+  };
 
   const handleSensitiveActionSubmit = async (event: FormEvent) => {
     event.preventDefault();
@@ -265,12 +352,18 @@ export function SettingsPage() {
                   </Button>
                 </div>
               ) : (
-                <Text className="text-sm text-zinc-600 dark:text-zinc-300">
-                  <Trans>
-                    MFA is currently off for this account. Enrollment support
-                    follows in the next rollout slice.
-                  </Trans>
-                </Text>
+                <div className="space-y-4">
+                  <Text className="text-sm text-zinc-600 dark:text-zinc-300">
+                    <Trans>
+                      MFA is currently off for this account. Set up an
+                      authenticator app now to require a second factor at sign
+                      in.
+                    </Trans>
+                  </Text>
+                  <Button color="blue" onClick={handleOpenEnrollment}>
+                    <Trans>Set up MFA</Trans>
+                  </Button>
+                </div>
               )}
             </div>
           )}
@@ -361,6 +454,112 @@ export function SettingsPage() {
                 </Button>
               </DialogActions>
             </div>
+          ) : null}
+        </DialogBody>
+      </Dialog>
+
+      <Dialog open={isEnrollmentDialogOpen} onClose={handleCloseEnrollment} size="2xl">
+        <DialogTitle>
+          <Trans>Set up MFA</Trans>
+        </DialogTitle>
+        <DialogDescription>
+          <Trans>
+            Scan this QR code with your authenticator app, or enter the setup
+            key manually, then confirm the current code to enable MFA.
+          </Trans>
+        </DialogDescription>
+
+        <DialogBody>
+          {isPreparingEnrollment ? (
+            <Text className="text-sm text-zinc-500 dark:text-zinc-400">
+              <Trans>Preparing MFA setup...</Trans>
+            </Text>
+          ) : enrollmentPreparationError ? (
+            <div className="space-y-6">
+              <div className="rounded-2xl border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">
+                <Text className="text-sm text-red-800 dark:text-red-200">
+                  {enrollmentPreparationError}
+                </Text>
+              </div>
+
+              <DialogActions>
+                <Button type="button" outline onClick={handleCloseEnrollment}>
+                  <Trans>Cancel</Trans>
+                </Button>
+                <Button type="button" color="blue" onClick={() => void loadEnrollmentPreparation()}>
+                  <Trans>Try again</Trans>
+                </Button>
+              </DialogActions>
+            </div>
+          ) : enrollmentPreparation ? (
+            <form className="space-y-6" onSubmit={handleEnrollmentSubmit}>
+              <MfaQrCode
+                value={enrollmentPreparation.otpauth_uri}
+                alt="Authenticator app QR code"
+              />
+
+              <div className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-800 dark:bg-zinc-900/60">
+                <Text className="text-sm text-zinc-700 dark:text-zinc-300">
+                  <Trans>Manual setup key</Trans>
+                </Text>
+                <code className="mt-3 block break-all rounded-xl border border-zinc-200 bg-white px-4 py-3 text-sm tracking-[0.18em] text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950 dark:text-white">
+                  {enrollmentPreparation.manual_entry_key}
+                </code>
+              </div>
+
+              <div className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-800 dark:bg-zinc-900/60">
+                <Text className="text-sm text-zinc-700 dark:text-zinc-300">
+                  <Trans>
+                    This setup expires at {enrollmentPreparation.expires_at}.
+                  </Trans>
+                </Text>
+              </div>
+
+              <Field>
+                <Label htmlFor="enrollment-code">
+                  <Trans>Authenticator code</Trans>
+                </Label>
+                <Input
+                  id="enrollment-code"
+                  name="enrollment-code"
+                  type="text"
+                  autoComplete="one-time-code"
+                  required
+                  value={enrollmentCode}
+                  onChange={(event) => setEnrollmentCode(event.target.value)}
+                  placeholder="123456"
+                  disabled={isSubmittingEnrollment}
+                />
+                {enrollmentCodeError ? (
+                  <ErrorMessage>{enrollmentCodeError}</ErrorMessage>
+                ) : null}
+              </Field>
+
+              <DialogActions>
+                <Button
+                  type="button"
+                  outline
+                  onClick={handleCloseEnrollment}
+                  disabled={isSubmittingEnrollment}
+                >
+                  <Trans>Cancel</Trans>
+                </Button>
+                <Button
+                  type="submit"
+                  color="blue"
+                  disabled={
+                    isSubmittingEnrollment || enrollmentCode.trim().length === 0
+                  }
+                  aria-busy={isSubmittingEnrollment}
+                >
+                  {isSubmittingEnrollment ? (
+                    <Trans>Processing...</Trans>
+                  ) : (
+                    <Trans>Confirm and enable MFA</Trans>
+                  )}
+                </Button>
+              </DialogActions>
+            </form>
           ) : null}
         </DialogBody>
       </Dialog>

--- a/src/pages/Settings/SettingsPage.tsx
+++ b/src/pages/Settings/SettingsPage.tsx
@@ -9,7 +9,8 @@ import {
   type FormEvent,
   type ReactNode,
 } from "react";
-import { Trans } from "@lingui/macro";
+import { Trans, msg } from "@lingui/macro";
+import { useLingui } from "@lingui/react";
 import type {
   MfaRecoveryCodeReveal,
   MfaStatus,
@@ -44,6 +45,7 @@ import {
   startTotpEnrollment,
 } from "../../services/authApi";
 import { MfaQrCode } from "../../components/MfaQrCode";
+import { formatDateTime } from "../../lib/dateUtils";
 
 type SensitiveMfaAction = "disable" | "regenerate";
 
@@ -90,6 +92,7 @@ function getSensitiveActionLabels(action: SensitiveMfaAction | null): {
 }
 
 export function SettingsPage() {
+  const { _, i18n } = useLingui();
   const [mfaStatus, setMfaStatus] = useState<MfaStatus | null>(null);
   const [isLoadingMfaStatus, setIsLoadingMfaStatus] = useState(true);
   const [mfaStatusError, setMfaStatusError] = useState<string | null>(null);
@@ -506,7 +509,7 @@ export function SettingsPage() {
             <form className="space-y-6" onSubmit={handleEnrollmentSubmit}>
               <MfaQrCode
                 value={enrollmentPreparation.otpauth_uri}
-                alt="Authenticator app QR code"
+                alt={_(msg`Authenticator app QR code`)}
               />
 
               <div className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-800 dark:bg-zinc-900/60">
@@ -521,7 +524,12 @@ export function SettingsPage() {
               <div className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-800 dark:bg-zinc-900/60">
                 <Text className="text-sm text-zinc-700 dark:text-zinc-300">
                   <Trans>
-                    This setup expires at {enrollmentPreparation.expires_at}.
+                    This setup expires at{" "}
+                    {formatDateTime(
+                      enrollmentPreparation.expires_at,
+                      i18n.locale
+                    )}
+                    .
                   </Trans>
                 </Text>
               </div>

--- a/src/pages/Settings/SettingsPage.tsx
+++ b/src/pages/Settings/SettingsPage.tsx
@@ -183,7 +183,7 @@ export function SettingsPage() {
   };
 
   const handleCloseEnrollment = () => {
-    if (isPreparingEnrollment || isSubmittingEnrollment) {
+    if (isSubmittingEnrollment) {
       return;
     }
 
@@ -548,9 +548,15 @@ export function SettingsPage() {
                   onChange={(event) => setEnrollmentCode(event.target.value)}
                   placeholder="123456"
                   disabled={isSubmittingEnrollment}
+                  aria-invalid={enrollmentCodeError ? true : undefined}
+                  aria-describedby={
+                    enrollmentCodeError ? "enrollment-code-error" : undefined
+                  }
                 />
                 {enrollmentCodeError ? (
-                  <ErrorMessage>{enrollmentCodeError}</ErrorMessage>
+                  <ErrorMessage id="enrollment-code-error">
+                    {enrollmentCodeError}
+                  </ErrorMessage>
                 ) : null}
               </Field>
 

--- a/src/pages/Settings/SettingsPage.tsx
+++ b/src/pages/Settings/SettingsPage.tsx
@@ -97,10 +97,13 @@ export function SettingsPage() {
   const [isPreparingEnrollment, setIsPreparingEnrollment] = useState(false);
   const [enrollmentPreparation, setEnrollmentPreparation] =
     useState<TotpEnrollmentPreparation | null>(null);
-  const [enrollmentPreparationError, setEnrollmentPreparationError] =
-    useState<string | null>(null);
+  const [enrollmentPreparationError, setEnrollmentPreparationError] = useState<
+    string | null
+  >(null);
   const [enrollmentCode, setEnrollmentCode] = useState("");
-  const [enrollmentCodeError, setEnrollmentCodeError] = useState<string | null>(null);
+  const [enrollmentCodeError, setEnrollmentCodeError] = useState<string | null>(
+    null
+  );
   const [isSubmittingEnrollment, setIsSubmittingEnrollment] = useState(false);
   const [revealedRecoveryCodes, setRevealedRecoveryCodes] =
     useState<MfaRecoveryCodeReveal | null>(null);
@@ -458,7 +461,11 @@ export function SettingsPage() {
         </DialogBody>
       </Dialog>
 
-      <Dialog open={isEnrollmentDialogOpen} onClose={handleCloseEnrollment} size="2xl">
+      <Dialog
+        open={isEnrollmentDialogOpen}
+        onClose={handleCloseEnrollment}
+        size="2xl"
+      >
         <DialogTitle>
           <Trans>Set up MFA</Trans>
         </DialogTitle>
@@ -486,7 +493,11 @@ export function SettingsPage() {
                 <Button type="button" outline onClick={handleCloseEnrollment}>
                   <Trans>Cancel</Trans>
                 </Button>
-                <Button type="button" color="blue" onClick={() => void loadEnrollmentPreparation()}>
+                <Button
+                  type="button"
+                  color="blue"
+                  onClick={() => void loadEnrollmentPreparation()}
+                >
                   <Trans>Try again</Trans>
                 </Button>
               </DialogActions>


### PR DESCRIPTION
## Summary
- add the missing MFA enrollment flow to the settings page for accounts without MFA enabled
- reuse the existing TOTP enrollment API and QR-code component to show setup material, manual entry fallback, and confirmation UX
- add focused settings-page coverage for enrollment start, successful confirmation, and inline confirmation errors
- record the completed enrollment slice in the frontend changelog

## Validation
- `npx vitest run src/pages/Settings/SettingsPage.test.tsx`
- `npx eslint src/pages/Settings/SettingsPage.tsx src/pages/Settings/SettingsPage.test.tsx`
- `npx tsc --noEmit -p tsconfig.json`
- `npx vitest run src/pages/Settings/SettingsPage.test.tsx src/pages/Login.test.tsx src/services/authApi.test.ts src/services/authTransport.test.ts`
- `npm run build`

## Links
- Closes #714
- Related: SecPal/.github#277