### PR TITLE
Fix for Superfluous trailing arguments

### DIFF
--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -574,14 +574,11 @@ describe("useAuth", () => {
 
     act(() => {
       localStorage.setItem("auth_user", JSON.stringify(mockUser));
-      const staleAuthEvent = new StorageEvent("storage");
-      Object.defineProperty(staleAuthEvent, "key", { value: "auth_user" });
-      Object.defineProperty(staleAuthEvent, "oldValue", { value: null });
-      Object.defineProperty(staleAuthEvent, "newValue", {
-        value: JSON.stringify(mockUser),
-      });
-      Object.defineProperty(staleAuthEvent, "storageArea", {
-        value: localStorage,
+      const staleAuthEvent = new StorageEvent("storage", {
+        key: "auth_user",
+        oldValue: null,
+        newValue: JSON.stringify(mockUser),
+        storageArea: localStorage,
       });
       window.dispatchEvent(staleAuthEvent);
     });


### PR DESCRIPTION
To fix the problem, construct the `StorageEvent` using both the required `type` argument and the optional `StorageEventInit` argument, instead of passing only `"storage"` and then mutating the event with `Object.defineProperty`. This aligns with the DOM API, avoids relying on mutability of event properties, and eliminates any “superfluous argument”/misuse pattern that CodeQL is flagging.

Concretely, in `src/hooks/useAuth.test.ts`, inside the `"ignores stale auth storage that reappears after explicit logout"` test, replace the block that creates `staleAuthEvent` and then calls `Object.defineProperty` four times with a single `new StorageEvent("storage", { ... })` call that sets `key`, `oldValue`, `newValue`, and `storageArea`. No imports are needed because `StorageEvent` is a global in the browser-like test environment. This change preserves the intended semantics—dispatching a `"storage"` event whose data matches the stale auth reappearance—while using the API correctly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._