### PR TITLE
feat(settings): add passkey removal flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a permission-gated Android provisioning UI with backend-issued enrollment session creation, QR display, status visibility, and revoke controls for Epic SecPal/.github#327.
 - Added browser passkey sign-in to the login flow, including the WebAuthn challenge client and focused frontend coverage for supported browsers and failure handling.
 - Added passkey visibility to the settings page, including enrolled-passkey listing and an unsupported-browser notice that does not hide existing server-side passkey data.
+- Added passkey removal to the settings page, including destructive controls for enrolled credentials, backend deletion, list refresh, and focused frontend coverage for successful and failing removal flows.
 - Added the missing MFA enrollment slice to the settings page so disabled accounts can start TOTP setup, scan a QR code or use the manual setup key, confirm the authenticator code, and immediately receive one-time recovery codes.
 - Added a reusable MFA QR-code component with browser-safe fallback messaging and focused component coverage so upcoming enrollment UI slices can render authenticator setup material without duplicating QR generation logic.
 - Added PWA offline persistence security and privacy [audit document](PWA_OFFLINE_PERSISTENCE_AUDIT.md) covering all client-side storage mechanisms (localStorage, sessionStorage, IndexedDB, Cache API, Service Worker state) with 10 findings, issue overlap analysis, and prioritized remediation recommendations.

