### PR TITLE
fix: omit non-leadership management level payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- normalized employee-create POST payloads so non-leadership submissions omit the internal `management_level: 0` sentinel on the wire and match the API's optional create-field contract for onboarding-ready staff creation
 - Standardized auth test fixtures and storage-event construction in `useAuth` coverage, aligned `SiteDetail` metadata date rendering with locale-aware `formatDate`, removed a redundant non-null timeout assertion in passkey browser helpers, and tightened Lingui guard tests with JSON import assertions, command/argument checks, and an appropriate unit-test timeout.
 - Isolated the Lingui catalog guard's nested `sync:purge` environment from parent Vitest and npm runner variables, and refreshed the checked-in locale artifacts so the guard no longer reports false drift in CI while still catching real catalog changes.
 - Added a Lingui catalog sync guard that re-runs the checked-in extract/compile flow during frontend test validation, restores the workspace afterward, and fails CI when new translatable strings were added without committing the resulting catalog updates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- normalized employee-create POST payloads so non-leadership submissions omit the internal `management_level: 0` sentinel on the wire and match the API's optional create-field contract for onboarding-ready staff creation
+- Normalized employee-create POST payloads so non-leadership submissions omit the internal `management_level: 0` sentinel on the wire and match the API's optional create-field contract for onboarding-ready staff creation.
 - Standardized auth test fixtures and storage-event construction in `useAuth` coverage, aligned `SiteDetail` metadata date rendering with locale-aware `formatDate`, removed a redundant non-null timeout assertion in passkey browser helpers, and tightened Lingui guard tests with JSON import assertions, command/argument checks, and an appropriate unit-test timeout.
 - Isolated the Lingui catalog guard's nested `sync:purge` environment from parent Vitest and npm runner variables, and refreshed the checked-in locale artifacts so the guard no longer reports false drift in CI while still catching real catalog changes.
 - Added a Lingui catalog sync guard that re-runs the checked-in extract/compile flow during frontend test validation, restores the workspace afterward, and fails CI when new translatable strings were added without committing the resulting catalog updates.

--- a/src/services/employeeApi.test.ts
+++ b/src/services/employeeApi.test.ts
@@ -57,6 +57,69 @@ describe("employeeApi - JSON Parsing Error Handling", () => {
       expect(organizationalUnitIdIsOptional).toBe(false);
     });
 
