### PR TITLE
Fix for Useless conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Removed the unreachable inline error panel from `EmployeeEdit` that duplicated the full-screen error view already returned by the early-return guard, eliminating a logically dead conditional branch.
 - Aligned the employee detail actions with the onboarding runtime workflow so HR/compliance users can confirm submitted onboarding dossiers via the dedicated admin endpoint and activation is only offered once the backend marks the employee `ready_for_activation`.
 - Aligned the authenticated onboarding wizard with the documented runtime API surface so it now loads ordered templates from `/v1/onboarding/templates`, reuses existing submissions from `/v1/onboarding/submissions`, saves and submits through the backend's POST upsert flow with `form_template_id`, and no longer exposes the stale PATCH-only or file-upload paths that the current runtime does not provide.
 - Replaced the protected-route startup dead-end on Android with a bounded auth-bootstrap recovery flow, so cached sessions no longer sit on an indefinite `Laden...` spinner when native session revalidation is slow or transiently fails; SecPal now shows an explicit retry/login recovery state and only clears auth immediately for real invalid-session errors.

--- a/src/pages/Employees/EmployeeEdit.tsx
+++ b/src/pages/Employees/EmployeeEdit.tsx
@@ -299,16 +299,6 @@ export function EmployeeEdit() {
           <Trans>Edit Employee</Trans>
         </Heading>
 
-        {error && !fetchLoading && (
-          <div className="mb-6 rounded-lg border border-red-200 bg-red-50 p-6 text-center dark:border-red-900 dark:bg-red-900/20">
-            <div className="mb-2 text-4xl">⚠️</div>
-            <Heading level={3} className="text-red-900 dark:text-red-400">
-              <Trans>Error</Trans>
-            </Heading>
-            <Text className="mt-2 text-red-700 dark:text-red-500">{error}</Text>
-          </div>
-        )}
-
         <form onSubmit={handleSubmit} className="space-y-8">
           {/* Personal Information */}
           <Fieldset>


### PR DESCRIPTION
## Summary

Removes the unreachable inline error panel from `EmployeeEdit` that was already handled by the full-screen early-return error view at line 270. The `{error && !fetchLoading && (...)}` block was logically dead code — the component never reaches it when `error` is set.

### Change

- Removed the duplicate inline error `<div>` from `src/pages/Employees/EmployeeEdit.tsx` (10 lines, no behavior change)
- Added CHANGELOG entry under `### Fixed`

No new imports, state, or tests required; coverage is already complete (Codecov reports all changed lines covered).

_Fix originally identified by Copilot Autofix._