### PR TITLE
feat: show enrolled passkeys in settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added passkey visibility to the settings page, including enrolled-passkey listing and an unsupported-browser notice that does not hide existing server-side passkey data.
 - Added the missing MFA enrollment slice to the settings page so disabled accounts can start TOTP setup, scan a QR code or use the manual setup key, confirm the authenticator code, and immediately receive one-time recovery codes.
 - Added a reusable MFA QR-code component with browser-safe fallback messaging and focused component coverage so upcoming enrollment UI slices can render authenticator setup material without duplicating QR generation logic.
 - Added PWA offline persistence security and privacy [audit document](PWA_OFFLINE_PERSISTENCE_AUDIT.md) covering all client-side storage mechanisms (localStorage, sessionStorage, IndexedDB, Cache API, Service Worker state) with 10 findings, issue overlap analysis, and prioritized remediation recommendations.

--- a/src/pages/Settings/SettingsPage.test.tsx
+++ b/src/pages/Settings/SettingsPage.test.tsx
@@ -168,6 +168,32 @@ describe("SettingsPage", () => {
     expect(screen.getByText(/work macbook touch id/i)).toBeInTheDocument();
   });
 
+  it("shows an empty passkey state when no credentials are enrolled", async () => {
+    vi.mocked(authApi.getPasskeys).mockResolvedValueOnce({ data: [] });
+
+    await renderSettingsPage();
+
+    expect(screen.getByText(/no passkeys enrolled yet/i)).toBeInTheDocument();
+  });
+
+  it("shows passkey loading errors returned by the API", async () => {
+    vi.mocked(authApi.getPasskeys).mockRejectedValueOnce(
+      new authApi.AuthApiError("Failed to load passkeys.")
+    );
+
+    await renderSettingsPage();
+
+    expect(screen.getByText(/failed to load passkeys/i)).toBeInTheDocument();
+  });
+
+  it("shows a fallback passkey loading error for unexpected failures", async () => {
+    vi.mocked(authApi.getPasskeys).mockRejectedValueOnce("unexpected");
+
+    await renderSettingsPage();
+
+    expect(screen.getByText(/failed to load passkeys/i)).toBeInTheDocument();
+  });
+
   it("shows an unsupported passkey message without hiding the enrolled list", async () => {
     Object.defineProperty(window, "PublicKeyCredential", {
       configurable: true,

--- a/src/pages/Settings/SettingsPage.test.tsx
+++ b/src/pages/Settings/SettingsPage.test.tsx
@@ -165,7 +165,9 @@ describe("SettingsPage", () => {
     expect(
       await screen.findByRole("heading", { name: /passkeys/i })
     ).toBeInTheDocument();
-    expect(screen.getByText(/work macbook touch id/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/work macbook touch id/i)
+    ).toBeInTheDocument();
   });
 
   it("shows an empty passkey state when no credentials are enrolled", async () => {
@@ -173,7 +175,9 @@ describe("SettingsPage", () => {
 
     await renderSettingsPage();
 
-    expect(screen.getByText(/no passkeys enrolled yet/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/no passkeys enrolled yet/i)
+    ).toBeInTheDocument();
   });
 
   it("shows passkey loading errors returned by the API", async () => {
@@ -183,7 +187,9 @@ describe("SettingsPage", () => {
 
     await renderSettingsPage();
 
-    expect(screen.getByText(/failed to load passkeys/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/failed to load passkeys/i)
+    ).toBeInTheDocument();
   });
 
   it("shows a fallback passkey loading error for unexpected failures", async () => {
@@ -191,7 +197,9 @@ describe("SettingsPage", () => {
 
     await renderSettingsPage();
 
-    expect(screen.getByText(/failed to load passkeys/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/failed to load passkeys/i)
+    ).toBeInTheDocument();
   });
 
   it("shows an unsupported passkey message without hiding the enrolled list", async () => {
@@ -206,7 +214,9 @@ describe("SettingsPage", () => {
     expect(
       screen.getByText(/this browser does not support passkeys/i)
     ).toBeInTheDocument();
-    expect(screen.getByText(/work macbook touch id/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/work macbook touch id/i)
+    ).toBeInTheDocument();
   });
 
   it("displays language selection section", async () => {

--- a/src/pages/Settings/SettingsPage.test.tsx
+++ b/src/pages/Settings/SettingsPage.test.tsx
@@ -33,6 +33,7 @@ vi.mock("../../services/authApi", async () => {
   const actual = await vi.importActual("../../services/authApi");
   return {
     ...actual,
+    getPasskeys: vi.fn(),
     getMfaStatus: vi.fn(),
     startTotpEnrollment: vi.fn(),
     confirmTotpEnrollment: vi.fn(),
@@ -113,6 +114,20 @@ function createTotpEnrollmentPreparationResponse() {
   };
 }
 
+function createPasskeyListResponse() {
+  return {
+    data: [
+      {
+        id: "credential-id",
+        label: "Work MacBook Touch ID",
+        created_at: "2026-04-06T09:12:00Z",
+        last_used_at: null,
+        transports: ["internal" as const],
+      },
+    ],
+  };
+}
+
 describe("SettingsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -122,6 +137,18 @@ describe("SettingsPage", () => {
     vi.mocked(authApi.getMfaStatus).mockResolvedValue(
       createDisabledMfaStatusResponse()
     );
+    vi.mocked(authApi.getPasskeys).mockResolvedValue(
+      createPasskeyListResponse()
+    );
+    Object.defineProperty(window, "PublicKeyCredential", {
+      configurable: true,
+      writable: true,
+      value: function PublicKeyCredential() {},
+    });
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: true,
+    });
   });
 
   it("renders the settings page with heading", async () => {
@@ -130,6 +157,30 @@ describe("SettingsPage", () => {
     expect(
       screen.getByRole("heading", { name: /settings/i })
     ).toBeInTheDocument();
+  });
+
+  it("lists enrolled passkeys", async () => {
+    await renderSettingsPage();
+
+    expect(
+      await screen.findByRole("heading", { name: /passkeys/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/work macbook touch id/i)).toBeInTheDocument();
+  });
+
+  it("shows an unsupported passkey message without hiding the enrolled list", async () => {
+    Object.defineProperty(window, "PublicKeyCredential", {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+
+    await renderSettingsPage();
+
+    expect(
+      screen.getByText(/this browser does not support passkeys/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/work macbook touch id/i)).toBeInTheDocument();
   });
 
   it("displays language selection section", async () => {

--- a/src/pages/Settings/SettingsPage.tsx
+++ b/src/pages/Settings/SettingsPage.tsx
@@ -14,6 +14,7 @@ import { useLingui } from "@lingui/react";
 import type {
   MfaRecoveryCodeReveal,
   MfaStatus,
+  PasskeyCredentialSummary,
   TotpEnrollmentPreparation,
   MfaVerificationMethod,
 } from "@/types/api";
@@ -40,6 +41,7 @@ import {
   AuthApiError,
   confirmTotpEnrollment,
   disableMfa,
+  getPasskeys,
   getMfaStatus,
   regenerateRecoveryCodes,
   startTotpEnrollment,
@@ -93,9 +95,19 @@ function getSensitiveActionLabels(action: SensitiveMfaAction | null): {
 
 export function SettingsPage() {
   const { _, i18n } = useLingui();
+  const supportsPasskeys = useMemo(
+    () =>
+      typeof window !== "undefined" &&
+      window.isSecureContext &&
+      typeof window.PublicKeyCredential !== "undefined",
+    []
+  );
   const [mfaStatus, setMfaStatus] = useState<MfaStatus | null>(null);
   const [isLoadingMfaStatus, setIsLoadingMfaStatus] = useState(true);
   const [mfaStatusError, setMfaStatusError] = useState<string | null>(null);
+  const [passkeys, setPasskeys] = useState<PasskeyCredentialSummary[]>([]);
+  const [isLoadingPasskeys, setIsLoadingPasskeys] = useState(true);
+  const [passkeyError, setPasskeyError] = useState<string | null>(null);
   const [isEnrollmentDialogOpen, setIsEnrollmentDialogOpen] = useState(false);
   const [isPreparingEnrollment, setIsPreparingEnrollment] = useState(false);
   const [enrollmentPreparation, setEnrollmentPreparation] =
@@ -149,6 +161,30 @@ export function SettingsPage() {
   useEffect(() => {
     void loadMfaStatus();
   }, [loadMfaStatus]);
+
+  const loadPasskeys = useCallback(async () => {
+    setIsLoadingPasskeys(true);
+    setPasskeyError(null);
+
+    try {
+      const response = await getPasskeys();
+      setPasskeys(response.data);
+    } catch (error) {
+      if (error instanceof AuthApiError) {
+        setPasskeyError(error.message);
+      } else if (error instanceof Error) {
+        setPasskeyError(error.message);
+      } else {
+        setPasskeyError("Failed to load passkeys.");
+      }
+    } finally {
+      setIsLoadingPasskeys(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadPasskeys();
+  }, [loadPasskeys]);
 
   const loadEnrollmentPreparation = useCallback(async () => {
     setIsPreparingEnrollment(true);
@@ -373,6 +409,63 @@ export function SettingsPage() {
               )}
             </div>
           )}
+        </div>
+      </section>
+
+      <Divider />
+
+      <section className="space-y-6">
+        <div>
+          <Heading level={2}>
+            <Trans>Passkeys</Trans>
+          </Heading>
+          <Text className="mt-1">
+            <Trans>
+              Review the passkeys currently enrolled for this account.
+            </Trans>
+          </Text>
+        </div>
+
+        <div className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900/60">
+          <div className="space-y-4">
+            {!supportsPasskeys ? (
+              <Text className="text-sm text-zinc-600 dark:text-zinc-300">
+                <Trans>This browser does not support passkeys.</Trans>
+              </Text>
+            ) : null}
+            {passkeyError ? (
+              <Text className="text-sm text-red-700 dark:text-red-300">
+                {passkeyError}
+              </Text>
+            ) : null}
+            {isLoadingPasskeys ? (
+              <Text className="text-sm text-zinc-500 dark:text-zinc-400">
+                <Trans>Loading passkeys...</Trans>
+              </Text>
+            ) : passkeys.length === 0 ? (
+              <Text className="text-sm text-zinc-600 dark:text-zinc-300">
+                <Trans>No passkeys enrolled yet.</Trans>
+              </Text>
+            ) : (
+              <div className="space-y-3">
+                {passkeys.map((passkey) => (
+                  <div
+                    key={passkey.id}
+                    className="rounded-2xl border border-zinc-200 bg-zinc-50 px-4 py-3 dark:border-zinc-800 dark:bg-zinc-900/60"
+                  >
+                    <p className="text-sm font-medium text-zinc-950 dark:text-white">
+                      {passkey.label}
+                    </p>
+                    <Text className="text-sm text-zinc-500 dark:text-zinc-400">
+                      <Trans>
+                        Added {formatDateTime(passkey.created_at, i18n.locale)}
+                      </Trans>
+                    </Text>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
       </section>
 

--- a/src/pages/Settings/SettingsPage.tsx
+++ b/src/pages/Settings/SettingsPage.tsx
@@ -442,7 +442,7 @@ export function SettingsPage() {
               <Text className="text-sm text-zinc-500 dark:text-zinc-400">
                 <Trans>Loading passkeys...</Trans>
               </Text>
-            ) : passkeys.length === 0 ? (
+            ) : !passkeyError && passkeys.length === 0 ? (
               <Text className="text-sm text-zinc-600 dark:text-zinc-300">
                 <Trans>No passkeys enrolled yet.</Trans>
               </Text>

--- a/src/services/authApi.test.ts
+++ b/src/services/authApi.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
+  getPasskeys,
   login,
   logout,
   logoutAll,
@@ -647,6 +648,30 @@ describe("authApi", () => {
           cache: "no-store",
         })
       );
+    });
+  });
+
+  describe("getPasskeys", () => {
+    it("fetches enrolled passkeys from /v1/me/passkeys", async () => {
+      const mockResponse = {
+        data: [
+          {
+            id: "credential-id",
+            label: "Work MacBook Touch ID",
+            created_at: "2026-04-06T09:12:00Z",
+            last_used_at: null,
+            transports: ["internal"],
+          },
+        ],
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockResponse,
+      } as Response);
+
+      await expect(getPasskeys()).resolves.toEqual(mockResponse);
     });
   });
 

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -8,6 +8,7 @@ import type {
   MfaStatusResponse,
   MfaTotpEnrollmentResponse,
   MfaVerificationCodeRequest,
+  PasskeyListResponse,
   SessionLoginResponse,
   TotpCodeRequest,
   VerificationNotificationResponse,
@@ -280,6 +281,25 @@ export async function getMfaStatus(): Promise<MfaStatusResponse> {
   return parseJsonResponse<MfaStatusResponse>(
     response,
     "MFA status fetch failed"
+  );
+}
+
+export async function getPasskeys(): Promise<PasskeyListResponse> {
+  const response = await apiFetch(buildApiUrl("/v1/me/passkeys"), {
+    method: "GET",
+    cache: "no-store",
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw await createAuthApiError(response, "Passkey list fetch failed");
+  }
+
+  return parseJsonResponse<PasskeyListResponse>(
+    response,
+    "Passkey list fetch failed"
   );
 }
 

--- a/src/types/api/auth.ts
+++ b/src/types/api/auth.ts
@@ -120,3 +120,23 @@ export interface MfaRecoveryCodeRevealPayload {
 export interface MfaRecoveryCodeRevealResponse {
   data: MfaRecoveryCodeRevealPayload;
 }
+
+export type PasskeyTransport =
+  | "ble"
+  | "hybrid"
+  | "internal"
+  | "nfc"
+  | "usb"
+  | (string & {});
+
+export interface PasskeyCredentialSummary {
+  id: string;
+  label: string;
+  created_at: string;
+  last_used_at: string | null;
+  transports: PasskeyTransport[];
+}
+
+export interface PasskeyListResponse {
+  data: PasskeyCredentialSummary[];
+}


### PR DESCRIPTION
## Summary
- show enrolled passkeys in the settings page
- keep the enrolled list visible even when the current browser cannot use passkeys
- add focused tests for supported and unsupported visibility states

## Validation
- npm run test:run -- src/services/authApi.test.ts src/pages/Settings/SettingsPage.test.tsx
- npm run typecheck
- npm run build

## Related
- Closes #766
- Part of #728
