### PR TITLE
Fix for Superfluous trailing arguments

### DIFF
--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -570,14 +570,12 @@ describe("useAuth", () => {
 
     act(() => {
       localStorage.setItem("auth_user", JSON.stringify(mockUser));
-      window.dispatchEvent(
-        new StorageEvent("storage", {
-          key: "auth_user",
-          oldValue: null,
-          newValue: JSON.stringify(mockUser),
-          storageArea: localStorage,
-        })
-      );
+      const storageEvent = new StorageEvent("storage");
+      (storageEvent as any).key = "auth_user";
+      (storageEvent as any).oldValue = null;
+      (storageEvent as any).newValue = JSON.stringify(mockUser);
+      (storageEvent as any).storageArea = localStorage;
+      window.dispatchEvent(storageEvent);
     });
 
     await waitFor(() => {

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -570,10 +570,11 @@ describe("useAuth", () => {
 
     act(() => {
       localStorage.setItem("auth_user", JSON.stringify(mockUser));
-      const staleAuthEvent = new StorageEvent("storage", {
-        key: "auth_user",
-        oldValue: null,
-        newValue: JSON.stringify(mockUser),
+      const staleAuthEvent = new StorageEvent("storage");
+      Object.defineProperty(staleAuthEvent, "key", { value: "auth_user" });
+      Object.defineProperty(staleAuthEvent, "oldValue", { value: null });
+      Object.defineProperty(staleAuthEvent, "newValue", {
+        value: JSON.stringify(mockUser),
       });
       Object.defineProperty(staleAuthEvent, "storageArea", {
         value: localStorage,

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -570,12 +570,13 @@ describe("useAuth", () => {
 
     act(() => {
       localStorage.setItem("auth_user", JSON.stringify(mockUser));
-      const storageEvent = new StorageEvent("storage");
-      (storageEvent as any).key = "auth_user";
-      (storageEvent as any).oldValue = null;
-      (storageEvent as any).newValue = JSON.stringify(mockUser);
-      (storageEvent as any).storageArea = localStorage;
-      window.dispatchEvent(storageEvent);
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: "auth_user",
+          oldValue: null,
+          newValue: JSON.stringify(mockUser),
+        })
+      );
     });
 
     await waitFor(() => {

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -570,13 +570,15 @@ describe("useAuth", () => {
 
     act(() => {
       localStorage.setItem("auth_user", JSON.stringify(mockUser));
-      window.dispatchEvent(
-        new StorageEvent("storage", {
-          key: "auth_user",
-          oldValue: null,
-          newValue: JSON.stringify(mockUser),
-        })
-      );
+      const staleAuthEvent = new StorageEvent("storage", {
+        key: "auth_user",
+        oldValue: null,
+        newValue: JSON.stringify(mockUser),
+      });
+      Object.defineProperty(staleAuthEvent, "storageArea", {
+        value: localStorage,
+      });
+      window.dispatchEvent(staleAuthEvent);
     });
 
     await waitFor(() => {


### PR DESCRIPTION
To fix the problem, avoid passing the event initialization dictionary as a second argument to `StorageEvent`, and instead construct the event with just its type and then assign the needed properties onto the event object. This ensures that no arguments are “ignored” by a simplified or non‑standard `StorageEvent` implementation, and it directly sets the fields the test depends on (`key`, `oldValue`, `newValue`, `storageArea`).

Concretely, in `src/hooks/useAuth.test.ts`, within the `act` block of the `"ignores stale auth storage that reappears after explicit logout"` test, replace the inline `new StorageEvent("storage", { ... })` with code that: (1) creates the event using `new StorageEvent("storage")`, (2) casts it to `any` (or `StorageEvent & { ... }`) and assigns `key`, `oldValue`, `newValue`, and `storageArea`, and then (3) calls `window.dispatchEvent(event)`. No new imports are required; this is all standard DOM API usage. The rest of the test logic remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._