### PR TITLE
fix: replace Trans component inside option elements with i18n string calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- replaced `<Trans>` component usage inside `<option>` elements in `EmployeeStatusOptions`, `EmployeeCreate` (contract type and org-unit placeholder), `SiteCreate`, and `SiteEdit` with `i18n._(msg\`...\`)`/`\_(msg\`...\`)`string calls to produce valid HTML;`<Trans>`renders a wrapper element that is invalid inside`<option>`
 - Fixed remaining CodeQL "superfluous trailing arguments" alerts in `useAuth` tests by consolidating `otherKeyEvent`, `crossTabLoginEvent`, and `invalidJsonEvent` constructors to use the full `StorageEventInit` dictionary, removing all residual `Object.defineProperty` boilerplate and making the test file consistent throughout.
 - Fixed a race condition in the `OnboardingLayout` sign-out handler where `logout()` was called before the API request; `logout()` and navigation to `/login` now happen only after a successful API logout call so local auth state is not prematurely cleared.
 - Added a user-facing inline error message in `OnboardingLayout` when the sign-out API call fails; local auth state is preserved so the user can retry, and an inline alert notifies them the server request did not complete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- replaced `<Trans>` component usage inside `<option>` elements in `EmployeeStatusOptions`, `EmployeeCreate` (contract type and org-unit placeholder), `SiteCreate`, and `SiteEdit` with `i18n._(msg\`...\`)`/`\_(msg\`...\`)`string calls to produce valid HTML;`<Trans>`renders a wrapper element that is invalid inside`<option>`
+- Replaced `<Trans>` component usage inside `<option>` elements in `EmployeeStatusOptions`, `EmployeeCreate` (contract type and org-unit placeholder), `SiteCreate`, `SiteEdit`, `ActivityLogList` (log-name filter), `CustomersPage` (status filter), `EmployeeList` (status filter), and `SitesPage` (type and status filters) with `_(msg\`...\`)`string calls to produce valid HTML, because`<Trans>`renders a wrapper element that is invalid inside`<option>` elements.
 - Fixed remaining CodeQL "superfluous trailing arguments" alerts in `useAuth` tests by consolidating `otherKeyEvent`, `crossTabLoginEvent`, and `invalidJsonEvent` constructors to use the full `StorageEventInit` dictionary, removing all residual `Object.defineProperty` boilerplate and making the test file consistent throughout.
 - Fixed a race condition in the `OnboardingLayout` sign-out handler where `logout()` was called before the API request; `logout()` and navigation to `/login` now happen only after a successful API logout call so local auth state is not prematurely cleared.
 - Added a user-facing inline error message in `OnboardingLayout` when the sign-out API call fails; local auth state is preserved so the user can retry, and an inline alert notifies them the server request did not complete.

--- a/src/pages/ActivityLog/ActivityLogList.tsx
+++ b/src/pages/ActivityLog/ActivityLogList.tsx
@@ -350,21 +350,11 @@ export function ActivityLogList() {
                   handleLogNameFilter(e.target.value || undefined)
                 }
               >
-                <option value="">
-                  <Trans>All logs</Trans>
-                </option>
-                <option value="default">
-                  <Trans>Default</Trans>
-                </option>
-                <option value="auth">
-                  <Trans>Authentication</Trans>
-                </option>
-                <option value="permission">
-                  <Trans>Permissions</Trans>
-                </option>
-                <option value="hr_access">
-                  <Trans>HR Access</Trans>
-                </option>
+                <option value="">{_(msg`All logs`)}</option>
+                <option value="default">{_(msg`Default`)}</option>
+                <option value="auth">{_(msg`Authentication`)}</option>
+                <option value="permission">{_(msg`Permissions`)}</option>
+                <option value="hr_access">{_(msg`HR Access`)}</option>
               </Select>
             </Field>
 

--- a/src/pages/Customers/CustomersPage.tsx
+++ b/src/pages/Customers/CustomersPage.tsx
@@ -118,15 +118,9 @@ export default function CustomersPage() {
             }
             onChange={(e) => handleStatusFilter(e.target.value)}
           >
