### PR TITLE
test: harden Android provisioning access control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added user-visible error message in `EmployeeEdit` when the form is submitted without a route `id`; previously the submission silently no-oped.
 - Replaced hardcoded locale-switched date validation error strings in `EmployeeEdit` with `i18n._(msg\`...\`)` calls so messages are properly translatable.
 
+- added targeted Android provisioning access-control regressions for hidden navigation and denied route access so the permission-gated provisioning UI in `frontend#751` stays covered end-to-end
+
 ### Changed
 
 - Replaced raw Android provisioning rollout-channel and session-status enum values with human-readable labels and operator guidance, so stale, revoked, and already-used enrollment sessions are easier to interpret in the frontend UI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed perpetual `fetchLoading` state in `EmployeeEdit` when `id` param is absent; `setFetchLoading(false)` is now called before the early return.
 - Added user-visible error message in `EmployeeEdit` when the form is submitted without a route `id`; previously the submission silently no-oped.
 - Replaced hardcoded locale-switched date validation error strings in `EmployeeEdit` with `i18n._(msg\`...\`)` calls so messages are properly translatable.
-
-- added targeted Android provisioning access-control regressions for hidden navigation and denied route access so the permission-gated provisioning UI in `frontend#751` stays covered end-to-end
+- Added targeted Android provisioning access-control regressions for hidden navigation and denied route access so the permission-gated provisioning UI in #751 stays covered end-to-end.
 
 ### Changed
 

--- a/src/components/FeatureRoute.test.tsx
+++ b/src/components/FeatureRoute.test.tsx
@@ -89,4 +89,58 @@ describe("FeatureRoute", () => {
     ).toBeInTheDocument();
     expect(screen.queryByText("Customers Content")).not.toBeInTheDocument();
   });
+  it("renders access denied when Android provisioning read access is missing", () => {
+    vi.mocked(authHook.useAuth).mockReturnValue({
+      isLoading: false,
+      isAuthenticated: true,
+      bootstrapRecoveryReason: null,
+      user: {
+        id: "1",
+        name: "User",
+        email: "user@secpal.dev",
+        emailVerified: true,
+      },
+      login: vi.fn(),
+      logout: vi.fn(),
+      retryBootstrap: vi.fn(),
+      hasRole: vi.fn(),
+      hasPermission: vi.fn(),
+      hasOrganizationalAccess: vi.fn(),
+    });
+    vi.mocked(capabilitiesHook.useUserCapabilities).mockReturnValue({
+      ...capabilities,
+      androidProvisioning: false,
+      actions: {
+        ...capabilities.actions,
+        androidProvisioning: { create: false, revoke: false },
+      },
+    });
+
+    render(
+      <I18nProvider i18n={i18n}>
+        <MemoryRouter initialEntries={["/android-provisioning"]}>
+          <Routes>
+            <Route
+              path="/android-provisioning"
+              element={
+                <FeatureRoute feature="androidProvisioning">
+                  <div>Android Provisioning Content</div>
+                </FeatureRoute>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </I18nProvider>
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /access denied/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/do not have permission to access this feature/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Android Provisioning Content")
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -868,5 +868,29 @@ describe("ApplicationLayout", () => {
       expect(screen.getByText("Android-Provisionierung")).toBeInTheDocument();
       expect(screen.queryByText("62KQbc")).not.toBeInTheDocument();
     });
+
+    it("hides the Android provisioning navigation entry without read access", () => {
+      localStorage.setItem(
+        "auth_user",
+        JSON.stringify({
+          id: 1,
+          name: "Admin User",
+          email: "admin@secpal.dev",
+          hasOrganizationalScopes: true,
+          roles: [],
+          permissions: ["activity_log.read"],
+        })
+      );
+
+      renderWithProviders(
+        <ApplicationLayout>
+          <div>Content</div>
+        </ApplicationLayout>
+      );
+
+      expect(
+        screen.queryByRole("link", { name: "Android Provisioning" })
+      ).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add Android provisioning route-guard regression coverage for missing read access
- add navigation regression coverage so the Android provisioning entry stays hidden for non-elevated users without enrollment read permission
- document the access-control hardening in the changelog to complete the remaining test coverage slice for `frontend#751`

## Validation
- `CI=1 npm run test -- src/components/FeatureRoute.test.tsx src/components/application-layout.test.tsx`
- `npm run typecheck`
- `npx eslint src/components/FeatureRoute.test.tsx src/components/application-layout.test.tsx`

Closes #751.
Part of SecPal/.github#327.