### PR TITLE
Fix for Superfluous trailing arguments

### DIFF
--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -710,11 +710,16 @@ describe("useAuth", () => {
       // Write the corrupt value so localStorage matches the event (real browser
       // cross-tab writes keep newValue and the actual storage in sync).
       localStorage.setItem("auth_user", "{invalid json{{");
-      const invalidJsonEvent = new StorageEvent("storage", {
-        key: "auth_user",
-        oldValue: JSON.stringify(mockUser),
-        newValue: "{invalid json{{",
-        storageArea: localStorage,
+      const invalidJsonEvent = new StorageEvent("storage");
+      Object.defineProperty(invalidJsonEvent, "key", { value: "auth_user" });
+      Object.defineProperty(invalidJsonEvent, "oldValue", {
+        value: JSON.stringify(mockUser),
+      });
+      Object.defineProperty(invalidJsonEvent, "newValue", {
+        value: "{invalid json{{",
+      });
+      Object.defineProperty(invalidJsonEvent, "storageArea", {
+        value: localStorage,
       });
       window.dispatchEvent(invalidJsonEvent);
     });


### PR DESCRIPTION
To fix this without changing intended functionality, avoid passing the initialization object into the `StorageEvent` constructor. Instead:

1. Construct the event with only its type: `new StorageEvent("storage")`.
2. Define the needed properties (`key`, `oldValue`, `newValue`, `storageArea`) on the event via `Object.defineProperty`.
3. Dispatch that patched event as before.

This keeps the test semantics (dispatching a storage event with the exact payload) while removing the superfluous-argument pattern flagged by CodeQL and improving compatibility with runtimes where the init dictionary is ignored.

Change region: `src/hooks/useAuth.test.ts`, in the test `"clears auth state when cross-tab auth storage contains invalid JSON"`, around lines 713–719.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._