### PR TITLE
refactor: extract onboarding step state helper

### DIFF
--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -21,7 +21,7 @@ msgstr "Vollständiger Name"
 msgid "Enabling..."
 msgstr "Aktiviere ..."
 
-#: src/pages/Onboarding/OnboardingWizard.tsx:308
+#: src/pages/Onboarding/OnboardingWizard.tsx:304
 msgid "Welcome to SecPal Onboarding"
 msgstr "Willkommen zum SecPal Onboarding"
 
@@ -785,7 +785,7 @@ msgstr "Diese Sitzung wurde widerrufen und kann nicht mehr für die Geräteeinri
 #: src/pages/Customers/CustomersPage.tsx:279
 #: src/pages/Employees/EmployeeList.tsx:336
 #: src/pages/Employees/EmployeeList.tsx:377
-#: src/pages/Onboarding/OnboardingWizard.tsx:74
+#: src/pages/Onboarding/OnboardingWizard.tsx:75
 #: src/pages/Sites/SitesPage.tsx:272
 #: src/pages/Sites/SitesPage.tsx:313
 msgid "Previous"
@@ -1131,7 +1131,7 @@ msgstr "Die Bereichszuweisung konnte nicht gespeichert werden."
 #: src/pages/Customers/CustomersPage.tsx:287
 #: src/pages/Employees/EmployeeList.tsx:343
 #: src/pages/Employees/EmployeeList.tsx:385
-#: src/pages/Onboarding/OnboardingWizard.tsx:90
+#: src/pages/Onboarding/OnboardingWizard.tsx:91
 #: src/pages/Sites/SitesPage.tsx:279
 #: src/pages/Sites/SitesPage.tsx:321
 msgid "Next"
@@ -1662,7 +1662,7 @@ msgstr "Alle"
 msgid "Invitation Mail Sent"
 msgstr "Einladungsmail verschickt"
 
-#: src/pages/Onboarding/OnboardingWizard.tsx:31
+#: src/pages/Onboarding/OnboardingWizard.tsx:32
 msgid "Step {currentStep} of {totalSteps}"
 msgstr "Schritt {currentStep} von {totalSteps}"
 
@@ -2015,7 +2015,7 @@ msgstr "Mitarbeiter laden..."
 msgid "Please correct the highlighted fields before submitting."
 msgstr "Bitte korrigieren Sie die hervorgehobenen Felder vor dem Absenden."
 
-#: src/pages/Onboarding/OnboardingWizard.tsx:86
+#: src/pages/Onboarding/OnboardingWizard.tsx:87
 msgid "Submit for Review"
 msgstr "Zur Überprüfung einreichen"
 
@@ -2321,7 +2321,7 @@ msgstr "Grund"
 msgid "Reminders about upcoming shifts and duties"
 msgstr "Erinnerungen an anstehende Schichten und Aufgaben"
 
-#: src/pages/Onboarding/OnboardingWizard.tsx:290
+#: src/pages/Onboarding/OnboardingWizard.tsx:286
 msgid "Loading onboarding..."
 msgstr "Onboarding laden..."
 
@@ -2380,7 +2380,7 @@ msgstr "Passkey wird überprüft …"
 msgid "Highest rank number the user can view (set to 255 for all, 0 or empty for non-leadership only). Range: 0-255"
 msgstr "Höchste Rangnummer, die der Benutzer sehen kann (255 für alle, 0 oder leer für Nicht-Führungskräfte). Bereich: 0-255"
 
-#: src/pages/Onboarding/OnboardingWizard.tsx:81
+#: src/pages/Onboarding/OnboardingWizard.tsx:82
 msgid "Save Draft"
 msgstr "Entwurf speichern"
 
@@ -2580,6 +2580,6 @@ msgstr "Telefon"
 msgid "This session has already been used to complete device bootstrap."
 msgstr "Diese Sitzung wurde bereits für den Geräte-Bootstrap verwendet."
 
-#: src/pages/Onboarding/OnboardingWizard.tsx:335
+#: src/pages/Onboarding/OnboardingWizard.tsx:331
 msgid "Form fields will be rendered based on schema"
 msgstr "Formularfelder werden basierend auf dem Schema gerendert"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -21,7 +21,7 @@ msgstr "Full Name"
 msgid "Enabling..."
 msgstr "Enabling..."
 
-#: src/pages/Onboarding/OnboardingWizard.tsx:308
+#: src/pages/Onboarding/OnboardingWizard.tsx:304
 msgid "Welcome to SecPal Onboarding"
 msgstr "Welcome to SecPal Onboarding"
 
