### PR TITLE
Fix for Superfluous trailing arguments

### DIFF
--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -655,9 +655,9 @@ describe("useAuth", () => {
     expect(result.current.isAuthenticated).toBe(false);
 
     act(() => {
-      const otherKeyEvent = new StorageEvent("storage", {
-        key: "some_other_key",
-        newValue: null,
+      const otherKeyEvent = new StorageEvent("storage");
+      Object.defineProperty(otherKeyEvent, "key", {
+        value: "some_other_key",
       });
       Object.defineProperty(otherKeyEvent, "storageArea", {
         value: localStorage,
@@ -685,10 +685,15 @@ describe("useAuth", () => {
 
     act(() => {
       localStorage.setItem("auth_user", JSON.stringify(newUser));
-      const crossTabLoginEvent = new StorageEvent("storage", {
-        key: "auth_user",
-        oldValue: null,
-        newValue: JSON.stringify(newUser),
+      const crossTabLoginEvent = new StorageEvent("storage");
+      Object.defineProperty(crossTabLoginEvent, "key", {
+        value: "auth_user",
+      });
+      Object.defineProperty(crossTabLoginEvent, "oldValue", {
+        value: null,
+      });
+      Object.defineProperty(crossTabLoginEvent, "newValue", {
+        value: JSON.stringify(newUser),
       });
       Object.defineProperty(crossTabLoginEvent, "storageArea", {
         value: localStorage,


### PR DESCRIPTION
In general, to fix “superfluous arguments” on a DOM event constructor, call the constructor only with the arguments that are actually supported in the analyzed environment, then manually assign any needed properties afterward. This avoids relying on an options object that CodeQL (and possibly the runtime) considers unused, while preserving the test semantics.

For this file, the best fix is to change the `new StorageEvent("storage", { ... })` calls to `new StorageEvent("storage")` and then set `key`, `oldValue`, and `newValue` explicitly on the created event object using `Object.defineProperty` (similar to how `storageArea` is already set). Specifically:
- In the test “ignores storage events for keys other than auth_user”, on line 658, replace the constructor call to only pass `"storage"`, then add a `Object.defineProperty` call to set the `key` property to `"some_other_key"` (and keep the existing `storageArea` definition).
- In the test “updates auth state when another tab logs in”, on line 688, again construct the event with only `"storage"`, then `defineProperty` for `key`, `oldValue`, and `newValue` with the same values currently passed in the object, and retain the existing `storageArea` definition.

No new imports or utilities are required; we only adjust how the event is constructed and its properties are set.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._