+    it("should omit management_level from the create payload for non-leadership employees", async () => {
+      const mockEmployee: EmployeeFormData = {
+        first_name: "John",
+        last_name: "Doe",
+        email: "john@secpal.dev",
+        position: "Security Guard",
+        date_of_birth: "1990-01-01",
+        contract_start_date: "2025-01-01",
+        organizational_unit_id: "unit-1",
+        status: "pre_contract",
+        contract_type: "full_time",
+        management_level: 0,
+        send_invitation: true,
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        headers: new Map(),
+        json: vi.fn().mockResolvedValue({
+          data: {
+            id: "emp-1",
+            employee_number: "E001",
+            ...mockEmployee,
+            full_name: "John Doe",
+            phone: null,
+            organizational_unit: { id: "unit-1", name: "Engineering" },
+            created_at: "2025-01-01T00:00:00Z",
+            updated_at: "2025-01-01T00:00:00Z",
+            onboarding_invitation: {
+              status: "sent",
+              requested_at: "2025-01-01T00:00:00Z",
+              token_created_at: "2025-01-01T00:00:00Z",
+              mail_sent_at: "2025-01-01T00:00:01Z",
+              mail_failed_at: null,
+              failure_reason: null,
+            },
+          },
+        }),
+      });
+
+      await createEmployee(mockEmployee);
+
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        expect.stringContaining("/v1/employees"),
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            first_name: "John",
+            last_name: "Doe",
+            email: "john@secpal.dev",
+            position: "Security Guard",
+            date_of_birth: "1990-01-01",
+            contract_start_date: "2025-01-01",
+            organizational_unit_id: "unit-1",
+            status: "pre_contract",
+            contract_type: "full_time",
+            send_invitation: true,
+          }),
+        })
+      );
+    });
+
     it("should throw error when JSON parsing fails on success response", async () => {
       const mockEmployee: EmployeeFormData = {
         first_name: "John",

--- a/src/services/employeeApi.test.ts
+++ b/src/services/employeeApi.test.ts
@@ -57,126 +57,6 @@ describe("employeeApi - JSON Parsing Error Handling", () => {
       expect(organizationalUnitIdIsOptional).toBe(false);
     });
 
-    it("should omit management_level from the create payload for non-leadership employees", async () => {
-      const mockEmployee: EmployeeFormData = {
-        first_name: "John",
-        last_name: "Doe",
-        email: "john@secpal.dev",
-        position: "Security Guard",
-        date_of_birth: "1990-01-01",
-        contract_start_date: "2025-01-01",
-        organizational_unit_id: "unit-1",
-        status: "pre_contract",
-        contract_type: "full_time",
-        management_level: 0,
-        send_invitation: true,
-      };
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: 201,
-        headers: new Map(),
-        json: vi.fn().mockResolvedValue({
-          data: {
-            id: "emp-1",
-            employee_number: "E001",
-            ...mockEmployee,
-            full_name: "John Doe",
-            phone: null,
-            organizational_unit: { id: "unit-1", name: "Engineering" },
-            created_at: "2025-01-01T00:00:00Z",
-            updated_at: "2025-01-01T00:00:00Z",
-            onboarding_invitation: {
-              status: "sent",
-              requested_at: "2025-01-01T00:00:00Z",
-              token_created_at: "2025-01-01T00:00:00Z",
-              mail_sent_at: "2025-01-01T00:00:01Z",
-              mail_failed_at: null,
-              failure_reason: null,
-            },
-          },
-        }),
-      });
-
-      await createEmployee(mockEmployee);
-
-      expect(mockFetch).toHaveBeenLastCalledWith(
-        expect.stringContaining("/v1/employees"),
-        expect.objectContaining({
-          method: "POST",
-          body: JSON.stringify({
-            first_name: "John",
-            last_name: "Doe",
-            email: "john@secpal.dev",
-            position: "Security Guard",
-            date_of_birth: "1990-01-01",
-            contract_start_date: "2025-01-01",
-            organizational_unit_id: "unit-1",
-            status: "pre_contract",
-            contract_type: "full_time",
-            send_invitation: true,
-          }),
-        })
-      );
-    });
-
-    it("should include management_level in the create payload for leadership employees", async () => {
-      const mockEmployee: EmployeeFormData = {
-        first_name: "Jane",
-        last_name: "Smith",
-        email: "jane@secpal.dev",
-        position: "Team Lead",
-        date_of_birth: "1985-06-15",
-        contract_start_date: "2025-01-01",
-        organizational_unit_id: "unit-2",
-        status: "pre_contract",
-        contract_type: "full_time",
-        management_level: 3,
-        send_invitation: false,
-      };
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: 201,
-        headers: new Map(),
-        json: vi.fn().mockResolvedValue({
-          data: {
-            id: "emp-2",
-            employee_number: "E002",
-            ...mockEmployee,
-            full_name: "Jane Smith",
-            phone: null,
-            organizational_unit: { id: "unit-2", name: "Leadership" },
-            created_at: "2025-01-01T00:00:00Z",
-            updated_at: "2025-01-01T00:00:00Z",
-            onboarding_invitation: null,
-          },
-        }),
-      });
-
-      await createEmployee(mockEmployee);
-
-      expect(mockFetch).toHaveBeenLastCalledWith(
-        expect.stringContaining("/v1/employees"),
-        expect.objectContaining({
-          method: "POST",
-          body: JSON.stringify({
-            first_name: "Jane",
-            last_name: "Smith",
-            email: "jane@secpal.dev",
-            position: "Team Lead",
-            date_of_birth: "1985-06-15",
-            contract_start_date: "2025-01-01",
-            organizational_unit_id: "unit-2",
-            status: "pre_contract",
-            contract_type: "full_time",
-            send_invitation: false,
-            management_level: 3,
-          }),
-        })
-      );
-    });
-
     it("should throw error when JSON parsing fails on success response", async () => {
       const mockEmployee: EmployeeFormData = {
         first_name: "John",
@@ -444,6 +324,138 @@ describe("employeeApi - JSON Parsing Error Handling", () => {
       await expect(createEmployee(mockEmployee)).rejects.toThrow(
         "Internal Server Error"
       );
+    });
+  });
+});
+
+describe("createEmployee - payload normalization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ authenticated: true }),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should omit management_level from the create payload for non-leadership employees", async () => {
+    const mockEmployee: EmployeeFormData = {
+      first_name: "John",
+      last_name: "Doe",
+      email: "john@secpal.dev",
+      position: "Security Guard",
+      date_of_birth: "1990-01-01",
+      contract_start_date: "2025-01-01",
+      organizational_unit_id: "unit-1",
+      status: "pre_contract",
+      contract_type: "full_time",
+      management_level: 0,
+      send_invitation: true,
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      headers: new Map(),
+      json: vi.fn().mockResolvedValue({
+        data: {
+          id: "emp-1",
+          employee_number: "E001",
+          ...mockEmployee,
+          full_name: "John Doe",
+          phone: null,
+          organizational_unit: { id: "unit-1", name: "Engineering" },
+          created_at: "2025-01-01T00:00:00Z",
+          updated_at: "2025-01-01T00:00:00Z",
+          onboarding_invitation: {
+            status: "sent",
+            requested_at: "2025-01-01T00:00:00Z",
+            token_created_at: "2025-01-01T00:00:00Z",
+            mail_sent_at: "2025-01-01T00:00:01Z",
+            mail_failed_at: null,
+            failure_reason: null,
+          },
+        },
+      }),
+    });
+
+    await createEmployee(mockEmployee);
+
+    const [url, options] = mockFetch.mock.lastCall! as [string, RequestInit];
+    expect(url).toContain("/v1/employees");
+    expect(options.method).toBe("POST");
+    const body = JSON.parse(options.body as string) as Record<string, unknown>;
+    expect(body).not.toHaveProperty("management_level");
+    expect(body).toMatchObject({
+      first_name: "John",
+      last_name: "Doe",
+      email: "john@secpal.dev",
+      position: "Security Guard",
+      date_of_birth: "1990-01-01",
+      contract_start_date: "2025-01-01",
+      organizational_unit_id: "unit-1",
+      status: "pre_contract",
+      contract_type: "full_time",
+      send_invitation: true,
+    });
+  });
+
+  it("should include management_level in the create payload for leadership employees", async () => {
+    const mockEmployee: EmployeeFormData = {
+      first_name: "Jane",
+      last_name: "Smith",
+      email: "jane@secpal.dev",
+      position: "Team Lead",
+      date_of_birth: "1985-06-15",
+      contract_start_date: "2025-01-01",
+      organizational_unit_id: "unit-2",
+      status: "pre_contract",
+      contract_type: "full_time",
+      management_level: 3,
+      send_invitation: false,
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      headers: new Map(),
+      json: vi.fn().mockResolvedValue({
+        data: {
+          id: "emp-2",
+          employee_number: "E002",
+          ...mockEmployee,
+          full_name: "Jane Smith",
+          phone: null,
+          organizational_unit: { id: "unit-2", name: "Leadership" },
+          created_at: "2025-01-01T00:00:00Z",
+          updated_at: "2025-01-01T00:00:00Z",
+          onboarding_invitation: null,
+        },
+      }),
+    });
+
+    await createEmployee(mockEmployee);
+
+    const [url, options] = mockFetch.mock.lastCall! as [string, RequestInit];
+    expect(url).toContain("/v1/employees");
+    expect(options.method).toBe("POST");
+    const body = JSON.parse(options.body as string) as Record<string, unknown>;
+    expect(body.management_level).toBe(3);
+    expect(body).toMatchObject({
+      first_name: "Jane",
+      last_name: "Smith",
+      email: "jane@secpal.dev",
+      position: "Team Lead",
+      date_of_birth: "1985-06-15",
+      contract_start_date: "2025-01-01",
+      organizational_unit_id: "unit-2",
+      status: "pre_contract",
+      contract_type: "full_time",
+      send_invitation: false,
     });
   });
 });