@@ -785,7 +785,7 @@ msgstr "This session was revoked and can no longer be used for device setup."
 #: src/pages/Customers/CustomersPage.tsx:279
 #: src/pages/Employees/EmployeeList.tsx:336
 #: src/pages/Employees/EmployeeList.tsx:377
-#: src/pages/Onboarding/OnboardingWizard.tsx:74
+#: src/pages/Onboarding/OnboardingWizard.tsx:75
 #: src/pages/Sites/SitesPage.tsx:272
 #: src/pages/Sites/SitesPage.tsx:313
 msgid "Previous"
@@ -1131,7 +1131,7 @@ msgstr "Failed to save scope assignment."
 #: src/pages/Customers/CustomersPage.tsx:287
 #: src/pages/Employees/EmployeeList.tsx:343
 #: src/pages/Employees/EmployeeList.tsx:385
-#: src/pages/Onboarding/OnboardingWizard.tsx:90
+#: src/pages/Onboarding/OnboardingWizard.tsx:91
 #: src/pages/Sites/SitesPage.tsx:279
 #: src/pages/Sites/SitesPage.tsx:321
 msgid "Next"
@@ -1662,7 +1662,7 @@ msgstr "All"
 msgid "Invitation Mail Sent"
 msgstr "Invitation Mail Sent"
 
-#: src/pages/Onboarding/OnboardingWizard.tsx:31
+#: src/pages/Onboarding/OnboardingWizard.tsx:32
 msgid "Step {currentStep} of {totalSteps}"
 msgstr "Step {currentStep} of {totalSteps}"
 
@@ -2015,7 +2015,7 @@ msgstr "Loading employees..."
 msgid "Please correct the highlighted fields before submitting."
 msgstr "Please correct the highlighted fields before submitting."
 
-#: src/pages/Onboarding/OnboardingWizard.tsx:86
+#: src/pages/Onboarding/OnboardingWizard.tsx:87
 msgid "Submit for Review"
 msgstr "Submit for Review"
 
@@ -2321,7 +2321,7 @@ msgstr "Reason"
 msgid "Reminders about upcoming shifts and duties"
 msgstr "Reminders about upcoming shifts and duties"
 
-#: src/pages/Onboarding/OnboardingWizard.tsx:290
+#: src/pages/Onboarding/OnboardingWizard.tsx:286
 msgid "Loading onboarding..."
 msgstr "Loading onboarding..."
 
@@ -2380,7 +2380,7 @@ msgstr "Verifying passkey…"
 msgid "Highest rank number the user can view (set to 255 for all, 0 or empty for non-leadership only). Range: 0-255"
 msgstr "Highest rank number the user can view (set to 255 for all, 0 or empty for non-leadership only). Range: 0-255"
 
-#: src/pages/Onboarding/OnboardingWizard.tsx:81
+#: src/pages/Onboarding/OnboardingWizard.tsx:82
 msgid "Save Draft"
 msgstr "Save Draft"
 
@@ -2580,6 +2580,6 @@ msgstr "Phone"
 msgid "This session has already been used to complete device bootstrap."
 msgstr "This session has already been used to complete device bootstrap."
 
-#: src/pages/Onboarding/OnboardingWizard.tsx:335
+#: src/pages/Onboarding/OnboardingWizard.tsx:331
 msgid "Form fields will be rendered based on schema"
 msgstr "Form fields will be rendered based on schema"

--- a/src/pages/Onboarding/OnboardingWizard.test.tsx
+++ b/src/pages/Onboarding/OnboardingWizard.test.tsx
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import type { OnboardingStep } from "../../services/onboardingApi";
+import { getOnboardingStepState } from "./onboardingWizardState";
+
+describe("getOnboardingStepState", () => {
+  it("returns submission data for the current onboarding step", () => {
+    const step: OnboardingStep = {
+      step_number: 1,
+      title: "Personal Information",
+      template_id: "template-1",
+      is_completed: false,
+      submission: {
+        id: "submission-1",
+        employee_id: "employee-1",
+        form_template_id: "template-1",
+        form_data: {
+          first_name: "Ada",
+        },
+        status: "draft",
+        created_at: "2026-04-18T00:00:00Z",
+        updated_at: "2026-04-18T00:00:00Z",
+      },
+    };
+
+    expect(getOnboardingStepState(step)).toEqual({
+      submission: step.submission,
+      formData: {
+        first_name: "Ada",
+      },
+    });
+  });
+
+  it("falls back to empty step state when the step has no submission", () => {
+    const step: OnboardingStep = {
+      step_number: 2,
+      title: "Identity Documents",
+      template_id: "template-2",
+      is_completed: false,
+      submission: null,
+    };
+
+    expect(getOnboardingStepState(step)).toEqual({
+      submission: null,
+      formData: {},
+    });
+  });
+});

