### PR TITLE
Fix for Superfluous trailing arguments

### DIFF
--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -683,11 +683,12 @@ describe("useAuth", () => {
     expect(result.current.isAuthenticated).toBe(false);
 
     act(() => {
-      const otherKeyEvent = new StorageEvent("storage", {
-        key: "some_other_key",
-        newValue: null,
-        storageArea: localStorage,
-      });
+      const otherKeyEvent = new Event("storage");
+      Object.defineProperties(otherKeyEvent, {
+        key: { value: "some_other_key" },
+        newValue: { value: null },
+        storageArea: { value: localStorage },
+      } satisfies Partial<Record<keyof StorageEventInit, PropertyDescriptor>>);
       window.dispatchEvent(otherKeyEvent);
     });
 


### PR DESCRIPTION
To fix this without changing functionality, replace the `StorageEvent` construction that passes an init object with a plain `Event("storage")`, then define the expected storage-event-like properties (`key`, `newValue`, `storageArea`) via `Object.defineProperties`, matching the already-used approach later in the file.

Best single fix:
- In `src/hooks/useAuth.test.ts`, inside test `"ignores storage events for keys other than auth_user"` (around lines 686–690), replace:
  - `new StorageEvent("storage", { ... })`
- With:
  - `new Event("storage")`
  - `Object.defineProperties(...)` to add `key`, `newValue`, and `storageArea`.
  
No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._