--- a/src/pages/Settings/SettingsPage.test.tsx
+++ b/src/pages/Settings/SettingsPage.test.tsx
@@ -33,6 +33,7 @@ vi.mock("../../services/authApi", async () => {
   const actual = await vi.importActual("../../services/authApi");
   return {
     ...actual,
+    deletePasskey: vi.fn(),
     getPasskeys: vi.fn(),
     getMfaStatus: vi.fn(),
     startTotpEnrollment: vi.fn(),
@@ -217,6 +218,45 @@ describe("SettingsPage", () => {
     expect(
       await screen.findByText(/work macbook touch id/i)
     ).toBeInTheDocument();
+  });
+
+  it("removes an enrolled passkey and refreshes the list", async () => {
+    vi.mocked(authApi.deletePasskey).mockResolvedValueOnce({
+      message: "Passkey deleted successfully.",
+      data: { remaining_passkeys: 0 },
+    });
+    vi.mocked(authApi.getPasskeys)
+      .mockResolvedValueOnce(createPasskeyListResponse())
+      .mockResolvedValueOnce({ data: [] });
+
+    await renderSettingsPage();
+
+    fireEvent.click(screen.getByRole("button", { name: /remove/i }));
+
+    await waitFor(() => {
+      expect(authApi.deletePasskey).toHaveBeenCalledWith("credential-id");
+      expect(authApi.getPasskeys).toHaveBeenCalledTimes(2);
+    });
+
+    expect(
+      screen.queryByText(/work macbook touch id/i)
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/no passkeys enrolled yet/i)).toBeInTheDocument();
+  });
+
+  it("shows passkey removal errors inline", async () => {
+    vi.mocked(authApi.deletePasskey).mockRejectedValueOnce(
+      new authApi.AuthApiError("Passkey deletion failed.")
+    );
+
+    await renderSettingsPage();
+
+    fireEvent.click(screen.getByRole("button", { name: /remove/i }));
+
+    expect(
+      await screen.findByText(/passkey deletion failed/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/work macbook touch id/i)).toBeInTheDocument();
   });
 
   it("displays language selection section", async () => {

--- a/src/pages/Settings/SettingsPage.test.tsx
+++ b/src/pages/Settings/SettingsPage.test.tsx
@@ -230,7 +230,6 @@ describe("SettingsPage", () => {
       .mockResolvedValueOnce({ data: [] });
 
     await renderSettingsPage();
-
     fireEvent.click(screen.getByRole("button", { name: /remove/i }));
 
     await waitFor(() => {
@@ -242,6 +241,64 @@ describe("SettingsPage", () => {
       screen.queryByText(/work macbook touch id/i)
     ).not.toBeInTheDocument();
     expect(screen.getByText(/no passkeys enrolled yet/i)).toBeInTheDocument();
+  });
+
+  it("shows a busy state while passkey removal is in flight", async () => {
+    let resolveDeletion:
+      | ((value: {
+          message: string;
+          data: { remaining_passkeys: number };
+        }) => void)
+      | undefined;
+
+    vi.mocked(authApi.deletePasskey).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveDeletion = resolve;
+        })
+    );
+    vi.mocked(authApi.getPasskeys)
+      .mockResolvedValueOnce(createPasskeyListResponse())
+      .mockResolvedValueOnce({ data: [] });
+
+    await renderSettingsPage();
+
+    fireEvent.click(screen.getByRole("button", { name: /remove/i }));
+
+    expect(screen.getByRole("button", { name: /removing/i })).toBeDisabled();
+
+    resolveDeletion?.({
+      message: "Passkey deleted successfully.",
+      data: { remaining_passkeys: 0 },
+    });
+
+    expect(
+      await screen.findByText(/no passkeys enrolled yet/i)
+    ).toBeInTheDocument();
+  });
+
+  it("shows generic Error removal failures inline", async () => {
+    vi.mocked(authApi.deletePasskey).mockRejectedValueOnce(
+      new Error("Deletion exploded.")
+    );
+
+    await renderSettingsPage();
+
+    fireEvent.click(screen.getByRole("button", { name: /remove/i }));
+
+    expect(await screen.findByText(/deletion exploded/i)).toBeInTheDocument();
+  });
+
+  it("shows fallback removal errors for unexpected failures", async () => {
+    vi.mocked(authApi.deletePasskey).mockRejectedValueOnce("unexpected");
+
+    await renderSettingsPage();
+
+    fireEvent.click(screen.getByRole("button", { name: /remove/i }));
+
+    expect(
+      await screen.findByText(/failed to delete passkey/i)
+    ).toBeInTheDocument();
   });
 
   it("shows passkey removal errors inline", async () => {

--- a/src/pages/Settings/SettingsPage.test.tsx
+++ b/src/pages/Settings/SettingsPage.test.tsx
@@ -235,12 +235,65 @@ describe("SettingsPage", () => {
     await waitFor(() => {
       expect(authApi.deletePasskey).toHaveBeenCalledWith("credential-id");
       expect(authApi.getPasskeys).toHaveBeenCalledTimes(2);
+      expect(
+        screen.queryByText(/work macbook touch id/i)
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByText(/no passkeys enrolled yet/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("disables all remove buttons while any removal is in flight", async () => {
+    let resolveDeletion:
+      | ((value: {
+          message: string;
+          data: { remaining_passkeys: number };
+        }) => void)
+      | undefined;
+
+    vi.mocked(authApi.deletePasskey).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveDeletion = resolve;
+        })
+    );
+    vi.mocked(authApi.getPasskeys).mockResolvedValueOnce({
+      data: [
+        {
+          id: "credential-id",
+          label: "Work MacBook Touch ID",
+          created_at: "2026-04-06T09:12:00Z",
+          last_used_at: null,
+          transports: ["internal" as const],
+        },
+        {
+          id: "credential-id-2",
+          label: "iPhone Face ID",
+          created_at: "2026-04-07T09:12:00Z",
+          last_used_at: null,
+          transports: ["internal" as const],
+        },
+      ],
     });
 
-    expect(
-      screen.queryByText(/work macbook touch id/i)
-    ).not.toBeInTheDocument();
-    expect(screen.getByText(/no passkeys enrolled yet/i)).toBeInTheDocument();
+    await renderSettingsPage();
+
+    const removeButtons = screen.getAllByRole("button", { name: /remove/i });
+    expect(removeButtons).toHaveLength(2);
+    fireEvent.click(removeButtons[0]!);
+
+    // ALL remove buttons must be disabled while any deletion is in flight
+    for (const button of screen.getAllByRole("button", {
+      name: /remove|removing/i,
+    })) {
+      expect(button).toBeDisabled();
+    }
+
+    resolveDeletion?.({
+      message: "Passkey deleted successfully.",
+      data: { remaining_passkeys: 1 },
+    });
   });
 
   it("shows a busy state while passkey removal is in flight", async () => {

--- a/src/pages/Settings/SettingsPage.test.tsx
+++ b/src/pages/Settings/SettingsPage.test.tsx
@@ -238,9 +238,7 @@ describe("SettingsPage", () => {
       expect(
         screen.queryByText(/work macbook touch id/i)
       ).not.toBeInTheDocument();
-      expect(
-        screen.getByText(/no passkeys enrolled yet/i)
-      ).toBeInTheDocument();
+      expect(screen.getByText(/no passkeys enrolled yet/i)).toBeInTheDocument();
     });
   });
 

--- a/src/pages/Settings/SettingsPage.tsx
+++ b/src/pages/Settings/SettingsPage.tsx
@@ -40,6 +40,7 @@ import {
 import {
   AuthApiError,
   confirmTotpEnrollment,
+  deletePasskey,
   disableMfa,
   getPasskeys,
   getMfaStatus,
@@ -108,6 +109,9 @@ export function SettingsPage() {
   const [passkeys, setPasskeys] = useState<PasskeyCredentialSummary[]>([]);
   const [isLoadingPasskeys, setIsLoadingPasskeys] = useState(true);
   const [passkeyError, setPasskeyError] = useState<string | null>(null);
+  const [removingPasskeyId, setRemovingPasskeyId] = useState<string | null>(
+    null
+  );
   const [isEnrollmentDialogOpen, setIsEnrollmentDialogOpen] = useState(false);
   const [isPreparingEnrollment, setIsPreparingEnrollment] = useState(false);
   const [enrollmentPreparation, setEnrollmentPreparation] =
@@ -185,6 +189,26 @@ export function SettingsPage() {
   useEffect(() => {
     void loadPasskeys();
   }, [loadPasskeys]);
+
+  const handlePasskeyRemoval = async (credentialId: string) => {
+    setPasskeyError(null);
+    setRemovingPasskeyId(credentialId);
+
+    try {
+      await deletePasskey(credentialId);
+      await loadPasskeys();
+    } catch (error) {
+      if (error instanceof AuthApiError) {
+        setPasskeyError(error.message);
+      } else if (error instanceof Error) {
+        setPasskeyError(error.message);
+      } else {
+        setPasskeyError("Failed to delete passkey.");
+      }
+    } finally {
+      setRemovingPasskeyId(null);
+    }
+  };
 
   const loadEnrollmentPreparation = useCallback(async () => {
     setIsPreparingEnrollment(true);
@@ -453,14 +477,31 @@ export function SettingsPage() {
                     key={passkey.id}
                     className="rounded-2xl border border-zinc-200 bg-zinc-50 px-4 py-3 dark:border-zinc-800 dark:bg-zinc-900/60"
                   >
-                    <p className="text-sm font-medium text-zinc-950 dark:text-white">
-                      {passkey.label}
-                    </p>
-                    <Text className="text-sm text-zinc-500 dark:text-zinc-400">
-                      <Trans>
-                        Added {formatDateTime(passkey.created_at, i18n.locale)}
-                      </Trans>
-                    </Text>
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                      <div>
+                        <p className="text-sm font-medium text-zinc-950 dark:text-white">
+                          {passkey.label}
+                        </p>
+                        <Text className="text-sm text-zinc-500 dark:text-zinc-400">
+                          <Trans>
+                            Added{" "}
+                            {formatDateTime(passkey.created_at, i18n.locale)}
+                          </Trans>
+                        </Text>
+                      </div>
+                      <Button
+                        type="button"
+                        color="red"
+                        disabled={removingPasskeyId === passkey.id}
+                        onClick={() => void handlePasskeyRemoval(passkey.id)}
+                      >
+                        {removingPasskeyId === passkey.id ? (
+                          <Trans>Removing...</Trans>
+                        ) : (
+                          <Trans>Remove</Trans>
+                        )}
+                      </Button>
+                    </div>
                   </div>
                 ))}
               </div>

--- a/src/pages/Settings/SettingsPage.tsx
+++ b/src/pages/Settings/SettingsPage.tsx
@@ -492,7 +492,7 @@ export function SettingsPage() {
                       <Button
                         type="button"
                         color="red"
-                        disabled={removingPasskeyId === passkey.id}
+                        disabled={removingPasskeyId !== null}
                         onClick={() => void handlePasskeyRemoval(passkey.id)}
                       >
                         {removingPasskeyId === passkey.id ? (

--- a/src/services/authApi.test.ts
+++ b/src/services/authApi.test.ts
@@ -791,6 +791,29 @@ describe("authApi", () => {
         })
       );
     });
+
+    it("surfaces JSON errors when passkey deletion fails", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({
+          message: "Passkey deletion failed.",
+          code: "NOT_FOUND",
+        }),
+      } as Response);
+
+      try {
+        await deletePasskey("missing-credential-id");
+        expect.fail("Expected deletePasskey to throw");
+      } catch (error) {
+        expect(error).toBeInstanceOf(AuthApiError);
+        expect((error as AuthApiError).message).toBe(
+          "Passkey deletion failed."
+        );
+        expect((error as AuthApiError).status).toBe(404);
+        expect((error as AuthApiError).code).toBe("NOT_FOUND");
+      }
+    });
   });
 
   describe("startTotpEnrollment", () => {

--- a/src/services/authApi.test.ts
+++ b/src/services/authApi.test.ts
@@ -766,7 +766,9 @@ describe("authApi", () => {
 
       await expect(getPasskeys()).resolves.toEqual(mockResponse);
     });
+  });
 
+  describe("deletePasskey", () => {
     it("deletes an enrolled passkey with DELETE /v1/me/passkeys/:credentialId", async () => {
       const mockResponse = {
         message: "Passkey deleted successfully.",

--- a/src/services/authApi.test.ts
+++ b/src/services/authApi.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   startPasskeyAuthenticationChallenge,
   verifyPasskeyAuthenticationChallenge,
+  deletePasskey,
   getPasskeys,
   login,
   logout,
@@ -764,6 +765,31 @@ describe("authApi", () => {
       } as Response);
 
       await expect(getPasskeys()).resolves.toEqual(mockResponse);
+    });
+
+    it("deletes an enrolled passkey with DELETE /v1/me/passkeys/:credentialId", async () => {
+      const mockResponse = {
+        message: "Passkey deleted successfully.",
+        data: { remaining_passkeys: 0 },
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockResponse,
+      } as Response);
+
+      await expect(deletePasskey("credential-id")).resolves.toEqual(
+        mockResponse
+      );
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/v1/me/passkeys/credential-id"),
+        expect.objectContaining({
+          method: "DELETE",
+          credentials: "include",
+          cache: "no-store",
+        })
+      );
     });
   });
 

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -8,6 +8,7 @@ import type {
   MfaStatusResponse,
   MfaTotpEnrollmentResponse,
   MfaVerificationCodeRequest,
+  PasskeyDeletionResponse,
   PasskeyAuthenticationChallengeResponse,
   PasskeyAuthenticationVerificationRequest,
   PasskeyListResponse,
@@ -352,6 +353,30 @@ export async function getPasskeys(): Promise<PasskeyListResponse> {
   return parseJsonResponse<PasskeyListResponse>(
     response,
     "Passkey list fetch failed"
+  );
+}
+
+export async function deletePasskey(
+  credentialId: string
+): Promise<PasskeyDeletionResponse> {
+  const response = await apiFetch(
+    buildApiUrl(`/v1/me/passkeys/${credentialId}`),
+    {
+      method: "DELETE",
+      cache: "no-store",
+      headers: {
+        Accept: "application/json",
+      },
+    }
+  );
+
+  if (!response.ok) {
+    throw await createAuthApiError(response, "Passkey deletion failed");
+  }
+
+  return parseJsonResponse<PasskeyDeletionResponse>(
+    response,
+    "Passkey deletion failed"
   );
 }
 

--- a/src/types/api/auth.ts
+++ b/src/types/api/auth.ts
@@ -66,14 +66,14 @@ export interface TokenAuthenticationResult {
 
 export type CompletedLoginResponse =
   | {
-    user: AuthenticatedUser;
-    authentication: SessionAuthenticationResult;
-  }
+      user: AuthenticatedUser;
+      authentication: SessionAuthenticationResult;
+    }
   | {
-    token: string;
-    user: AuthenticatedUser;
-    authentication: TokenAuthenticationResult;
-  };
+      token: string;
+      user: AuthenticatedUser;
+      authentication: TokenAuthenticationResult;
+    };
 
 export interface MfaStatus {
   enabled: boolean;

--- a/src/types/api/auth.ts
+++ b/src/types/api/auth.ts
@@ -142,6 +142,13 @@ export interface PasskeyListResponse {
   data: PasskeyCredentialSummary[];
 }
 
+export interface PasskeyDeletionResponse {
+  message: string;
+  data: {
+    remaining_passkeys: number;
+  };
+}
+
 export interface PasskeyCredentialDescriptor {
   type: "public-key";
   id: string;


### PR DESCRIPTION
# Description

Adds the settings-page passkey removal slice for issue #769. Enrolled credentials now expose a remove action, call the backend delete endpoint, and refresh the server-backed list so the UI reflects the remaining passkeys.

Fixes #769

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] npm run typecheck
- [x] npm run test:run -- src/services/authApi.test.ts src/pages/Settings/SettingsPage.test.tsx
- [x] npm run build

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
