### PR TITLE
fix: recompute notification preferences on locale change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Removed stale memoization from `NotificationPreferences` so translated preference labels now recompute correctly when the active Lingui locale changes, resolving frontend issue #878.
 - Wrapped `authStorage.setUser()` persistence in a WebCrypto error boundary so rare PBKDF2/AES failures now log, clear stale `auth_user` state, and return cleanly instead of bubbling an unhandled rejection during login/bootstrap flows; includes focused regression coverage for issue #871.
 - Resolved issue #874 by refactoring the remaining `react-hooks/set-state-in-effect` violations across list/detail loaders, dialog reset flows, and organizational-unit tree state derivation; restored the rule to `error` in `eslint.config.js` and added a focused lint regression test for the tracked files.
 - Guarded auth-storage event and pageshow handlers with an in-memory `hasLogoutBarrierRef` check after `await authStorage.getUser()` to prevent an async race where an in-flight bootstrap `setUser()` clears the localStorage logout barrier (via `clearLogoutBarrier()`) before the stale-storage handler resumes, which caused a post-logout StorageEvent to restore the authenticated user.

--- a/src/components/NotificationPreferences.test.tsx
+++ b/src/components/NotificationPreferences.test.tsx
@@ -1,12 +1,14 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, waitFor } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import { screen } from "@testing-library/dom";
 import userEvent from "@testing-library/user-event";
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
+import { messages as deMessages } from "@/locales/de/messages.mjs";
+import { messages as enMessages } from "@/locales/en/messages.mjs";
 import { NotificationPreferences } from "./NotificationPreferences";
 import * as useNotificationsModule from "@/hooks/useNotifications";
 
