### PR TITLE
test: stabilize issue874 lint regression coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Split the heavy `issue874-react-hooks-set-state-in-effect` lint regression into smaller tracked-file batches and gave each batch a dedicated 30-second timeout so `npm run test:coverage` no longer times out on one monolithic ESLint spawn under full-suite coverage load, resolving frontend issue #899.
 - Increased PBKDF2 iteration count from 5,000 to 600,000 (OWASP minimum for PBKDF2-HMAC-SHA256) for new auth-storage envelopes while preserving reads of legacy v1 envelopes during rollout, hardening key derivation without forcing deploy-time logouts.
 - Replaced `Buffer.from` with `TextEncoder` in `Login.test.tsx` `textBytes` helper for cross-platform Web API compatibility.
 - Fixed incorrect `ApiError` constructor argument order in `employeeApi.ts` BWR export and BWR status update error paths: the third argument now correctly passes `normalizeApiErrorErrors(error.errors) ?? undefined` (errors array) instead of `response` (the Response object).

--- a/tests/unit/lint/issue874-react-hooks-set-state-in-effect.test.ts
+++ b/tests/unit/lint/issue874-react-hooks-set-state-in-effect.test.ts
@@ -70,8 +70,19 @@ function lintTrackedFiles(trackedFiles: string[]) {
     {
       cwd: repoRoot,
       encoding: "utf8",
+      timeout: ISSUE_874_BATCH_TIMEOUT_MS,
+      killSignal: "SIGTERM",
     }
   );
+
+  if (
+    result.signal === "SIGTERM" ||
+    result.error?.message?.includes("ETIMEDOUT")
+  ) {
+    throw new Error(
+      `ESLint timed out after ${ISSUE_874_BATCH_TIMEOUT_MS}ms for batch: ${trackedFiles.join(", ")}`
+    );
+  }
 
   expect(result.error).toBeUndefined();
   expect(result.status, result.stderr).toBe(0);

--- a/tests/unit/lint/issue874-react-hooks-set-state-in-effect.test.ts
+++ b/tests/unit/lint/issue874-react-hooks-set-state-in-effect.test.ts
@@ -31,54 +31,77 @@ const issue874Files = [
   "src/pages/Sites/SitesPage.tsx",
 ];
 
+const ISSUE_874_FILE_BATCH_SIZE = 4;
+const ISSUE_874_BATCH_TIMEOUT_MS = 30_000;
+
+type LintReportEntry = {
+  filePath: string;
+  messages: Array<{ ruleId: string | null; line: number; column: number }>;
+};
+
+function chunkFiles(files: string[], batchSize: number): string[][] {
+  const batches: string[][] = [];
+
+  for (let index = 0; index < files.length; index += batchSize) {
+    batches.push(files.slice(index, index + batchSize));
+  }
+
+  return batches;
+}
+
+function lintTrackedFiles(trackedFiles: string[]) {
+  const eslintCli = path.join(
+    repoRoot,
+    "node_modules",
+    "eslint",
+    "bin",
+    "eslint.js"
+  );
+  const result = spawnSync(
+    process.execPath,
+    [
+      eslintCli,
+      ...trackedFiles,
+      "--rule",
+      "react-hooks/set-state-in-effect:error",
+      "--format",
+      "json",
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+    }
+  );
+
+  expect(result.error).toBeUndefined();
+  expect(result.status, result.stderr).toBe(0);
+
+  const output = result.stdout.trim();
+  expect(output).not.toBe("");
+
+  const report = JSON.parse(output) as LintReportEntry[];
+
+  return report.flatMap((entry) =>
+    entry.messages
+      .filter((message) => message.ruleId === "react-hooks/set-state-in-effect")
+      .map((message) => ({
+        filePath: path.relative(repoRoot, entry.filePath),
+        line: message.line,
+        column: message.column,
+      }))
+  );
+}
+
 describe("Issue 874 lint regression", () => {
-  it("has no react-hooks/set-state-in-effect violations in the tracked files", () => {
-    const eslintCli = path.join(
-      repoRoot,
-      "node_modules",
-      "eslint",
-      "bin",
-      "eslint.js"
-    );
-    const result = spawnSync(
-      process.execPath,
-      [
-        eslintCli,
-        ...issue874Files,
-        "--rule",
-        "react-hooks/set-state-in-effect:error",
-        "--format",
-        "json",
-      ],
-      {
-        cwd: repoRoot,
-        encoding: "utf8",
-      }
-    );
-
-    expect(result.error).toBeUndefined();
-    expect(result.status, result.stderr).toBe(0);
-
-    const output = result.stdout.trim();
-    expect(output).not.toBe("");
-
-    const report = JSON.parse(output) as Array<{
-      filePath: string;
-      messages: Array<{ ruleId: string | null; line: number; column: number }>;
-    }>;
-
-    const violations = report.flatMap((entry) =>
-      entry.messages
-        .filter(
-          (message) => message.ruleId === "react-hooks/set-state-in-effect"
-        )
-        .map((message) => ({
-          filePath: path.relative(repoRoot, entry.filePath),
-          line: message.line,
-          column: message.column,
-        }))
-    );
-
-    expect(violations).toEqual([]);
-  });
+  it.each(
+    chunkFiles(issue874Files, ISSUE_874_FILE_BATCH_SIZE).map(
+      (trackedFiles, index) => [index + 1, trackedFiles] as const
+    )
+  )(
+    "has no react-hooks/set-state-in-effect violations in tracked batch %i",
+    (_batchNumber, trackedFiles) => {
+      expect(lintTrackedFiles(trackedFiles)).toEqual([]);
+    },
+    ISSUE_874_BATCH_TIMEOUT_MS
+  );
 });


### PR DESCRIPTION
## Summary
- split the issue 874 lint regression into smaller tracked-file batches instead of one monolithic ESLint invocation
- add a dedicated per-batch timeout so the regression stays meaningful under `npm run test:coverage`
- update `CHANGELOG.md` for frontend issue #899

## Validation
- `npm run test:coverage -- tests/unit/lint/issue874-react-hooks-set-state-in-effect.test.ts`
- `npx eslint tests/unit/lint/issue874-react-hooks-set-state-in-effect.test.ts`
- `npm run test:coverage`

## Current blockers
The full coverage suite still fails, but the original issue 899 timeout is no longer among the failing tests. Remaining unrelated failures observed locally:
- `src/App.test.tsx > App`
- `src/components/ProtectedRoute.test.tsx > ProtectedRoute > shows a retry recovery state instead of spinning forever when bootstrap stalls`
- `src/contexts/AuthContext.test.tsx > AuthContext > login updates permission state > updates hasOrganizationalAccess after login`
- `src/pages/Login.test.tsx > Login > shows a verifying prompt while the passkey verify request is in progress`
- `src/pages/Login.test.tsx > Login > verifies an MFA challenge and continues the session login flow`

Closes #899.