### PR TITLE
Fix for Superfluous trailing arguments

### DIFF
--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -537,11 +537,12 @@ describe("useAuth", () => {
 
     act(() => {
       localStorage.removeItem("auth_user");
-      const crossTabLogoutEvent = new StorageEvent("storage", {
-        key: "auth_user",
-        oldValue: JSON.stringify(mockUser),
-        newValue: null,
-        storageArea: localStorage,
+      const crossTabLogoutEvent = new Event("storage");
+      Object.defineProperties(crossTabLogoutEvent, {
+        key: { value: "auth_user" },
+        oldValue: { value: JSON.stringify(mockUser) },
+        newValue: { value: null },
+        storageArea: { value: localStorage },
       });
       window.dispatchEvent(crossTabLogoutEvent);
     });

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -543,7 +543,7 @@ describe("useAuth", () => {
         oldValue: { value: JSON.stringify(mockUser) },
         newValue: { value: null },
         storageArea: { value: localStorage },
-      });
+      } satisfies Partial<Record<keyof StorageEventInit, PropertyDescriptor>>);
       window.dispatchEvent(crossTabLogoutEvent);
     });
 


### PR DESCRIPTION
Use a generic `Event` for `"storage"` and assign the needed `StorageEvent`-like fields onto it before dispatch. This avoids calling `StorageEvent` with an init object (the flagged pattern), keeps behavior equivalent for listeners that read `key/newValue/oldValue/storageArea`, and is robust in test environments.

Apply the change in `src/hooks/useAuth.test.ts` in the test block around lines 540–547:
- Replace `new StorageEvent("storage", { ... })` with `new Event("storage")`.
- Set `key`, `oldValue`, `newValue`, and `storageArea` via `Object.defineProperties(...)`.
- Dispatch the resulting event as before.

No imports or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._