### PR TITLE
Fix for Superfluous trailing arguments

### DIFF
--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -711,11 +711,12 @@ describe("useAuth", () => {
 
     act(() => {
       localStorage.setItem("auth_user", JSON.stringify(newUser));
-      const crossTabLoginEvent = new StorageEvent("storage", {
-        key: "auth_user",
-        oldValue: null,
-        newValue: JSON.stringify(newUser),
-        storageArea: localStorage,
+      const crossTabLoginEvent = new Event("storage");
+      Object.defineProperties(crossTabLoginEvent, {
+        key: { value: "auth_user" },
+        oldValue: { value: null },
+        newValue: { value: JSON.stringify(newUser) },
+        storageArea: { value: localStorage },
       });
       window.dispatchEvent(crossTabLoginEvent);
     });

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -717,7 +717,7 @@ describe("useAuth", () => {
         oldValue: { value: null },
         newValue: { value: JSON.stringify(newUser) },
         storageArea: { value: localStorage },
-      });
+      } satisfies Partial<Record<keyof StorageEventInit, PropertyDescriptor>>);
       window.dispatchEvent(crossTabLoginEvent);
     });
 


### PR DESCRIPTION
To fix this without changing behavior, replace the `new StorageEvent("storage", {...})` call with creation of a plain `"storage"` event and define the needed fields (`key`, `oldValue`, `newValue`, `storageArea`) via `Object.defineProperties`. Then dispatch that event.

Best single change in `src/hooks/useAuth.test.ts`:
- In the test **"updates auth state when another tab logs in"**, inside the `act(() => { ... })` block around line 714:
  - Replace `const crossTabLoginEvent = new StorageEvent("storage", { ... });`
  - With:
    - `const crossTabLoginEvent = new Event("storage");`
    - `Object.defineProperties(crossTabLoginEvent, { ... });` for `key`, `oldValue`, `newValue`, `storageArea`.
- Keep `window.dispatchEvent(crossTabLoginEvent);` unchanged.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._