### PR TITLE
fix: abort passkey browser prompts on timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Passkey browser credential prompts are now aborted via `AbortController` when the frontend safety timeout fires, so the browser dismisses the credential picker instead of leaving it open indefinitely after a timeout.
+- Passkey browser credential prompts are now aborted via `AbortController` when the frontend safety timeout fires, so the browser dismisses the credential picker instead of letting it remain open until the browser timeout elapses after a frontend timeout.
 - Passkey login now confirms the session with a follow-up GET /v1/me after the verify endpoint succeeds, aligning with the password login flow and catching silent session establishment failures.
 - Passkey login and add-passkey buttons now show step-by-step progress so users can tell exactly where each flow is and whether the browser is waiting for their interaction: login uses challenge → browser prompt → verifying → confirming session, while add-passkey uses challenge → browser prompt → saving.
 - Added step-by-step `[SecPal]` console diagnostics to the passkey login and registration flows so real-browser failures can be traced through DevTools.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Passkey browser credential prompts are now aborted via `AbortController` when the frontend safety timeout fires, so the browser dismisses the credential picker instead of leaving it open indefinitely after a timeout.
 - Passkey login now confirms the session with a follow-up GET /v1/me after the verify endpoint succeeds, aligning with the password login flow and catching silent session establishment failures.
 - Passkey login and add-passkey buttons now show step-by-step progress so users can tell exactly where each flow is and whether the browser is waiting for their interaction: login uses challenge → browser prompt → verifying → confirming session, while add-passkey uses challenge → browser prompt → saving.
 - Added step-by-step `[SecPal]` console diagnostics to the passkey login and registration flows so real-browser failures can be traced through DevTools.

