### PR TITLE
fix: clean WebAuthn options and add AbortController timeout safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed passkey enrollment hanging on "Adding passkey..." by stripping null `authenticatorAttachment` values from `AuthenticatorSelectionCriteria`, picking only `id` and `name` from the `rp` object (omitting deprecated `icon: null`), and omitting empty `excludeCredentials` arrays before passing options to `navigator.credentials.create()`.
+- Added an `AbortController` timeout safety net to both `getPasskeyAttestation` and `getPasskeyAssertion` so the WebAuthn ceremony is cancelled if the browser exceeds the server-specified timeout plus a 5-second grace period, preventing indefinite UI hangs.
+- Added explicit `AbortError` handling in the passkey sign-in and passkey registration error paths so timed-out WebAuthn ceremonies show a clear "timed out" message instead of a raw abort error.
 - Added a user-friendly cancellation message when the browser WebAuthn dialog is dismissed or denied during passkey registration.
 - Fixed passkey browser login failing with "Resident credentials or empty allowCredentials lists are not supported" by omitting empty `allowCredentials` from the WebAuthn options, checking conditional-mediation availability with a safe fallback to `optional`, and surfacing a user-friendly message when passkey sign-in encounters an unsupported-browser or cancelled-ceremony error.
 - Added the missing German translations for the remaining passkey action labels in Settings so add and remove flows no longer fall back to English in the shipped `de` locale.

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -485,6 +485,42 @@ describe("Login", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows a timeout message when passkey sign-in is aborted", async () => {
+    vi.mocked(passkeyBrowser.isPasskeySupported).mockReturnValue(true);
+    vi.mocked(
+      authApi.startPasskeyAuthenticationChallenge
+    ).mockResolvedValueOnce({
+      data: {
+        challenge_id: "550e8400-e29b-41d4-a716-446655440099",
+        public_key: {
+          challenge: "Zm9vYmFy",
+          rp_id: "app.secpal.dev",
+          timeout: 60000,
+          user_verification: "preferred",
+        },
+        mediation: "optional",
+        expires_at: "2026-04-06T12:00:00Z",
+      },
+    });
+    const abortError = new DOMException(
+      "The operation was aborted.",
+      "AbortError"
+    );
+    vi.mocked(passkeyBrowser.getPasskeyAssertion).mockRejectedValueOnce(
+      abortError
+    );
+
+    renderLogin();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /sign in with passkey/i })
+    );
+
+    expect(
+      await screen.findByText(/passkey sign-in timed out/i)
+    ).toBeInTheDocument();
+  });
+
   it("shows an unsupported-browser message when passkey sign-in fails with a resident-credentials error", async () => {
     vi.mocked(passkeyBrowser.isPasskeySupported).mockReturnValue(true);
     vi.mocked(

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -287,6 +287,8 @@ export function Login() {
         setError(
           "Passkey sign-in was cancelled or not permitted by the browser."
         );
+      } else if (err instanceof DOMException && err.name === "AbortError") {
+        setError("Passkey sign-in timed out. Please try again.");
       } else if (err instanceof Error) {
         if (
           err.message.includes("resident credentials") ||

--- a/src/pages/Settings/SettingsPage.test.tsx
+++ b/src/pages/Settings/SettingsPage.test.tsx
@@ -350,6 +350,29 @@ describe("SettingsPage", () => {
     ).not.toBeDisabled();
   });
 
+  it("shows timeout message when passkey registration is aborted", async () => {
+    vi.mocked(authApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
+      createPasskeyRegistrationChallengeResponse()
+    );
+    vi.mocked(passkeyBrowser.getPasskeyAttestation).mockRejectedValueOnce(
+      new DOMException("The operation was aborted.", "AbortError")
+    );
+
+    await renderSettingsPage();
+
+    fireEvent.change(screen.getByLabelText(/passkey label/i), {
+      target: { value: "Security Key" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /add passkey/i }));
+
+    expect(
+      await screen.findByText(/passkey registration timed out/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /add passkey/i })
+    ).not.toBeDisabled();
+  });
+
   it("shows generic error when browser attestation fails unexpectedly", async () => {
     vi.mocked(authApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
       createPasskeyRegistrationChallengeResponse()

--- a/src/pages/Settings/SettingsPage.tsx
+++ b/src/pages/Settings/SettingsPage.tsx
@@ -256,6 +256,8 @@ export function SettingsPage() {
         setPasskeyError(
           "Passkey registration was cancelled or not permitted by the browser."
         );
+      } else if (error instanceof DOMException && error.name === "AbortError") {
+        setPasskeyError("Passkey registration timed out. Please try again.");
       } else if (error instanceof Error) {
         setPasskeyError(error.message);
       } else {

--- a/src/services/passkeyBrowser.test.ts
+++ b/src/services/passkeyBrowser.test.ts
@@ -125,22 +125,31 @@ describe("passkeyBrowser", () => {
       "conditional"
     );
 
-    expect(getCredential).toHaveBeenCalledWith({
-      mediation: "conditional",
-      publicKey: {
-        challenge: toArrayBuffer("challenge"),
-        rpId: "app.secpal.dev",
-        timeout: 60000,
-        userVerification: "preferred",
-        allowCredentials: [
-          {
-            type: "public-key",
-            id: toArrayBuffer("credential-id"),
-            transports: ["internal", "usb"],
-          },
-        ],
-      },
-    });
+    expect(getCredential).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mediation: "conditional",
+        publicKey: {
+          challenge: toArrayBuffer("challenge"),
+          rpId: "app.secpal.dev",
+          timeout: 60000,
+          userVerification: "preferred",
+          allowCredentials: [
+            {
+              type: "public-key",
+              id: toArrayBuffer("credential-id"),
+              transports: ["internal", "usb"],
+            },
+          ],
+        },
+      })
+    );
+
+    const callOptions = getCredential.mock.calls[0]![0]! as Record<
+      string,
+      unknown
+    >;
+    expect(callOptions).toHaveProperty("signal");
+    expect(callOptions.signal).toBeInstanceOf(AbortSignal);
 
     expect(credential).toEqual({
       id: "credential-id",
@@ -552,5 +561,212 @@ describe("passkeyBrowser", () => {
     });
 
     expect(await isConditionalMediationAvailable()).toBe(false);
+  });
+
+  it("strips null authenticatorAttachment from the registration options", async () => {
+    const registrationOptions: PasskeyRegistrationPublicKeyOptions = {
+      challenge: toBase64Url("challenge"),
+      rp: { id: "app.secpal.dev", name: "SecPal" },
+      user: {
+        id: toBase64Url("user-id"),
+        name: "test@secpal.dev",
+        display_name: "Test User",
+      },
+      pub_key_cred_params: [{ type: "public-key", alg: -7 }],
+      attestation: "none",
+      authenticator_selection: {
+        authenticator_attachment: null as unknown as "platform",
+        resident_key: "preferred",
+        require_resident_key: false,
+        user_verification: "preferred",
+      },
+    };
+
+    const createCredential = vi.fn().mockResolvedValue({
+      id: "credential-id",
+      rawId: toArrayBuffer("raw-id"),
+      type: "public-key",
+      response: {
+        clientDataJSON: toArrayBuffer("client-data"),
+        attestationObject: toArrayBuffer("attestation-object"),
+        getTransports: () => [],
+      },
+      getClientExtensionResults: () => ({}),
+    } as unknown as PublicKeyCredential);
+
+    vi.stubGlobal("PublicKeyCredential", class PublicKeyCredentialMock {});
+    Object.defineProperty(navigator, "credentials", {
+      configurable: true,
+      value: { get: vi.fn(), create: createCredential },
+    });
+
+    await getPasskeyAttestation(registrationOptions);
+
+    const callOptions = createCredential.mock
+      .calls[0]![0]! as CredentialCreationOptions;
+    expect(callOptions.publicKey?.authenticatorSelection).toBeDefined();
+    expect(callOptions.publicKey?.authenticatorSelection).not.toHaveProperty(
+      "authenticatorAttachment"
+    );
+    expect(callOptions.publicKey?.authenticatorSelection?.residentKey).toBe(
+      "preferred"
+    );
+  });
+
+  it("only picks id and name from rp, excluding icon and other fields", async () => {
+    const registrationOptions: PasskeyRegistrationPublicKeyOptions = {
+      challenge: toBase64Url("challenge"),
+      rp: {
+        id: "app.secpal.dev",
+        name: "SecPal",
+        icon: null as unknown as string,
+      } as PasskeyRegistrationPublicKeyOptions["rp"],
+      user: {
+        id: toBase64Url("user-id"),
+        name: "test@secpal.dev",
+        display_name: "Test User",
+      },
+      pub_key_cred_params: [{ type: "public-key", alg: -7 }],
+      attestation: "none",
+    };
+
+    const createCredential = vi.fn().mockResolvedValue({
+      id: "credential-id",
+      rawId: toArrayBuffer("raw-id"),
+      type: "public-key",
+      response: {
+        clientDataJSON: toArrayBuffer("client-data"),
+        attestationObject: toArrayBuffer("attestation-object"),
+        getTransports: () => [],
+      },
+      getClientExtensionResults: () => ({}),
+    } as unknown as PublicKeyCredential);
+
+    vi.stubGlobal("PublicKeyCredential", class PublicKeyCredentialMock {});
+    Object.defineProperty(navigator, "credentials", {
+      configurable: true,
+      value: { get: vi.fn(), create: createCredential },
+    });
+
+    await getPasskeyAttestation(registrationOptions);
+
+    const callOptions = createCredential.mock
+      .calls[0]![0]! as CredentialCreationOptions;
+    expect(callOptions.publicKey?.rp).toEqual({
+      id: "app.secpal.dev",
+      name: "SecPal",
+    });
+    expect(callOptions.publicKey?.rp).not.toHaveProperty("icon");
+  });
+
+  it("omits excludeCredentials from the registration call when exclude_credentials is empty", async () => {
+    const registrationOptions: PasskeyRegistrationPublicKeyOptions = {
+      challenge: toBase64Url("challenge"),
+      rp: { id: "app.secpal.dev", name: "SecPal" },
+      user: {
+        id: toBase64Url("user-id"),
+        name: "test@secpal.dev",
+        display_name: "Test User",
+      },
+      pub_key_cred_params: [{ type: "public-key", alg: -7 }],
+      attestation: "none",
+      exclude_credentials: [],
+    };
+
+    const createCredential = vi.fn().mockResolvedValue({
+      id: "credential-id",
+      rawId: toArrayBuffer("raw-id"),
+      type: "public-key",
+      response: {
+        clientDataJSON: toArrayBuffer("client-data"),
+        attestationObject: toArrayBuffer("attestation-object"),
+        getTransports: () => [],
+      },
+      getClientExtensionResults: () => ({}),
+    } as unknown as PublicKeyCredential);
+
+    vi.stubGlobal("PublicKeyCredential", class PublicKeyCredentialMock {});
+    Object.defineProperty(navigator, "credentials", {
+      configurable: true,
+      value: { get: vi.fn(), create: createCredential },
+    });
+
+    await getPasskeyAttestation(registrationOptions);
+
+    const callOptions = createCredential.mock
+      .calls[0]![0]! as CredentialCreationOptions;
+    expect(callOptions.publicKey).not.toHaveProperty("excludeCredentials");
+  });
+
+  it("passes an AbortSignal to navigator.credentials.create during attestation", async () => {
+    const registrationOptions: PasskeyRegistrationPublicKeyOptions = {
+      challenge: toBase64Url("challenge"),
+      rp: { id: "app.secpal.dev", name: "SecPal" },
+      user: {
+        id: toBase64Url("user-id"),
+        name: "test@secpal.dev",
+        display_name: "Test User",
+      },
+      pub_key_cred_params: [{ type: "public-key", alg: -7 }],
+      attestation: "none",
+      timeout: 30000,
+    };
+
+    const createCredential = vi.fn().mockResolvedValue({
+      id: "credential-id",
+      rawId: toArrayBuffer("raw-id"),
+      type: "public-key",
+      response: {
+        clientDataJSON: toArrayBuffer("client-data"),
+        attestationObject: toArrayBuffer("attestation-object"),
+        getTransports: () => [],
+      },
+      getClientExtensionResults: () => ({}),
+    } as unknown as PublicKeyCredential);
+
+    vi.stubGlobal("PublicKeyCredential", class PublicKeyCredentialMock {});
+    Object.defineProperty(navigator, "credentials", {
+      configurable: true,
+      value: { get: vi.fn(), create: createCredential },
+    });
+
+    await getPasskeyAttestation(registrationOptions);
+
+    const callOptions = createCredential.mock.calls[0]![0]! as Record<
+      string,
+      unknown
+    >;
+    expect(callOptions).toHaveProperty("signal");
+    expect(callOptions.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("passes an AbortSignal to navigator.credentials.get during assertion", async () => {
+    const getCredential = vi.fn().mockResolvedValue({
+      id: "credential-id",
+      rawId: toArrayBuffer("raw-id"),
+      type: "public-key",
+      response: {
+        clientDataJSON: toArrayBuffer("client-data"),
+        authenticatorData: toArrayBuffer("authenticator-data"),
+        signature: toArrayBuffer("signature"),
+        userHandle: null,
+      },
+      getClientExtensionResults: () => ({}),
+    } as unknown as PublicKeyCredential);
+
+    vi.stubGlobal("PublicKeyCredential", class PublicKeyCredentialMock {});
+    Object.defineProperty(navigator, "credentials", {
+      configurable: true,
+      value: { get: getCredential },
+    });
+
+    await getPasskeyAssertion(authenticationOptions, "required");
+
+    const callOptions = getCredential.mock.calls[0]![0]! as Record<
+      string,
+      unknown
+    >;
+    expect(callOptions).toHaveProperty("signal");
+    expect(callOptions.signal).toBeInstanceOf(AbortSignal);
   });
 });

--- a/src/services/passkeyBrowser.ts
+++ b/src/services/passkeyBrowser.ts
@@ -131,26 +131,52 @@ function createAuthenticationOptions(
   };
 }
 
+function buildAuthenticatorSelection(
+  selection: NonNullable<
+    PasskeyRegistrationPublicKeyOptions["authenticator_selection"]
+  >
+): AuthenticatorSelectionCriteria {
+  const result: AuthenticatorSelectionCriteria = {};
+
+  if (
+    selection.authenticator_attachment === "platform" ||
+    selection.authenticator_attachment === "cross-platform"
+  ) {
+    result.authenticatorAttachment = selection.authenticator_attachment;
+  }
+
+  if (selection.resident_key) {
+    result.residentKey = selection.resident_key;
+  }
+
+  if (typeof selection.require_resident_key === "boolean") {
+    result.requireResidentKey = selection.require_resident_key;
+  }
+
+  if (selection.user_verification) {
+    result.userVerification = selection.user_verification;
+  }
+
+  return result;
+}
+
 function createRegistrationOptions(
   options: PasskeyRegistrationPublicKeyOptions
 ): CredentialCreationOptions {
   const authenticatorSelection = options.authenticator_selection
-    ? {
-        authenticatorAttachment:
-          options.authenticator_selection.authenticator_attachment,
-        residentKey: options.authenticator_selection.resident_key,
-        requireResidentKey:
-          options.authenticator_selection.require_resident_key,
-        userVerification: options.authenticator_selection.user_verification,
-      }
+    ? buildAuthenticatorSelection(options.authenticator_selection)
     : undefined;
 
   const attestation = normalizeAttestation(options.attestation);
 
+  const mappedExcludeCredentials = options.exclude_credentials?.length
+    ? options.exclude_credentials.map(mapDescriptor)
+    : undefined;
+
   return {
     publicKey: {
       challenge: fromBase64Url(options.challenge),
-      rp: options.rp,
+      rp: { id: options.rp.id, name: options.rp.name },
       user: {
         id: fromBase64Url(options.user.id),
         name: options.user.name,
@@ -161,8 +187,12 @@ function createRegistrationOptions(
         alg: parameter.alg,
       })),
       timeout: options.timeout,
-      excludeCredentials: options.exclude_credentials?.map(mapDescriptor),
-      authenticatorSelection,
+      ...(mappedExcludeCredentials !== undefined
+        ? { excludeCredentials: mappedExcludeCredentials }
+        : {}),
+      ...(authenticatorSelection !== undefined
+        ? { authenticatorSelection }
+        : {}),
       ...(attestation !== undefined ? { attestation } : {}),
     },
   };
@@ -231,9 +261,25 @@ export async function getPasskeyAssertion(
 ): Promise<PasskeyAuthenticationCredential> {
   assertPasskeySupport();
 
-  const credential = await navigator.credentials.get(
-    createAuthenticationOptions(options, mediation)
+  const requestOptions = createAuthenticationOptions(options, mediation);
+
+  const abortController = new AbortController();
+  const safetyTimeout = (options.timeout ?? 60_000) + 5_000;
+  const timeoutId = window.setTimeout(
+    () => abortController.abort(),
+    safetyTimeout
   );
+
+  let credential: Credential | null;
+
+  try {
+    credential = await navigator.credentials.get({
+      ...requestOptions,
+      signal: abortController.signal,
+    });
+  } finally {
+    window.clearTimeout(timeoutId);
+  }
 
   if (
     !credential ||
@@ -289,9 +335,28 @@ export async function getPasskeyAttestation(
     throw new Error("Passkeys are not available in this browser.");
   }
 
-  const credential = await navigator.credentials.create(
-    createRegistrationOptions(options)
+  const creationOptions = createRegistrationOptions(options);
+
+  // Use an AbortController so the browser ceremony is cancelled if the
+  // WebAuthn timeout passes without user interaction.  This prevents the
+  // UI from staying stuck on "Adding passkey..." indefinitely.
+  const abortController = new AbortController();
+  const safetyTimeout = (options.timeout ?? 60_000) + 5_000;
+  const timeoutId = window.setTimeout(
+    () => abortController.abort(),
+    safetyTimeout
   );
+
+  let credential: Credential | null;
+
+  try {
+    credential = await navigator.credentials.create({
+      ...creationOptions,
+      signal: abortController.signal,
+    });
+  } finally {
+    window.clearTimeout(timeoutId);
+  }
 
   if (
     !credential ||


### PR DESCRIPTION
## Problem

The API registration challenge includes `authenticatorAttachment: null`, `rp.icon: null`, and `excludeCredentials: []` from the webauthn-lib serializer. When the frontend passes `authenticatorAttachment: null` to `navigator.credentials.create()`, browsers coerce JSON null to DOMString `"null"`, which is not a valid `AuthenticatorAttachment` enum value. This prevents the WebAuthn dialog from appearing, causing enrollment to hang indefinitely.

Additionally, there was no timeout safety net: if the browser WebAuthn ceremony stalled for any reason, the UI would remain stuck on "Adding passkey..." forever.

## Fix

### Options cleanup (`passkeyBrowser.ts`)
- New `buildAuthenticatorSelection()` helper: only includes `authenticatorAttachment` when the value is `"platform"` or `"cross-platform"`
- `createRegistrationOptions()` picks only `id` and `name` from `rp` (no `icon: null` passthrough)
- Empty `excludeCredentials` arrays are omitted (conditional spread, matching `allowCredentials` pattern)

### AbortController timeout
- `getPasskeyAttestation()` and `getPasskeyAssertion()` now create an `AbortController` with a safety timeout of `server_timeout + 5000ms`
- The signal is passed to `navigator.credentials.create()` / `.get()`, ensuring the ceremony is cancelled if the browser exceeds the timeout

### Error handling
- `Login.tsx` and `SettingsPage.tsx` now handle `DOMException` with `name === "AbortError"` explicitly, showing "timed out" messages instead of raw abort errors

## Testing

- 5 new tests in `passkeyBrowser.test.ts`: null authenticatorAttachment stripping, rp icon exclusion, empty excludeCredentials omission, AbortSignal presence in create/get
- Updated existing assertion test for the new `signal` property
- All 25 passkeyBrowser tests, 35 SettingsPage tests, and 48 Login tests pass (108 total)
- TypeScript, ESLint, Prettier all clean

## Companion PR

API companion: SecPal/api#819 (server-side defense-in-depth)
