### PR TITLE
fix(layout): bound logout with timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Added the missing German translations for the EmployeeDetail "Confirm Onboarding" action and the onboarding sign-out failure message so those UI states no longer fall back to English.
+- Bounded `ApplicationLayout` sign-out with an 8-second timeout so a hung logout request still clears local auth state and returns the browser user to the login screen.
 - Fixed a race condition in the `ApplicationLayout` logout handler where `logout()` was called before the API request; `logout()` now runs inside the `finally` block so authTransport.logout() can complete before local state is cleared.
 - Replaced `<Trans>` component usage inside `<option>` elements in `EmployeeStatusOptions`, `EmployeeCreate` (contract type and org-unit placeholder), `SiteCreate`, `SiteEdit`, `ActivityLogList` (log-name filter), `CustomersPage` (status filter), `EmployeeList` (status filter), and `SitesPage` (type and status filters) with `_(msg\`...\`)`string calls to produce valid HTML, because`<Trans>`renders a wrapper element that is invalid inside`<option>` elements.
 - Fixed remaining CodeQL "superfluous trailing arguments" alerts in `useAuth` tests by consolidating `otherKeyEvent`, `crossTabLoginEvent`, and `invalidJsonEvent` constructors to use the full `StorageEventInit` dictionary, removing all residual `Object.defineProperty` boilerplate and making the test file consistent throughout.

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  act,
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
@@ -367,6 +373,57 @@ describe("ApplicationLayout", () => {
       expect(localStorage.getItem("auth_user")).toBeNull();
 
       consoleSpy.mockRestore();
+    });
+
+    it("completes client-side logout when the logout API hangs past the timeout", async () => {
+      const mockLogout = vi.mocked(authApi.logout);
+      mockLogout.mockImplementation(() => new Promise(() => undefined));
+
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      renderWithProviders(
+        <ApplicationLayout>
+          <div>Content</div>
+        </ApplicationLayout>
+      );
+
+      await openUserMenu();
+
+      const signOutButton = screen.getByRole("menuitem", { name: /sign out/i });
+
+      vi.useFakeTimers();
+
+      try {
+        fireEvent.click(signOutButton);
+
+        expect(mockLogout).toHaveBeenCalledTimes(1);
+        expect(localStorage.getItem("auth_user")).not.toBeNull();
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(7999);
+        });
+        expect(localStorage.getItem("auth_user")).not.toBeNull();
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(1);
+        });
+
+        expect(
+          consoleSpy.mock.calls.some(
+            ([message, error]) =>
+              message === "Logout API call failed:" &&
+              error instanceof Error &&
+              error.message.includes("timed out after 8000ms")
+          )
+        ).toBe(true);
+        expect(localStorage.getItem("auth_user")).toBeNull();
+        expect(clearSensitiveClientState).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+        consoleSpy.mockRestore();
+      }
     });
   });
 

--- a/src/components/application-layout.tsx
+++ b/src/components/application-layout.tsx
@@ -161,6 +161,29 @@ function UserMenuItems({ onLogout }: { onLogout: () => void }) {
   );
 }
 
+const LOGOUT_TIMEOUT_MS = 8000;
+
+async function logoutWithTimeout(logoutRequest: Promise<void>): Promise<void> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    await Promise.race([
+      logoutRequest,
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(
+            new Error(`Logout request timed out after ${LOGOUT_TIMEOUT_MS}ms.`)
+          );
+        }, LOGOUT_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
 export function ApplicationLayout({ children }: { children: React.ReactNode }) {
   const { user, logout } = useAuth();
   const capabilities = useUserCapabilities();
@@ -170,7 +193,7 @@ export function ApplicationLayout({ children }: { children: React.ReactNode }) {
 
   const handleLogout = async () => {
     try {
-      await authTransport.logout();
+      await logoutWithTimeout(authTransport.logout());
     } catch (error) {
       console.error("Logout API call failed:", error);
     } finally {


### PR DESCRIPTION
# Description

Bounds the `ApplicationLayout` sign-out path with an 8-second timeout so a hung logout request still clears local auth state and returns the browser user to `/login`.

Fixes #771

Follow-up tracked separately: #775

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] npm run typecheck
- [x] npm run test:run -- src/components/application-layout.test.tsx
- [x] npm run test:coverage -- src/components/application-layout.test.tsx
- [x] npm run build

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
