### PR TITLE
Fix for Superfluous trailing arguments

### DIFF
--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -569,11 +569,12 @@ describe("useAuth", () => {
 
     act(() => {
       localStorage.setItem("auth_user", JSON.stringify(mockUser));
-      const staleAuthEvent = new StorageEvent("storage", {
-        key: "auth_user",
-        oldValue: null,
-        newValue: JSON.stringify(mockUser),
-        storageArea: localStorage,
+      const staleAuthEvent = new StorageEvent("storage");
+      Object.defineProperties(staleAuthEvent, {
+        key: { value: "auth_user" },
+        oldValue: { value: null },
+        newValue: { value: JSON.stringify(mockUser) },
+        storageArea: { value: localStorage },
       });
       window.dispatchEvent(staleAuthEvent);
     });


### PR DESCRIPTION
To fix this without changing test intent, create the `StorageEvent` with only the required event type and then define the needed properties (`key`, `oldValue`, `newValue`, `storageArea`) on the event object before dispatching it.

Best single fix in `src/hooks/useAuth.test.ts` around lines 572–578:
- Replace `new StorageEvent("storage", { ... })` with `new StorageEvent("storage")`.
- Use `Object.defineProperties` to attach the expected storage event fields.
- Keep `window.dispatchEvent(staleAuthEvent);` unchanged.

This removes the superfluous constructor argument while preserving the payload the hook logic expects.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._