--- a/src/pages/Onboarding/OnboardingWizard.tsx
+++ b/src/pages/Onboarding/OnboardingWizard.tsx
@@ -14,6 +14,7 @@ import {
 import { Heading } from "../../components/heading";
 import { Button } from "../../components/button";
 import { Text } from "../../components/text";
+import { getOnboardingStepState } from "./onboardingWizardState";
 
 function ProgressIndicator({
   currentStep,
@@ -108,18 +109,6 @@ export function OnboardingWizard() {
   const [saving, setSaving] = useState(false);
   const currentStepTemplateId = steps[currentStepIndex]?.template_id;
 
-  function syncStepState(step: OnboardingStep | undefined) {
-    const currentSubmission = step?.submission ?? null;
-
-    setSubmission(currentSubmission);
-    setFormData(
-      currentSubmission?.form_data &&
-        typeof currentSubmission.form_data === "object"
-        ? currentSubmission.form_data
-        : {}
-    );
-  }
-
   useEffect(() => {
     let active = true;
 
@@ -132,7 +121,10 @@ export function OnboardingWizard() {
         setError(null);
         setLoading(data.length > 0);
         setSteps(data);
-        syncStepState(data[0]);
+
+        const stepState = getOnboardingStepState(data[0]);
+        setSubmission(stepState.submission);
+        setFormData(stepState.formData);
       })
       .catch((err) => {
         if (!active) {
@@ -254,11 +246,13 @@ export function OnboardingWizard() {
       currentStepIndex < steps.length - 1
     ) {
       const nextStep = steps[currentStepIndex + 1];
+      const nextStepState = getOnboardingStepState(nextStep);
 
       setLoading(true);
       setError(null);
       setTemplate(null);
-      syncStepState(nextStep);
+      setSubmission(nextStepState.submission);
+      setFormData(nextStepState.formData);
       setCurrentStepIndex(currentStepIndex + 1);
     }
   }
@@ -266,11 +260,13 @@ export function OnboardingWizard() {
   function handlePrevious() {
     if (currentStepIndex > 0) {
       const previousStep = steps[currentStepIndex - 1];
+      const previousStepState = getOnboardingStepState(previousStep);
 
       setLoading(true);
       setError(null);
       setTemplate(null);
-      syncStepState(previousStep);
+      setSubmission(previousStepState.submission);
+      setFormData(previousStepState.formData);
       setCurrentStepIndex(currentStepIndex - 1);
     }
   }

--- a/src/pages/Onboarding/onboardingWizardState.test.ts
+++ b/src/pages/Onboarding/onboardingWizardState.test.ts
@@ -47,4 +47,27 @@ describe("getOnboardingStepState", () => {
       formData: {},
     });
   });
+
+  it("falls back to empty formData when submission has null form_data", () => {
+    const step: OnboardingStep = {
+      step_number: 3,
+      title: "Bank Details",
+      template_id: "template-3",
+      is_completed: false,
+      submission: {
+        id: "submission-3",
+        employee_id: "employee-1",
+        form_template_id: "template-3",
+        form_data: null,
+        status: "draft",
+        created_at: "2026-04-18T00:00:00Z",
+        updated_at: "2026-04-18T00:00:00Z",
+      },
+    };
+
+    expect(getOnboardingStepState(step)).toEqual({
+      submission: step.submission,
+      formData: {},
+    });
+  });
 });

--- a/src/pages/Onboarding/onboardingWizardState.ts
+++ b/src/pages/Onboarding/onboardingWizardState.ts
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type {
+  OnboardingStep,
+  OnboardingSubmission,
+} from "../../services/onboardingApi";
+
+export function getOnboardingStepState(step: OnboardingStep | undefined): {
+  submission: OnboardingSubmission | null;
+  formData: Record<string, unknown>;
+} {
+  const submission = step?.submission ?? null;
+
+  return {
+    submission,
+    formData:
+      submission?.form_data && typeof submission.form_data === "object"
+        ? submission.form_data
+        : {},
+  };
+}


### PR DESCRIPTION
## Summary
- extract the onboarding step-to-submission/form-data derivation into a dedicated helper module
- remove the component-scoped `syncStepState(...)` function from `OnboardingWizard`
- add focused regression coverage for the extracted onboarding step-state helper

## Validation
- `npx vitest run src/pages/Onboarding/OnboardingWizard.test.tsx`
- `npx eslint src/pages/Onboarding/OnboardingWizard.tsx src/pages/Onboarding/OnboardingWizard.test.tsx src/pages/Onboarding/onboardingWizardState.ts`
- `npx tsc --noEmit`
- `npx vitest run src/App.test.tsx src/pages/Onboarding/OnboardingWizard.test.tsx`

Closes #880
