### PR TITLE
Fix for Useless conditional

### DIFF
--- a/src/pages/Customers/CustomerDetail.tsx
+++ b/src/pages/Customers/CustomerDetail.tsx
@@ -35,7 +35,8 @@ export default function CustomerDetail() {
   const navigate = useNavigate();
   const [customer, setCustomer] = useState<Customer | null>(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
@@ -43,12 +44,12 @@ export default function CustomerDetail() {
     async function loadCustomer() {
       if (!id) return;
       setLoading(true);
-      setError(null);
+      setLoadError(null);
       try {
         const data = await getCustomer(id);
         setCustomer(data);
       } catch (err) {
-        setError(
+        setLoadError(
           err instanceof Error ? err.message : "Failed to load customer"
         );
       } finally {
@@ -62,13 +63,13 @@ export default function CustomerDetail() {
     if (!customer) return;
 
     setDeleting(true);
-    setError(null);
+    setDeleteError(null);
 
     try {
       await deleteCustomer(customer.id);
       navigate("/customers");
     } catch (err) {
-      setError(
+      setDeleteError(
         err instanceof Error ? err.message : "Failed to delete customer"
       );
       setDeleting(false);
@@ -84,11 +85,11 @@ export default function CustomerDetail() {
     );
   }
 
-  if (error || !customer) {
+  if (loadError || !customer) {
     return (
       <div className="text-center py-12">
         <Text className="text-red-600">
-          {error || <Trans>Customer not found</Trans>}
+          {loadError || <Trans>Customer not found</Trans>}
         </Text>
         <Button href="/customers" outline className="mt-4">
           <Trans>Back to Customers</Trans>
@@ -262,7 +263,9 @@ export default function CustomerDetail() {
             </Trans>
           </DialogDescription>
           <DialogBody>
-            {error && <Text className="text-red-600 mb-4">{error}</Text>}
+            {deleteError && (
+              <Text className="text-red-600 mb-4">{deleteError}</Text>
+            )}
           </DialogBody>
           <DialogActions>
             <Button

--- a/src/pages/Customers/CustomerDetail.tsx
+++ b/src/pages/Customers/CustomerDetail.tsx
@@ -235,7 +235,10 @@ export default function CustomerDetail() {
           {capabilities.actions.customers.delete && (
             <Button
               outline
-              onClick={() => setShowDeleteDialog(true)}
+              onClick={() => {
+                setDeleteError(null);
+                setShowDeleteDialog(true);
+              }}
               disabled={deleting}
             >
               <Trans>Delete</Trans>


### PR DESCRIPTION
In general, the fix is to avoid overloading a single `error` state for both initial data‑loading errors and delete‑operation errors. By separating these into two distinct pieces of state, we ensure that: (1) the early return for load failure is controlled only by the load error, and (2) the dialog’s error message depends only on delete failures, which can occur even when the main page content is successfully rendered. This makes it clear to both human readers and static analyzers that the dialog condition is meaningful and not always false.

Concretely, in `src/pages/Customers/CustomerDetail.tsx`:

- Introduce two states: `loadError` and `deleteError`, instead of the single `error`.
- In `loadCustomer`, use `setLoadError` instead of `setError` when handling fetch failures, and reset `loadError` before loading.
- In `handleDelete`, use `setDeleteError` instead of `setError`, and reset `deleteError` before attempting deletion.
- Update the early return branch to check `loadError` instead of `error`, and render `loadError` as the message.
- In the delete dialog, change `{error && ...}` to `{deleteError && ...}`, and render `deleteError`.

No other behaviour changes: the loading logic, navigation, and dialog visibility remain the same; only the error scoping is clarified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._