### PR TITLE
Fix for Superfluous trailing arguments

### DIFF
--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -605,11 +605,14 @@ describe("useAuth", () => {
 
     act(() => {
       localStorage.setItem("auth_user", JSON.stringify(mockUser));
-      const staleAuthEvent = new StorageEvent("storage", {
-        key: "auth_user",
-        oldValue: null,
-        newValue: JSON.stringify(mockUser),
-        storageArea: localStorage,
+      const staleAuthEvent = new StorageEvent("storage");
+      Object.defineProperty(staleAuthEvent, "key", { value: "auth_user" });
+      Object.defineProperty(staleAuthEvent, "oldValue", { value: null });
+      Object.defineProperty(staleAuthEvent, "newValue", {
+        value: JSON.stringify(mockUser),
+      });
+      Object.defineProperty(staleAuthEvent, "storageArea", {
+        value: localStorage,
       });
       window.dispatchEvent(staleAuthEvent);
     });

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -605,15 +605,13 @@ describe("useAuth", () => {
 
     act(() => {
       localStorage.setItem("auth_user", JSON.stringify(mockUser));
-      const staleAuthEvent = new StorageEvent("storage");
-      Object.defineProperty(staleAuthEvent, "key", { value: "auth_user" });
-      Object.defineProperty(staleAuthEvent, "oldValue", { value: null });
-      Object.defineProperty(staleAuthEvent, "newValue", {
-        value: JSON.stringify(mockUser),
-      });
-      Object.defineProperty(staleAuthEvent, "storageArea", {
-        value: localStorage,
-      });
+      const staleAuthEvent = new Event("storage");
+      Object.defineProperties(staleAuthEvent, {
+        key: { value: "auth_user" },
+        oldValue: { value: null },
+        newValue: { value: JSON.stringify(mockUser) },
+        storageArea: { value: localStorage },
+      } satisfies Partial<Record<keyof StorageEventInit, PropertyDescriptor>>);
       window.dispatchEvent(staleAuthEvent);
     });
 


### PR DESCRIPTION
To fix this without changing intended functionality, construct the `StorageEvent` using only the supported argument(s), then assign the needed properties (`key`, `oldValue`, `newValue`, `storageArea`) via `Object.defineProperty` before dispatch. This preserves test semantics (a storage event containing auth_user changes) while avoiding superfluous constructor arguments.

Best single fix in `src/hooks/useAuth.test.ts` (around lines 608–614): replace the two-argument `new StorageEvent("storage", {...})` with a one-argument constructor and explicit property definitions for the same values.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._