### PR TITLE
fix: handle empty allowCredentials in passkey browser login flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed passkey browser login failing with "Resident credentials or empty allowCredentials lists are not supported" by omitting empty `allowCredentials` from the WebAuthn options, checking conditional-mediation availability with a safe fallback to `optional`, and surfacing a user-friendly message when passkey sign-in encounters an unsupported-browser or cancelled-ceremony error.
 - Added the missing German translations for the remaining passkey action labels in Settings so add and remove flows no longer fall back to English in the shipped `de` locale.
 - Removed a React `act(...)` warning from the `SettingsPage` passkey-removal test by wrapping the deferred `resolveDeletion` call in `act` and waiting for the post-deletion UI to settle, so the covered removal flow no longer leaks async state updates out of the test boundary.
 - Completed the missing German Lingui translations for current passkey and Android provisioning UI so security and enrollment screens no longer fall back to English in the shipped `de` locale.

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -272,7 +272,7 @@ describe("Login", () => {
       )
     ).rejects.toThrow("Passkeys are not available in this browser.");
 
-    vi.stubGlobal("PublicKeyCredential", class PublicKeyCredentialMock { });
+    vi.stubGlobal("PublicKeyCredential", class PublicKeyCredentialMock {});
     Object.defineProperty(navigator, "credentials", {
       configurable: true,
       value: {
@@ -535,7 +535,7 @@ describe("Login", () => {
     const mockVerifyMfaChallenge = vi.mocked(authApi.verifyMfaChallenge);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => { });
+      .mockImplementation(() => {});
 
     mockLogin.mockResolvedValueOnce({
       challenge: {
@@ -611,7 +611,7 @@ describe("Login", () => {
   it("shows an error when MFA challenge response has an unexpected mode", async () => {
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => { });
+      .mockImplementation(() => {});
     vi.mocked(authApi.verifyMfaChallenge).mockResolvedValueOnce({
       user: createAuthUser(),
       authentication: {
@@ -670,7 +670,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => { });
+      .mockImplementation(() => {});
 
     mockLogin.mockRejectedValueOnce(
       new authApi.AuthApiError("Server Error", undefined, 500)
@@ -710,7 +710,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => { });
+      .mockImplementation(() => {});
     mockLogin.mockRejectedValueOnce(new Error("Network error"));
 
     renderLogin();
@@ -744,7 +744,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => { });
+      .mockImplementation(() => {});
     mockLogin.mockRejectedValueOnce("string error");
 
     renderLogin();

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -272,7 +272,7 @@ describe("Login", () => {
       )
     ).rejects.toThrow("Passkeys are not available in this browser.");
 
-    vi.stubGlobal("PublicKeyCredential", class PublicKeyCredentialMock {});
+    vi.stubGlobal("PublicKeyCredential", class PublicKeyCredentialMock { });
     Object.defineProperty(navigator, "credentials", {
       configurable: true,
       value: {
@@ -391,6 +391,78 @@ describe("Login", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows a cancelled message when passkey sign-in is rejected with NotAllowedError", async () => {
+    vi.mocked(passkeyBrowser.isPasskeySupported).mockReturnValue(true);
+    vi.mocked(
+      authApi.startPasskeyAuthenticationChallenge
+    ).mockResolvedValueOnce({
+      data: {
+        challenge_id: "550e8400-e29b-41d4-a716-446655440099",
+        public_key: {
+          challenge: "Zm9vYmFy",
+          rp_id: "app.secpal.dev",
+          timeout: 60000,
+          user_verification: "preferred",
+        },
+        mediation: "optional",
+        expires_at: "2026-04-06T12:00:00Z",
+      },
+    });
+    const notAllowed = new DOMException(
+      "The operation is not allowed.",
+      "NotAllowedError"
+    );
+    vi.mocked(passkeyBrowser.getPasskeyAssertion).mockRejectedValueOnce(
+      notAllowed
+    );
+
+    renderLogin();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /sign in with passkey/i })
+    );
+
+    expect(
+      await screen.findByText(
+        /passkey sign-in was cancelled or not permitted by the browser/i
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("shows an unsupported-browser message when passkey sign-in fails with a resident-credentials error", async () => {
+    vi.mocked(passkeyBrowser.isPasskeySupported).mockReturnValue(true);
+    vi.mocked(
+      authApi.startPasskeyAuthenticationChallenge
+    ).mockResolvedValueOnce({
+      data: {
+        challenge_id: "550e8400-e29b-41d4-a716-446655440099",
+        public_key: {
+          challenge: "Zm9vYmFy",
+          rp_id: "app.secpal.dev",
+          timeout: 60000,
+          user_verification: "preferred",
+        },
+        mediation: "optional",
+        expires_at: "2026-04-06T12:00:00Z",
+      },
+    });
+    vi.mocked(passkeyBrowser.getPasskeyAssertion).mockRejectedValueOnce(
+      new Error(
+        "Resident credentials or empty allowCredentials lists are not supported"
+      )
+    );
+
+    renderLogin();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /sign in with passkey/i })
+    );
+
+    expect(
+      await screen.findByText(/your browser does not support passkey sign-in/i)
+    ).toBeInTheDocument();
+  });
+
   it("verifies an MFA challenge and continues the session login flow", async () => {
     const mockLogin = vi.mocked(authApi.login);
     const mockVerifyMfaChallenge = vi.mocked(authApi.verifyMfaChallenge);
@@ -463,7 +535,7 @@ describe("Login", () => {
     const mockVerifyMfaChallenge = vi.mocked(authApi.verifyMfaChallenge);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => {});
+      .mockImplementation(() => { });
 
     mockLogin.mockResolvedValueOnce({
       challenge: {
@@ -539,7 +611,7 @@ describe("Login", () => {
   it("shows an error when MFA challenge response has an unexpected mode", async () => {
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => {});
+      .mockImplementation(() => { });
     vi.mocked(authApi.verifyMfaChallenge).mockResolvedValueOnce({
       user: createAuthUser(),
       authentication: {
@@ -598,7 +670,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => {});
+      .mockImplementation(() => { });
 
     mockLogin.mockRejectedValueOnce(
       new authApi.AuthApiError("Server Error", undefined, 500)
@@ -638,7 +710,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => {});
+      .mockImplementation(() => { });
     mockLogin.mockRejectedValueOnce(new Error("Network error"));
 
     renderLogin();
@@ -672,7 +744,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => {});
+      .mockImplementation(() => { });
     mockLogin.mockRejectedValueOnce("string error");
 
     renderLogin();

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -51,6 +51,7 @@ vi.mock("../hooks/useOnlineStatus", () => ({
 vi.mock("../services/passkeyBrowser", () => ({
   isPasskeySupported: vi.fn(),
   getPasskeyAssertion: vi.fn(),
+  isConditionalMediationAvailable: vi.fn().mockResolvedValue(true),
 }));
 
 const renderLogin = () => {

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -372,6 +372,62 @@ describe("Login", () => {
     });
   });
 
+  it("falls back to optional mediation when conditional mediation is unavailable", async () => {
+    vi.mocked(passkeyBrowser.isPasskeySupported).mockReturnValue(true);
+    vi.mocked(
+      passkeyBrowser.isConditionalMediationAvailable
+    ).mockResolvedValueOnce(false);
+    vi.mocked(
+      authApi.startPasskeyAuthenticationChallenge
+    ).mockResolvedValueOnce({
+      data: {
+        challenge_id: "550e8400-e29b-41d4-a716-446655440099",
+        public_key: {
+          challenge: "Zm9vYmFy",
+          rp_id: "app.secpal.dev",
+          timeout: 60000,
+          user_verification: "preferred",
+        },
+        mediation: "conditional",
+        expires_at: "2026-04-06T12:00:00Z",
+      },
+    });
+    vi.mocked(passkeyBrowser.getPasskeyAssertion).mockResolvedValueOnce({
+      id: "credential-id",
+      raw_id: "credential-id",
+      type: "public-key",
+      response: {
+        client_data_json: "Y2xpZW50",
+        authenticator_data: "YXV0aA",
+        signature: "c2lnbmF0dXJl",
+      },
+      client_extension_results: {},
+    });
+    vi.mocked(
+      authApi.verifyPasskeyAuthenticationChallenge
+    ).mockResolvedValueOnce({
+      user: createAuthUser(),
+      authentication: {
+        mode: "session",
+        method: "passkey",
+        mfa_completed: true,
+      },
+    });
+
+    renderLogin();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /sign in with passkey/i })
+    );
+
+    await waitFor(() => {
+      expect(passkeyBrowser.getPasskeyAssertion).toHaveBeenCalledWith(
+        expect.anything(),
+        "optional"
+      );
+    });
+  });
+
   it("shows passkey sign-in errors inline when the passkey flow fails", async () => {
     vi.mocked(passkeyBrowser.isPasskeySupported).mockReturnValue(true);
     vi.mocked(

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -18,6 +18,7 @@ import { sanitizeAuthUser } from "../services/authState";
 import { checkHealth, HealthStatus } from "../services/healthApi";
 import {
   getPasskeyAssertion,
+  isConditionalMediationAvailable,
   isPasskeySupported,
 } from "../services/passkeyBrowser";
 import { AuthLayout } from "../components/auth-layout";
@@ -237,9 +238,18 @@ export function Login() {
 
     try {
       const challengeResponse = await startPasskeyAuthenticationChallenge();
+
+      let mediation = challengeResponse.data.mediation;
+      if (
+        mediation === "conditional" &&
+        !(await isConditionalMediationAvailable())
+      ) {
+        mediation = "optional";
+      }
+
       const credential = await getPasskeyAssertion(
         challengeResponse.data.public_key,
-        challengeResponse.data.mediation
+        mediation
       );
       const response = await verifyPasskeyAuthenticationChallenge(
         challengeResponse.data.challenge_id,
@@ -270,8 +280,24 @@ export function Login() {
 
       if (err instanceof AuthApiError) {
         setError(err.message);
+      } else if (
+        err instanceof DOMException &&
+        err.name === "NotAllowedError"
+      ) {
+        setError(
+          "Passkey sign-in was cancelled or not permitted by the browser."
+        );
       } else if (err instanceof Error) {
-        setError(err.message);
+        if (
+          err.message.includes("resident credentials") ||
+          err.message.includes("allowCredentials")
+        ) {
+          setError(
+            "Your browser does not support passkey sign-in. Please use your email and password instead."
+          );
+        } else {
+          setError(err.message);
+        }
       } else {
         setError(
           "An unexpected passkey sign-in error occurred. Please try again."

--- a/src/services/passkeyBrowser.test.ts
+++ b/src/services/passkeyBrowser.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getPasskeyAssertion,
   getPasskeyAttestation,
+  isConditionalMediationAvailable,
   isPasskeySupported,
   isPasskeyRegistrationSupported,
 } from "./passkeyBrowser";
@@ -455,5 +456,101 @@ describe("passkeyBrowser", () => {
     const callOptions = createCredential.mock
       .calls[0]![0]! as CredentialCreationOptions;
     expect(callOptions.publicKey).toHaveProperty("attestation", "none");
+  });
+
+  it("omits allowCredentials from the browser call when allow_credentials is empty", async () => {
+    const optionsWithEmptyCredentials: PasskeyAuthenticationPublicKeyOptions = {
+      ...authenticationOptions,
+      allow_credentials: [],
+    };
+
+    const getCredential = vi.fn().mockResolvedValue({
+      id: "credential-id",
+      rawId: toArrayBuffer("raw-id"),
+      type: "public-key",
+      response: {
+        clientDataJSON: toArrayBuffer("client-data"),
+        authenticatorData: toArrayBuffer("authenticator-data"),
+        signature: toArrayBuffer("signature"),
+        userHandle: null,
+      },
+      getClientExtensionResults: () => ({}),
+    } as unknown as PublicKeyCredential);
+
+    vi.stubGlobal("PublicKeyCredential", class PublicKeyCredentialMock {});
+    Object.defineProperty(navigator, "credentials", {
+      configurable: true,
+      value: { get: getCredential },
+    });
+
+    await getPasskeyAssertion(optionsWithEmptyCredentials, "conditional");
+
+    const callOptions = getCredential.mock
+      .calls[0]![0]! as CredentialRequestOptions;
+    expect(callOptions.publicKey).not.toHaveProperty("allowCredentials");
+  });
+
+  it("omits allowCredentials from the browser call when allow_credentials is undefined", async () => {
+    const optionsWithoutCredentials: PasskeyAuthenticationPublicKeyOptions = {
+      challenge: toBase64Url("challenge"),
+      rp_id: "app.secpal.dev",
+      timeout: 60000,
+      user_verification: "preferred",
+    };
+
+    const getCredential = vi.fn().mockResolvedValue({
+      id: "credential-id",
+      rawId: toArrayBuffer("raw-id"),
+      type: "public-key",
+      response: {
+        clientDataJSON: toArrayBuffer("client-data"),
+        authenticatorData: toArrayBuffer("authenticator-data"),
+        signature: toArrayBuffer("signature"),
+        userHandle: null,
+      },
+      getClientExtensionResults: () => ({}),
+    } as unknown as PublicKeyCredential);
+
+    vi.stubGlobal("PublicKeyCredential", class PublicKeyCredentialMock {});
+    Object.defineProperty(navigator, "credentials", {
+      configurable: true,
+      value: { get: getCredential },
+    });
+
+    await getPasskeyAssertion(optionsWithoutCredentials, "optional");
+
+    const callOptions = getCredential.mock
+      .calls[0]![0]! as CredentialRequestOptions;
+    expect(callOptions.publicKey).not.toHaveProperty("allowCredentials");
+  });
+
+  it("returns true for isConditionalMediationAvailable when the browser supports it", async () => {
+    vi.stubGlobal("PublicKeyCredential", {
+      isConditionalMediationAvailable: vi.fn().mockResolvedValue(true),
+    });
+
+    expect(await isConditionalMediationAvailable()).toBe(true);
+  });
+
+  it("returns false for isConditionalMediationAvailable when the method is absent", async () => {
+    vi.stubGlobal("PublicKeyCredential", {});
+
+    expect(await isConditionalMediationAvailable()).toBe(false);
+  });
+
+  it("returns false for isConditionalMediationAvailable when PublicKeyCredential is undefined", async () => {
+    Reflect.deleteProperty(window, "PublicKeyCredential");
+
+    expect(await isConditionalMediationAvailable()).toBe(false);
+  });
+
+  it("returns false for isConditionalMediationAvailable when the check throws", async () => {
+    vi.stubGlobal("PublicKeyCredential", {
+      isConditionalMediationAvailable: vi
+        .fn()
+        .mockRejectedValue(new Error("not supported")),
+    });
+
+    expect(await isConditionalMediationAvailable()).toBe(false);
   });
 });

--- a/src/services/passkeyBrowser.ts
+++ b/src/services/passkeyBrowser.ts
@@ -109,6 +109,9 @@ function createAuthenticationOptions(
   mediation: string
 ): CredentialRequestOptions {
   const normalizedMediation = normalizeMediation(mediation);
+  const mappedCredentials = options.allow_credentials?.length
+    ? options.allow_credentials.map(mapDescriptor)
+    : undefined;
 
   return {
     ...(normalizedMediation !== undefined
@@ -121,7 +124,9 @@ function createAuthenticationOptions(
       userVerification: options.user_verification as
         | UserVerificationRequirement
         | undefined,
-      allowCredentials: options.allow_credentials?.map(mapDescriptor),
+      ...(mappedCredentials !== undefined
+        ? { allowCredentials: mappedCredentials }
+        : {}),
     },
   };
 }
@@ -197,6 +202,27 @@ export function isPasskeyRegistrationSupported(): boolean {
   return (
     isPasskeySupported() && typeof navigator.credentials?.create === "function"
   );
+}
+
+export async function isConditionalMediationAvailable(): Promise<boolean> {
+  if (
+    typeof window === "undefined" ||
+    typeof window.PublicKeyCredential === "undefined"
+  ) {
+    return false;
+  }
+
+  if (
+    typeof PublicKeyCredential.isConditionalMediationAvailable !== "function"
+  ) {
+    return false;
+  }
+
+  try {
+    return await PublicKeyCredential.isConditionalMediationAvailable();
+  } catch {
+    return false;
+  }
 }
 
 export async function getPasskeyAssertion(


### PR DESCRIPTION
## Summary

Fixes passkey browser sign-in failing with "Resident credentials or empty allowCredentials lists are not supported" by handling the empty `allowCredentials` case and improving error handling in the passkey login flow.

## Root Cause

When the API returns an empty `allow_credentials` array for a discoverable-credential WebAuthn challenge, the frontend passed it through as `allowCredentials: []` to `navigator.credentials.get()`. Browsers that enforce the WebAuthn spec reject this — the key must be absent (not empty) for discoverable-credential flows.

## Changes

- **`passkeyBrowser.ts` (`createAuthenticationOptions`)**: Omit `allowCredentials` from the WebAuthn options when the API array is empty or missing.
- **`passkeyBrowser.ts` (`isConditionalMediationAvailable`)**: New exported function that safely checks `PublicKeyCredential.isConditionalMediationAvailable()` with fallback to `false`.
- **`Login.tsx` (`handlePasskeySignIn`)**: Check conditional mediation availability with a safe fallback to `"optional"`. Handle `NotAllowedError` (user cancelled) gracefully. Surface a user-friendly message for unsupported-browser errors.
- **`passkeyBrowser.test.ts`**: Six new tests covering empty-array omission (2 tests) and conditional-mediation availability detection (4 scenarios).

## Companion PR

- API-side fix: SecPal/api#816

## Validation

- 20 passkeyBrowser tests pass (including 6 new tests)
- TypeScript: clean (`tsc --noEmit`)
- ESLint: 0 warnings
- Prettier: formatted
- REUSE: compliant
