### PR TITLE
docs: add canonical product description to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ SPDX-License-Identifier: CC0-1.0
 [![codecov](https://codecov.io/gh/SecPal/frontend/branch/main/graph/badge.svg)](https://codecov.io/gh/SecPal/frontend)
 [![License](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](LICENSE)
 
-React/TypeScript frontend for the SecPal platform.
+React/TypeScript frontend for SecPal — operations software for German private security services.
 
 ## 📱 Progressive Web App (PWA)
 


### PR DESCRIPTION
## Summary

Replaces the generic "React/TypeScript frontend for the SecPal platform" intro line with the canonical product description.

**Before:** "React/TypeScript frontend for the SecPal platform."
**After:** "React/TypeScript frontend for SecPal — operations software for German private security services."

## Checklist

- [x] One topic, one PR
- [x] No behavior change — documentation only
- [x] Commit is GPG-signed

Closes #835
Part of SecPal/.github#340