### PR TITLE
Fix for Superfluous trailing arguments

### DIFF
--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -501,11 +501,12 @@ describe("useAuth", () => {
 
     act(() => {
       localStorage.removeItem("auth_user");
-      const crossTabLogoutEvent = new StorageEvent("storage", {
-        key: "auth_user",
-        oldValue: JSON.stringify(mockUser),
-        newValue: null,
-        storageArea: localStorage,
+      const crossTabLogoutEvent = new StorageEvent("storage");
+      Object.defineProperties(crossTabLogoutEvent, {
+        key: { value: "auth_user" },
+        oldValue: { value: JSON.stringify(mockUser) },
+        newValue: { value: null },
+        storageArea: { value: localStorage },
       });
       window.dispatchEvent(crossTabLogoutEvent);
     });


### PR DESCRIPTION
To fix this without changing test intent, create the `StorageEvent` with only the event type, then define the expected event properties (`key`, `oldValue`, `newValue`, `storageArea`) via `Object.defineProperties` before dispatching. This avoids passing potentially ignored trailing constructor args while preserving behavior checked by the hook.

Apply this in `src/hooks/useAuth.test.ts` at the test `"clears auth state when another tab removes auth storage"` (around lines 504–509). No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._