### PR TITLE
test: stabilize onboarding redirect route coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Stabilized `App` route test reliability by seeding `auth_user` localStorage fixture through the same `sanitizePersistedAuthUser` path the runtime uses, eliminating races on onboarding redirect assertions caused by stale or mismatched fixture shapes.
 - Passkey browser credential prompts are now aborted via `AbortController` when the frontend safety timeout fires, so the browser dismisses the credential picker instead of letting it remain open until the browser timeout elapses after a frontend timeout.
 - Passkey login now confirms the session with a follow-up GET /v1/me after the verify endpoint succeeds, aligning with the password login flow and catching silent session establishment failures.
 - Passkey login and add-passkey buttons now show step-by-step progress so users can tell exactly where each flow is and whether the browser is waiting for their interaction: login uses challenge → browser prompt → verifying → confirming session, while add-passkey uses challenge → browser prompt → saving.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
 import { screen } from "@testing-library/dom";
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
 import App from "./App";
+import { sanitizePersistedAuthUser } from "./services/authState";
 
 const { mockGetCurrentUser } = vi.hoisted(() => ({
   mockGetCurrentUser: vi.fn(),
@@ -28,6 +29,18 @@ async function renderWithI18n(component: React.ReactElement) {
   return result;
 }
 
+function seedPersistedAuthUser(user: Record<string, unknown>) {
+  const persistedUser = sanitizePersistedAuthUser(user);
+
+  if (!persistedUser) {
+    throw new Error("Failed to seed persisted auth user for test");
+  }
+
+  localStorage.setItem("auth_user", JSON.stringify(persistedUser));
+
+  return persistedUser;
+}
+
 describe("App", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -38,22 +51,28 @@ describe("App", () => {
     mockGetCurrentUser.mockImplementation(async () => {
       const storedUser = localStorage.getItem("auth_user");
 
-      return storedUser
-        ? (JSON.parse(storedUser) as {
-            id: number;
-            name: string;
-            email: string;
-            emailVerified?: boolean;
-            roles?: string[];
-            permissions?: string[];
-            hasOrganizationalScopes?: boolean;
-          })
-        : {
-            id: 1,
-            name: "Fallback User",
-            email: "fallback@secpal.dev",
-          };
+      if (!storedUser) {
+        throw new Error("No stored auth user available for bootstrap");
+      }
+
+      return JSON.parse(storedUser) as {
+        id: string;
+        name: string;
+        email: string;
+        emailVerified?: boolean;
+        roles?: string[];
+        permissions?: string[];
+        hasOrganizationalScopes?: boolean;
+        hasCustomerAccess?: boolean;
+        hasSiteAccess?: boolean;
+        employeeStatus?: string;
+        onboardingWorkflowStatus?: string;
+      };
     });
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it("renders login page when not authenticated", async () => {
@@ -82,16 +101,13 @@ describe("App", () => {
   it("shows not found for activity-logs when the user cannot discover that feature", async () => {
     window.history.replaceState({}, "", "/activity-logs");
 
-    localStorage.setItem(
-      "auth_user",
-      JSON.stringify({
+    seedPersistedAuthUser({
         id: 1,
         name: "User",
         email: "user@secpal.dev",
         emailVerified: true,
         permissions: [],
-      })
-    );
+      });
 
     await renderWithI18n(<App />);
 
@@ -103,16 +119,13 @@ describe("App", () => {
   it("shows not found for the legacy organizational-units route when the user lacks organizational access", async () => {
     window.history.replaceState({}, "", "/organizational-units");
 
-    localStorage.setItem(
-      "auth_user",
-      JSON.stringify({
+    seedPersistedAuthUser({
         id: 1,
         name: "User",
         email: "user@secpal.dev",
         emailVerified: true,
         hasOrganizationalScopes: false,
-      })
-    );
+      });
 
     await renderWithI18n(<App />);
 
@@ -124,9 +137,7 @@ describe("App", () => {
   it("shows not found for organization routes when the user only has scopes but no elevated feature capability", async () => {
     window.history.replaceState({}, "", "/organization");
 
-    localStorage.setItem(
-      "auth_user",
-      JSON.stringify({
+    seedPersistedAuthUser({
         id: 1,
         name: "User",
         email: "user@secpal.dev",
@@ -134,8 +145,7 @@ describe("App", () => {
         hasOrganizationalScopes: true,
         roles: [],
         permissions: [],
-      })
-    );
+      });
 
     await renderWithI18n(<App />);
 
@@ -147,16 +157,13 @@ describe("App", () => {
   it("shows not found for customer routes when the user cannot discover that feature", async () => {
     window.history.replaceState({}, "", "/customers");
 
-    localStorage.setItem(
-      "auth_user",
-      JSON.stringify({
+    seedPersistedAuthUser({
         id: 1,
         name: "User",
         email: "user@secpal.dev",
         emailVerified: true,
         permissions: [],
-      })
-    );
+      });
 
     await renderWithI18n(<App />);
 
@@ -168,16 +175,13 @@ describe("App", () => {
   it("shows not found for site routes when the user cannot discover that feature", async () => {
     window.history.replaceState({}, "", "/sites");
 
-    localStorage.setItem(
-      "auth_user",
-      JSON.stringify({
+    seedPersistedAuthUser({
         id: 1,
         name: "User",
         email: "user@secpal.dev",
         emailVerified: true,
         permissions: [],
-      })
-    );
+      });
 
     await renderWithI18n(<App />);
 
@@ -189,16 +193,13 @@ describe("App", () => {
   it("shows not found for customer-scoped site routes when the user cannot discover that feature", async () => {
     window.history.replaceState({}, "", "/sites/customer/123");
 
-    localStorage.setItem(
-      "auth_user",
-      JSON.stringify({
+    seedPersistedAuthUser({
         id: 1,
         name: "User",
         email: "user@secpal.dev",
         emailVerified: true,
         permissions: [],
-      })
-    );
+      });
 
     await renderWithI18n(<App />);
 
@@ -210,16 +211,13 @@ describe("App", () => {
   it("shows access denied for known customer action routes when the user lacks create permission", async () => {
     window.history.replaceState({}, "", "/customers/new");
 
-    localStorage.setItem(
-      "auth_user",
-      JSON.stringify({
+    seedPersistedAuthUser({
         id: 1,
         name: "User",
         email: "user@secpal.dev",
         emailVerified: true,
         permissions: ["customers.read"],
-      })
-    );
+      });
 
     await renderWithI18n(<App />);
 
@@ -232,16 +230,13 @@ describe("App", () => {
   it("shows access denied for known customer edit routes when the user lacks update permission", async () => {
     window.history.replaceState({}, "", "/customers/123/edit");
 
-    localStorage.setItem(
-      "auth_user",
-      JSON.stringify({
+    seedPersistedAuthUser({
         id: 1,
         name: "User",
         email: "user@secpal.dev",
         emailVerified: true,
         permissions: ["customers.read"],
-      })
-    );
+      });
 
     await renderWithI18n(<App />);
 
@@ -254,16 +249,13 @@ describe("App", () => {
   it("shows access denied for known site action routes when the user lacks create permission", async () => {
     window.history.replaceState({}, "", "/sites/new");
 
-    localStorage.setItem(
-      "auth_user",
-      JSON.stringify({
+    seedPersistedAuthUser({
         id: 1,
         name: "User",
         email: "user@secpal.dev",
         emailVerified: true,
         permissions: ["sites.read"],
-      })
-    );
+      });
 
     await renderWithI18n(<App />);
 
@@ -276,16 +268,13 @@ describe("App", () => {
   it("shows access denied for known site edit routes when the user lacks update permission", async () => {
     window.history.replaceState({}, "", "/sites/123/edit");
 
-    localStorage.setItem(
-      "auth_user",
-      JSON.stringify({
+    seedPersistedAuthUser({
         id: 1,
         name: "User",
         email: "user@secpal.dev",
         emailVerified: true,
         permissions: ["sites.read"],
-      })
-    );
+      });
 
     await renderWithI18n(<App />);
 
@@ -298,17 +287,14 @@ describe("App", () => {
   it("shows access denied for known employee action routes when the user lacks create permission", async () => {
     window.history.replaceState({}, "", "/employees/create");
 
-    localStorage.setItem(
-      "auth_user",
-      JSON.stringify({
+    seedPersistedAuthUser({
         id: 1,
         name: "User",
         email: "user@secpal.dev",
         emailVerified: true,
         hasOrganizationalScopes: true,
         permissions: ["employees.read"],
-      })
-    );
+      });
 
     await renderWithI18n(<App />);
 
@@ -321,17 +307,14 @@ describe("App", () => {
   it("shows access denied for known employee edit routes when the user lacks update permission", async () => {
     window.history.replaceState({}, "", "/employees/123/edit");
 
-    localStorage.setItem(
-      "auth_user",
-      JSON.stringify({
+    seedPersistedAuthUser({
         id: 1,
         name: "User",
         email: "user@secpal.dev",
         emailVerified: true,
         hasOrganizationalScopes: true,
         permissions: ["employees.read"],
-      })
-    );
+      });
 
     await renderWithI18n(<App />);
 
@@ -344,9 +327,7 @@ describe("App", () => {
   it("redirects the legacy organizational-units route to the canonical organization route for authorized users", async () => {
     window.history.replaceState({}, "", "/organizational-units");
 
-    localStorage.setItem(
-      "auth_user",
-      JSON.stringify({
+    seedPersistedAuthUser({
         id: 1,
         name: "User",
         email: "user@secpal.dev",
@@ -354,8 +335,7 @@ describe("App", () => {
         hasOrganizationalScopes: true,
         roles: ["Manager"],
         permissions: [],
-      })
-    );
+      });
 
     await renderWithI18n(<App />);
 
@@ -369,15 +349,12 @@ describe("App", () => {
   it("shows a not found state for authenticated users on unknown app routes", async () => {
     window.history.replaceState({}, "", "/dashboard");
 
-    localStorage.setItem(
-      "auth_user",
-      JSON.stringify({
+    seedPersistedAuthUser({
         id: 1,
         name: "User",
         email: "user@secpal.dev",
         emailVerified: true,
-      })
-    );
+      });
 
     await renderWithI18n(<App />);
 
@@ -391,9 +368,7 @@ describe("App", () => {
   it("redirects pre-contract authenticated users from the app home route to onboarding", async () => {
     window.history.replaceState({}, "", "/");
 
-    localStorage.setItem(
-      "auth_user",
-      JSON.stringify({
+    seedPersistedAuthUser({
         id: 1,
         name: "Pre-Contract User",
         email: "new.hire@secpal.dev",
@@ -405,8 +380,7 @@ describe("App", () => {
             status: "account_initialized",
           },
         },
-      })
-    );
+      });
 
     await renderWithI18n(<App />);
 
@@ -418,9 +392,7 @@ describe("App", () => {
   it("renders onboarding-only routes without the normal application navigation for pre-contract users", async () => {
     window.history.replaceState({}, "", "/onboarding");
 
-    localStorage.setItem(
-      "auth_user",
-      JSON.stringify({
+    seedPersistedAuthUser({
         id: 1,
         name: "Pre-Contract User",
         email: "new.hire@secpal.dev",
@@ -432,8 +404,7 @@ describe("App", () => {
             status: "changes_requested",
           },
         },
-      })
-    );
+      });
 
     await renderWithI18n(<App />);
 
@@ -452,9 +423,7 @@ describe("App", () => {
   it("redirects active authenticated users away from onboarding-only routes", async () => {
     window.history.replaceState({}, "", "/onboarding");
 
-    localStorage.setItem(
-      "auth_user",
-      JSON.stringify({
+    seedPersistedAuthUser({
         id: 1,
         name: "Active User",
         email: "guard@secpal.dev",
@@ -466,10 +435,13 @@ describe("App", () => {
             status: "active",
           },
         },
-      })
-    );
+      });
 
     await renderWithI18n(<App />);
+
+    expect(
+      await screen.findByRole("heading", { name: /welcome to secpal/i })
+    ).toBeInTheDocument();
 
     await waitFor(() => {
       expect(window.location.pathname).toBe("/");

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { cleanup, render, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
 import { screen } from "@testing-library/dom";
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
@@ -69,10 +69,6 @@ describe("App", () => {
         onboardingWorkflowStatus?: string;
       };
     });
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   it("renders login page when not authenticated", async () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -102,12 +102,12 @@ describe("App", () => {
     window.history.replaceState({}, "", "/activity-logs");
 
     seedPersistedAuthUser({
-        id: 1,
-        name: "User",
-        email: "user@secpal.dev",
-        emailVerified: true,
-        permissions: [],
-      });
+      id: 1,
+      name: "User",
+      email: "user@secpal.dev",
+      emailVerified: true,
+      permissions: [],
+    });
 
     await renderWithI18n(<App />);
 
@@ -120,12 +120,12 @@ describe("App", () => {
     window.history.replaceState({}, "", "/organizational-units");
 
     seedPersistedAuthUser({
-        id: 1,
-        name: "User",
-        email: "user@secpal.dev",
-        emailVerified: true,
-        hasOrganizationalScopes: false,
-      });
+      id: 1,
+      name: "User",
+      email: "user@secpal.dev",
+      emailVerified: true,
+      hasOrganizationalScopes: false,
+    });
 
     await renderWithI18n(<App />);
 
@@ -138,14 +138,14 @@ describe("App", () => {
     window.history.replaceState({}, "", "/organization");
 
     seedPersistedAuthUser({
-        id: 1,
-        name: "User",
-        email: "user@secpal.dev",
-        emailVerified: true,
-        hasOrganizationalScopes: true,
-        roles: [],
-        permissions: [],
-      });
+      id: 1,
+      name: "User",
+      email: "user@secpal.dev",
+      emailVerified: true,
+      hasOrganizationalScopes: true,
+      roles: [],
+      permissions: [],
+    });
 
     await renderWithI18n(<App />);
 
@@ -158,12 +158,12 @@ describe("App", () => {
     window.history.replaceState({}, "", "/customers");
 
     seedPersistedAuthUser({
-        id: 1,
-        name: "User",
-        email: "user@secpal.dev",
-        emailVerified: true,
-        permissions: [],
-      });
+      id: 1,
+      name: "User",
+      email: "user@secpal.dev",
+      emailVerified: true,
+      permissions: [],
+    });
 
     await renderWithI18n(<App />);
 
@@ -176,12 +176,12 @@ describe("App", () => {
     window.history.replaceState({}, "", "/sites");
 
     seedPersistedAuthUser({
-        id: 1,
-        name: "User",
-        email: "user@secpal.dev",
-        emailVerified: true,
-        permissions: [],
-      });
+      id: 1,
+      name: "User",
+      email: "user@secpal.dev",
+      emailVerified: true,
+      permissions: [],
+    });
 
     await renderWithI18n(<App />);
 
@@ -194,12 +194,12 @@ describe("App", () => {
     window.history.replaceState({}, "", "/sites/customer/123");
 
     seedPersistedAuthUser({
-        id: 1,
-        name: "User",
-        email: "user@secpal.dev",
-        emailVerified: true,
-        permissions: [],
-      });
+      id: 1,
+      name: "User",
+      email: "user@secpal.dev",
+      emailVerified: true,
+      permissions: [],
+    });
 
     await renderWithI18n(<App />);
 
@@ -212,12 +212,12 @@ describe("App", () => {
     window.history.replaceState({}, "", "/customers/new");
 
     seedPersistedAuthUser({
-        id: 1,
-        name: "User",
-        email: "user@secpal.dev",
-        emailVerified: true,
-        permissions: ["customers.read"],
-      });
+      id: 1,
+      name: "User",
+      email: "user@secpal.dev",
+      emailVerified: true,
+      permissions: ["customers.read"],
+    });
 
     await renderWithI18n(<App />);
 
@@ -231,12 +231,12 @@ describe("App", () => {
     window.history.replaceState({}, "", "/customers/123/edit");
 
     seedPersistedAuthUser({
-        id: 1,
-        name: "User",
-        email: "user@secpal.dev",
-        emailVerified: true,
-        permissions: ["customers.read"],
-      });
+      id: 1,
+      name: "User",
+      email: "user@secpal.dev",
+      emailVerified: true,
+      permissions: ["customers.read"],
+    });
 
     await renderWithI18n(<App />);
 
@@ -250,12 +250,12 @@ describe("App", () => {
     window.history.replaceState({}, "", "/sites/new");
 
     seedPersistedAuthUser({
-        id: 1,
-        name: "User",
-        email: "user@secpal.dev",
-        emailVerified: true,
-        permissions: ["sites.read"],
-      });
+      id: 1,
+      name: "User",
+      email: "user@secpal.dev",
+      emailVerified: true,
+      permissions: ["sites.read"],
+    });
 
     await renderWithI18n(<App />);
 
@@ -269,12 +269,12 @@ describe("App", () => {
     window.history.replaceState({}, "", "/sites/123/edit");
 
     seedPersistedAuthUser({
-        id: 1,
-        name: "User",
-        email: "user@secpal.dev",
-        emailVerified: true,
-        permissions: ["sites.read"],
-      });
+      id: 1,
+      name: "User",
+      email: "user@secpal.dev",
+      emailVerified: true,
+      permissions: ["sites.read"],
+    });
 
     await renderWithI18n(<App />);
 
@@ -288,13 +288,13 @@ describe("App", () => {
     window.history.replaceState({}, "", "/employees/create");
 
     seedPersistedAuthUser({
-        id: 1,
-        name: "User",
-        email: "user@secpal.dev",
-        emailVerified: true,
-        hasOrganizationalScopes: true,
-        permissions: ["employees.read"],
-      });
+      id: 1,
+      name: "User",
+      email: "user@secpal.dev",
+      emailVerified: true,
+      hasOrganizationalScopes: true,
+      permissions: ["employees.read"],
+    });
 
     await renderWithI18n(<App />);
 
@@ -308,13 +308,13 @@ describe("App", () => {
     window.history.replaceState({}, "", "/employees/123/edit");
 
     seedPersistedAuthUser({
-        id: 1,
-        name: "User",
-        email: "user@secpal.dev",
-        emailVerified: true,
-        hasOrganizationalScopes: true,
-        permissions: ["employees.read"],
-      });
+      id: 1,
+      name: "User",
+      email: "user@secpal.dev",
+      emailVerified: true,
+      hasOrganizationalScopes: true,
+      permissions: ["employees.read"],
+    });
 
     await renderWithI18n(<App />);
 
@@ -328,14 +328,14 @@ describe("App", () => {
     window.history.replaceState({}, "", "/organizational-units");
 
     seedPersistedAuthUser({
-        id: 1,
-        name: "User",
-        email: "user@secpal.dev",
-        emailVerified: true,
-        hasOrganizationalScopes: true,
-        roles: ["Manager"],
-        permissions: [],
-      });
+      id: 1,
+      name: "User",
+      email: "user@secpal.dev",
+      emailVerified: true,
+      hasOrganizationalScopes: true,
+      roles: ["Manager"],
+      permissions: [],
+    });
 
     await renderWithI18n(<App />);
 
@@ -350,11 +350,11 @@ describe("App", () => {
     window.history.replaceState({}, "", "/dashboard");
 
     seedPersistedAuthUser({
-        id: 1,
-        name: "User",
-        email: "user@secpal.dev",
-        emailVerified: true,
-      });
+      id: 1,
+      name: "User",
+      email: "user@secpal.dev",
+      emailVerified: true,
+    });
 
     await renderWithI18n(<App />);
 
@@ -369,18 +369,18 @@ describe("App", () => {
     window.history.replaceState({}, "", "/");
 
     seedPersistedAuthUser({
-        id: 1,
-        name: "Pre-Contract User",
-        email: "new.hire@secpal.dev",
-        emailVerified: true,
-        employee: {
-          id: "employee-1",
-          status: "pre_contract",
-          onboarding_workflow: {
-            status: "account_initialized",
-          },
+      id: 1,
+      name: "Pre-Contract User",
+      email: "new.hire@secpal.dev",
+      emailVerified: true,
+      employee: {
+        id: "employee-1",
+        status: "pre_contract",
+        onboarding_workflow: {
+          status: "account_initialized",
         },
-      });
+      },
+    });
 
     await renderWithI18n(<App />);
 
@@ -393,18 +393,18 @@ describe("App", () => {
     window.history.replaceState({}, "", "/onboarding");
 
     seedPersistedAuthUser({
-        id: 1,
-        name: "Pre-Contract User",
-        email: "new.hire@secpal.dev",
-        emailVerified: true,
-        employee: {
-          id: "employee-1",
-          status: "pre_contract",
-          onboarding_workflow: {
-            status: "changes_requested",
-          },
+      id: 1,
+      name: "Pre-Contract User",
+      email: "new.hire@secpal.dev",
+      emailVerified: true,
+      employee: {
+        id: "employee-1",
+        status: "pre_contract",
+        onboarding_workflow: {
+          status: "changes_requested",
         },
-      });
+      },
+    });
 
     await renderWithI18n(<App />);
 
@@ -424,18 +424,18 @@ describe("App", () => {
     window.history.replaceState({}, "", "/onboarding");
 
     seedPersistedAuthUser({
-        id: 1,
-        name: "Active User",
-        email: "guard@secpal.dev",
-        emailVerified: true,
-        employee: {
-          id: "employee-2",
+      id: 1,
+      name: "Active User",
+      email: "guard@secpal.dev",
+      emailVerified: true,
+      employee: {
+        id: "employee-2",
+        status: "active",
+        onboarding_workflow: {
           status: "active",
-          onboarding_workflow: {
-            status: "active",
-          },
         },
-      });
+      },
+    });
 
     await renderWithI18n(<App />);
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -25,7 +25,7 @@ vi.mock("./services/authApi", async () => {
 async function renderWithI18n(component: React.ReactElement) {
   const result = render(<I18nProvider i18n={i18n}>{component}</I18nProvider>);
   // Wait for any async state updates to settle
-  await waitFor(() => {});
+  await waitFor(() => { });
   return result;
 }
 
@@ -36,7 +36,7 @@ function seedPersistedAuthUser(user: Record<string, unknown>) {
     throw new Error("Failed to seed persisted auth user for test");
   }
 
-  localStorage.setItem("auth_user", JSON.stringify(persistedUser));
+  localStorage.setItem("auth_user", JSON.stringify(persistedUser)); // codeql[js/clear-text-storage-of-sensitive-data] -- test-only helper; same pattern used in src/services/storage.ts (dismissed)
 
   return persistedUser;
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -25,7 +25,7 @@ vi.mock("./services/authApi", async () => {
 async function renderWithI18n(component: React.ReactElement) {
   const result = render(<I18nProvider i18n={i18n}>{component}</I18nProvider>);
   // Wait for any async state updates to settle
-  await waitFor(() => { });
+  await waitFor(() => {});
   return result;
 }
 


### PR DESCRIPTION
Fixes #833

## Summary

- align App route tests with the persisted auth-user shape used by the runtime
- seed stored auth state through the same sanitization path as the application
- make the onboarding redirect assertion wait for a real post-bootstrap destination instead of racing raw localStorage fixtures

## Validation

- timeout 90s ./node_modules/.bin/vitest run src/App.test.tsx --reporter=dot
- timeout 90s ./node_modules/.bin/eslint src/App.test.tsx
- timeout 90s ./node_modules/.bin/tsc --noEmit -p tsconfig.json

## Follow-up

- supersedes duplicate frontend issues #824, #815, and #792 tracking the same onboarding redirect test failure
