### PR TITLE
Fix for Superfluous trailing arguments

### DIFF
--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -746,11 +746,12 @@ describe("useAuth", () => {
       // Write the corrupt value so localStorage matches the event (real browser
       // cross-tab writes keep newValue and the actual storage in sync).
       localStorage.setItem("auth_user", "{invalid json{{");
-      const invalidJsonEvent = new StorageEvent("storage", {
-        key: "auth_user",
-        oldValue: JSON.stringify(mockUser),
-        newValue: "{invalid json{{",
-        storageArea: localStorage,
+      const invalidJsonEvent = new Event("storage");
+      Object.defineProperties(invalidJsonEvent, {
+        key: { value: "auth_user" },
+        oldValue: { value: JSON.stringify(mockUser) },
+        newValue: { value: "{invalid json{{" },
+        storageArea: { value: localStorage },
       });
       window.dispatchEvent(invalidJsonEvent);
     });

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -752,7 +752,7 @@ describe("useAuth", () => {
         oldValue: { value: JSON.stringify(mockUser) },
         newValue: { value: "{invalid json{{" },
         storageArea: { value: localStorage },
-      });
+      } satisfies Partial<Record<keyof StorageEventInit, PropertyDescriptor>>);
       window.dispatchEvent(invalidJsonEvent);
     });
 


### PR DESCRIPTION
To fix this without changing intended functionality, replace the `StorageEvent` construction in the failing test with a plain `Event` and attach the expected storage fields (`key`, `oldValue`, `newValue`, `storageArea`) via `Object.defineProperties`. This avoids passing a potentially ignored second constructor argument while preserving the same event payload the hook expects.

Edit only `src/hooks/useAuth.test.ts`, in the test **"clears auth state when cross-tab auth storage contains invalid JSON"**, specifically the `act` block around current lines 749–754.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._