### PR TITLE
Fix for Superfluous trailing arguments

### DIFF
--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -675,11 +675,12 @@ describe("useAuth", () => {
 
     act(() => {
       localStorage.setItem("auth_user", JSON.stringify(newUser));
-      const crossTabLoginEvent = new StorageEvent("storage", {
-        key: "auth_user",
-        oldValue: null,
-        newValue: JSON.stringify(newUser),
-        storageArea: localStorage,
+      const crossTabLoginEvent = new Event("storage");
+      Object.defineProperties(crossTabLoginEvent, {
+        key: { value: "auth_user" },
+        oldValue: { value: null },
+        newValue: { value: JSON.stringify(newUser) },
+        storageArea: { value: localStorage },
       });
       window.dispatchEvent(crossTabLoginEvent);
     });


### PR DESCRIPTION
To fix this without changing test intent, avoid calling `StorageEvent` with a second argument and instead dispatch an `Event("storage")` whose `key`, `oldValue`, `newValue`, and `storageArea` properties are defined via `Object.defineProperties`. This preserves current test behavior (listeners reading storage-event fields still get the same values) while removing the “extra arguments” pattern CodeQL flags.

Edit only `src/hooks/useAuth.test.ts`, specifically the block in the test **"updates auth state when another tab logs in"** around line 678 where `new StorageEvent("storage", {...})` is created.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._