### PR TITLE
Fix for Superfluous trailing arguments

### DIFF
--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -501,18 +501,13 @@ describe("useAuth", () => {
 
     act(() => {
       localStorage.removeItem("auth_user");
-      const storageEvent = document.createEvent("StorageEvent");
-      storageEvent.initStorageEvent(
-        "storage",
-        false,
-        false,
-        "auth_user",
-        JSON.stringify(mockUser),
-        null,
-        window.location.href,
-        localStorage
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: "auth_user",
+          oldValue: JSON.stringify(mockUser),
+          newValue: null,
+        })
       );
-      window.dispatchEvent(storageEvent);
     });
 
     await waitFor(() => {

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -501,13 +501,18 @@ describe("useAuth", () => {
 
     act(() => {
       localStorage.removeItem("auth_user");
-      const event = new StorageEvent("storage", {
-        key: "auth_user",
-        oldValue: JSON.stringify(mockUser),
-        newValue: null,
+      const crossTabLogoutEvent = new StorageEvent("storage");
+      Object.defineProperty(crossTabLogoutEvent, "key", {
+        value: "auth_user",
       });
-      Object.defineProperty(event, "storageArea", { value: localStorage });
-      window.dispatchEvent(event);
+      Object.defineProperty(crossTabLogoutEvent, "oldValue", {
+        value: JSON.stringify(mockUser),
+      });
+      Object.defineProperty(crossTabLogoutEvent, "newValue", { value: null });
+      Object.defineProperty(crossTabLogoutEvent, "storageArea", {
+        value: localStorage,
+      });
+      window.dispatchEvent(crossTabLogoutEvent);
     });
 
     await waitFor(() => {

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -501,13 +501,13 @@ describe("useAuth", () => {
 
     act(() => {
       localStorage.removeItem("auth_user");
-      window.dispatchEvent(
-        new StorageEvent("storage", {
-          key: "auth_user",
-          oldValue: JSON.stringify(mockUser),
-          newValue: null,
-        })
-      );
+      const event = new StorageEvent("storage", {
+        key: "auth_user",
+        oldValue: JSON.stringify(mockUser),
+        newValue: null,
+      });
+      Object.defineProperty(event, "storageArea", { value: localStorage });
+      window.dispatchEvent(event);
     });
 
     await waitFor(() => {

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -501,14 +501,18 @@ describe("useAuth", () => {
 
     act(() => {
       localStorage.removeItem("auth_user");
-      window.dispatchEvent(
-        new StorageEvent("storage", {
-          key: "auth_user",
-          oldValue: JSON.stringify(mockUser),
-          newValue: null,
-          storageArea: localStorage,
-        })
+      const storageEvent = document.createEvent("StorageEvent");
+      storageEvent.initStorageEvent(
+        "storage",
+        false,
+        false,
+        "auth_user",
+        JSON.stringify(mockUser),
+        null,
+        window.location.href,
+        localStorage
       );
+      window.dispatchEvent(storageEvent);
     });
 
     await waitFor(() => {


### PR DESCRIPTION
In general, to fix “superfluous arguments” issues, ensure that functions or constructors are only called with the number and types of parameters they are defined to accept, moving any extra data into supported configuration methods or properties. For DOM events, this often means either using the correct `Event` constructor signature or using `document.createEvent` plus the appropriate `init…` method rather than passing unsupported extra arguments.

For this file, the best targeted fix is to stop passing the second argument to the `StorageEvent` constructor and instead create and initialize the event via `document.createEvent("StorageEvent")` and `initStorageEvent`. That way, we don’t change the test’s intent: we still fire a `"storage"` event whose `key`, `oldValue`, `newValue`, and `storageArea` match the previous object, but we no longer rely on a constructor signature that CodeQL believes takes only one parameter. Concretely, on lines 504–511, replace `new StorageEvent("storage", { ... })` with creation of a `storageEvent` variable using `document.createEvent("StorageEvent")`, a call to `storageEvent.initStorageEvent(...)` with the appropriate values, and then dispatch that `storageEvent`. No new imports are needed; `document` and `StorageEvent` (or at least `document.createEvent`) are already provided by the test environment.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._