### PR TITLE
perf: cache passkey auth storage fixture envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Cached the encrypted auth-storage envelope used by the Playwright passkey fixture so repeated `installStoredAuthUser()` calls no longer pay the 600,000-iteration PBKDF2 cost more than once per identical seeded user/token combination, resolving frontend issue #916.
 - Split the heavy `issue874-react-hooks-set-state-in-effect` lint regression into smaller tracked-file batches and gave each batch a dedicated 30-second timeout so `npm run test:coverage` no longer times out on one monolithic ESLint spawn under full-suite coverage load, resolving frontend issue #899.
 - Increased PBKDF2 iteration count from 5,000 to 600,000 (OWASP minimum for PBKDF2-HMAC-SHA256) for new auth-storage envelopes while preserving reads of legacy v1 envelopes during rollout, hardening key derivation without forcing deploy-time logouts.
 - Replaced `Buffer.from` with `TextEncoder` in `Login.test.tsx` `textBytes` helper for cross-platform Web API compatibility.

--- a/tests/e2e/passkeys.spec.ts
+++ b/tests/e2e/passkeys.spec.ts
@@ -2,12 +2,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { expect, test, type Page, type Route } from "@playwright/test";
+import { installStoredAuthUser } from "../utils/passkeyAuthStorage";
 
-const AUTH_STORAGE_SCHEME = "pbkdf2-aes-cbc-hmac-sha256";
-const AUTH_STORAGE_VERSION = 2;
-const AUTH_STORAGE_PBKDF2_ITERATIONS = 600_000;
-const AUTH_STORAGE_HALF_KEY_BYTES = 32;
-const AUTH_STORAGE_DERIVED_KEY_BYTES = AUTH_STORAGE_HALF_KEY_BYTES * 2;
 const AUTH_STORAGE_CSRF_TOKEN = "playwright-test-csrf-token";
 
 const authUser = {
@@ -175,114 +171,12 @@ async function installPasskeyBrowserMocks(
   );
 }
 
