### PR TITLE
fix: hydrate canonical user after browser-session login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Made browser-session login prefer the canonical `GET /v1/me` user payload immediately after authentication, so capability-gated navigation no longer comes up incomplete until the first manual refresh.
 - Aligned MFA recovery-code placeholders, frontend fixtures, and service mocks with the canonical API payload shape of raw 8-character uppercase alphanumeric codes so the browser UI no longer teaches a grouped `XXXX-XXXX` format that differs from what the backend stores and returns.
 - Made the checked-in Lingui `.po` catalogs the only frontend translation authority, removing the Translation.io-specific sync overlay so catalog maintenance now stays entirely repo-local.
 - Refreshed the shipped MFA/login locale artifacts from the repo-local Lingui catalogs so the new MFA settings UI no longer falls back to raw Lingui message IDs in production.

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -3,7 +3,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { NativeAuthBridge } from "./authTransport";
-import { getAuthTransport, resolveAuthTransport } from "./authTransport";
+import { AuthApiError, getAuthTransport, resolveAuthTransport } from "./authTransport";
 
 const {
   mockBrowserLogin,
@@ -131,6 +131,37 @@ describe("authTransport", () => {
         hasOrganizationalScopes: true,
         hasCustomerAccess: true,
         hasSiteAccess: true,
+      },
+    });
+  });
+
+  it("falls back to the login payload when the current-user fetch fails", async () => {
+    mockBrowserLogin.mockResolvedValueOnce({
+      user: {
+        id: 1,
+        name: "Login User",
+        email: "user@secpal.dev",
+        emailVerified: true,
+      },
+    });
+    mockBrowserGetCurrentUser.mockRejectedValueOnce(
+      new AuthApiError("Unauthorized")
+    );
+
+    const transport = getAuthTransport();
+    const result = await transport.login({
+      email: "user@secpal.dev",
+      password: "password123",
+    });
+
+    expect(mockBrowserGetCurrentUser).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      status: "authenticated",
+      user: {
+        id: "1",
+        name: "Login User",
+        email: "user@secpal.dev",
+        emailVerified: true,
       },
     });
   });

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -86,6 +86,55 @@ describe("authTransport", () => {
     }
   });
 
+  it("prefers the canonical current-user payload after a browser-session login", async () => {
+    mockBrowserLogin.mockResolvedValueOnce({
+      user: {
+        id: 1,
+        name: "Customer User",
+        email: "customer@secpal.dev",
+        emailVerified: true,
+        hasCustomerAccess: true,
+      },
+    });
+    mockBrowserGetCurrentUser.mockResolvedValueOnce({
+      id: 1,
+      name: "Manager User",
+      email: "manager@secpal.dev",
+      emailVerified: true,
+      roles: ["Manager"],
+      permissions: ["employees.read", "activity_log.read"],
+      hasOrganizationalScopes: true,
+      hasCustomerAccess: true,
+      hasSiteAccess: true,
+    });
+
+    const transport = getAuthTransport();
+    const result = await transport.login({
+      email: "customer@secpal.dev",
+      password: "password123",
+    });
+
+    expect(mockBrowserLogin).toHaveBeenCalledWith({
+      email: "customer@secpal.dev",
+      password: "password123",
+    });
+    expect(mockBrowserGetCurrentUser).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      status: "authenticated",
+      user: {
+        id: "1",
+        name: "Manager User",
+        email: "manager@secpal.dev",
+        emailVerified: true,
+        roles: ["Manager"],
+        permissions: ["employees.read", "activity_log.read"],
+        hasOrganizationalScopes: true,
+        hasCustomerAccess: true,
+        hasSiteAccess: true,
+      },
+    });
+  });
+
   it("reports browser network availability from navigator.onLine", async () => {
     const onLineSpy = vi
       .spyOn(window.navigator, "onLine", "get")

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -3,7 +3,11 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { NativeAuthBridge } from "./authTransport";
-import { AuthApiError, getAuthTransport, resolveAuthTransport } from "./authTransport";
+import {
+  AuthApiError,
+  getAuthTransport,
+  resolveAuthTransport,
+} from "./authTransport";
 
 const {
   mockBrowserLogin,

--- a/src/services/authTransport.ts
+++ b/src/services/authTransport.ts
@@ -104,11 +104,14 @@ const browserSessionAuthTransport: AuthTransport = {
           "Browser-session current-user fetch"
         ),
       };
-    } catch {
-      return {
-        status: "authenticated",
-        user: loginUser,
-      };
+    } catch (err) {
+      if (err instanceof Error) {
+        return {
+          status: "authenticated",
+          user: loginUser,
+        };
+      }
+      throw err;
     }
   },
   async logout(): Promise<void> {

--- a/src/services/authTransport.ts
+++ b/src/services/authTransport.ts
@@ -92,10 +92,25 @@ const browserSessionAuthTransport: AuthTransport = {
       };
     }
 
-    return {
-      status: "authenticated",
-      user: sanitizeAuthPayload(result, "Browser-session login"),
-    };
+    const loginUser = sanitizeAuthPayload(result, "Browser-session login");
+
+    try {
+      const currentUser = await getBrowserSessionCurrentUser();
+
+      return {
+        status: "authenticated",
+        user: sanitizeAuthPayload(
+          currentUser,
+          "Browser-session current-user fetch"
+        ),
+      };
+    } catch {
+      return {
+        status: "authenticated",
+        user: loginUser,
+      };
+    }
+
   },
   async logout(): Promise<void> {
     await logoutBrowserSession();

--- a/src/services/authTransport.ts
+++ b/src/services/authTransport.ts
@@ -110,7 +110,6 @@ const browserSessionAuthTransport: AuthTransport = {
         user: loginUser,
       };
     }
-
   },
   async logout(): Promise<void> {
     await logoutBrowserSession();


### PR DESCRIPTION
## Summary
- hydrate browser-session login with the canonical GET /v1/me user payload immediately after authentication
- keep the original login payload only as a fallback when the canonical current-user fetch is temporarily unavailable
- add regression coverage for the incomplete post-login navigation case and document the fix in the changelog

## Problem
Fresh browser-session logins could render an incomplete capability-gated navigation menu until the first manual refresh. A refresh corrected the menu because bootstrap revalidation fetched the canonical current-user payload, while the immediate post-login state still depended on the initial login response.

## Validation
- npm test -- --run src/services/authTransport.test.ts
- npm exec eslint -- src/services/authTransport.ts src/services/authTransport.test.ts --max-warnings 0
- npm run typecheck -- --pretty false