--- a/src/services/passkeyBrowser.test.ts
+++ b/src/services/passkeyBrowser.test.ts
@@ -148,7 +148,9 @@ describe("passkeyBrowser", () => {
       string,
       unknown
     >;
-    expect(callOptions).not.toHaveProperty("signal");
+    expect(callOptions).toHaveProperty("signal");
+    expect(callOptions.signal).toBeDefined();
+    expect((callOptions.signal as AbortSignal).aborted).toBe(false);
 
     expect(credential).toEqual({
       id: "credential-id",
@@ -746,7 +748,7 @@ describe("passkeyBrowser", () => {
     expect(callOptions.publicKey).not.toHaveProperty("excludeCredentials");
   });
 
-  it("does not pass an AbortSignal to navigator.credentials.create during attestation", async () => {
+  it("passes an AbortSignal to navigator.credentials.create during attestation", async () => {
     const registrationOptions: PasskeyRegistrationPublicKeyOptions = {
       challenge: toBase64Url("challenge"),
       rp: { id: "app.secpal.dev", name: "SecPal" },
@@ -784,10 +786,12 @@ describe("passkeyBrowser", () => {
       string,
       unknown
     >;
-    expect(callOptions).not.toHaveProperty("signal");
+    expect(callOptions).toHaveProperty("signal");
+    expect(callOptions.signal).toBeDefined();
+    expect((callOptions.signal as AbortSignal).aborted).toBe(false);
   });
 
-  it("times out attestation even when the browser ignores the abort signal", async () => {
+  it("times out attestation and aborts the browser request after the wrapper timeout", async () => {
     vi.useFakeTimers();
 
     const registrationOptions: PasskeyRegistrationPublicKeyOptions = {
@@ -804,7 +808,10 @@ describe("passkeyBrowser", () => {
     };
 
     const createCredential = vi.fn(
-      () => new Promise<PublicKeyCredential | null>(() => {})
+      (options: CredentialCreationOptions) => {
+        void options;
+        return new Promise<PublicKeyCredential | null>(() => {});
+      }
     );
 
     vi.stubGlobal("PublicKeyCredential", class PublicKeyCredentialMock {});
@@ -814,18 +821,27 @@ describe("passkeyBrowser", () => {
     });
 
     const promise = getPasskeyAttestation(registrationOptions);
+    const callOptions = createCredential.mock.calls[0]![0]! as Record<
+      string,
+      unknown
+    >;
+    const signal = callOptions.signal as AbortSignal;
     const expectation = expect(promise).rejects.toMatchObject({
       name: "AbortError",
     });
+
+    expect(signal.aborted).toBe(false);
 
     await vi.advanceTimersByTimeAsync(5_026);
 
     await expectation;
 
+    expect(signal.aborted).toBe(true);
+
     vi.useRealTimers();
   });
 
-  it("does not pass an AbortSignal to navigator.credentials.get during assertion", async () => {
+  it("passes an AbortSignal to navigator.credentials.get during assertion", async () => {
     const getCredential = vi.fn().mockResolvedValue({
       id: "credential-id",
       rawId: toArrayBuffer("raw-id"),
@@ -851,14 +867,19 @@ describe("passkeyBrowser", () => {
       string,
       unknown
     >;
-    expect(callOptions).not.toHaveProperty("signal");
+    expect(callOptions).toHaveProperty("signal");
+    expect(callOptions.signal).toBeDefined();
+    expect((callOptions.signal as AbortSignal).aborted).toBe(false);
   });
 
-  it("times out assertion even when the browser ignores the abort signal", async () => {
+  it("times out assertion and aborts the browser request after the wrapper timeout", async () => {
     vi.useFakeTimers();
 
     const getCredential = vi.fn(
-      () => new Promise<PublicKeyCredential | null>(() => {})
+      (options: CredentialRequestOptions) => {
+        void options;
+        return new Promise<PublicKeyCredential | null>(() => {});
+      }
     );
 
     vi.stubGlobal("PublicKeyCredential", class PublicKeyCredentialMock {});
@@ -874,13 +895,22 @@ describe("passkeyBrowser", () => {
       },
       "required"
     );
+    const callOptions = getCredential.mock.calls[0]![0]! as Record<
+      string,
+      unknown
+    >;
+    const signal = callOptions.signal as AbortSignal;
     const expectation = expect(promise).rejects.toMatchObject({
       name: "AbortError",
     });
 
+    expect(signal.aborted).toBe(false);
+
     await vi.advanceTimersByTimeAsync(5_026);
 
     await expectation;
+
+    expect(signal.aborted).toBe(true);
 
     vi.useRealTimers();
   });

--- a/src/services/passkeyBrowser.test.ts
+++ b/src/services/passkeyBrowser.test.ts
@@ -807,12 +807,10 @@ describe("passkeyBrowser", () => {
       timeout: 25,
     };
 
-    const createCredential = vi.fn(
-      (options: CredentialCreationOptions) => {
-        void options;
-        return new Promise<PublicKeyCredential | null>(() => {});
-      }
-    );
+    const createCredential = vi.fn((options: CredentialCreationOptions) => {
+      void options;
+      return new Promise<PublicKeyCredential | null>(() => {});
+    });
 
     vi.stubGlobal("PublicKeyCredential", class PublicKeyCredentialMock {});
     Object.defineProperty(navigator, "credentials", {
@@ -875,12 +873,10 @@ describe("passkeyBrowser", () => {
   it("times out assertion and aborts the browser request after the wrapper timeout", async () => {
     vi.useFakeTimers();
 
-    const getCredential = vi.fn(
-      (options: CredentialRequestOptions) => {
-        void options;
-        return new Promise<PublicKeyCredential | null>(() => {});
-      }
-    );
+    const getCredential = vi.fn((options: CredentialRequestOptions) => {
+      void options;
+      return new Promise<PublicKeyCredential | null>(() => {});
+    });
 
     vi.stubGlobal("PublicKeyCredential", class PublicKeyCredentialMock {});
     Object.defineProperty(navigator, "credentials", {

--- a/src/services/passkeyBrowser.ts
+++ b/src/services/passkeyBrowser.ts
@@ -220,7 +220,8 @@ function encodeUserHandle(
 
 async function awaitCredentialOperation<T>(
   operation: Promise<T>,
-  timeoutMs: number
+  timeoutMs: number,
+  onTimeout?: () => void
 ): Promise<T> {
   let timeoutId: number;
 
@@ -244,6 +245,15 @@ async function awaitCredentialOperation<T>(
         timeoutMs
       );
       reject(new DOMException("The operation was aborted.", "AbortError"));
+
+      if (onTimeout) {
+        Promise.resolve().then(() => {
+          console.info(
+            "[SecPal] awaitCredentialOperation: aborting underlying browser request after timeout"
+          );
+          onTimeout();
+        });
+      }
     }, timeoutMs);
   });
 
@@ -311,11 +321,17 @@ export async function getPasskeyAssertion(
     safetyTimeout
   );
 
+  const abortController = new AbortController();
+
   let credential: Credential | null;
   try {
     credential = await awaitCredentialOperation(
-      navigator.credentials.get(requestOptions),
-      safetyTimeout
+      navigator.credentials.get({
+        ...requestOptions,
+        signal: abortController.signal,
+      }),
+      safetyTimeout,
+      () => abortController.abort()
     );
     console.info("[SecPal] Passkey assertion: browser returned credential");
   } catch (error) {
@@ -390,11 +406,17 @@ export async function getPasskeyAttestation(
     safetyTimeout
   );
 
+  const abortController = new AbortController();
+
   let credential: Credential | null;
   try {
     credential = await awaitCredentialOperation(
-      navigator.credentials.create(creationOptions),
-      safetyTimeout
+      navigator.credentials.create({
+        ...creationOptions,
+        signal: abortController.signal,
+      }),
+      safetyTimeout,
+      () => abortController.abort()
     );
     console.info("[SecPal] Passkey attestation: browser returned credential");
   } catch (error) {


### PR DESCRIPTION
## Summary

- reintroduce `AbortSignal` for browser passkey get/create calls so the browser credential picker can be dismissed after the frontend safety timeout fires
- keep the wrapper timeout authoritative by rejecting first and aborting the underlying WebAuthn request immediately afterwards
- update passkey browser regression tests to cover the signal path and the timeout-driven abort behaviour

## Validation

- `npx vitest run src/services/passkeyBrowser.test.ts`
- `npx eslint src/services/passkeyBrowser.ts src/services/passkeyBrowser.test.ts`
- `npx tsc --noEmit -p tsconfig.json`

Fixes #834
