### PR TITLE
test: wrap App legacy auth bootstrap in act

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -437,37 +437,45 @@ describe("App", () => {
   });
 
   it("keeps supporting legacy cleartext persisted auth state on unknown authenticated routes", async () => {
+    const originalConsoleError = console.error.bind(console);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => {});
+      .mockImplementation((...args: Parameters<typeof console.error>) => {
+        if (!args.some((a) => String(a).includes("not wrapped in act"))) {
+          originalConsoleError(...args);
+        }
+      });
 
-    window.history.replaceState({}, "", "/dashboard");
+    try {
+      window.history.replaceState({}, "", "/dashboard");
 
-    seedLegacyPersistedAuthUser({
-      id: 1,
-      name: "User",
-      email: "user@secpal.dev",
-      emailVerified: true,
-    });
+      seedLegacyPersistedAuthUser({
+        id: 1,
+        name: "User",
+        email: "user@secpal.dev",
+        emailVerified: true,
+      });
 
-    await renderWithI18n(<App />);
+      await renderWithI18n(<App />);
 
-    expect(
-      await screen.findByText(
-        /Page Not Found/i,
-        {},
-        { timeout: ROUTE_NAVIGATION_TIMEOUT_MS }
-      )
-    ).toBeInTheDocument();
+      expect(
+        await screen.findByText(
+          /Page Not Found/i,
+          {},
+          { timeout: ROUTE_NAVIGATION_TIMEOUT_MS }
+        )
+      ).toBeInTheDocument();
 
-    expect(window.location.pathname).toBe("/dashboard");
+      expect(window.location.pathname).toBe("/dashboard");
 
-    const actWarnings = consoleErrorSpy.mock.calls
-      .flatMap((call) => call.map((entry) => String(entry)))
-      .filter((message) => message.includes("not wrapped in act"));
+      const actWarnings = consoleErrorSpy.mock.calls
+        .flatMap((call) => call.map((entry) => String(entry)))
+        .filter((message) => message.includes("not wrapped in act"));
 
-    expect(actWarnings).toEqual([]);
-    consoleErrorSpy.mockRestore();
+      expect(actWarnings).toEqual([]);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 
   it("redirects pre-contract authenticated users from the app home route to onboarding", async () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
-import { render, waitFor } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import { screen } from "@testing-library/dom";
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
@@ -37,9 +37,14 @@ vi.spyOn(globalThis, "fetch").mockRejectedValue(
 
 // Helper to render with I18n and wait for async updates
 async function renderWithI18n(component: React.ReactElement) {
-  const result = render(<I18nProvider i18n={i18n}>{component}</I18nProvider>);
-  // Wait for microtasks queued during initial render/effects to settle
-  await Promise.resolve();
+  let result!: ReturnType<typeof render>;
+
+  await act(async () => {
+    result = render(<I18nProvider i18n={i18n}>{component}</I18nProvider>);
+    // Wait for microtasks queued during initial render/effects to settle.
+    await Promise.resolve();
+  });
+
   return result;
 }
 
@@ -146,15 +151,19 @@ describe("App", () => {
       permissions: [],
     });
 
-    await renderWithI18n(<App />);
+    let notFoundHeading: Awaited<ReturnType<typeof screen.findByText>> | null =
+      null;
 
-    expect(
-      await screen.findByText(
+    await act(async () => {
+      await renderWithI18n(<App />);
+      notFoundHeading = await screen.findByText(
         /Page Not Found/i,
         {},
         { timeout: ROUTE_NAVIGATION_TIMEOUT_MS }
-      )
-    ).toBeInTheDocument();
+      );
+    });
+
+    expect(notFoundHeading).toBeInTheDocument();
   });
 
   it("shows not found for the legacy organizational-units route when the user lacks organizational access", async () => {
@@ -432,6 +441,10 @@ describe("App", () => {
   });
 
   it("keeps supporting legacy cleartext persisted auth state on unknown authenticated routes", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
     window.history.replaceState({}, "", "/dashboard");
 
     seedLegacyPersistedAuthUser({
@@ -452,6 +465,13 @@ describe("App", () => {
     ).toBeInTheDocument();
 
     expect(window.location.pathname).toBe("/dashboard");
+
+    const actWarnings = consoleErrorSpy.mock.calls
+      .flatMap((call) => call.map((entry) => String(entry)))
+      .filter((message) => message.includes("not wrapped in act"));
+
+    expect(actWarnings).toEqual([]);
+    consoleErrorSpy.mockRestore();
   });
 
   it("redirects pre-contract authenticated users from the app home route to onboarding", async () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -151,19 +151,15 @@ describe("App", () => {
       permissions: [],
     });
 
-    let notFoundHeading: Awaited<ReturnType<typeof screen.findByText>> | null =
-      null;
+    await renderWithI18n(<App />);
 
-    await act(async () => {
-      await renderWithI18n(<App />);
-      notFoundHeading = await screen.findByText(
+    expect(
+      await screen.findByText(
         /Page Not Found/i,
         {},
         { timeout: ROUTE_NAVIGATION_TIMEOUT_MS }
-      );
-    });
-
-    expect(notFoundHeading).toBeInTheDocument();
+      )
+    ).toBeInTheDocument();
   });
 
   it("shows not found for the legacy organizational-units route when the user lacks organizational access", async () => {


### PR DESCRIPTION
## Summary
- make the legacy cleartext auth compatibility case in `src/App.test.tsx` assert that no React `act(...)` warning is emitted
- wrap the shared App test render helper so the legacy bootstrap update path settles inside `act(...)`
- track the unrelated broader `App.test.tsx` route failures separately in #907 instead of mixing them into this PR

## Validation
- `npx vitest run src/App.test.tsx -t "keeps supporting legacy cleartext persisted auth state"`
- `npm run lint`
- `npm run typecheck`

## Notes
- Closes #905
- Follow-up tracker for broader App route failures on current main: #907
- No changelog entry: internal test maintenance only