### PR TITLE
Fix for Superfluous trailing arguments

### DIFF
--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -713,14 +713,12 @@ describe("useAuth", () => {
       // Write the corrupt value so localStorage matches the event (real browser
       // cross-tab writes keep newValue and the actual storage in sync).
       localStorage.setItem("auth_user", "{invalid json{{");
-      window.dispatchEvent(
-        new StorageEvent("storage", {
-          key: "auth_user",
-          oldValue: JSON.stringify(mockUser),
-          newValue: "{invalid json{{",
-          storageArea: localStorage,
-        })
-      );
+      const storageEvent = new StorageEvent("storage") as StorageEvent;
+      (storageEvent as any).key = "auth_user";
+      (storageEvent as any).oldValue = JSON.stringify(mockUser);
+      (storageEvent as any).newValue = "{invalid json{{";
+      (storageEvent as any).storageArea = localStorage;
+      window.dispatchEvent(storageEvent);
     });
 
     await waitFor(() => {

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -713,12 +713,13 @@ describe("useAuth", () => {
       // Write the corrupt value so localStorage matches the event (real browser
       // cross-tab writes keep newValue and the actual storage in sync).
       localStorage.setItem("auth_user", "{invalid json{{");
-      const storageEvent = new StorageEvent("storage") as StorageEvent;
-      (storageEvent as any).key = "auth_user";
-      (storageEvent as any).oldValue = JSON.stringify(mockUser);
-      (storageEvent as any).newValue = "{invalid json{{";
-      (storageEvent as any).storageArea = localStorage;
-      window.dispatchEvent(storageEvent);
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: "auth_user",
+          oldValue: JSON.stringify(mockUser),
+          newValue: "{invalid json{{",
+        })
+      );
     });
 
     await waitFor(() => {

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -713,13 +713,15 @@ describe("useAuth", () => {
       // Write the corrupt value so localStorage matches the event (real browser
       // cross-tab writes keep newValue and the actual storage in sync).
       localStorage.setItem("auth_user", "{invalid json{{");
-      window.dispatchEvent(
-        new StorageEvent("storage", {
-          key: "auth_user",
-          oldValue: JSON.stringify(mockUser),
-          newValue: "{invalid json{{",
-        })
-      );
+      const invalidJsonEvent = new StorageEvent("storage", {
+        key: "auth_user",
+        oldValue: JSON.stringify(mockUser),
+        newValue: "{invalid json{{",
+      });
+      Object.defineProperty(invalidJsonEvent, "storageArea", {
+        value: localStorage,
+      });
+      window.dispatchEvent(invalidJsonEvent);
     });
 
     await waitFor(() => {

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -715,10 +715,13 @@ describe("useAuth", () => {
       // Write the corrupt value so localStorage matches the event (real browser
       // cross-tab writes keep newValue and the actual storage in sync).
       localStorage.setItem("auth_user", "{invalid json{{");
-      const invalidJsonEvent = new StorageEvent("storage", {
-        key: "auth_user",
-        oldValue: JSON.stringify(mockUser),
-        newValue: "{invalid json{{",
+      const invalidJsonEvent = new StorageEvent("storage");
+      Object.defineProperty(invalidJsonEvent, "key", { value: "auth_user" });
+      Object.defineProperty(invalidJsonEvent, "oldValue", {
+        value: JSON.stringify(mockUser),
+      });
+      Object.defineProperty(invalidJsonEvent, "newValue", {
+        value: "{invalid json{{",
       });
       Object.defineProperty(invalidJsonEvent, "storageArea", {
         value: localStorage,


### PR DESCRIPTION
In general, to fix “extra trailing arguments” for DOM event constructors, we should avoid passing a second argument when the environment might not support it, and instead create the event with just the type string and then assign the necessary properties onto the event object before dispatching it. This keeps the behavior explicit and avoids relying on specific constructor signatures.

For this file, the best fix is to replace `new StorageEvent("storage", { ... })` with a call that only passes the event type, then cast to `StorageEvent` (to satisfy TypeScript) and manually assign `key`, `oldValue`, `newValue`, and `storageArea` before dispatching. This preserves test behavior (the event that listeners see has all the same properties) while avoiding any extra arguments to the constructor, satisfying CodeQL. No imports need to be changed or added; we only modify the block inside the `act` call in the “clears auth state when cross-tab auth storage contains invalid JSON” test, around line 716–723.

Concretely:
- Inside the `act(() => { ... })` block:
  - Replace the `window.dispatchEvent(new StorageEvent("storage", { ... }))` call with creation of the event via `new StorageEvent("storage")` (or `document.createEvent` if you prefer) and direct property assignment on that object.
  - Then dispatch that event with `window.dispatchEvent(storageEvent);`.
- Keep all property values (`key`, `oldValue`, `newValue`, `storageArea`) exactly the same as in the original object literal.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._