### PR TITLE
fix: move logout() to finally block in ApplicationLayout handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a race condition in the `ApplicationLayout` logout handler where `logout()` was called before the API request; `logout()` now runs inside the `finally` block so authTransport.logout() can complete before local state is cleared.
 - Replaced `<Trans>` component usage inside `<option>` elements in `EmployeeStatusOptions`, `EmployeeCreate` (contract type and org-unit placeholder), `SiteCreate`, `SiteEdit`, `ActivityLogList` (log-name filter), `CustomersPage` (status filter), `EmployeeList` (status filter), and `SitesPage` (type and status filters) with `_(msg\`...\`)`string calls to produce valid HTML, because`<Trans>`renders a wrapper element that is invalid inside`<option>` elements.
 - Fixed remaining CodeQL "superfluous trailing arguments" alerts in `useAuth` tests by consolidating `otherKeyEvent`, `crossTabLoginEvent`, and `invalidJsonEvent` constructors to use the full `StorageEventInit` dictionary, removing all residual `Object.defineProperty` boilerplate and making the test file consistent throughout.
 - Fixed a race condition in the `OnboardingLayout` sign-out handler where `logout()` was called before the API request; `logout()` and navigation to `/login` now happen only after a successful API logout call so local auth state is not prematurely cleared.

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -304,7 +304,7 @@ describe("ApplicationLayout", () => {
       expect(clearSensitiveClientState).toHaveBeenCalledTimes(1);
     });
 
-    it("clears local state before API call (prevents race condition)", async () => {
+    it("clears local state after API call completes (finally block)", async () => {
       let wasLocalStorageClearedBeforeApiCall = false;
 
       const mockLogout = vi.mocked(authApi.logout);
@@ -327,7 +327,9 @@ describe("ApplicationLayout", () => {
 
       await waitFor(() => {
         expect(mockLogout).toHaveBeenCalled();
-        expect(wasLocalStorageClearedBeforeApiCall).toBe(true);
+        // Local state should NOT be cleared before the API call —
+        // logout() now runs in the finally block after authTransport.logout()
+        expect(wasLocalStorageClearedBeforeApiCall).toBe(false);
       });
     });
 

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -304,7 +304,7 @@ describe("ApplicationLayout", () => {
       expect(clearSensitiveClientState).toHaveBeenCalledTimes(1);
     });
 
-    it("clears local state after API call completes (finally block)", async () => {
+    it("does not clear local state before API call completes, then clears it in finally (ordering guarantee)", async () => {
       let wasLocalStorageClearedBeforeApiCall = false;
 
       const mockLogout = vi.mocked(authApi.logout);
@@ -330,6 +330,8 @@ describe("ApplicationLayout", () => {
         // Local state should NOT be cleared before the API call —
         // logout() now runs in the finally block after authTransport.logout()
         expect(wasLocalStorageClearedBeforeApiCall).toBe(false);
+        // Local state IS cleared after the API call settles (finally block ran)
+        expect(vi.mocked(clearSensitiveClientState)).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/src/components/application-layout.tsx
+++ b/src/components/application-layout.tsx
@@ -161,14 +161,12 @@ export function ApplicationLayout({ children }: { children: React.ReactNode }) {
   const location = useLocation();
 
   const handleLogout = async () => {
-    // Clear local state FIRST to prevent race conditions
-    logout();
-
     try {
       await authTransport.logout();
     } catch (error) {
       console.error("Logout API call failed:", error);
     } finally {
+      logout();
       navigate("/login");
     }
   };


### PR DESCRIPTION
## Summary

`logout()` was called before `authTransport.logout()`, clearing local auth state prematurely and risking a race condition where the API call runs with stale context.

`logout()` now runs inside the `finally` block so the API call completes (or fails) first and local state cleanup always happens.

## Changed files

- **application-layout.tsx** — `handleLogout` handler
- **application-layout.test.tsx** — updated assertion to match finally-block behavior

## Context

Mirrors the same fix already applied to `OnboardingLayout` in PR #726. Found during a codebase-wide audit of Copilot AI quality findings.
