### PR TITLE
Remove legacy auth storage compatibility

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -96,6 +96,11 @@ At minimum verify:
   tenant-, or user-derived UI state across session changes or auth
   transitions; prove dependency lists invalidate correctly and add focused
   regression coverage.
+- Reject AI-generated compatibility keep-alives that preserve obsolete
+  frontend contracts, storage formats, or input aliases without a proven live
+  caller. Because the SecPal project is still under `1.x`, prefer removing
+  unnecessary compatibility paths over carrying them forward, especially when
+  they weaken security, correctness, or contract clarity.
 
 ## Repository Conventions
 
@@ -104,7 +109,15 @@ At minimum verify:
 - Keep presentation in components and reusable logic in hooks or API clients.
 - Prefer functional components, named exports, and existing design-system patterns before new abstractions.
 - Preserve strict TypeScript, accessibility, semantic HTML, focus behavior, and responsive layouts.
+- Auth and other sensitive user-derived state must not be persisted in
+  cleartext browser storage. Use the approved storage abstraction for runtime
+  code, and in tests seed auth state through `authStorage.setUser()` or a real
+  current-format encrypted envelope when browser-only setup is unavoidable.
 
 ## Scope Notes
 
 - Do not add dependencies or create documentation files unless the task requires them.
+- Because the SecPal project is still under `1.x`, breaking changes are
+  acceptable when they remove insecure or obsolete compatibility layers. When
+  taking that route, update tests and `CHANGELOG.md` in the same change set
+  instead of keeping a legacy path alive by default.

--- a/.github/instructions/react-typescript.instructions.md
+++ b/.github/instructions/react-typescript.instructions.md
@@ -16,6 +16,10 @@ applyTo: "src/**/*.ts,src/**/*.tsx,tests/**/*.ts,tests/**/*.tsx,vite.config.ts"
 - Maintain accessibility, semantic markup, and responsive behavior.
 - Default boolean security flags (e.g. `emailVerified`) to `false` in sanitization layers; never leave them
   `undefined` on authenticated state.
+- Do not persist auth state or other sensitive user-derived data via direct
+  cleartext `localStorage`/`sessionStorage` writes. Use the approved storage
+  abstraction in runtime code, and in tests seed authenticated state through
+  `authStorage.setUser()` or a real current-format encrypted envelope.
 - Scope `role="status"` and `aria-live` to the exact dynamic content region, not to wider containers that
   also hold headings or interactive controls.
 - For AI-suggested async fixes, prove ordering with tests; when cleanup must happen after an awaited call settles,
@@ -23,3 +27,7 @@ applyTo: "src/**/*.ts,src/**/*.tsx,tests/**/*.ts,tests/**/*.tsx,vite.config.ts"
 - Keep plain-text-only HTML contexts such as `<option>` children free of wrapper components; use translated strings,
   not `<Trans>` or other element-producing helpers.
 - Keep load, action, and destructive-flow error state separate when they drive different UI branches.
+- Because the SecPal project is still under `1.x`, do not preserve obsolete
+  compatibility shims by default. If a legacy storage format, input alias, or
+  deprecated frontend contract has no proven live caller, prefer removing it
+  and updating tests and changelog coverage in the same change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Wired the central Copilot-instructions validator into `quality.yml` so frontend pull requests now fail automatically when known React AI-risk guardrails or generic AI-triage guidance are missing from the runtime baseline
+- Dropped restoration of legacy cleartext and pre-v2 encrypted `auth_user` localStorage payloads; unsupported auth-storage records are now purged instead of being restored, and frontend test fixtures now seed authenticated state through the encrypted storage path only
 
 ### Removed
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -61,21 +61,6 @@ async function seedPersistedAuthUser(user: Record<string, unknown>) {
   return persistedUser;
 }
 