-            <option value="">
-              <Trans>All Status</Trans>
-            </option>
-            <option value="true">
-              <Trans>Active</Trans>
-            </option>
-            <option value="false">
-              <Trans>Inactive</Trans>
-            </option>
+            <option value="">{_(msg`All Status`)}</option>
+            <option value="true">{_(msg`Active`)}</option>
+            <option value="false">{_(msg`Inactive`)}</option>
           </Select>
         </Field>
       </div>

--- a/src/pages/Employees/EmployeeCreate.tsx
+++ b/src/pages/Employees/EmployeeCreate.tsx
@@ -715,11 +715,9 @@ export function EmployeeCreate() {
                     disabled={unitsLoading}
                   >
                     <option value="">
-                      {unitsLoading ? (
-                        <Trans>Loading...</Trans>
-                      ) : (
-                        <Trans>Select organizational unit</Trans>
-                      )}
+                      {unitsLoading
+                        ? i18n._(msg`Loading...`)
+                        : i18n._(msg`Select organizational unit`)}
                     </option>
                     {organizationalUnits.map((unit) => (
                       <option key={unit.id} value={unit.id}>
@@ -874,18 +872,10 @@ export function EmployeeCreate() {
                       handleChange("contract_type", e.target.value)
                     }
                   >
-                    <option value="full_time">
-                      <Trans>Full Time</Trans>
-                    </option>
-                    <option value="part_time">
-                      <Trans>Part Time</Trans>
-                    </option>
-                    <option value="minijob">
-                      <Trans>Minijob</Trans>
-                    </option>
-                    <option value="freelance">
-                      <Trans>Freelance</Trans>
-                    </option>
+                    <option value="full_time">{i18n._(msg`Full Time`)}</option>
+                    <option value="part_time">{i18n._(msg`Part Time`)}</option>
+                    <option value="minijob">{i18n._(msg`Minijob`)}</option>
+                    <option value="freelance">{i18n._(msg`Freelance`)}</option>
                   </Select>
                   {fieldErrors.contract_type && (
                     <ErrorMessage id={getFieldErrorId("contract_type")}>

--- a/src/pages/Employees/EmployeeList.tsx
+++ b/src/pages/Employees/EmployeeList.tsx
@@ -206,24 +206,12 @@ export function EmployeeList() {
                 )
               }
             >
-              <option value="">
-                <Trans>All</Trans>
-              </option>
-              <option value="applicant">
-                <Trans>Applicant</Trans>
-              </option>
-              <option value="pre_contract">
-                <Trans>Pre-Contract</Trans>
-              </option>
-              <option value="active">
-                <Trans>Active</Trans>
-              </option>
-              <option value="on_leave">
-                <Trans>On Leave</Trans>
-              </option>
-              <option value="terminated">
-                <Trans>Terminated</Trans>
-              </option>
+              <option value="">{_(msg`All`)}</option>
+              <option value="applicant">{_(msg`Applicant`)}</option>
+              <option value="pre_contract">{_(msg`Pre-Contract`)}</option>
+              <option value="active">{_(msg`Active`)}</option>
+              <option value="on_leave">{_(msg`On Leave`)}</option>
+              <option value="terminated">{_(msg`Terminated`)}</option>
             </Select>
           </Field>
         </div>

--- a/src/pages/Employees/EmployeeStatusOptions.tsx
+++ b/src/pages/Employees/EmployeeStatusOptions.tsx
@@ -1,26 +1,18 @@
 // SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { Trans } from "@lingui/macro";
+import { msg } from "@lingui/macro";
+import { useLingui } from "@lingui/react";
 
 export function EmployeeStatusOptions() {
+  const { _ } = useLingui();
   return (
     <>
-      <option value="applicant">
-        <Trans>Applicant</Trans>
-      </option>
-      <option value="pre_contract">
-        <Trans>Pre-Contract</Trans>
-      </option>
-      <option value="active">
-        <Trans>Active</Trans>
-      </option>
-      <option value="on_leave">
-        <Trans>On Leave</Trans>
-      </option>
-      <option value="terminated">
-        <Trans>Terminated</Trans>
-      </option>
+      <option value="applicant">{_(msg`Applicant`)}</option>
+      <option value="pre_contract">{_(msg`Pre-Contract`)}</option>
+      <option value="active">{_(msg`Active`)}</option>
+      <option value="on_leave">{_(msg`On Leave`)}</option>
+      <option value="terminated">{_(msg`Terminated`)}</option>
     </>
   );
 }

--- a/src/pages/Sites/SiteCreate.tsx
+++ b/src/pages/Sites/SiteCreate.tsx
@@ -268,12 +268,8 @@ export default function SiteCreate() {
               value={formData.type}
               onChange={(e) => updateField("type", e.target.value as SiteType)}
             >
-              <option value="permanent">
-                <Trans>Permanent</Trans>
-              </option>
-              <option value="temporary">
-                <Trans>Temporary</Trans>
-              </option>
+              <option value="permanent">{_(msg`Permanent`)}</option>
+              <option value="temporary">{_(msg`Temporary`)}</option>
             </Select>
           </Field>
         </FieldGroup>

--- a/src/pages/Sites/SiteEdit.tsx
+++ b/src/pages/Sites/SiteEdit.tsx
@@ -259,12 +259,8 @@ export default function SiteEdit() {
               value={formData.type || "permanent"}
               onChange={(e) => updateField("type", e.target.value as SiteType)}
             >
-              <option value="permanent">
-                <Trans>Permanent</Trans>
-              </option>
-              <option value="temporary">
-                <Trans>Temporary</Trans>
-              </option>
+              <option value="permanent">{_(msg`Permanent`)}</option>
+              <option value="temporary">{_(msg`Temporary`)}</option>
             </Select>
           </Field>
         </FieldGroup>

--- a/src/pages/Sites/SitesPage.tsx
+++ b/src/pages/Sites/SitesPage.tsx
@@ -130,15 +130,9 @@ export default function SitesPage() {
             value={filters.type || ""}
             onChange={(e) => handleTypeFilter(e.target.value)}
           >
-            <option value="">
-              <Trans>All Types</Trans>
-            </option>
-            <option value="permanent">
-              <Trans>Permanent</Trans>
-            </option>
-            <option value="temporary">
-              <Trans>Temporary</Trans>
-            </option>
+            <option value="">{_(msg`All Types`)}</option>
+            <option value="permanent">{_(msg`Permanent`)}</option>
+            <option value="temporary">{_(msg`Temporary`)}</option>
           </Select>
         </Field>
         <Field>
@@ -152,15 +146,9 @@ export default function SitesPage() {
             }
             onChange={(e) => handleStatusFilter(e.target.value)}
           >
-            <option value="">
-              <Trans>All Status</Trans>
-            </option>
-            <option value="true">
-              <Trans>Active</Trans>
-            </option>
-            <option value="false">
-              <Trans>Inactive</Trans>
-            </option>
+            <option value="">{_(msg`All Status`)}</option>
+            <option value="true">{_(msg`Active`)}</option>
+            <option value="false">{_(msg`Inactive`)}</option>
           </Select>
         </Field>
       </div>


### PR DESCRIPTION
## Summary

The `<Trans>` macro renders a wrapper element (`<span>`) which produces invalid HTML when placed inside `<option>`. This replaces all remaining `<Trans>` usages inside `<option>` elements with `_(msg`...`)` or `i18n._(msg`...`)` string interpolation.

## Changed files

- **EmployeeStatusOptions.tsx** — all 5 status option labels
- **EmployeeCreate.tsx** — 4 contract-type options and org-unit placeholder
- **SiteCreate.tsx** — 2 site-type options
- **SiteEdit.tsx** — 2 site-type options

## Context

This follows the same pattern applied to EmployeeEdit in PR #757, which was a Copilot AI quality finding. This PR covers the remaining instances found across the codebase.
