### PR TITLE
Fix for Superfluous trailing arguments

### DIFF
--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -647,10 +647,10 @@ describe("useAuth", () => {
     expect(result.current.isAuthenticated).toBe(false);
 
     act(() => {
-      const otherKeyEvent = new StorageEvent("storage", {
-        key: "some_other_key",
-        newValue: null,
-        storageArea: localStorage,
+      const otherKeyEvent = new Event("storage");
+      Object.defineProperty(otherKeyEvent, "key", {
+        value: "some_other_key",
+        configurable: true,
       });
       window.dispatchEvent(otherKeyEvent);
     });


### PR DESCRIPTION
To fix this without changing functionality, replace the problematic `StorageEvent` constructor call in the `"ignores storage events for keys other than auth_user"` test with a plain `Event("storage")`, then attach a `key` property (`"some_other_key"`) via `Object.defineProperty`. This keeps the test intent intact (simulate a storage event for a different key) while avoiding the constructor overload that CodeQL flags.

Edit only `src/hooks/useAuth.test.ts`, specifically the block around lines 649–655.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._