### PR TITLE
fix(tests): consolidate remaining StorageEvent init-object patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed remaining CodeQL "superfluous trailing arguments" alerts in `useAuth` tests by consolidating `otherKeyEvent`, `crossTabLoginEvent`, and `invalidJsonEvent` constructors to use the full `StorageEventInit` dictionary, removing all residual `Object.defineProperty` boilerplate and making the test file consistent throughout.
 - Fixed a race condition in the `OnboardingLayout` sign-out handler where `logout()` was called before the API request; `logout()` and navigation to `/login` now happen only after a successful API logout call so local auth state is not prematurely cleared.
 - Added a user-facing inline error message in `OnboardingLayout` when the sign-out API call fails; local auth state is preserved so the user can retry, and an inline alert notifies them the server request did not complete.
 - Replaced invalid `<Trans>` component usage inside `<option>` elements in `EmployeeEdit` with `i18n._(msg\`...\`)` calls to produce valid HTML and avoid rendering issues with the organisational unit dropdown placeholder.

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -653,9 +653,7 @@ describe("useAuth", () => {
       const otherKeyEvent = new StorageEvent("storage", {
         key: "some_other_key",
         newValue: null,
-      });
-      Object.defineProperty(otherKeyEvent, "storageArea", {
-        value: localStorage,
+        storageArea: localStorage,
       });
       window.dispatchEvent(otherKeyEvent);
     });
@@ -684,9 +682,7 @@ describe("useAuth", () => {
         key: "auth_user",
         oldValue: null,
         newValue: JSON.stringify(newUser),
-      });
-      Object.defineProperty(crossTabLoginEvent, "storageArea", {
-        value: localStorage,
+        storageArea: localStorage,
       });
       window.dispatchEvent(crossTabLoginEvent);
     });
@@ -716,16 +712,11 @@ describe("useAuth", () => {
       // Write the corrupt value so localStorage matches the event (real browser
       // cross-tab writes keep newValue and the actual storage in sync).
       localStorage.setItem("auth_user", "{invalid json{{");
-      const invalidJsonEvent = new StorageEvent("storage");
-      Object.defineProperty(invalidJsonEvent, "key", { value: "auth_user" });
-      Object.defineProperty(invalidJsonEvent, "oldValue", {
-        value: JSON.stringify(mockUser),
-      });
-      Object.defineProperty(invalidJsonEvent, "newValue", {
-        value: "{invalid json{{",
-      });
-      Object.defineProperty(invalidJsonEvent, "storageArea", {
-        value: localStorage,
+      const invalidJsonEvent = new StorageEvent("storage", {
+        key: "auth_user",
+        oldValue: JSON.stringify(mockUser),
+        newValue: "{invalid json{{",
+        storageArea: localStorage,
       });
       window.dispatchEvent(invalidJsonEvent);
     });


### PR DESCRIPTION
Fix remaining three CodeQL "superfluous trailing arguments" alerts in `src/hooks/useAuth.test.ts` by applying the same `StorageEventInit` dictionary approach used in PR #752 and PR #753.

## Changes

- `otherKeyEvent` (line ~658): moved `storageArea` from `Object.defineProperty` into the init object; removed the separate `defineProperty` call.
- `crossTabLoginEvent` (line ~685): same — `storageArea` moved into the init object.
- `invalidJsonEvent` (line ~717): converted `new StorageEvent("storage")` + four `Object.defineProperty` calls to a single `new StorageEvent("storage", { key, oldValue, newValue, storageArea })` call.

All 27 `useAuth` tests continue to pass.

## Why not PRs 754–756

PR 754 used `new StorageEvent()` (no args), which is invalid TypeScript — `type: string` is required. PRs 755 and 756 went in the wrong direction (converting working init-object code back to `Object.defineProperty`). All three were closed with explanation.