--- a/src/services/employeeApi.test.ts
+++ b/src/services/employeeApi.test.ts
@@ -120,6 +120,63 @@ describe("employeeApi - JSON Parsing Error Handling", () => {
       );
     });
 
+    it("should include management_level in the create payload for leadership employees", async () => {
+      const mockEmployee: EmployeeFormData = {
+        first_name: "Jane",
+        last_name: "Smith",
+        email: "jane@secpal.dev",
+        position: "Team Lead",
+        date_of_birth: "1985-06-15",
+        contract_start_date: "2025-01-01",
+        organizational_unit_id: "unit-2",
+        status: "pre_contract",
+        contract_type: "full_time",
+        management_level: 3,
+        send_invitation: false,
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        headers: new Map(),
+        json: vi.fn().mockResolvedValue({
+          data: {
+            id: "emp-2",
+            employee_number: "E002",
+            ...mockEmployee,
+            full_name: "Jane Smith",
+            phone: null,
+            organizational_unit: { id: "unit-2", name: "Leadership" },
+            created_at: "2025-01-01T00:00:00Z",
+            updated_at: "2025-01-01T00:00:00Z",
+            onboarding_invitation: null,
+          },
+        }),
+      });
+
+      await createEmployee(mockEmployee);
+
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        expect.stringContaining("/v1/employees"),
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            first_name: "Jane",
+            last_name: "Smith",
+            email: "jane@secpal.dev",
+            position: "Team Lead",
+            date_of_birth: "1985-06-15",
+            contract_start_date: "2025-01-01",
+            organizational_unit_id: "unit-2",
+            status: "pre_contract",
+            contract_type: "full_time",
+            send_invitation: false,
+            management_level: 3,
+          }),
+        })
+      );
+    });
+
     it("should throw error when JSON parsing fails on success response", async () => {
       const mockEmployee: EmployeeFormData = {
         first_name: "John",

--- a/src/services/employeeApi.ts
+++ b/src/services/employeeApi.ts
@@ -90,6 +90,12 @@ export async function fetchEmployee(id: string): Promise<Employee> {
 export async function createEmployee(
   employee: EmployeeFormData
 ): Promise<Employee> {
+  const { management_level: managementLevel, ...restEmployee } = employee;
+  const payload =
+    managementLevel > 0
+      ? { ...restEmployee, management_level: managementLevel }
+      : restEmployee;
+
   const url = `${apiConfig.baseUrl}/v1/employees`;
   const response = await apiFetch(url, {
     method: "POST",
@@ -97,7 +103,7 @@ export async function createEmployee(
       "Content-Type": "application/json",
       Accept: "application/json",
     },
-    body: JSON.stringify(employee),
+    body: JSON.stringify(payload),
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary
- omit `management_level` from employee create payloads for non-leadership hires
- keep leadership payloads unchanged when a positive rank is selected
- add a service-level regression test for the wire payload shape

## Validation
- `npx vitest run src/services/employeeApi.test.ts`
- `npm run typecheck`
- `npm run lint`

## Context
- companion runtime fix: SecPal/api#905
