### PR TITLE
test: suppress legacy auth helper CodeQL alert

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -63,6 +63,8 @@ function seedLegacyPersistedAuthUser(user: Record<string, unknown>) {
     throw new Error("Failed to seed legacy persisted auth user for test");
   }
 
+  // codeql[js/clear-text-storage-of-sensitive-data]: intentional legacy
+  // test scaffolding for backward-compat coverage of cleartext persisted auth.
   localStorage.setItem("auth_user", JSON.stringify(persistedUser));
   mockGetCurrentUser.mockResolvedValue(persistedUser);
 


### PR DESCRIPTION
## Summary
- add a targeted CodeQL suppression comment to the intentional legacy cleartext auth test helper in `src/App.test.tsx`
- keep the legacy compatibility test behavior unchanged so backward-compat coverage still exercises the cleartext restore path
- track the unrelated React `act(...)` test warning separately in #905 instead of mixing it into this PR

## Validation
- `npx vitest run src/App.test.tsx -t "keeps supporting legacy cleartext persisted auth state"`
- `npm run lint`
- `npm run typecheck`

## Notes
- Closes #904
- Follow-up warning tracker: #905
- No changelog entry: internal test/governance maintenance only