@@ -30,6 +32,9 @@ describe("NotificationPreferences", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    i18n.load("en", enMessages);
+    i18n.load("de", deMessages);
+    i18n.activate("en");
 
     mockUseNotifications.mockReturnValue({
       permission: "granted",
@@ -365,6 +370,27 @@ describe("NotificationPreferences", () => {
   });
 
   describe("translation updates", () => {
+    it("should recompute translated preferences when the locale changes", async () => {
+      const { rerender } = await renderWithI18n(<NotificationPreferences />);
+
+      expect(screen.getByText("Security Alerts")).toBeInTheDocument();
+
+      await act(async () => {
+        i18n.activate("de");
+      });
+
+      rerender(
+        <I18nProvider i18n={i18n}>
+          <NotificationPreferences />
+        </I18nProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Sicherheitswarnungen")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("Security Alerts")).not.toBeInTheDocument();
+    });
+
     it("should update translations when locale changes without excessive re-renders", async () => {
       // Track render count to detect infinite loop
       let renderCount = 0;

--- a/src/components/NotificationPreferences.test.tsx
+++ b/src/components/NotificationPreferences.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
 import { act, render, waitFor } from "@testing-library/react";
 import { screen } from "@testing-library/dom";
 import userEvent from "@testing-library/user-event";
@@ -29,11 +29,14 @@ describe("NotificationPreferences", () => {
   const mockRequestPermission = vi.fn();
   const mockShowNotification = vi.fn();
 
+  beforeAll(() => {
+    i18n.load("en", enMessages);
+    i18n.load("de", deMessages);
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
-    i18n.load("en", enMessages);
-    i18n.load("de", deMessages);
     i18n.activate("en");
 
     mockUseNotifications.mockReturnValue({

--- a/src/components/NotificationPreferences.tsx
+++ b/src/components/NotificationPreferences.tsx
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { useState, useMemo } from "react";
+import { useState } from "react";
 import { Trans, msg } from "@lingui/macro";
 import { useLingui } from "@lingui/react";
 import { useNotifications } from "@/hooks/useNotifications";
@@ -130,13 +130,11 @@ export function NotificationPreferences() {
     StoredNotificationPreference[]
   >(loadStoredPreferences);
 
-  const translatedPreferences = useMemo<NotificationPreference[]>(
-    () =>
-      preferences.map((pref) => ({
-        ...pref,
-        ...getTranslationsForCategory(pref.category, i18n),
-      })),
-    [preferences, i18n]
+  const translatedPreferences: NotificationPreference[] = preferences.map(
+    (pref) => ({
+      ...pref,
+      ...getTranslationsForCategory(pref.category, i18n),
+    })
   );
 
   const [isEnabling, setIsEnabling] = useState(false);

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "Full Name"
 msgstr "Vollständiger Name"
 
-#: src/components/NotificationPreferences.tsx:254
+#: src/components/NotificationPreferences.tsx:252
 msgid "Enabling..."
 msgstr "Aktiviere ..."
 
@@ -91,7 +91,7 @@ msgstr "MFA deaktivieren"
 msgid "Front desk tablet"
 msgstr "Empfangstablet"
 
-#: src/components/NotificationPreferences.tsx:299
+#: src/components/NotificationPreferences.tsx:297
 msgid "✓ Notifications are enabled. You'll receive updates based on your preferences."
 msgstr "✓ Benachrichtigungen sind aktiviert. Sie erhalten Updates basierend auf Ihren Einstellungen."
 
@@ -177,7 +177,7 @@ msgstr "Keine organisatorischen Einheiten"
 msgid "More options"
 msgstr "weitere Optionen"
 
-#: src/components/NotificationPreferences.tsx:271
+#: src/components/NotificationPreferences.tsx:269
 msgid "Choose which notifications you want to receive"
 msgstr "Wählen Sie, welche Benachrichtigungen Sie erhalten möchten"
 
@@ -259,7 +259,7 @@ msgstr "Alle Einheiten"
 msgid "Add child"
 msgstr "Untergeordnete Einheit hinzufügen"
 
-#: src/components/NotificationPreferences.tsx:201
+#: src/components/NotificationPreferences.tsx:199
 msgid "Test Notification"
 msgstr "Test-Benachrichtigung"
 
@@ -346,7 +346,7 @@ msgstr "Qualifikationen"
 msgid "Name"
 msgstr "Name"
 
-#: src/components/NotificationPreferences.tsx:175
+#: src/components/NotificationPreferences.tsx:173
 msgid "Notifications Enabled"
 msgstr "Benachrichtigungen aktiviert"
 
@@ -517,7 +517,7 @@ msgstr "BWR-Export erstellen"
 msgid "Search"
 msgstr "Suche"
 
-#: src/components/NotificationPreferences.tsx:202
+#: src/components/NotificationPreferences.tsx:200
 msgid "This is a test notification from SecPal"
 msgstr "Dies ist eine Testbenachrichtigung von SecPal"
 
@@ -633,7 +633,7 @@ msgstr "Im Browser abschließen …"
 msgid "e.g., Berlin Branch"
 msgstr "z.B. Niederlassung Berlin"
 
-#: src/components/NotificationPreferences.tsx:176
+#: src/components/NotificationPreferences.tsx:174
 msgid "You'll now receive important updates from SecPal"
 msgstr "Sie erhalten jetzt wichtige Updates von SecPal"
 
@@ -798,7 +798,7 @@ msgstr "Vorherige"
 msgid "Postal Code"
 msgstr "Postleitzahl"
 
-#: src/components/NotificationPreferences.tsx:256
+#: src/components/NotificationPreferences.tsx:254
 msgid "Enable Notifications"
 msgstr "Benachrichtigungen aktivieren"
 
@@ -1357,7 +1357,7 @@ msgstr "BWR-Export wird erstellt..."
 msgid "Site Number"
 msgstr "Standort Nummer"
 
-#: src/components/NotificationPreferences.tsx:242
+#: src/components/NotificationPreferences.tsx:240
 msgid "Enable notifications to receive important updates about security alerts, shift reminders, and system notifications."
 msgstr "Aktivieren Sie Benachrichtigungen, um wichtige Updates zu Sicherheitswarnungen, Schichterinnerungen und Systembenachrichtigungen zu erhalten."
 
@@ -2275,7 +2275,7 @@ msgstr "Über uns"
 msgid "Passkeys"
 msgstr "Passkeys"
 
-#: src/components/NotificationPreferences.tsx:275
+#: src/components/NotificationPreferences.tsx:273
 msgid "Send Test"
 msgstr "Test senden"
 
@@ -2296,7 +2296,7 @@ msgstr "Profil"
 msgid "Orphaned Genesis"
 msgstr "Verwaiste Genesis"
 
-#: src/components/NotificationPreferences.tsx:268
+#: src/components/NotificationPreferences.tsx:266
 msgid "Notification Preferences"
 msgstr "Präferenzen für Benachrichtigungen"
 
@@ -2368,7 +2368,7 @@ msgstr "Keine Einheit ausgewählt"
 msgid "Log Name"
 msgstr "Log Name"
 
-#: src/components/NotificationPreferences.tsx:215
+#: src/components/NotificationPreferences.tsx:213
 msgid "Notifications are not supported in your browser. Please use a modern browser like Chrome, Firefox, or Safari."
 msgstr "Benachrichtigungen werden von Ihrem Browser nicht unterstützt. Bitte verwenden Sie einen modernen Browser wie Chrome, Firefox oder Safari."
 
@@ -2504,7 +2504,7 @@ msgstr "Details zum Aktivitätsprotokoll"
 msgid "View Profile"
 msgstr "Profil ansehen"
 
-#: src/components/NotificationPreferences.tsx:228
+#: src/components/NotificationPreferences.tsx:226
 msgid "Notifications have been blocked. Please enable them in your browser settings to receive important updates."
 msgstr "Benachrichtigungen wurden blockiert. Bitte aktivieren Sie sie in den Einstellungen Ihres Browsers, um wichtige Updates zu erhalten."
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "Full Name"
 msgstr "Full Name"
 
-#: src/components/NotificationPreferences.tsx:254
+#: src/components/NotificationPreferences.tsx:252
 msgid "Enabling..."
 msgstr "Enabling..."
 
@@ -91,7 +91,7 @@ msgstr "Disable MFA"
 msgid "Front desk tablet"
 msgstr "Front desk tablet"
 
-#: src/components/NotificationPreferences.tsx:299
+#: src/components/NotificationPreferences.tsx:297
 msgid "✓ Notifications are enabled. You'll receive updates based on your preferences."
 msgstr "✓ Notifications are enabled. You'll receive updates based on your preferences."
 
@@ -177,7 +177,7 @@ msgstr "No Organizational Units"
 msgid "More options"
 msgstr "More options"
 
-#: src/components/NotificationPreferences.tsx:271
+#: src/components/NotificationPreferences.tsx:269
 msgid "Choose which notifications you want to receive"
 msgstr "Choose which notifications you want to receive"
 
@@ -259,7 +259,7 @@ msgstr "All Units"
 msgid "Add child"
 msgstr "Add child"
 
-#: src/components/NotificationPreferences.tsx:201
+#: src/components/NotificationPreferences.tsx:199
 msgid "Test Notification"
 msgstr "Test Notification"
 
@@ -346,7 +346,7 @@ msgstr "Qualifications"
 msgid "Name"
 msgstr "Name"
 
-#: src/components/NotificationPreferences.tsx:175
+#: src/components/NotificationPreferences.tsx:173
 msgid "Notifications Enabled"
 msgstr "Notifications Enabled"
 
@@ -517,7 +517,7 @@ msgstr "Generate BWR Export"
 msgid "Search"
 msgstr "Search"
 
-#: src/components/NotificationPreferences.tsx:202
+#: src/components/NotificationPreferences.tsx:200
 msgid "This is a test notification from SecPal"
 msgstr "This is a test notification from SecPal"
 
@@ -633,7 +633,7 @@ msgstr "Complete in your browser…"
 msgid "e.g., Berlin Branch"
 msgstr "e.g., Berlin Branch"
 
-#: src/components/NotificationPreferences.tsx:176
+#: src/components/NotificationPreferences.tsx:174
 msgid "You'll now receive important updates from SecPal"
 msgstr "You'll now receive important updates from SecPal"
 
@@ -798,7 +798,7 @@ msgstr "Previous"
 msgid "Postal Code"
 msgstr "Postal Code"
 
-#: src/components/NotificationPreferences.tsx:256
+#: src/components/NotificationPreferences.tsx:254
 msgid "Enable Notifications"
 msgstr "Enable Notifications"
 
@@ -1357,7 +1357,7 @@ msgstr "Generating BWR Export..."
 msgid "Site Number"
 msgstr "Site Number"
 
-#: src/components/NotificationPreferences.tsx:242
+#: src/components/NotificationPreferences.tsx:240
 msgid "Enable notifications to receive important updates about security alerts, shift reminders, and system notifications."
 msgstr "Enable notifications to receive important updates about security alerts, shift reminders, and system notifications."
 
@@ -2275,7 +2275,7 @@ msgstr "About"
 msgid "Passkeys"
 msgstr "Passkeys"
 
-#: src/components/NotificationPreferences.tsx:275
+#: src/components/NotificationPreferences.tsx:273
 msgid "Send Test"
 msgstr "Send Test"
 
@@ -2296,7 +2296,7 @@ msgstr "Profile"
 msgid "Orphaned Genesis"
 msgstr "Orphaned Genesis"
 
-#: src/components/NotificationPreferences.tsx:268
+#: src/components/NotificationPreferences.tsx:266
 msgid "Notification Preferences"
 msgstr "Notification Preferences"
 
@@ -2368,7 +2368,7 @@ msgstr "No unit selected"
 msgid "Log Name"
 msgstr "Log Name"
 
-#: src/components/NotificationPreferences.tsx:215
+#: src/components/NotificationPreferences.tsx:213
 msgid "Notifications are not supported in your browser. Please use a modern browser like Chrome, Firefox, or Safari."
 msgstr "Notifications are not supported in your browser. Please use a modern browser like Chrome, Firefox, or Safari."
 
@@ -2504,7 +2504,7 @@ msgstr "Activity Log Details"
 msgid "View Profile"
 msgstr "View Profile"
 
-#: src/components/NotificationPreferences.tsx:228
+#: src/components/NotificationPreferences.tsx:226
 msgid "Notifications have been blocked. Please enable them in your browser settings to receive important updates."
 msgstr "Notifications have been blocked. Please enable them in your browser settings to receive important updates."
 


### PR DESCRIPTION
## Summary

- remove stale memoization from `NotificationPreferences` so translated labels recompute on locale changes
- add a focused regression test that proves the same component updates from English to German when the active Lingui locale changes
- resync Lingui catalog references and record the visible fix in `CHANGELOG.md`

## Testing

- `npx vitest run src/components/NotificationPreferences.test.tsx`
- `npm run lint`
- `npm run typecheck`
- `npx vitest run tests/lingui.sync.test.ts`
- `npx vitest run tests/unit/lint/issue874-react-hooks-set-state-in-effect.test.ts`
- `npm run test:coverage` ⛔ currently blocked by unrelated timeout tracked in #899

Closes #878
Related to #899
