### PR TITLE
test(auth): remove SettingsPage act warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Removed a React `act(...)` warning from the `SettingsPage` passkey-removal test by wrapping the deferred `resolveDeletion` call in `act` and waiting for the post-deletion UI to settle, so the covered removal flow no longer leaks async state updates out of the test boundary.
 - Added the missing German translations for the EmployeeDetail "Confirm Onboarding" action and the onboarding sign-out failure message so those UI states no longer fall back to English.
 - Bounded `ApplicationLayout` sign-out with an 8-second timeout so a hung logout request still clears local auth state and returns the browser user to the login screen.
 - Bounded `OnboardingLayout` sign-out with an 8-second timeout so hung logout requests still clear local auth state and return the user to `/login`, while real API failures continue to show the inline retry message.

--- a/src/pages/Settings/SettingsPage.test.tsx
+++ b/src/pages/Settings/SettingsPage.test.tsx
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  act,
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
@@ -385,6 +391,9 @@ describe("SettingsPage", () => {
   });
 
   it("disables all remove buttons while any removal is in flight", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
     let resolveDeletion:
       | ((value: {
           message: string;
@@ -430,10 +439,27 @@ describe("SettingsPage", () => {
       expect(button).toBeDisabled();
     }
 
-    resolveDeletion?.({
-      message: "Passkey deleted successfully.",
-      data: { remaining_passkeys: 1 },
+    await act(async () => {
+      resolveDeletion?.({
+        message: "Passkey deleted successfully.",
+        data: { remaining_passkeys: 1 },
+      });
     });
+
+    await waitFor(() => {
+      expect(authApi.getPasskeys).toHaveBeenCalledTimes(2);
+      expect(screen.getAllByRole("button", { name: /remove/i })).toHaveLength(
+        1
+      );
+    });
+
+    expect(
+      consoleErrorSpy.mock.calls.some(([message]) =>
+        String(message).includes("not wrapped in act")
+      )
+    ).toBe(false);
+
+    consoleErrorSpy.mockRestore();
   });
 
   it("shows a busy state while passkey removal is in flight", async () => {

--- a/src/pages/Settings/SettingsPage.test.tsx
+++ b/src/pages/Settings/SettingsPage.test.tsx
@@ -439,27 +439,34 @@ describe("SettingsPage", () => {
       expect(button).toBeDisabled();
     }
 
-    await act(async () => {
-      resolveDeletion?.({
-        message: "Passkey deleted successfully.",
-        data: { remaining_passkeys: 1 },
+    try {
+      await act(async () => {
+        resolveDeletion?.({
+          message: "Passkey deleted successfully.",
+          data: { remaining_passkeys: 1 },
+        });
       });
-    });
 
-    await waitFor(() => {
-      expect(authApi.getPasskeys).toHaveBeenCalledTimes(2);
-      expect(screen.getAllByRole("button", { name: /remove/i })).toHaveLength(
-        1
+      await waitFor(() => {
+        expect(authApi.getPasskeys).toHaveBeenCalledTimes(2);
+        expect(screen.getAllByRole("button", { name: /remove/i })).toHaveLength(
+          1
+        );
+      });
+
+      expect(
+        consoleErrorSpy.mock.calls.some(([message]) =>
+          String(message).includes("not wrapped in act")
+        )
+      ).toBe(false);
+
+      const unexpectedErrors = consoleErrorSpy.mock.calls.filter(
+        ([message]) => !String(message).includes("not wrapped in act")
       );
-    });
-
-    expect(
-      consoleErrorSpy.mock.calls.some(([message]) =>
-        String(message).includes("not wrapped in act")
-      )
-    ).toBe(false);
-
-    consoleErrorSpy.mockRestore();
+      expect(unexpectedErrors).toHaveLength(0);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 
   it("shows a busy state while passkey removal is in flight", async () => {


### PR DESCRIPTION
## Summary
- remove the remaining React `act(...)` warning from the SettingsPage passkey-removal test
- wait for the post-deletion UI to settle before ending the test
- assert that the warning does not reappear in the covered removal flow

## Validation
- `npm exec vitest run src/pages/Settings/SettingsPage.test.tsx`
- `npm exec vitest run src/pages/Login.test.tsx src/pages/Settings/SettingsPage.test.tsx src/services/authApi.test.ts src/services/passkeyBrowser.test.ts`
- `npx eslint src/pages/Settings/SettingsPage.test.tsx`

Closes #806