-function encodeBase64(bytes: Uint8Array): string {
-  return Buffer.from(bytes).toString("base64");
-}
-
-function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
-  return bytes.buffer.slice(
-    bytes.byteOffset,
-    bytes.byteOffset + bytes.byteLength
-  ) as ArrayBuffer;
-}
-
-async function createEncryptedStoredAuthUser(user: Record<string, unknown>) {
-  const textEncoder = new TextEncoder();
-  const keyMaterial = `secpal-auth-storage:${AUTH_STORAGE_CSRF_TOKEN}`;
-  const salt = crypto.getRandomValues(new Uint8Array(16));
-  const iv = crypto.getRandomValues(new Uint8Array(16));
-  const baseKey = await crypto.subtle.importKey(
-    "raw",
-    textEncoder.encode(keyMaterial),
-    "PBKDF2",
-    false,
-    ["deriveBits"]
-  );
-  const derivedBits = await crypto.subtle.deriveBits(
-    {
-      name: "PBKDF2",
-      hash: "SHA-256",
-      salt: toArrayBuffer(salt),
-      iterations: AUTH_STORAGE_PBKDF2_ITERATIONS,
-    },
-    baseKey,
-    AUTH_STORAGE_DERIVED_KEY_BYTES * 8
-  );
-  const derivedKey = new Uint8Array(derivedBits);
-  const encryptionKeyBytes = derivedKey.slice(0, AUTH_STORAGE_HALF_KEY_BYTES);
-  const macKeyBytes = derivedKey.slice(AUTH_STORAGE_HALF_KEY_BYTES);
-
-  const [encryptionKey, macKey] = await Promise.all([
-    crypto.subtle.importKey(
-      "raw",
-      encryptionKeyBytes,
-      { name: "AES-CBC", length: AUTH_STORAGE_HALF_KEY_BYTES * 8 },
-      false,
-      ["encrypt"]
-    ),
-    crypto.subtle.importKey(
-      "raw",
-      macKeyBytes,
-      { name: "HMAC", hash: "SHA-256" },
-      false,
-      ["sign"]
-    ),
-  ]);
-  const ciphertext = new Uint8Array(
-    await crypto.subtle.encrypt(
-      { name: "AES-CBC", iv: toArrayBuffer(iv) },
-      encryptionKey,
-      textEncoder.encode(JSON.stringify(user))
-    )
-  );
-  const envelopeWithoutMac = {
-    scheme: AUTH_STORAGE_SCHEME,
-    version: AUTH_STORAGE_VERSION,
-    salt: encodeBase64(salt),
-    iv: encodeBase64(iv),
-    ciphertext: encodeBase64(ciphertext),
-  };
-  const mac = await crypto.subtle.sign(
-    "HMAC",
-    macKey,
-    textEncoder.encode(
-      [
-        envelopeWithoutMac.scheme,
-        String(envelopeWithoutMac.version),
-        envelopeWithoutMac.salt,
-        envelopeWithoutMac.iv,
-        envelopeWithoutMac.ciphertext,
-      ].join(".")
-    )
-  );
-
-  return JSON.stringify({
-    ...envelopeWithoutMac,
-    mac: encodeBase64(new Uint8Array(mac)),
-  });
-}
-
-async function installStoredAuthUser(page: Page) {
-  const encryptedUser = await createEncryptedStoredAuthUser(authUser);
-
-  await page.addInitScript(
-    ({ csrfToken, storedUser }) => {
-      document.cookie = `XSRF-TOKEN=${encodeURIComponent(csrfToken)}; path=/`;
-      window.localStorage.setItem("auth_user", storedUser);
-    },
-    {
-      csrfToken: AUTH_STORAGE_CSRF_TOKEN,
-      storedUser: encryptedUser,
-    }
-  );
-}
-
 test.describe("Passkeys", () => {
   test("registers a passkey and refreshes the enrolled list", async ({
     page,
   }) => {
     await installPasskeyBrowserMocks(page);
-    await installStoredAuthUser(page);
+    await installStoredAuthUser(page, authUser, AUTH_STORAGE_CSRF_TOKEN);
 
     let passkeyListCalls = 0;
 
@@ -450,7 +344,7 @@ test.describe("Passkeys", () => {
     page,
   }) => {
     await installPasskeyBrowserMocks(page);
-    await installStoredAuthUser(page);
+    await installStoredAuthUser(page, authUser, AUTH_STORAGE_CSRF_TOKEN);
 
     let storedPasskeys: Array<typeof registrationVerification.data.credential> =
       [];

--- a/tests/unit/passkeyAuthStorage.test.ts
+++ b/tests/unit/passkeyAuthStorage.test.ts
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearStoredAuthUserCache,
+  getEncryptedStoredAuthUser,
+} from "../utils/passkeyAuthStorage";
+
+const authUser = {
+  id: "1",
+  name: "Test User",
+  email: "test@example.com",
+  emailVerified: true,
+  roles: [],
+  permissions: [],
+  hasOrganizationalScopes: false,
+  hasCustomerAccess: false,
+  hasSiteAccess: false,
+};
+
+describe("passkeyAuthStorage", () => {
+  afterEach(() => {
+    clearStoredAuthUserCache();
+    vi.restoreAllMocks();
+  });
+
+  it("reuses the derived auth envelope across repeated helper calls", async () => {
+    const deriveBitsSpy = vi.spyOn(crypto.subtle, "deriveBits");
+
+    const firstEnvelope = await getEncryptedStoredAuthUser(
+      authUser,
+      "playwright-test-csrf-token"
+    );
+    const secondEnvelope = await getEncryptedStoredAuthUser(
+      authUser,
+      "playwright-test-csrf-token"
+    );
+
+    expect(secondEnvelope).toBe(firstEnvelope);
+    expect(deriveBitsSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/utils/passkeyAuthStorage.ts
+++ b/tests/utils/passkeyAuthStorage.ts
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { Page } from "@playwright/test";
+
+const AUTH_STORAGE_SCHEME = "pbkdf2-aes-cbc-hmac-sha256";
+const AUTH_STORAGE_VERSION = 2;
+const AUTH_STORAGE_PBKDF2_ITERATIONS = 600_000;
+const AUTH_STORAGE_HALF_KEY_BYTES = 32;
+const AUTH_STORAGE_DERIVED_KEY_BYTES = AUTH_STORAGE_HALF_KEY_BYTES * 2;
+
+const storedAuthUserCache = new Map<string, Promise<string>>();
+
+function encodeBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64");
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength
+  ) as ArrayBuffer;
+}
+
+function getStoredAuthUserCacheKey(
+  user: Record<string, unknown>,
+  csrfToken: string
+): string {
+  return `${csrfToken}:${JSON.stringify(user)}`;
+}
+
+export function clearStoredAuthUserCache(): void {
+  storedAuthUserCache.clear();
+}
+
+export async function getEncryptedStoredAuthUser(
+  user: Record<string, unknown>,
+  csrfToken: string
+): Promise<string> {
+  const cacheKey = getStoredAuthUserCacheKey(user, csrfToken);
+  const cachedStoredAuthUser = storedAuthUserCache.get(cacheKey);
+
+  if (cachedStoredAuthUser) {
+    return await cachedStoredAuthUser;
+  }
+
+  const encryptedStoredAuthUserPromise = createEncryptedStoredAuthUser(
+    user,
+    csrfToken
+  );
+  storedAuthUserCache.set(cacheKey, encryptedStoredAuthUserPromise);
+
+  try {
+    return await encryptedStoredAuthUserPromise;
+  } catch (error) {
+    storedAuthUserCache.delete(cacheKey);
+    throw error;
+  }
+}
+
+async function createEncryptedStoredAuthUser(
+  user: Record<string, unknown>,
+  csrfToken: string
+): Promise<string> {
+  const textEncoder = new TextEncoder();
+  const keyMaterial = `secpal-auth-storage:${csrfToken}`;
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const iv = crypto.getRandomValues(new Uint8Array(16));
+  const baseKey = await crypto.subtle.importKey(
+    "raw",
+    textEncoder.encode(keyMaterial),
+    "PBKDF2",
+    false,
+    ["deriveBits"]
+  );
+  const derivedBits = await crypto.subtle.deriveBits(
+    {
+      name: "PBKDF2",
+      hash: "SHA-256",
+      salt: toArrayBuffer(salt),
+      iterations: AUTH_STORAGE_PBKDF2_ITERATIONS,
+    },
+    baseKey,
+    AUTH_STORAGE_DERIVED_KEY_BYTES * 8
+  );
+  const derivedKey = new Uint8Array(derivedBits);
+  const encryptionKeyBytes = derivedKey.slice(0, AUTH_STORAGE_HALF_KEY_BYTES);
+  const macKeyBytes = derivedKey.slice(AUTH_STORAGE_HALF_KEY_BYTES);
+
+  const [encryptionKey, macKey] = await Promise.all([
+    crypto.subtle.importKey(
+      "raw",
+      encryptionKeyBytes,
+      { name: "AES-CBC", length: AUTH_STORAGE_HALF_KEY_BYTES * 8 },
+      false,
+      ["encrypt"]
+    ),
+    crypto.subtle.importKey(
+      "raw",
+      macKeyBytes,
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"]
+    ),
+  ]);
+  const ciphertext = new Uint8Array(
+    await crypto.subtle.encrypt(
+      { name: "AES-CBC", iv: toArrayBuffer(iv) },
+      encryptionKey,
+      textEncoder.encode(JSON.stringify(user))
+    )
+  );
+  const envelopeWithoutMac = {
+    scheme: AUTH_STORAGE_SCHEME,
+    version: AUTH_STORAGE_VERSION,
+    salt: encodeBase64(salt),
+    iv: encodeBase64(iv),
+    ciphertext: encodeBase64(ciphertext),
+  };
+  const mac = await crypto.subtle.sign(
+    "HMAC",
+    macKey,
+    textEncoder.encode(
+      [
+        envelopeWithoutMac.scheme,
+        String(envelopeWithoutMac.version),
+        envelopeWithoutMac.salt,
+        envelopeWithoutMac.iv,
+        envelopeWithoutMac.ciphertext,
+      ].join(".")
+    )
+  );
+
+  return JSON.stringify({
+    ...envelopeWithoutMac,
+    mac: encodeBase64(new Uint8Array(mac)),
+  });
+}
+
+export async function installStoredAuthUser(
+  page: Page,
+  user: Record<string, unknown>,
+  csrfToken: string
+): Promise<void> {
+  const storedUser = await getEncryptedStoredAuthUser(user, csrfToken);
+
+  await page.addInitScript(
+    ({ currentCsrfToken, encryptedUser }) => {
+      document.cookie = `XSRF-TOKEN=${encodeURIComponent(currentCsrfToken)}; path=/`;
+      window.localStorage.setItem("auth_user", encryptedUser);
+    },
+    {
+      currentCsrfToken: csrfToken,
+      encryptedUser: storedUser,
+    }
+  );
+}


### PR DESCRIPTION
## Summary

- cache the Playwright passkey auth-user fixture envelope for identical seeded user and CSRF-token inputs so repeated helper calls do not redo the 600,000-iteration PBKDF2 work
- move the passkey auth-user seeding logic into a dedicated test utility with focused regression coverage for the cache path
- update the frontend changelog for issue #916

## Testing

- npx vitest run tests/unit/passkeyAuthStorage.test.ts
- npm run typecheck
- npx eslint tests/e2e/passkeys.spec.ts tests/unit/passkeyAuthStorage.test.ts tests/utils/passkeyAuthStorage.ts
- PLAYWRIGHT_SKIP_GLOBAL_LOGIN=1 npx playwright test tests/e2e/passkeys.spec.ts --project=chromium

## Related

- Closes #916

## Checklist

- [x] Single topic
- [x] TDD via focused regression test first
- [x] CHANGELOG updated
