### PR TITLE
docs: strengthen validation governance with test-impact and PR body-file rules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -74,8 +74,8 @@ At minimum verify:
 - REUSE compliance was checked when changed files require it
 - when a fix alters observable behavior, state lifecycle, error handling, or security constraints,
   the corresponding tests were identified and updated in the same commit
-- before pushing behavioral or security-critical changes, affected tests were run locally
-  (`PREFLIGHT_RUN_TESTS=1 git push` or invoke the test runner directly)
+- before pushing changes that alter observable behavior, state lifecycle, error handling, or security constraints,
+  affected tests were run locally (`PREFLIGHT_RUN_TESTS=1 git push` or invoke the test runner directly)
 - the local 4-pass review was completed, including DRY, KISS, YAGNI, SOLID,
   quality-first, and issue-management checks
 - no bypass was used

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,6 +57,8 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
 - When local review finds zero issues, commit and push the finished branch before opening any PR.
 - The first PR state must be draft. Do not open a normal PR first.
 - Mark a draft PR ready only after the final self-review in the PR view still finds zero issues.
+- When creating or editing PRs programmatically, write multi-line body content to a file and use
+  `--body-file` to prevent shell escaping issues.
 
 ## Required Validation
 
@@ -70,6 +72,10 @@ At minimum verify:
 - `CHANGELOG.md` was updated for real changes
 - commits are GPG-signed
 - REUSE compliance was checked when changed files require it
+- when a fix alters observable behavior, state lifecycle, error handling, or security constraints,
+  the corresponding tests were identified and updated in the same commit
+- before pushing behavioral or security-critical changes, affected tests were run locally
+  (`PREFLIGHT_RUN_TESTS=1 git push` or invoke the test runner directly)
 - the local 4-pass review was completed, including DRY, KISS, YAGNI, SOLID,
   quality-first, and issue-management checks
 - no bypass was used

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Strengthened Copilot governance: require test-impact analysis and same-commit test updates when a fix alters observable behavior, explicitly recommend `PREFLIGHT_RUN_TESTS=1` for behavioral or security changes, and mandate `--body-file` for programmatic PR creation to prevent shell escaping issues.
+- Added a behavior-change reminder to the preflight skip-tests hint so the pre-push hook explicitly warns about enabling tests for security or state-lifecycle fixes.
+
 ### Added
 
 - Added the missing MFA enrollment slice to the settings page so disabled accounts can start TOTP setup, scan a QR code or use the manual setup key, confirm the authenticator code, and immediately receive one-time recovery codes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Strengthened Copilot governance: require test-impact analysis and same-commit test updates when a fix alters observable behavior, explicitly recommend `PREFLIGHT_RUN_TESTS=1` for behavioral or security changes, and mandate `--body-file` for programmatic PR creation to prevent shell escaping issues.
-- Added a behavior-change reminder to the preflight skip-tests hint so the pre-push hook explicitly warns about enabling tests for security or state-lifecycle fixes.
-
 ### Added
 
 - Added the missing MFA enrollment slice to the settings page so disabled accounts can start TOTP setup, scan a QR code or use the manual setup key, confirm the authenticator code, and immediately receive one-time recovery codes.
@@ -42,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Strengthened Copilot governance: require test-impact analysis and same-commit test updates when a fix alters observable behavior, explicitly recommend `PREFLIGHT_RUN_TESTS=1` in preflight guidance for behavioral, security, or state-lifecycle changes, and mandate `--body-file` for programmatic PR creation to prevent shell escaping issues.
 - Isolated authenticated `pre_contract` users into an onboarding-only shell, redirecting them away from normal app routes until activation and sending non-pre-contract users back to the canonical app entry when they hit `/onboarding`.
 - Aligned the public onboarding completion flow with the current backend runtime by removing the unsupported profile-photo bootstrap field, submitting the documented JSON payload to `POST /v1/onboarding/complete`, and accepting the session-based completion response without a frontend token assumption
 - Made browser-session login prefer the canonical `GET /v1/me` user payload immediately after authentication, so capability-gated navigation no longer comes up incomplete until the first manual refresh.

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -149,6 +149,7 @@ if [ -f pnpm-lock.yaml ] && command -v pnpm >/dev/null 2>&1; then
     pnpm run --if-present test:run
   else
     echo "ℹ️  Skipping tests in pre-push hook (enable via PREFLIGHT_RUN_TESTS=1)" >&2
+    echo "   ⚠️  Enable for behavior, security, or state-lifecycle changes" >&2
     echo "   Tests will run in CI pipeline" >&2
   fi
 elif [ -f package-lock.json ] && command -v npm >/dev/null 2>&1; then
@@ -170,6 +171,7 @@ elif [ -f package-lock.json ] && command -v npm >/dev/null 2>&1; then
     npm run --if-present test:run
   else
     echo "ℹ️  Skipping tests in pre-push hook (enable via PREFLIGHT_RUN_TESTS=1)" >&2
+    echo "   ⚠️  Enable for behavior, security, or state-lifecycle changes" >&2
     echo "   Tests will run in CI pipeline" >&2
   fi
 elif [ -f yarn.lock ] && command -v yarn >/dev/null 2>&1; then
@@ -206,6 +208,7 @@ elif [ -f yarn.lock ] && command -v yarn >/dev/null 2>&1; then
     fi
   else
     echo "ℹ️  Skipping tests in pre-push hook (enable via PREFLIGHT_RUN_TESTS=1)" >&2
+    echo "   ⚠️  Enable for behavior, security, or state-lifecycle changes" >&2
     echo "   Tests will run in CI pipeline" >&2
   fi
 fi


### PR DESCRIPTION
## Summary

Codifies prevention learnings from the recent CI failure audit into repo governance. Adds explicit rules that were missing from the validation checklists.

## Changes

### Copilot Instructions (`.github/copilot-instructions.md`)

**Required Validation** — new checklist items:
- When a fix alters observable behavior, state lifecycle, error handling, or security constraints, the corresponding tests must be identified and updated in the same commit
- Before pushing behavioral or security-critical changes, affected tests must be run locally (`PREFLIGHT_RUN_TESTS=1 git push` or invoke the test runner directly)

**Issue And PR Discipline** — new rule:
- When creating or editing PRs programmatically, write multi-line body content to a file and use `--body-file` to prevent shell escaping issues

### Preflight Script (`scripts/preflight.sh`)

- Strengthened the skip-tests hint message to explicitly warn about enabling tests for behavior, security, or state-lifecycle changes

## Motivation

Recent CI failures were caused by:
1. Behavior-changing fixes pushed without updating tests that depended on the old behavior
2. PR bodies created with `mcp_github_create_pull_request` double-escaping `\n` characters

These governance additions prevent recurrence by making test-impact analysis and file-based PR bodies explicit checklist items.
