### PR TITLE
fix: align MFA recovery code format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Aligned MFA recovery-code placeholders, frontend fixtures, and service mocks with the canonical API payload shape of raw 8-character uppercase alphanumeric codes so the browser UI no longer teaches a grouped `XXXX-XXXX` format that differs from what the backend stores and returns.
 - Made the checked-in Lingui `.po` catalogs the only frontend translation authority, removing the Translation.io-specific sync overlay so catalog maintenance now stays entirely repo-local.
 - Refreshed the shipped MFA/login locale artifacts from the repo-local Lingui catalogs so the new MFA settings UI no longer falls back to raw Lingui message IDs in production.
 - Removed the inset desktop content frame beneath the top navigation so the page surface now spans edge to edge without the previous side and bottom border effect.

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -299,7 +299,7 @@ describe("Login", () => {
     const mockVerifyMfaChallenge = vi.mocked(authApi.verifyMfaChallenge);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => { });
+      .mockImplementation(() => {});
 
     mockLogin.mockResolvedValueOnce({
       challenge: {
@@ -364,10 +364,9 @@ describe("Login", () => {
   it("switches to the recovery code input when the recovery code method is selected", async () => {
     await openMfaDialog();
     fireEvent.click(screen.getByRole("radio", { name: /recovery code/i }));
-    expect(screen.getByRole("textbox", { name: /recovery code/i })).toHaveAttribute(
-      "placeholder",
-      "B6F42Q8P"
-    );
+    expect(
+      screen.getByRole("textbox", { name: /recovery code/i })
+    ).toHaveAttribute("placeholder", "B6F42Q8P");
     expect(
       screen.queryByRole("textbox", { name: /authenticator code/i })
     ).not.toBeInTheDocument();
@@ -376,7 +375,7 @@ describe("Login", () => {
   it("shows an error when MFA challenge response has an unexpected mode", async () => {
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => { });
+      .mockImplementation(() => {});
     vi.mocked(authApi.verifyMfaChallenge).mockResolvedValueOnce({
       user: createAuthUser(),
       authentication: {
@@ -435,7 +434,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => { });
+      .mockImplementation(() => {});
 
     mockLogin.mockRejectedValueOnce(
       new authApi.AuthApiError("Server Error", undefined, 500)
@@ -475,7 +474,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => { });
+      .mockImplementation(() => {});
     mockLogin.mockRejectedValueOnce(new Error("Network error"));
 
     renderLogin();
@@ -509,7 +508,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => { });
+      .mockImplementation(() => {});
     mockLogin.mockRejectedValueOnce("string error");
 
     renderLogin();

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -299,7 +299,7 @@ describe("Login", () => {
     const mockVerifyMfaChallenge = vi.mocked(authApi.verifyMfaChallenge);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => {});
+      .mockImplementation(() => { });
 
     mockLogin.mockResolvedValueOnce({
       challenge: {
@@ -364,9 +364,10 @@ describe("Login", () => {
   it("switches to the recovery code input when the recovery code method is selected", async () => {
     await openMfaDialog();
     fireEvent.click(screen.getByRole("radio", { name: /recovery code/i }));
-    expect(
-      screen.getByRole("textbox", { name: /recovery code/i })
-    ).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: /recovery code/i })).toHaveAttribute(
+      "placeholder",
+      "B6F42Q8P"
+    );
     expect(
       screen.queryByRole("textbox", { name: /authenticator code/i })
     ).not.toBeInTheDocument();
@@ -375,7 +376,7 @@ describe("Login", () => {
   it("shows an error when MFA challenge response has an unexpected mode", async () => {
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => {});
+      .mockImplementation(() => { });
     vi.mocked(authApi.verifyMfaChallenge).mockResolvedValueOnce({
       user: createAuthUser(),
       authentication: {
@@ -434,7 +435,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => {});
+      .mockImplementation(() => { });
 
     mockLogin.mockRejectedValueOnce(
       new authApi.AuthApiError("Server Error", undefined, 500)
@@ -474,7 +475,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => {});
+      .mockImplementation(() => { });
     mockLogin.mockRejectedValueOnce(new Error("Network error"));
 
     renderLogin();
@@ -508,7 +509,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => {});
+      .mockImplementation(() => { });
     mockLogin.mockRejectedValueOnce("string error");
 
     renderLogin();

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -572,7 +572,7 @@ export function Login() {
                   value={mfaCode}
                   onChange={(event) => setMfaCode(event.target.value)}
                   placeholder={
-                    mfaMethod === "recovery_code" ? "B6F4-2Q8P" : "123456"
+                    mfaMethod === "recovery_code" ? "B6F42Q8P" : "123456"
                   }
                   disabled={isVerifyingMfa}
                   aria-invalid={mfaError ? true : undefined}

--- a/src/pages/Settings/SettingsPage.test.tsx
+++ b/src/pages/Settings/SettingsPage.test.tsx
@@ -85,14 +85,14 @@ function createRecoveryRevealResponse() {
       status: createEnabledMfaStatusResponse().data,
       recovery_codes: {
         codes: [
-          "B6F4-2Q8P",
-          "F9LM-7N2R",
-          "HT4V-3KQ1",
-          "J8PW-6CX5",
-          "M2TR-9DZ7",
-          "Q4YS-8LB2",
-          "V7NK-5HF9",
-          "X3CE-1RM6",
+          "B6F42Q8P",
+          "F9LM7N2R",
+          "HT4V3KQ1",
+          "J8PW6CX5",
+          "M2TR9DZ7",
+          "Q4YS8LB2",
+          "V7NK5HF9",
+          "X3CE1RM6",
         ],
         generated_at: "2026-04-01T09:12:00Z",
       },
@@ -378,6 +378,10 @@ describe("SettingsPage", () => {
 
     await screen.findByRole("heading", { name: /disable mfa/i });
 
+    expect(
+      screen.getByRole("textbox", { name: /^authenticator code$/i })
+    ).toHaveAttribute("placeholder", "123456");
+
     fireEvent.change(
       screen.getByRole("textbox", { name: /^authenticator code$/i }),
       {
@@ -429,6 +433,26 @@ describe("SettingsPage", () => {
     expect(
       await screen.findByText(/invalid authenticator code/i)
     ).toBeInTheDocument();
+  });
+
+  it("shows the canonical raw recovery-code placeholder for sensitive MFA actions", async () => {
+    vi.mocked(authApi.getMfaStatus).mockResolvedValueOnce(
+      createEnabledMfaStatusResponse()
+    );
+
+    renderWithProviders(<SettingsPage />);
+
+    await screen.findByText(/authenticator app/i);
+    fireEvent.click(
+      screen.getByRole("button", { name: /regenerate recovery codes/i })
+    );
+
+    await screen.findByRole("heading", { name: /regenerate recovery codes/i });
+    fireEvent.click(screen.getByRole("radio", { name: /recovery code/i }));
+
+    expect(
+      screen.getByRole("textbox", { name: /^recovery code$/i })
+    ).toHaveAttribute("placeholder", "B6F42Q8P");
   });
 
   it("requires acknowledgment before closing recovery codes dialog", async () => {

--- a/src/pages/Settings/SettingsPage.tsx
+++ b/src/pages/Settings/SettingsPage.tsx
@@ -654,7 +654,7 @@ export function SettingsPage() {
                   value={sensitiveCode}
                   onChange={(event) => setSensitiveCode(event.target.value)}
                   placeholder={
-                    sensitiveMethod === "totp" ? "123456" : "B6F4-2Q8P"
+                    sensitiveMethod === "totp" ? "123456" : "B6F42Q8P"
                   }
                   disabled={isSubmittingSensitiveAction}
                 />

--- a/src/services/authApi.test.ts
+++ b/src/services/authApi.test.ts
@@ -713,7 +713,7 @@ describe("authApi", () => {
             enrolled_at: "2026-04-01T09:10:00Z",
           },
           recovery_codes: {
-            codes: ["B6F4-2Q8P", "F9LM-7N2R"],
+            codes: ["B6F42Q8P", "F9LM7N2R"],
             generated_at: "2026-04-01T09:12:00Z",
           },
         },
@@ -771,7 +771,7 @@ describe("authApi", () => {
             enrolled_at: "2026-04-01T09:10:00Z",
           },
           recovery_codes: {
-            codes: ["X3CE-1RM6", "V7NK-5HF9"],
+            codes: ["X3CE1RM6", "V7NK5HF9"],
             generated_at: "2026-04-01T10:00:00Z",
           },
         },


### PR DESCRIPTION
## Summary
- align login and settings recovery-code placeholders with the canonical raw 8-character API format
- update frontend fixtures and service mocks so tests no longer teach grouped `XXXX-XXXX` recovery codes
- add focused assertions that the recovery-code UI now reflects the canonical payload shape

## Validation
- `npx vitest run src/pages/Login.test.tsx src/pages/Settings/SettingsPage.test.tsx src/services/authApi.test.ts`
- `npx eslint src/pages/Login.tsx src/pages/Login.test.tsx src/pages/Settings/SettingsPage.tsx src/pages/Settings/SettingsPage.test.tsx src/services/authApi.test.ts`
- `npx tsc --noEmit -p tsconfig.json`
- local pre-push preflight (`eslint`, `tsc --noEmit`, REUSE, domain policy)

## Scope
- Closes #722
- Refs SecPal/.github#322