### PR TITLE
test: migrate auth fixtures to authStorage

### DIFF
--- a/src/components/ProtectedRoute.test.tsx
+++ b/src/components/ProtectedRoute.test.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, vi, beforeEach } from "vitest";

--- a/src/components/ProtectedRoute.test.tsx
+++ b/src/components/ProtectedRoute.test.tsx
@@ -7,7 +7,7 @@ import {
   fireEvent,
   render,
   screen,
-  waitFor,
+  waitFor as waitForTestingLibrary,
 } from "@testing-library/react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { I18nProvider } from "@lingui/react";
@@ -18,6 +18,8 @@ import {
   BOOTSTRAP_REVALIDATION_TIMEOUT_MS,
 } from "../contexts/AuthContext";
 import { AuthApiError } from "../services/authApi";
+import { sanitizePersistedAuthUser } from "../services/authState";
+import { authStorage } from "../services/storage";
 
 const mockNavigate = vi.fn();
 const { mockGetCurrentUser, mockSendVerificationNotification } = vi.hoisted(
@@ -48,12 +50,18 @@ vi.mock("react-router-dom", async () => {
 });
 
 const TestComponent = () => <div>Protected Content</div>;
+const AUTH_ROUTE_TIMEOUT_MS = 20_000;
 const unverifiedUser = {
   id: 1,
   name: "Test",
   email: "test@secpal.dev",
   emailVerified: false,
 };
+
+function setCsrfTokenCookie(value: string): void {
+  document.cookie = `XSRF-TOKEN=;expires=${new Date(0).toUTCString()};path=/`;
+  document.cookie = `XSRF-TOKEN=${encodeURIComponent(value)};path=/`;
+}
 
 const renderProtectedRoute = () => {
   return render(
@@ -76,9 +84,27 @@ const renderProtectedRoute = () => {
   );
 };
 
-const persistAuthUser = (user = unverifiedUser) => {
-  localStorage.setItem("auth_user", JSON.stringify(user));
+const persistAuthUser = async (user: Record<string, unknown> = unverifiedUser) => {
+  const persistedUser = sanitizePersistedAuthUser(user);
+
+  if (!persistedUser) {
+    throw new Error("Failed to seed persisted auth user for test");
+  }
+
+  await authStorage.setUser(persistedUser);
+  mockGetCurrentUser.mockResolvedValue(persistedUser);
 };
+
+async function waitForProtectedRoute(
+  assertion: Parameters<typeof waitForTestingLibrary>[0],
+  timeout = AUTH_ROUTE_TIMEOUT_MS
+) {
+  await waitForTestingLibrary(assertion, {
+    timeout,
+  });
+}
+
+const waitFor = waitForProtectedRoute;
 
 describe("ProtectedRoute", () => {
   beforeEach(() => {
@@ -86,6 +112,7 @@ describe("ProtectedRoute", () => {
     // entries from failed tests from leaking into subsequent tests.
     vi.resetAllMocks();
     localStorage.clear();
+    setCsrfTokenCookie("test-csrf-token");
     i18n.load("en", {});
     i18n.activate("en");
   });
@@ -105,15 +132,12 @@ describe("ProtectedRoute", () => {
       emailVerified: true,
     });
 
-    localStorage.setItem(
-      "auth_user",
-      JSON.stringify({
-        id: 1,
-        name: "Test",
-        email: "test@secpal.dev",
-        emailVerified: true,
-      })
-    );
+    await persistAuthUser({
+      id: 1,
+      name: "Test",
+      email: "test@secpal.dev",
+      emailVerified: true,
+    });
 
     renderProtectedRoute();
 
@@ -126,18 +150,15 @@ describe("ProtectedRoute", () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it("shows loading instead of protected content while stored auth is revalidated", () => {
+  it("shows loading instead of protected content while stored auth is revalidated", async () => {
     mockGetCurrentUser.mockReturnValueOnce(new Promise(() => undefined));
 
-    localStorage.setItem(
-      "auth_user",
-      JSON.stringify({
-        id: 1,
-        name: "Test",
-        email: "test@secpal.dev",
-        emailVerified: true,
-      })
-    );
+    await persistAuthUser({
+      id: 1,
+      name: "Test",
+      email: "test@secpal.dev",
+      emailVerified: true,
+    });
 
     renderProtectedRoute();
 
@@ -153,15 +174,12 @@ describe("ProtectedRoute", () => {
       })
     );
 
-    localStorage.setItem(
-      "auth_user",
-      JSON.stringify({
-        id: 1,
-        name: "Test",
-        email: "test@secpal.dev",
-        emailVerified: true,
-      })
-    );
+    await persistAuthUser({
+      id: 1,
+      name: "Test",
+      email: "test@secpal.dev",
+      emailVerified: true,
+    });
 
     renderProtectedRoute();
 
@@ -176,48 +194,29 @@ describe("ProtectedRoute", () => {
 
   it("shows a retry recovery state instead of spinning forever when bootstrap stalls", async () => {
     mockGetCurrentUser.mockReturnValueOnce(new Promise(() => undefined));
-    vi.useFakeTimers();
 
-    try {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "Test",
-          email: "test@secpal.dev",
-          emailVerified: true,
-        })
-      );
+    await persistAuthUser({
+      id: 1,
+      name: "Test",
+      email: "test@secpal.dev",
+      emailVerified: true,
+    });
 
-      renderProtectedRoute();
+    renderProtectedRoute();
 
-      await act(async () => {
-        // restoreAndRevalidate() awaits authStorage.getUser() before registering
-        // the stall timer. getUser() has two nested async levels (getUser outer +
-        // decryptPersistedAuthUser inner), so flush both microtasks first.
-        await Promise.resolve();
-        await Promise.resolve();
-        vi.advanceTimersByTime(BOOTSTRAP_REVALIDATION_TIMEOUT_MS);
-        await Promise.resolve();
-        await Promise.resolve();
-      });
-
-      expect(
-        screen.getByRole("heading", {
-          name: /still loading your secure session/i,
-        })
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: /retry/i })
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: /go to login/i })
-      ).toBeInTheDocument();
-      expect(screen.queryByText("Protected Content")).not.toBeInTheDocument();
-      expect(mockNavigate).not.toHaveBeenCalled();
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(
+      await screen.findByRole(
+        "heading",
+        { name: /still loading your secure session/i },
+        { timeout: BOOTSTRAP_REVALIDATION_TIMEOUT_MS + 2_000 }
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /go to login/i })
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Protected Content")).not.toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it("retries bootstrap recovery when the user requests it", async () => {
@@ -232,49 +231,31 @@ describe("ProtectedRoute", () => {
         emailVerified: true,
       });
 
-    vi.useFakeTimers();
 
-    try {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "Test",
-          email: "test@secpal.dev",
-          emailVerified: true,
-        })
-      );
+    await persistAuthUser({
+      id: 1,
+      name: "Test",
+      email: "test@secpal.dev",
+      emailVerified: true,
+    });
 
-      renderProtectedRoute();
+    renderProtectedRoute();
 
-      await act(async () => {
-        // restoreAndRevalidate() awaits authStorage.getUser() before registering
-        // the stall timer. getUser() has two nested async levels (getUser outer +
-        // decryptPersistedAuthUser inner), so flush both microtasks first.
-        await Promise.resolve();
-        await Promise.resolve();
-        vi.advanceTimersByTime(BOOTSTRAP_REVALIDATION_TIMEOUT_MS);
-        await Promise.resolve();
-        await Promise.resolve();
-      });
+    await screen.findByRole(
+      "button",
+      { name: /retry/i },
+      { timeout: BOOTSTRAP_REVALIDATION_TIMEOUT_MS + 2_000 }
+    );
 
-      // Switch to real timers before retry so the new bootstrap can complete
-      // its WebCrypto setUser operations without fake-timer interference.
-      vi.useRealTimers();
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    });
 
-      await act(async () => {
-        fireEvent.click(screen.getByRole("button", { name: /retry/i }));
-      });
-
-      // Wait for the successful bootstrap to show protected content.
-      await waitFor(() => {
-        expect(screen.getByText("Protected Content")).toBeInTheDocument();
-      });
-      expect(mockGetCurrentUser).toHaveBeenCalledTimes(2);
-      expect(mockNavigate).not.toHaveBeenCalled();
-    } finally {
-      vi.useRealTimers();
-    }
+    await waitFor(() => {
+      expect(screen.getByText("Protected Content")).toBeInTheDocument();
+    });
+    expect(mockGetCurrentUser).toHaveBeenCalledTimes(2);
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it("shows loading state initially", () => {
@@ -335,15 +316,17 @@ describe("ProtectedRoute", () => {
 
   it("shows the dedicated email verification gate for authenticated unverified users", async () => {
     mockGetCurrentUser.mockResolvedValueOnce(unverifiedUser);
-    persistAuthUser();
+    await persistAuthUser();
 
     renderProtectedRoute();
 
-    await waitFor(() => {
-      expect(
-        screen.getByRole("heading", { name: /verify your email address/i })
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByRole(
+        "heading",
+        { name: /verify your email address/i },
+        { timeout: AUTH_ROUTE_TIMEOUT_MS }
+      )
+    ).toBeInTheDocument();
 
     expect(screen.getByText(/test@secpal\.dev/i)).toBeInTheDocument();
     expect(
@@ -362,18 +345,22 @@ describe("ProtectedRoute", () => {
     mockSendVerificationNotification.mockResolvedValueOnce({
       message: "Verification link sent successfully.",
     });
-    persistAuthUser();
+    await persistAuthUser();
 
     renderProtectedRoute();
 
     fireEvent.click(
       await screen.findByRole("button", {
         name: /send verification email again/i,
-      })
+      }, { timeout: AUTH_ROUTE_TIMEOUT_MS })
     );
 
     expect(
-      await screen.findByText(/verification link sent successfully\./i)
+      await screen.findByText(
+        /verification link sent successfully\./i,
+        {},
+        { timeout: AUTH_ROUTE_TIMEOUT_MS }
+      )
     ).toBeInTheDocument();
     fireEvent.click(
       screen.getByRole("button", { name: /i have verified my email/i })
@@ -389,35 +376,41 @@ describe("ProtectedRoute", () => {
     mockSendVerificationNotification.mockRejectedValueOnce(
       new AuthApiError("Too many requests.")
     );
-    persistAuthUser();
+    await persistAuthUser();
 
     renderProtectedRoute();
 
     fireEvent.click(
       await screen.findByRole("button", {
         name: /send verification email again/i,
-      })
+      }, { timeout: AUTH_ROUTE_TIMEOUT_MS })
     );
 
-    expect(await screen.findByText(/too many requests\./i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/too many requests\./i, {}, {
+        timeout: AUTH_ROUTE_TIMEOUT_MS,
+      })
+    ).toBeInTheDocument();
   });
 
   it("shows a generic error when resend rejects with a non-Error value", async () => {
     mockGetCurrentUser.mockResolvedValueOnce(unverifiedUser);
     mockSendVerificationNotification.mockRejectedValueOnce("network-failed");
-    persistAuthUser();
+    await persistAuthUser();
 
     renderProtectedRoute();
 
     fireEvent.click(
       await screen.findByRole("button", {
         name: /send verification email again/i,
-      })
+      }, { timeout: AUTH_ROUTE_TIMEOUT_MS })
     );
 
     expect(
       await screen.findByText(
-        /we could not send a new verification email\. please try again\./i
+        /we could not send a new verification email\. please try again\./i,
+        {},
+        { timeout: AUTH_ROUTE_TIMEOUT_MS }
       )
     ).toBeInTheDocument();
   });

--- a/src/components/ProtectedRoute.test.tsx
+++ b/src/components/ProtectedRoute.test.tsx
@@ -84,7 +84,9 @@ const renderProtectedRoute = () => {
   );
 };
 
-const persistAuthUser = async (user: Record<string, unknown> = unverifiedUser) => {
+const persistAuthUser = async (
+  user: Record<string, unknown> = unverifiedUser
+) => {
   const persistedUser = sanitizePersistedAuthUser(user);
 
   if (!persistedUser) {
@@ -231,7 +233,6 @@ describe("ProtectedRoute", () => {
         emailVerified: true,
       });
 
-
     await persistAuthUser({
       id: 1,
       name: "Test",
@@ -350,9 +351,13 @@ describe("ProtectedRoute", () => {
     renderProtectedRoute();
 
     fireEvent.click(
-      await screen.findByRole("button", {
-        name: /send verification email again/i,
-      }, { timeout: AUTH_ROUTE_TIMEOUT_MS })
+      await screen.findByRole(
+        "button",
+        {
+          name: /send verification email again/i,
+        },
+        { timeout: AUTH_ROUTE_TIMEOUT_MS }
+      )
     );
 
     expect(
@@ -381,15 +386,23 @@ describe("ProtectedRoute", () => {
     renderProtectedRoute();
 
     fireEvent.click(
-      await screen.findByRole("button", {
-        name: /send verification email again/i,
-      }, { timeout: AUTH_ROUTE_TIMEOUT_MS })
+      await screen.findByRole(
+        "button",
+        {
+          name: /send verification email again/i,
+        },
+        { timeout: AUTH_ROUTE_TIMEOUT_MS }
+      )
     );
 
     expect(
-      await screen.findByText(/too many requests\./i, {}, {
-        timeout: AUTH_ROUTE_TIMEOUT_MS,
-      })
+      await screen.findByText(
+        /too many requests\./i,
+        {},
+        {
+          timeout: AUTH_ROUTE_TIMEOUT_MS,
+        }
+      )
     ).toBeInTheDocument();
   });
 
@@ -401,9 +414,13 @@ describe("ProtectedRoute", () => {
     renderProtectedRoute();
 
     fireEvent.click(
-      await screen.findByRole("button", {
-        name: /send verification email again/i,
-      }, { timeout: AUTH_ROUTE_TIMEOUT_MS })
+      await screen.findByRole(
+        "button",
+        {
+          name: /send verification email again/i,
+        },
+        { timeout: AUTH_ROUTE_TIMEOUT_MS }
+      )
     );
 
     expect(

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -383,15 +383,12 @@ describe("useAuth", () => {
       expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
     });
 
-    await waitFor(
-      () => {
-        expect(result.current.isLoading).toBe(false);
-        expect(result.current.user).toEqual(mockUser);
-        expect(result.current.isAuthenticated).toBe(true);
-        expect(result.current.bootstrapRecoveryReason).toBe("timeout");
-      },
-      BOOTSTRAP_REVALIDATION_TIMEOUT_MS + 2_000
-    );
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.user).toEqual(mockUser);
+      expect(result.current.isAuthenticated).toBe(true);
+      expect(result.current.bootstrapRecoveryReason).toBe("timeout");
+    }, BOOTSTRAP_REVALIDATION_TIMEOUT_MS + 2_000);
   });
 
   it("keeps stored auth when offline without revalidation", async () => {

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { renderHook, act, waitFor } from "@testing-library/react";
+import {
+  renderHook,
+  act,
+  waitFor as waitForTestingLibrary,
+} from "@testing-library/react";
 import {
   AuthProvider,
   BOOTSTRAP_REVALIDATION_TIMEOUT_MS,
@@ -17,6 +21,8 @@ import { syncOfflineSessionAccess } from "../lib/serviceWorkerSession";
 const { mockGetCurrentUser } = vi.hoisted(() => ({
   mockGetCurrentUser: vi.fn(),
 }));
+
+const AUTH_BOOTSTRAP_TIMEOUT_MS = 20_000;
 
 vi.mock("../services/authApi", async () => {
   const actual = await vi.importActual("../services/authApi");
@@ -50,6 +56,33 @@ function createDeferredPromise<T>() {
 
   return { promise, resolve, reject };
 }
+
+async function persistAuthUser(user: Record<string, unknown>): Promise<string> {
+  const persistedUser = sanitizePersistedAuthUser(user);
+
+  if (!persistedUser) {
+    throw new Error("Failed to seed persisted auth user for test");
+  }
+
+  await authStorage.setUser(persistedUser);
+  mockGetCurrentUser.mockResolvedValue(persistedUser);
+  const storedUser = localStorage.getItem("auth_user");
+
+  expect(storedUser).not.toBeNull();
+
+  return storedUser as string;
+}
+
+async function waitForAuthState(
+  assertion: Parameters<typeof waitForTestingLibrary>[0],
+  timeout = AUTH_BOOTSTRAP_TIMEOUT_MS
+) {
+  await waitForTestingLibrary(assertion, {
+    timeout,
+  });
+}
+
+const waitFor = waitForAuthState;
 
 async function expectEncryptedStoredUser(
   expectedUser: Record<string, unknown>
@@ -303,7 +336,7 @@ describe("useAuth", () => {
     const originalNativeBridge = authGlobal.SecPalNativeAuthBridge;
 
     authGlobal.SecPalNativeAuthBridge = nativeBridge;
-    localStorage.setItem("auth_user", JSON.stringify(mockUser));
+    await persistAuthUser(mockUser);
 
     try {
       const { result } = renderHook(() => useAuth(), {
@@ -337,40 +370,31 @@ describe("useAuth", () => {
     };
     const deferred = createDeferredPromise<typeof mockUser>();
 
-    vi.useFakeTimers();
+    await persistAuthUser(mockUser);
+    mockGetCurrentUser.mockImplementation(() => deferred.promise);
 
-    try {
-      localStorage.setItem("auth_user", JSON.stringify(mockUser));
-      mockGetCurrentUser.mockImplementation(() => deferred.promise);
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: AuthProvider,
+    });
 
-      const { result } = renderHook(() => useAuth(), {
-        wrapper: AuthProvider,
-      });
+    expect(result.current.isLoading).toBe(true);
 
-      expect(result.current.isLoading).toBe(true);
-
-      await act(async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-      });
-
+    await waitFor(() => {
       expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
+    });
 
-      await act(async () => {
-        vi.advanceTimersByTime(BOOTSTRAP_REVALIDATION_TIMEOUT_MS);
-        await Promise.resolve();
-      });
-
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.user).toEqual(mockUser);
-      expect(result.current.isAuthenticated).toBe(true);
-      expect(result.current.bootstrapRecoveryReason).toBe("timeout");
-    } finally {
-      vi.useRealTimers();
-    }
+    await waitFor(
+      () => {
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.user).toEqual(mockUser);
+        expect(result.current.isAuthenticated).toBe(true);
+        expect(result.current.bootstrapRecoveryReason).toBe("timeout");
+      },
+      BOOTSTRAP_REVALIDATION_TIMEOUT_MS + 2_000
+    );
   });
 
-  it("keeps stored auth when offline without revalidation", () => {
+  it("keeps stored auth when offline without revalidation", async () => {
     const mockUser = {
       id: "1",
       name: "Test User",
@@ -378,7 +402,7 @@ describe("useAuth", () => {
       emailVerified: false,
     };
 
-    localStorage.setItem("auth_user", JSON.stringify(mockUser));
+    await persistAuthUser(mockUser);
 
     const onLineSpy = vi
       .spyOn(window.navigator, "onLine", "get")
@@ -388,7 +412,9 @@ describe("useAuth", () => {
       wrapper: AuthProvider,
     });
 
-    expect(result.current.isLoading).toBe(false);
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
     expect(result.current.user).toEqual(mockUser);
     expect(result.current.isAuthenticated).toBe(true);
     expect(mockGetCurrentUser).not.toHaveBeenCalled();
@@ -431,7 +457,7 @@ describe("useAuth", () => {
   it("logout clears user", async () => {
     const mockUser = { id: "1", name: "Test User", email: "test@secpal.dev" };
 
-    localStorage.setItem("auth_user", JSON.stringify(mockUser));
+    await persistAuthUser(mockUser);
 
     const { result } = renderHook(() => useAuth(), {
       wrapper: AuthProvider,
@@ -454,7 +480,7 @@ describe("useAuth", () => {
   it("logout stores only the minimal logout barrier flag", async () => {
     const mockUser = { id: "1", name: "Test User", email: "test@secpal.dev" };
 
-    localStorage.setItem("auth_user", JSON.stringify(mockUser));
+    await persistAuthUser(mockUser);
 
     const { result } = renderHook(() => useAuth(), {
       wrapper: AuthProvider,
@@ -498,7 +524,7 @@ describe("useAuth", () => {
 
   it("logs out when session:expired event is emitted", async () => {
     const mockUser = { id: 1, name: "Test User", email: "test@secpal.dev" };
-    localStorage.setItem("auth_user", JSON.stringify(mockUser));
+    await persistAuthUser(mockUser);
 
     const { result } = renderHook(() => useAuth(), {
       wrapper: AuthProvider,
@@ -538,7 +564,7 @@ describe("useAuth", () => {
   it("clears auth state when another tab removes auth storage", async () => {
     const mockUser = { id: "1", name: "Test User", email: "test@secpal.dev" };
 
-    localStorage.setItem("auth_user", JSON.stringify(mockUser));
+    const storedUser = await persistAuthUser(mockUser);
 
     const { result } = renderHook(() => useAuth(), {
       wrapper: AuthProvider,
@@ -553,7 +579,7 @@ describe("useAuth", () => {
       const crossTabLogoutEvent = new Event("storage");
       Object.defineProperties(crossTabLogoutEvent, {
         key: { value: "auth_user" },
-        oldValue: { value: JSON.stringify(mockUser) },
+        oldValue: { value: storedUser },
         newValue: { value: null },
         storageArea: { value: localStorage },
       } satisfies Partial<Record<keyof StorageEventInit, PropertyDescriptor>>);
@@ -571,7 +597,7 @@ describe("useAuth", () => {
   it("drops restored in-memory auth state when pageshow finds no stored user", async () => {
     const mockUser = { id: 1, name: "Test User", email: "test@secpal.dev" };
 
-    localStorage.setItem("auth_user", JSON.stringify(mockUser));
+    await persistAuthUser(mockUser);
 
     const { result } = renderHook(() => useAuth(), {
       wrapper: AuthProvider,
@@ -599,7 +625,7 @@ describe("useAuth", () => {
   it("ignores stale auth storage that reappears after explicit logout", async () => {
     const mockUser = { id: 1, name: "Test User", email: "test@secpal.dev" };
 
-    localStorage.setItem("auth_user", JSON.stringify(mockUser));
+    await persistAuthUser(mockUser);
 
     const { result } = renderHook(() => useAuth(), {
       wrapper: AuthProvider,
@@ -617,13 +643,13 @@ describe("useAuth", () => {
       expect(result.current.isAuthenticated).toBe(false);
     });
 
-    act(() => {
-      localStorage.setItem("auth_user", JSON.stringify(mockUser));
+    await act(async () => {
+      const newStoredValue = await persistAuthUser(mockUser);
       const staleAuthEvent = new Event("storage");
       Object.defineProperties(staleAuthEvent, {
         key: { value: "auth_user" },
         oldValue: { value: null },
-        newValue: { value: JSON.stringify(mockUser) },
+        newValue: { value: newStoredValue },
         storageArea: { value: localStorage },
       } satisfies Partial<Record<keyof StorageEventInit, PropertyDescriptor>>);
       window.dispatchEvent(staleAuthEvent);
@@ -634,13 +660,15 @@ describe("useAuth", () => {
     });
 
     expect(result.current.user).toBeNull();
-    expect(localStorage.getItem("auth_user")).toBeNull();
+    await waitFor(() => {
+      expect(localStorage.getItem("auth_user")).toBeNull();
+    });
   });
 
   it("rejects BFCache-style auth restoration after explicit logout", async () => {
     const mockUser = { id: 1, name: "Test User", email: "test@secpal.dev" };
 
-    localStorage.setItem("auth_user", JSON.stringify(mockUser));
+    await persistAuthUser(mockUser);
 
     const { result } = renderHook(() => useAuth(), {
       wrapper: AuthProvider,
@@ -658,8 +686,8 @@ describe("useAuth", () => {
       expect(result.current.isAuthenticated).toBe(false);
     });
 
-    act(() => {
-      localStorage.setItem("auth_user", JSON.stringify(mockUser));
+    await act(async () => {
+      await persistAuthUser(mockUser);
       window.dispatchEvent(
         new PageTransitionEvent("pageshow", { persisted: true })
       );
@@ -670,13 +698,15 @@ describe("useAuth", () => {
     });
 
     expect(result.current.user).toBeNull();
-    expect(localStorage.getItem("auth_user")).toBeNull();
+    await waitFor(() => {
+      expect(localStorage.getItem("auth_user")).toBeNull();
+    });
   });
 
-  it("does not bootstrap /v1/me when a logout barrier blocks stale auth storage", () => {
+  it("does not bootstrap /v1/me when a logout barrier blocks stale auth storage", async () => {
     const staleUser = { id: 1, name: "Stale User", email: "stale@secpal.dev" };
 
-    localStorage.setItem("auth_user", JSON.stringify(staleUser));
+    await persistAuthUser(staleUser);
     localStorage.setItem("auth_logout_barrier", "1");
 
     const { result } = renderHook(() => useAuth(), {
@@ -725,13 +755,13 @@ describe("useAuth", () => {
       emailVerified: false,
     };
 
-    act(() => {
-      localStorage.setItem("auth_user", JSON.stringify(newUser));
+    await act(async () => {
+      const storedUser = await persistAuthUser(newUser);
       const crossTabLoginEvent = new Event("storage");
       Object.defineProperties(crossTabLoginEvent, {
         key: { value: "auth_user" },
         oldValue: { value: null },
-        newValue: { value: JSON.stringify(newUser) },
+        newValue: { value: storedUser },
         storageArea: { value: localStorage },
       } satisfies Partial<Record<keyof StorageEventInit, PropertyDescriptor>>);
       window.dispatchEvent(crossTabLoginEvent);
@@ -748,7 +778,7 @@ describe("useAuth", () => {
   it("clears auth state when cross-tab auth storage contains invalid JSON", async () => {
     const mockUser = { id: 1, name: "Test User", email: "test@secpal.dev" };
 
-    localStorage.setItem("auth_user", JSON.stringify(mockUser));
+    const storedUser = await persistAuthUser(mockUser);
 
     const { result } = renderHook(() => useAuth(), {
       wrapper: AuthProvider,
@@ -765,7 +795,7 @@ describe("useAuth", () => {
       const invalidJsonEvent = new Event("storage");
       Object.defineProperties(invalidJsonEvent, {
         key: { value: "auth_user" },
-        oldValue: { value: JSON.stringify(mockUser) },
+        oldValue: { value: storedUser },
         newValue: { value: "{invalid json{{" },
         storageArea: { value: localStorage },
       } satisfies Partial<Record<keyof StorageEventInit, PropertyDescriptor>>);
@@ -789,13 +819,14 @@ describe("useAuth", () => {
       email: "bootstrap@secpal.dev",
     };
 
-    localStorage.setItem("auth_user", JSON.stringify(mockUser));
+    await persistAuthUser(mockUser);
 
     const { result } = renderHook(() => useAuth(), {
       wrapper: AuthProvider,
     });
 
     await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
       expect(result.current.isAuthenticated).toBe(true);
     });
 
@@ -809,14 +840,11 @@ describe("useAuth", () => {
     });
 
     await waitFor(() => {
-      expect(result.current.isAuthenticated).toBe(true);
+      expect(syncOfflineSessionAccess).toHaveBeenCalledWith(true);
     });
 
-    await waitFor(() => {
-      expect(result.current.user).not.toBeNull();
-    });
-    // The reconcile-path calls syncOfflineAuthState(true) which forwards to syncOfflineSessionAccess.
-    expect(syncOfflineSessionAccess).toHaveBeenCalledWith(true);
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.user).not.toBeNull();
     expect(clearSensitiveClientState).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/lint/issue889-auth-storage-fixtures.test.ts
+++ b/tests/unit/lint/issue889-auth-storage-fixtures.test.ts
@@ -17,7 +17,7 @@ const trackedFiles = [
 ];
 
 const directAuthUserWritePattern =
-  /localStorage\.setItem\(\s*["']auth_user["']\s*,\s*JSON\.stringify\(/;
+  /(?:(?:window|globalThis)\s*\.\s*)?localStorage\s*\.\s*setItem\(\s*["']auth_user["']\s*,\s*JSON\s*\.\s*stringify\(/;
 
 describe("Issue 889 auth storage fixture regression", () => {
   it("does not seed auth_user test state via direct localStorage JSON writes", () => {

--- a/tests/unit/lint/issue889-auth-storage-fixtures.test.ts
+++ b/tests/unit/lint/issue889-auth-storage-fixtures.test.ts
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../.."
+);
+
+const trackedFiles = [
+  "src/hooks/useAuth.test.ts",
+  "src/components/ProtectedRoute.test.tsx",
+];
+
+const directAuthUserWritePattern =
+  /localStorage\.setItem\(\s*["']auth_user["']\s*,\s*JSON\.stringify\(/;
+
+describe("Issue 889 auth storage fixture regression", () => {
+  it("does not seed auth_user test state via direct localStorage JSON writes", () => {
+    const offendingFiles = trackedFiles.filter((relativePath) => {
+      const fileContents = readFileSync(
+        path.join(repoRoot, relativePath),
+        "utf8"
+      );
+
+      return directAuthUserWritePattern.test(fileContents);
+    });
+
+    expect(offendingFiles).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- migrate valid persisted auth test fixtures in `useAuth.test.ts` and `ProtectedRoute.test.tsx` to `authStorage.setUser()` helpers
- align the affected auth tests with encrypted-storage bootstrap requirements by seeding `XSRF-TOKEN`, awaiting async persistence, and waiting for bootstrap/logout-barrier flows explicitly
- add a regression guard test that fails if those two files reintroduce direct `localStorage.setItem("auth_user", JSON.stringify(...))` fixture writes

## Validation
- `npm run typecheck`
- `npm run lint`
- `npx vitest run tests/unit/lint/issue889-auth-storage-fixtures.test.ts src/hooks/useAuth.test.ts src/components/ProtectedRoute.test.tsx`

## Notes
- Closes #889
- No changelog entry: internal test maintenance only