-function seedLegacyPersistedAuthUser(user: Record<string, unknown>) {
-  const persistedUser = sanitizePersistedAuthUser(user);
-
-  if (!persistedUser) {
-    throw new Error("Failed to seed legacy persisted auth user for test");
-  }
-
-  // codeql[js/clear-text-storage-of-sensitive-data]: intentional legacy
-  // test scaffolding for backward-compat coverage of cleartext persisted auth.
-  localStorage.setItem("auth_user", JSON.stringify(persistedUser));
-  mockGetCurrentUser.mockResolvedValue(persistedUser);
-
-  return persistedUser;
-}
-
 describe("App", () => {
   // Pre-load all lazily-imported route modules once before any test runs.
   // Without this, each test that renders a route with a lazy component creates
@@ -434,48 +419,6 @@ describe("App", () => {
     });
 
     expect(screen.queryByText(/Page Not Found/i)).not.toBeInTheDocument();
-  });
-
-  it("keeps supporting legacy cleartext persisted auth state on unknown authenticated routes", async () => {
-    const originalConsoleError = console.error.bind(console);
-    const consoleErrorSpy = vi
-      .spyOn(console, "error")
-      .mockImplementation((...args: Parameters<typeof console.error>) => {
-        if (!args.some((a) => String(a).includes("not wrapped in act"))) {
-          originalConsoleError(...args);
-        }
-      });
-
-    try {
-      window.history.replaceState({}, "", "/dashboard");
-
-      seedLegacyPersistedAuthUser({
-        id: 1,
-        name: "User",
-        email: "user@secpal.dev",
-        emailVerified: true,
-      });
-
-      await renderWithI18n(<App />);
-
-      expect(
-        await screen.findByText(
-          /Page Not Found/i,
-          {},
-          { timeout: ROUTE_NAVIGATION_TIMEOUT_MS }
-        )
-      ).toBeInTheDocument();
-
-      expect(window.location.pathname).toBe("/dashboard");
-
-      const actWarnings = consoleErrorSpy.mock.calls
-        .flatMap((call) => call.map((entry) => String(entry)))
-        .filter((message) => message.includes("not wrapped in act"));
-
-      expect(actWarnings).toEqual([]);
-    } finally {
-      consoleErrorSpy.mockRestore();
-    }
   });
 
   it("redirects pre-contract authenticated users from the app home route to onboarding", async () => {

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -41,9 +41,9 @@ const QUERY_TIMEOUT = 15000;
 // Mock ResizeObserver for HeadlessUI Menu component
 beforeAll(() => {
   global.ResizeObserver = class ResizeObserver {
-    observe() { }
-    unobserve() { }
-    disconnect() { }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
   };
 });
 
@@ -378,7 +378,7 @@ describe("ApplicationLayout", () => {
 
       const consoleSpy = vi
         .spyOn(console, "error")
-        .mockImplementation(() => { });
+        .mockImplementation(() => {});
 
       renderWithProviders(
         <ApplicationLayout>
@@ -412,7 +412,7 @@ describe("ApplicationLayout", () => {
 
       const consoleSpy = vi
         .spyOn(console, "error")
-        .mockImplementation(() => { });
+        .mockImplementation(() => {});
 
       renderWithProviders(
         <ApplicationLayout>
@@ -785,9 +785,9 @@ describe("ApplicationLayout", () => {
         { route: "/activity-logs" }
       );
 
-      const activityLogsLink = (await screen.findByText("Activity Logs")).closest(
-        "a"
-      );
+      const activityLogsLink = (
+        await screen.findByText("Activity Logs")
+      ).closest("a");
       expect(activityLogsLink).toHaveAttribute("href", "/activity-logs");
     });
 
@@ -805,9 +805,9 @@ describe("ApplicationLayout", () => {
         </ApplicationLayout>
       );
 
-      const activityLogsLink = (await screen.findByText("Activity Logs")).closest(
-        "a"
-      );
+      const activityLogsLink = (
+        await screen.findByText("Activity Logs")
+      ).closest("a");
       expect(activityLogsLink).toHaveAttribute("href", "/activity-logs");
     });
   });

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -71,13 +71,13 @@ async function seedAuthenticatedUser(user: Record<string, unknown>) {
   }
 
   const authenticatedUser: AuthenticatedUser = {
+    ...persistedUser,
     roles: [],
     permissions: [],
     hasOrganizationalScopes: false,
     hasCustomerAccess: false,
     hasSiteAccess: false,
-    emailVerified: persistedUser.emailVerified ?? true,
-    ...persistedUser,
+    emailVerified: persistedUser.emailVerified ?? false,
   };
 
   vi.mocked(authApi.getCurrentUser).mockResolvedValue(authenticatedUser);

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -24,8 +24,12 @@ import { MemoryRouter } from "react-router-dom";
 import { ApplicationLayout } from "./application-layout";
 import { AuthProvider } from "../contexts/AuthContext";
 import * as authApi from "../services/authApi";
+import { sanitizePersistedAuthUser } from "../services/authState";
+import { authStorage } from "../services/storage";
 import { clearSensitiveClientState } from "../lib/clientStateCleanup";
 import { messages as deMessages } from "../locales/de/messages.mjs";
+
+type AuthenticatedUser = Awaited<ReturnType<typeof authApi.getCurrentUser>>;
 
 vi.mock("../services/authApi");
 vi.mock("../lib/clientStateCleanup", () => ({
@@ -37,9 +41,9 @@ const QUERY_TIMEOUT = 15000;
 // Mock ResizeObserver for HeadlessUI Menu component
 beforeAll(() => {
   global.ResizeObserver = class ResizeObserver {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
+    observe() { }
+    unobserve() { }
+    disconnect() { }
   };
 });
 
@@ -55,6 +59,30 @@ const renderWithProviders = (
     </MemoryRouter>
   );
 };
+
+async function seedAuthenticatedUser(user: Record<string, unknown>) {
+  const persistedUser = sanitizePersistedAuthUser({
+    emailVerified: true,
+    ...user,
+  });
+
+  if (!persistedUser) {
+    throw new Error("Failed to seed authenticated user for test");
+  }
+
+  const authenticatedUser: AuthenticatedUser = {
+    roles: [],
+    permissions: [],
+    hasOrganizationalScopes: false,
+    hasCustomerAccess: false,
+    hasSiteAccess: false,
+    emailVerified: persistedUser.emailVerified ?? true,
+    ...persistedUser,
+  };
+
+  vi.mocked(authApi.getCurrentUser).mockResolvedValue(authenticatedUser);
+  await authStorage.setUser(persistedUser);
+}
 
 async function openUserMenu() {
   const userMenuButton = screen.getByRole("button", {
@@ -75,26 +103,20 @@ async function openUserMenu() {
 
 describe("ApplicationLayout", () => {
   const SLOW_TEST_TIMEOUT = 20000;
+  const authenticatedUser = {
+    id: 1,
+    name: "John Doe",
+    email: "john@secpal.dev",
+    emailVerified: true,
+  };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     localStorage.clear();
     i18n.load("en", {});
     i18n.activate("en");
 
-    vi.mocked(authApi.getCurrentUser).mockImplementation(
-      () => new Promise(() => undefined)
-    );
-
-    // Set up authenticated user
-    localStorage.setItem(
-      "auth_user",
-      JSON.stringify({
-        id: 1,
-        name: "John Doe",
-        email: "john@secpal.dev",
-      })
-    );
+    await seedAuthenticatedUser(authenticatedUser);
   });
 
   describe("rendering", () => {
@@ -162,7 +184,7 @@ describe("ApplicationLayout", () => {
       expect(userMenuButton).toBeInTheDocument();
     });
 
-    it("renders user initials in avatar", () => {
+    it("renders user initials in avatar", async () => {
       renderWithProviders(
         <ApplicationLayout>
           <div>Content</div>
@@ -170,7 +192,7 @@ describe("ApplicationLayout", () => {
       );
 
       // Avatar in navbar (stacked layout has avatar only in navbar)
-      const avatars = screen.getAllByText("JD");
+      const avatars = await screen.findAllByText("JD");
       expect(avatars.length).toBeGreaterThanOrEqual(1);
     });
   });
@@ -356,7 +378,7 @@ describe("ApplicationLayout", () => {
 
       const consoleSpy = vi
         .spyOn(console, "error")
-        .mockImplementation(() => {});
+        .mockImplementation(() => { });
 
       renderWithProviders(
         <ApplicationLayout>
@@ -390,7 +412,7 @@ describe("ApplicationLayout", () => {
 
       const consoleSpy = vi
         .spyOn(console, "error")
-        .mockImplementation(() => {});
+        .mockImplementation(() => { });
 
       renderWithProviders(
         <ApplicationLayout>
@@ -437,15 +459,12 @@ describe("ApplicationLayout", () => {
   });
 
   describe("getInitials helper", () => {
-    it("generates correct initials for two-word name", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "Jane Smith",
-          email: "jane@secpal.dev",
-        })
-      );
+    it("generates correct initials for two-word name", async () => {
+      await seedAuthenticatedUser({
+        id: 1,
+        name: "Jane Smith",
+        email: "jane@secpal.dev",
+      });
 
       renderWithProviders(
         <ApplicationLayout>
@@ -454,19 +473,16 @@ describe("ApplicationLayout", () => {
       );
 
       // Avatar in navbar (stacked layout has avatar only in navbar)
-      const avatars = screen.getAllByText("JS");
+      const avatars = await screen.findAllByText("JS");
       expect(avatars.length).toBeGreaterThanOrEqual(1);
     });
 
-    it("generates correct initials for single-word name", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "Admin",
-          email: "admin@secpal.dev",
-        })
-      );
+    it("generates correct initials for single-word name", async () => {
+      await seedAuthenticatedUser({
+        id: 1,
+        name: "Admin",
+        email: "admin@secpal.dev",
+      });
 
       renderWithProviders(
         <ApplicationLayout>
@@ -475,19 +491,16 @@ describe("ApplicationLayout", () => {
       );
 
       // Avatar in navbar (stacked layout has avatar only in navbar)
-      const avatars = screen.getAllByText("A");
+      const avatars = await screen.findAllByText("A");
       expect(avatars.length).toBeGreaterThanOrEqual(1);
     });
 
-    it("generates correct initials for three-word name (max 2)", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "John Paul Smith",
-          email: "john@secpal.dev",
-        })
-      );
+    it("generates correct initials for three-word name (max 2)", async () => {
+      await seedAuthenticatedUser({
+        id: 1,
+        name: "John Paul Smith",
+        email: "john@secpal.dev",
+      });
 
       renderWithProviders(
         <ApplicationLayout>
@@ -496,18 +509,16 @@ describe("ApplicationLayout", () => {
       );
 
       // Avatar in navbar (stacked layout has avatar only in navbar)
-      const avatars = screen.getAllByText("JP");
+      const avatars = await screen.findAllByText("JP");
       expect(avatars.length).toBeGreaterThanOrEqual(1);
     });
 
-    it("shows fallback U when user name is missing", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          email: "user@secpal.dev",
-        })
-      );
+    it("shows fallback U when user name is missing", async () => {
+      await seedAuthenticatedUser({
+        id: 1,
+        name: "   ",
+        email: "user@secpal.dev",
+      });
 
       renderWithProviders(
         <ApplicationLayout>
@@ -522,16 +533,13 @@ describe("ApplicationLayout", () => {
   });
 
   describe("permission-based navigation", () => {
-    it("hides Organization link when user has no organizational scopes", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "John Doe",
-          email: "john@secpal.dev",
-          hasOrganizationalScopes: false,
-        })
-      );
+    it("hides Organization link when user has no organizational scopes", async () => {
+      await seedAuthenticatedUser({
+        id: 1,
+        name: "John Doe",
+        email: "john@secpal.dev",
+        hasOrganizationalScopes: false,
+      });
 
       renderWithProviders(
         <ApplicationLayout>
@@ -542,16 +550,13 @@ describe("ApplicationLayout", () => {
       expect(screen.queryByText("Organization")).not.toBeInTheDocument();
     });
 
-    it("hides Customers link when user has no organizational scopes", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "John Doe",
-          email: "john@secpal.dev",
-          hasOrganizationalScopes: false,
-        })
-      );
+    it("hides Customers link when user has no organizational scopes", async () => {
+      await seedAuthenticatedUser({
+        id: 1,
+        name: "John Doe",
+        email: "john@secpal.dev",
+        hasOrganizationalScopes: false,
+      });
 
       renderWithProviders(
         <ApplicationLayout>
@@ -562,18 +567,15 @@ describe("ApplicationLayout", () => {
       expect(screen.queryByText("Customers")).not.toBeInTheDocument();
     });
 
-    it("keeps management links hidden for scope-only users", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "John Doe",
-          email: "john@secpal.dev",
-          hasOrganizationalScopes: true,
-          roles: [],
-          permissions: [],
-        })
-      );
+    it("keeps management links hidden for scope-only users", async () => {
+      await seedAuthenticatedUser({
+        id: 1,
+        name: "John Doe",
+        email: "john@secpal.dev",
+        hasOrganizationalScopes: true,
+        roles: [],
+        permissions: [],
+      });
 
       renderWithProviders(
         <ApplicationLayout>
@@ -586,18 +588,15 @@ describe("ApplicationLayout", () => {
       expect(screen.queryByText("Employees")).not.toBeInTheDocument();
     });
 
-    it("shows management links for elevated organization roles", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "John Doe",
-          email: "john@secpal.dev",
-          hasOrganizationalScopes: true,
-          roles: ["Manager"],
-          permissions: [],
-        })
-      );
+    it("shows management links for elevated organization roles", async () => {
+      await seedAuthenticatedUser({
+        id: 1,
+        name: "John Doe",
+        email: "john@secpal.dev",
+        hasOrganizationalScopes: true,
+        roles: ["Manager"],
+        permissions: [],
+      });
 
       renderWithProviders(
         <ApplicationLayout>
@@ -605,23 +604,20 @@ describe("ApplicationLayout", () => {
         </ApplicationLayout>
       );
 
-      expect(screen.getByText("Organization")).toBeInTheDocument();
-      expect(screen.getByText("Customers")).toBeInTheDocument();
-      expect(screen.getByText("Employees")).toBeInTheDocument();
+      expect(await screen.findByText("Organization")).toBeInTheDocument();
+      expect(await screen.findByText("Customers")).toBeInTheDocument();
+      expect(await screen.findByText("Employees")).toBeInTheDocument();
     });
 
-    it("shows Customers for users with explicit customer permissions", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "John Doe",
-          email: "john@secpal.dev",
-          hasOrganizationalScopes: false,
-          roles: [],
-          permissions: ["customers.read"],
-        })
-      );
+    it("shows Customers for users with explicit customer permissions", async () => {
+      await seedAuthenticatedUser({
+        id: 1,
+        name: "John Doe",
+        email: "john@secpal.dev",
+        hasOrganizationalScopes: false,
+        roles: [],
+        permissions: ["customers.read"],
+      });
 
       renderWithProviders(
         <ApplicationLayout>
@@ -629,24 +625,21 @@ describe("ApplicationLayout", () => {
         </ApplicationLayout>
       );
 
-      expect(screen.getByText("Customers")).toBeInTheDocument();
+      expect(await screen.findByText("Customers")).toBeInTheDocument();
       expect(screen.queryByText("Organization")).not.toBeInTheDocument();
       expect(screen.queryByText("Employees")).not.toBeInTheDocument();
     });
 
-    it("shows Customers for users with backend scoped-access flags", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "John Doe",
-          email: "john@secpal.dev",
-          hasOrganizationalScopes: false,
-          hasCustomerAccess: true,
-          roles: [],
-          permissions: [],
-        })
-      );
+    it("shows Customers for users with backend scoped-access flags", async () => {
+      await seedAuthenticatedUser({
+        id: 1,
+        name: "John Doe",
+        email: "john@secpal.dev",
+        hasOrganizationalScopes: false,
+        hasCustomerAccess: true,
+        roles: [],
+        permissions: [],
+      });
 
       renderWithProviders(
         <ApplicationLayout>
@@ -654,21 +647,18 @@ describe("ApplicationLayout", () => {
         </ApplicationLayout>
       );
 
-      expect(screen.getByText("Customers")).toBeInTheDocument();
+      expect(await screen.findByText("Customers")).toBeInTheDocument();
       expect(screen.queryByText("Organization")).not.toBeInTheDocument();
       expect(screen.queryByText("Employees")).not.toBeInTheDocument();
     });
 
-    it("always shows Home", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "John Doe",
-          email: "john@secpal.dev",
-          hasOrganizationalScopes: false,
-        })
-      );
+    it("always shows Home", async () => {
+      await seedAuthenticatedUser({
+        id: 1,
+        name: "John Doe",
+        email: "john@secpal.dev",
+        hasOrganizationalScopes: false,
+      });
 
       renderWithProviders(
         <ApplicationLayout>
@@ -679,16 +669,12 @@ describe("ApplicationLayout", () => {
       expect(screen.getByText("Home")).toBeInTheDocument();
     });
 
-    it("treats undefined hasOrganizationalScopes as false", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "John Doe",
-          email: "john@secpal.dev",
-          // hasOrganizationalScopes not set
-        })
-      );
+    it("treats undefined hasOrganizationalScopes as false", async () => {
+      await seedAuthenticatedUser({
+        id: 1,
+        name: "John Doe",
+        email: "john@secpal.dev",
+      });
 
       renderWithProviders(
         <ApplicationLayout>
@@ -750,16 +736,13 @@ describe("ApplicationLayout", () => {
   });
 
   describe("Activity Logs Navigation", () => {
-    it("shows Activity Logs menu item when user has permission", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "Admin User",
-          email: "admin@secpal.dev",
-          permissions: ["activity_log.read"],
-        })
-      );
+    it("shows Activity Logs menu item when user has permission", async () => {
+      await seedAuthenticatedUser({
+        id: 1,
+        name: "Admin User",
+        email: "admin@secpal.dev",
+        permissions: ["activity_log.read"],
+      });
 
       renderWithProviders(
         <ApplicationLayout>
@@ -767,19 +750,16 @@ describe("ApplicationLayout", () => {
         </ApplicationLayout>
       );
 
-      expect(screen.getByText("Activity Logs")).toBeInTheDocument();
+      expect(await screen.findByText("Activity Logs")).toBeInTheDocument();
     });
 
-    it("hides Activity Logs menu item when user lacks permission", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "Regular User",
-          email: "user@secpal.dev",
-          permissions: [],
-        })
-      );
+    it("hides Activity Logs menu item when user lacks permission", async () => {
+      await seedAuthenticatedUser({
+        id: 1,
+        name: "Regular User",
+        email: "user@secpal.dev",
+        permissions: [],
+      });
 
       renderWithProviders(
         <ApplicationLayout>
@@ -790,16 +770,13 @@ describe("ApplicationLayout", () => {
       expect(screen.queryByText("Activity Logs")).not.toBeInTheDocument();
     });
 
-    it("highlights Activity Logs when on that page", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "Admin User",
-          email: "admin@secpal.dev",
-          permissions: ["activity_log.read"],
-        })
-      );
+    it("highlights Activity Logs when on that page", async () => {
+      await seedAuthenticatedUser({
+        id: 1,
+        name: "Admin User",
+        email: "admin@secpal.dev",
+        permissions: ["activity_log.read"],
+      });
 
       renderWithProviders(
         <ApplicationLayout>
@@ -808,20 +785,19 @@ describe("ApplicationLayout", () => {
         { route: "/activity-logs" }
       );
 
-      const activityLogsLink = screen.getByText("Activity Logs").closest("a");
+      const activityLogsLink = (await screen.findByText("Activity Logs")).closest(
+        "a"
+      );
       expect(activityLogsLink).toHaveAttribute("href", "/activity-logs");
     });
 
-    it("links to /activity-logs route", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "Admin User",
-          email: "admin@secpal.dev",
-          permissions: ["activity_log.read"],
-        })
-      );
+    it("links to /activity-logs route", async () => {
+      await seedAuthenticatedUser({
+        id: 1,
+        name: "Admin User",
+        email: "admin@secpal.dev",
+        permissions: ["activity_log.read"],
+      });
 
       renderWithProviders(
         <ApplicationLayout>
@@ -829,7 +805,9 @@ describe("ApplicationLayout", () => {
         </ApplicationLayout>
       );
 
-      const activityLogsLink = screen.getByText("Activity Logs").closest("a");
+      const activityLogsLink = (await screen.findByText("Activity Logs")).closest(
+        "a"
+      );
       expect(activityLogsLink).toHaveAttribute("href", "/activity-logs");
     });
   });
@@ -841,23 +819,20 @@ describe("ApplicationLayout", () => {
       });
     });
 
-    it("renders the localized German label instead of the raw Lingui message id", () => {
+    it("renders the localized German label instead of the raw Lingui message id", async () => {
       act(() => {
         i18n.load("de", deMessages);
         i18n.activate("de");
       });
 
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "Admin User",
-          email: "admin@secpal.dev",
-          hasOrganizationalScopes: true,
-          roles: ["Manager"],
-          permissions: ["android_enrollment.read"],
-        })
-      );
+      await seedAuthenticatedUser({
+        id: 1,
+        name: "Admin User",
+        email: "admin@secpal.dev",
+        hasOrganizationalScopes: true,
+        roles: ["Manager"],
+        permissions: ["android_enrollment.read"],
+      });
 
       renderWithProviders(
         <ApplicationLayout>
@@ -865,22 +840,21 @@ describe("ApplicationLayout", () => {
         </ApplicationLayout>
       );
 
-      expect(screen.getByText("Android-Provisionierung")).toBeInTheDocument();
+      expect(
+        await screen.findByText("Android-Provisionierung")
+      ).toBeInTheDocument();
       expect(screen.queryByText("62KQbc")).not.toBeInTheDocument();
     });
 
-    it("hides the Android provisioning navigation entry without read access", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "Admin User",
-          email: "admin@secpal.dev",
-          hasOrganizationalScopes: true,
-          roles: [],
-          permissions: ["activity_log.read"],
-        })
-      );
+    it("hides the Android provisioning navigation entry without read access", async () => {
+      await seedAuthenticatedUser({
+        id: 1,
+        name: "Admin User",
+        email: "admin@secpal.dev",
+        hasOrganizationalScopes: true,
+        roles: [],
+        permissions: ["activity_log.read"],
+      });
 
       renderWithProviders(
         <ApplicationLayout>

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -5,6 +5,8 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, act, waitFor } from "@testing-library/react";
 import { AuthProvider } from "./AuthContext";
 import { useAuth } from "../hooks/useAuth";
+import { sanitizePersistedAuthUser } from "../services/authState";
+import { authStorage } from "../services/storage";
 
 vi.mock("../services/authApi", () => ({
   getCurrentUser: vi.fn(),
@@ -45,6 +47,19 @@ function PermissionTestComponent({
   );
 }
 
+async function seedStoredUser(user: Record<string, unknown>) {
+  const persistedUser = sanitizePersistedAuthUser({
+    emailVerified: false,
+    ...user,
+  });
+
+  if (!persistedUser) {
+    throw new Error("Failed to seed persisted auth user for test");
+  }
+
+  await authStorage.setUser(persistedUser);
+}
+
 describe("AuthContext", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -53,16 +68,13 @@ describe("AuthContext", () => {
   });
 
   describe("hasRole", () => {
-    it("returns true when user has the specified role", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "Test User",
-          email: "test@secpal.dev",
-          roles: ["Admin", "Manager"],
-        })
-      );
+    it("returns true when user has the specified role", async () => {
+      await seedStoredUser({
+        id: 1,
+        name: "Test User",
+        email: "test@secpal.dev",
+        roles: ["Admin", "Manager"],
+      });
 
       render(
         <AuthProvider>
@@ -70,19 +82,18 @@ describe("AuthContext", () => {
         </AuthProvider>
       );
 
-      expect(screen.getByTestId("hasRole")).toHaveTextContent("true");
+      await waitFor(() => {
+        expect(screen.getByTestId("hasRole")).toHaveTextContent("true");
+      });
     });
 
-    it("returns false when user does not have the specified role", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "Test User",
-          email: "test@secpal.dev",
-          roles: ["Guard"],
-        })
-      );
+    it("returns false when user does not have the specified role", async () => {
+      await seedStoredUser({
+        id: 1,
+        name: "Test User",
+        email: "test@secpal.dev",
+        roles: ["Guard"],
+      });
 
       render(
         <AuthProvider>
@@ -90,18 +101,17 @@ describe("AuthContext", () => {
         </AuthProvider>
       );
 
-      expect(screen.getByTestId("hasRole")).toHaveTextContent("false");
+      await waitFor(() => {
+        expect(screen.getByTestId("hasRole")).toHaveTextContent("false");
+      });
     });
 
-    it("returns false when user has no roles", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "Test User",
-          email: "test@secpal.dev",
-        })
-      );
+    it("returns false when user has no roles", async () => {
+      await seedStoredUser({
+        id: 1,
+        name: "Test User",
+        email: "test@secpal.dev",
+      });
 
       render(
         <AuthProvider>
@@ -109,7 +119,9 @@ describe("AuthContext", () => {
         </AuthProvider>
       );
 
-      expect(screen.getByTestId("hasRole")).toHaveTextContent("false");
+      await waitFor(() => {
+        expect(screen.getByTestId("hasRole")).toHaveTextContent("false");
+      });
     });
 
     it("returns false when user is null", () => {
@@ -124,16 +136,13 @@ describe("AuthContext", () => {
   });
 
   describe("hasPermission", () => {
-    it("returns true for direct permission match", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "Test User",
-          email: "test@secpal.dev",
-          permissions: ["employees.read", "employees.create"],
-        })
-      );
+    it("returns true for direct permission match", async () => {
+      await seedStoredUser({
+        id: 1,
+        name: "Test User",
+        email: "test@secpal.dev",
+        permissions: ["employees.read", "employees.create"],
+      });
 
       render(
         <AuthProvider>
@@ -141,19 +150,18 @@ describe("AuthContext", () => {
         </AuthProvider>
       );
 
-      expect(screen.getByTestId("hasPermission")).toHaveTextContent("true");
+      await waitFor(() => {
+        expect(screen.getByTestId("hasPermission")).toHaveTextContent("true");
+      });
     });
 
-    it("returns false when permission is not present", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "Test User",
-          email: "test@secpal.dev",
-          permissions: ["employees.read"],
-        })
-      );
+    it("returns false when permission is not present", async () => {
+      await seedStoredUser({
+        id: 1,
+        name: "Test User",
+        email: "test@secpal.dev",
+        permissions: ["employees.read"],
+      });
 
       render(
         <AuthProvider>
@@ -161,19 +169,18 @@ describe("AuthContext", () => {
         </AuthProvider>
       );
 
-      expect(screen.getByTestId("hasPermission")).toHaveTextContent("false");
+      await waitFor(() => {
+        expect(screen.getByTestId("hasPermission")).toHaveTextContent("false");
+      });
     });
 
-    it("returns true for wildcard permission match", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "Test User",
-          email: "test@secpal.dev",
-          permissions: ["employees.*"],
-        })
-      );
+    it("returns true for wildcard permission match", async () => {
+      await seedStoredUser({
+        id: 1,
+        name: "Test User",
+        email: "test@secpal.dev",
+        permissions: ["employees.*"],
+      });
 
       render(
         <AuthProvider>
@@ -181,19 +188,18 @@ describe("AuthContext", () => {
         </AuthProvider>
       );
 
-      expect(screen.getByTestId("hasPermission")).toHaveTextContent("true");
+      await waitFor(() => {
+        expect(screen.getByTestId("hasPermission")).toHaveTextContent("true");
+      });
     });
 
-    it("does not match wildcard across different resources", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "Test User",
-          email: "test@secpal.dev",
-          permissions: ["employees.*"],
-        })
-      );
+    it("does not match wildcard across different resources", async () => {
+      await seedStoredUser({
+        id: 1,
+        name: "Test User",
+        email: "test@secpal.dev",
+        permissions: ["employees.*"],
+      });
 
       render(
         <AuthProvider>
@@ -201,18 +207,17 @@ describe("AuthContext", () => {
         </AuthProvider>
       );
 
-      expect(screen.getByTestId("hasPermission")).toHaveTextContent("false");
+      await waitFor(() => {
+        expect(screen.getByTestId("hasPermission")).toHaveTextContent("false");
+      });
     });
 
-    it("returns false when user has no permissions", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "Test User",
-          email: "test@secpal.dev",
-        })
-      );
+    it("returns false when user has no permissions", async () => {
+      await seedStoredUser({
+        id: 1,
+        name: "Test User",
+        email: "test@secpal.dev",
+      });
 
       render(
         <AuthProvider>
@@ -220,7 +225,9 @@ describe("AuthContext", () => {
         </AuthProvider>
       );
 
-      expect(screen.getByTestId("hasPermission")).toHaveTextContent("false");
+      await waitFor(() => {
+        expect(screen.getByTestId("hasPermission")).toHaveTextContent("false");
+      });
     });
 
     it("returns false when user is null", () => {
@@ -233,16 +240,13 @@ describe("AuthContext", () => {
       expect(screen.getByTestId("hasPermission")).toHaveTextContent("false");
     });
 
-    it("handles permission without dot separator", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "Test User",
-          email: "test@secpal.dev",
-          permissions: ["admin"],
-        })
-      );
+    it("handles permission without dot separator", async () => {
+      await seedStoredUser({
+        id: 1,
+        name: "Test User",
+        email: "test@secpal.dev",
+        permissions: ["admin"],
+      });
 
       render(
         <AuthProvider>
@@ -250,21 +254,20 @@ describe("AuthContext", () => {
         </AuthProvider>
       );
 
-      expect(screen.getByTestId("hasPermission")).toHaveTextContent("true");
+      await waitFor(() => {
+        expect(screen.getByTestId("hasPermission")).toHaveTextContent("true");
+      });
     });
   });
 
   describe("hasOrganizationalAccess", () => {
-    it("returns true when hasOrganizationalScopes is true", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "Test User",
-          email: "test@secpal.dev",
-          hasOrganizationalScopes: true,
-        })
-      );
+    it("returns true when hasOrganizationalScopes is true", async () => {
+      await seedStoredUser({
+        id: 1,
+        name: "Test User",
+        email: "test@secpal.dev",
+        hasOrganizationalScopes: true,
+      });
 
       render(
         <AuthProvider>
@@ -272,19 +275,18 @@ describe("AuthContext", () => {
         </AuthProvider>
       );
 
-      expect(screen.getByTestId("hasOrgAccess")).toHaveTextContent("true");
+      await waitFor(() => {
+        expect(screen.getByTestId("hasOrgAccess")).toHaveTextContent("true");
+      });
     });
 
-    it("returns false when hasOrganizationalScopes is false", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "Test User",
-          email: "test@secpal.dev",
-          hasOrganizationalScopes: false,
-        })
-      );
+    it("returns false when hasOrganizationalScopes is false", async () => {
+      await seedStoredUser({
+        id: 1,
+        name: "Test User",
+        email: "test@secpal.dev",
+        hasOrganizationalScopes: false,
+      });
 
       render(
         <AuthProvider>
@@ -292,18 +294,17 @@ describe("AuthContext", () => {
         </AuthProvider>
       );
 
-      expect(screen.getByTestId("hasOrgAccess")).toHaveTextContent("false");
+      await waitFor(() => {
+        expect(screen.getByTestId("hasOrgAccess")).toHaveTextContent("false");
+      });
     });
 
-    it("returns false when hasOrganizationalScopes is undefined", () => {
-      localStorage.setItem(
-        "auth_user",
-        JSON.stringify({
-          id: 1,
-          name: "Test User",
-          email: "test@secpal.dev",
-        })
-      );
+    it("returns false when hasOrganizationalScopes is undefined", async () => {
+      await seedStoredUser({
+        id: 1,
+        name: "Test User",
+        email: "test@secpal.dev",
+      });
 
       render(
         <AuthProvider>
@@ -311,7 +312,9 @@ describe("AuthContext", () => {
         </AuthProvider>
       );
 
-      expect(screen.getByTestId("hasOrgAccess")).toHaveTextContent("false");
+      await waitFor(() => {
+        expect(screen.getByTestId("hasOrgAccess")).toHaveTextContent("false");
+      });
     });
 
     it("returns false when user is null", () => {

--- a/src/lib/clientStateCleanup.test.ts
+++ b/src/lib/clientStateCleanup.test.ts
@@ -34,7 +34,7 @@ describe("clearSensitiveClientState", () => {
   it("clears auth storage, sensitive caches, and deletes the IndexedDB database", async () => {
     const deleteSpy = vi.spyOn(db, "delete");
 
-    localStorage.setItem("auth_user", JSON.stringify({ id: 1 }));
+    localStorage.setItem("auth_user", "opaque-auth-storage-envelope");
     localStorage.setItem("auth_token", "legacy-token");
     localStorage.setItem(
       "secpal-notification-preferences",
@@ -97,9 +97,9 @@ describe("clearSensitiveClientState", () => {
   it("falls back to clearing IndexedDB tables when deleting the database fails", async () => {
     const deleteError = new Error("Delete blocked by another connection");
     const deleteSpy = vi.spyOn(db, "delete").mockRejectedValueOnce(deleteError);
-    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => { });
 
-    localStorage.setItem("auth_user", JSON.stringify({ id: 1 }));
+    localStorage.setItem("auth_user", "opaque-auth-storage-envelope");
     localStorage.setItem(
       "secpal-notification-preferences",
       JSON.stringify([{ category: "alerts", enabled: true }])

--- a/src/lib/clientStateCleanup.test.ts
+++ b/src/lib/clientStateCleanup.test.ts
@@ -97,7 +97,7 @@ describe("clearSensitiveClientState", () => {
   it("falls back to clearing IndexedDB tables when deleting the database fails", async () => {
     const deleteError = new Error("Delete blocked by another connection");
     const deleteSpy = vi.spyOn(db, "delete").mockRejectedValueOnce(deleteError);
-    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => { });
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     localStorage.setItem("auth_user", "opaque-auth-storage-envelope");
     localStorage.setItem(

--- a/src/services/storage.test.ts
+++ b/src/services/storage.test.ts
@@ -246,10 +246,7 @@ describe("authStorage", () => {
       .spyOn(console, "error")
       .mockImplementation(() => undefined);
 
-    localStorage.setItem(
-      "auth_user",
-      JSON.stringify({ stale: true, email: "stale@secpal.dev" })
-    );
+    localStorage.setItem("auth_user", "stale-auth-storage-record");
 
     vi.spyOn(globalThis.crypto.subtle, "deriveBits").mockRejectedValue(
       cryptoFailure
@@ -264,20 +261,33 @@ describe("authStorage", () => {
     expect(localStorage.getItem("auth_user")).toBeNull();
   });
 
-  it("keeps reading legacy cleartext persisted auth state for compatibility", async () => {
-    const legacyUser = {
-      id: "1",
-      name: "Legacy User",
-      email: "legacy@secpal.dev",
-      emailVerified: false,
-    };
+  it("clears unsupported unencrypted auth snapshots", () => {
+    const unsupportedStoredUser =
+      '{"id":"1","name":"Legacy User","email":"legacy@secpal.dev","emailVerified":false}';
 
-    localStorage.setItem("auth_user", JSON.stringify(legacyUser));
+    localStorage.setItem(
+      "auth_user",
+      unsupportedStoredUser
+    );
 
-    await expect(authStorage.getUser()).resolves.toEqual(legacyUser);
+    expect(authStorage.getUserSnapshot()).toBeNull();
+    expect(localStorage.getItem("auth_user")).toBeNull();
   });
 
-  it("keeps reading legacy encrypted auth state after increasing PBKDF2 iterations", async () => {
+  it("clears unsupported unencrypted persisted auth state", async () => {
+    const unsupportedStoredUser =
+      '{"id":"1","name":"Legacy User","email":"legacy@secpal.dev","emailVerified":false}';
+
+    localStorage.setItem(
+      "auth_user",
+      unsupportedStoredUser
+    );
+
+    await expect(authStorage.getUser()).resolves.toBeNull();
+    expect(localStorage.getItem("auth_user")).toBeNull();
+  });
+
+  it("clears unsupported legacy encrypted auth state after the format upgrade", async () => {
     const legacyUser = {
       id: "1",
       name: "Legacy Encrypted User",
@@ -290,6 +300,7 @@ describe("authStorage", () => {
       await createLegacyEncryptedEnvelope(legacyUser, "test-csrf-token")
     );
 
-    await expect(authStorage.getUser()).resolves.toEqual(legacyUser);
+    await expect(authStorage.getUser()).resolves.toBeNull();
+    expect(localStorage.getItem("auth_user")).toBeNull();
   });
 });

--- a/src/services/storage.test.ts
+++ b/src/services/storage.test.ts
@@ -265,10 +265,7 @@ describe("authStorage", () => {
     const unsupportedStoredUser =
       '{"id":"1","name":"Legacy User","email":"legacy@secpal.dev","emailVerified":false}';
 
-    localStorage.setItem(
-      "auth_user",
-      unsupportedStoredUser
-    );
+    localStorage.setItem("auth_user", unsupportedStoredUser);
 
     expect(authStorage.getUserSnapshot()).toBeNull();
     expect(localStorage.getItem("auth_user")).toBeNull();
@@ -278,10 +275,7 @@ describe("authStorage", () => {
     const unsupportedStoredUser =
       '{"id":"1","name":"Legacy User","email":"legacy@secpal.dev","emailVerified":false}';
 
-    localStorage.setItem(
-      "auth_user",
-      unsupportedStoredUser
-    );
+    localStorage.setItem("auth_user", unsupportedStoredUser);
 
     await expect(authStorage.getUser()).resolves.toBeNull();
     expect(localStorage.getItem("auth_user")).toBeNull();

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -6,9 +6,7 @@ import { sanitizePersistedAuthUser, type PersistedAuthUser } from "./authState";
 import { getCsrfTokenFromCookie } from "./csrf";
 
 const AUTH_STORAGE_SCHEME = "pbkdf2-aes-cbc-hmac-sha256";
-const AUTH_STORAGE_LEGACY_VERSION = 1;
 const AUTH_STORAGE_VERSION = 2;
-const AUTH_STORAGE_LEGACY_PBKDF2_ITERATIONS = 5_000;
 const AUTH_STORAGE_PBKDF2_ITERATIONS = 600_000;
 const AUTH_STORAGE_SALT_BYTES = 16;
 const AUTH_STORAGE_IV_BYTES = 16;
@@ -18,9 +16,7 @@ const AUTH_STORAGE_DERIVED_KEY_BYTES = AUTH_STORAGE_HALF_KEY_BYTES * 2;
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
-type AuthStorageVersion =
-  | typeof AUTH_STORAGE_LEGACY_VERSION
-  | typeof AUTH_STORAGE_VERSION;
+type AuthStorageVersion = typeof AUTH_STORAGE_VERSION;
 
 interface AuthStorageEnvelope {
   scheme: typeof AUTH_STORAGE_SCHEME;
@@ -32,15 +28,11 @@ interface AuthStorageEnvelope {
 }
 
 function isAuthStorageVersion(value: unknown): value is AuthStorageVersion {
-  return (
-    value === AUTH_STORAGE_LEGACY_VERSION || value === AUTH_STORAGE_VERSION
-  );
+  return value === AUTH_STORAGE_VERSION;
 }
 
-function getAuthStorageIterations(version: AuthStorageVersion): number {
-  return version === AUTH_STORAGE_LEGACY_VERSION
-    ? AUTH_STORAGE_LEGACY_PBKDF2_ITERATIONS
-    : AUTH_STORAGE_PBKDF2_ITERATIONS;
+function getAuthStorageIterations(): number {
+  return AUTH_STORAGE_PBKDF2_ITERATIONS;
 }
 
 function getAuthStorageKeyMaterial(): string | null {
@@ -226,7 +218,7 @@ async function encryptPersistedAuthUser(
   const { encryptionKey, macKey } = await deriveAuthStorageKeys(
     keyMaterial,
     salt,
-    getAuthStorageIterations(AUTH_STORAGE_VERSION)
+    getAuthStorageIterations()
   );
   const ciphertext = await encryptAuthPayload(
     JSON.stringify(user),
@@ -289,7 +281,7 @@ async function decryptPersistedAuthUser(
   }
 
   if (!isAuthStorageEnvelope(parsedStoredUser)) {
-    return sanitizePersistedAuthUser(parsedStoredUser);
+    return null;
   }
 
   const keyMaterial = getAuthStorageKeyMaterial();
@@ -308,7 +300,7 @@ async function decryptPersistedAuthUser(
   const { encryptionKey, macKey } = await deriveAuthStorageKeys(
     keyMaterial,
     decodeBase64(parsedStoredUser.salt),
-    getAuthStorageIterations(parsedStoredUser.version)
+    getAuthStorageIterations()
   );
   const isMacValid = await verifyEnvelopeMac(
     envelopeWithoutMac,
@@ -412,17 +404,11 @@ class LocalStorageAuthStorage implements AuthStorage {
     try {
       const parsedStoredUser = JSON.parse(storedUser) as unknown;
 
-      if (isAuthStorageEnvelope(parsedStoredUser)) {
-        return null;
-      }
-
-      const sanitizedUser = sanitizePersistedAuthUser(parsedStoredUser);
-
-      if (!sanitizedUser) {
+      if (!isAuthStorageEnvelope(parsedStoredUser)) {
         return this.clearInvalidStoredUser();
       }
 
-      return sanitizedUser;
+      return null;
     } catch (error) {
       return this.handleStoredUserError(
         "Failed to parse stored user snapshot:",

--- a/tests/e2e/passkeys.spec.ts
+++ b/tests/e2e/passkeys.spec.ts
@@ -3,6 +3,13 @@
 
 import { expect, test, type Page, type Route } from "@playwright/test";
 
+const AUTH_STORAGE_SCHEME = "pbkdf2-aes-cbc-hmac-sha256";
+const AUTH_STORAGE_VERSION = 2;
+const AUTH_STORAGE_PBKDF2_ITERATIONS = 600_000;
+const AUTH_STORAGE_HALF_KEY_BYTES = 32;
+const AUTH_STORAGE_DERIVED_KEY_BYTES = AUTH_STORAGE_HALF_KEY_BYTES * 2;
+const AUTH_STORAGE_CSRF_TOKEN = "playwright-test-csrf-token";
+
 const authUser = {
   id: "1",
   name: "Test User",
@@ -168,10 +175,106 @@ async function installPasskeyBrowserMocks(
   );
 }
 
+function encodeBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64");
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength
+  ) as ArrayBuffer;
+}
+
+async function createEncryptedStoredAuthUser(user: Record<string, unknown>) {
+  const textEncoder = new TextEncoder();
+  const keyMaterial = `secpal-auth-storage:${AUTH_STORAGE_CSRF_TOKEN}`;
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const iv = crypto.getRandomValues(new Uint8Array(16));
+  const baseKey = await crypto.subtle.importKey(
+    "raw",
+    textEncoder.encode(keyMaterial),
+    "PBKDF2",
+    false,
+    ["deriveBits"]
+  );
+  const derivedBits = await crypto.subtle.deriveBits(
+    {
+      name: "PBKDF2",
+      hash: "SHA-256",
+      salt: toArrayBuffer(salt),
+      iterations: AUTH_STORAGE_PBKDF2_ITERATIONS,
+    },
+    baseKey,
+    AUTH_STORAGE_DERIVED_KEY_BYTES * 8
+  );
+  const derivedKey = new Uint8Array(derivedBits);
+  const encryptionKeyBytes = derivedKey.slice(0, AUTH_STORAGE_HALF_KEY_BYTES);
+  const macKeyBytes = derivedKey.slice(AUTH_STORAGE_HALF_KEY_BYTES);
+
+  const [encryptionKey, macKey] = await Promise.all([
+    crypto.subtle.importKey(
+      "raw",
+      encryptionKeyBytes,
+      { name: "AES-CBC", length: AUTH_STORAGE_HALF_KEY_BYTES * 8 },
+      false,
+      ["encrypt"]
+    ),
+    crypto.subtle.importKey(
+      "raw",
+      macKeyBytes,
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"]
+    ),
+  ]);
+  const ciphertext = new Uint8Array(
+    await crypto.subtle.encrypt(
+      { name: "AES-CBC", iv: toArrayBuffer(iv) },
+      encryptionKey,
+      textEncoder.encode(JSON.stringify(user))
+    )
+  );
+  const envelopeWithoutMac = {
+    scheme: AUTH_STORAGE_SCHEME,
+    version: AUTH_STORAGE_VERSION,
+    salt: encodeBase64(salt),
+    iv: encodeBase64(iv),
+    ciphertext: encodeBase64(ciphertext),
+  };
+  const mac = await crypto.subtle.sign(
+    "HMAC",
+    macKey,
+    textEncoder.encode(
+      [
+        envelopeWithoutMac.scheme,
+        String(envelopeWithoutMac.version),
+        envelopeWithoutMac.salt,
+        envelopeWithoutMac.iv,
+        envelopeWithoutMac.ciphertext,
+      ].join(".")
+    )
+  );
+
+  return JSON.stringify({
+    ...envelopeWithoutMac,
+    mac: encodeBase64(new Uint8Array(mac)),
+  });
+}
+
 async function installStoredAuthUser(page: Page) {
-  await page.addInitScript((user) => {
-    window.localStorage.setItem("auth_user", JSON.stringify(user));
-  }, authUser);
+  const encryptedUser = await createEncryptedStoredAuthUser(authUser);
+
+  await page.addInitScript(
+    ({ csrfToken, storedUser }) => {
+      document.cookie = `XSRF-TOKEN=${encodeURIComponent(csrfToken)}; path=/`;
+      window.localStorage.setItem("auth_user", storedUser);
+    },
+    {
+      csrfToken: AUTH_STORAGE_CSRF_TOKEN,
+      storedUser: encryptedUser,
+    }
+  );
 }
 
 test.describe("Passkeys", () => {

--- a/tests/unit/lint/issue889-auth-storage-fixtures.test.ts
+++ b/tests/unit/lint/issue889-auth-storage-fixtures.test.ts
@@ -4,16 +4,35 @@
 import { describe, expect, it } from "vitest";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 
 const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "../../.."
 );
 
+function collectTrackedFiles(relativeDir: string): string[] {
+  const absoluteDir = path.join(repoRoot, relativeDir);
+  const entries = readdirSync(absoluteDir, { withFileTypes: true });
+
+  return entries.flatMap((entry) => {
+    const relativePath = path.join(relativeDir, entry.name);
+
+    if (entry.isDirectory()) {
+      return collectTrackedFiles(relativePath);
+    }
+
+    if (!/\.(test|spec)\.tsx?$/.test(entry.name)) {
+      return [];
+    }
+
+    return [relativePath];
+  });
+}
+
 const trackedFiles = [
-  "src/hooks/useAuth.test.ts",
-  "src/components/ProtectedRoute.test.tsx",
+  ...collectTrackedFiles("src"),
+  ...collectTrackedFiles("tests"),
 ];
 
 const directAuthUserWritePattern =


### PR DESCRIPTION
## Summary
- remove restoration of legacy cleartext and pre-v2 encrypted auth storage payloads
- migrate affected frontend and E2E fixtures to the current encrypted auth storage path
- document the repo-local under-1.x compatibility-removal rule in the Copilot instructions

## Validation
- npm run lint
- npm run typecheck
- npm exec -- vitest run src/services/storage.test.ts src/App.test.tsx src/contexts/AuthContext.test.tsx src/components/application-layout.test.tsx tests/unit/lint/issue889-auth-storage-fixtures.test.ts
- npm exec -- vitest run src/services/storage.test.ts src/components/application-layout.test.tsx

## Notes
- Full Playwright passkey coverage remains blocked by the existing login failure in tests/e2e/global-setup.ts outside this branch.

Closes #914
