### PR TITLE
Fix for Superfluous trailing arguments

### DIFF
--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -501,16 +501,11 @@ describe("useAuth", () => {
 
     act(() => {
       localStorage.removeItem("auth_user");
-      const crossTabLogoutEvent = new StorageEvent("storage");
-      Object.defineProperty(crossTabLogoutEvent, "key", {
-        value: "auth_user",
-      });
-      Object.defineProperty(crossTabLogoutEvent, "oldValue", {
-        value: JSON.stringify(mockUser),
-      });
-      Object.defineProperty(crossTabLogoutEvent, "newValue", { value: null });
-      Object.defineProperty(crossTabLogoutEvent, "storageArea", {
-        value: localStorage,
+      const crossTabLogoutEvent = new StorageEvent("storage", {
+        key: "auth_user",
+        oldValue: JSON.stringify(mockUser),
+        newValue: null,
+        storageArea: localStorage,
       });
       window.dispatchEvent(crossTabLogoutEvent);
     });


### PR DESCRIPTION
In general, to fix “superfluous argument” issues, you should call the function/constructor with only the parameters that are actually used and defined in its signature, or, if the argument is meaningful, pass it in the correct position and form so the analysis can see it is used. Here, the constructor for `StorageEvent` supports two parameters: the type string and an optional initialization object. Instead of creating the event with only the type and then manually defining its properties via `Object.defineProperty`, we should create it with both arguments, putting all the desired properties inside the `StorageEventInit` object.

Concretely, in `src/hooks/useAuth.test.ts` around line 504, replace:

- The bare `new StorageEvent("storage")` constructor call.
- The subsequent `Object.defineProperty` blocks for `key`, `oldValue`, `newValue`, and `storageArea`.

with a single call to `new StorageEvent("storage", { ... })` that sets `key`, `oldValue`, `newValue`, and `storageArea` in the init object. This preserves the intended behavior (a `storage` event with those properties) while removing the pattern that triggered CodeQL. No new imports or helper functions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._