### PR TITLE
refactor: drop legacy onboarding template alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Wired the central Copilot-instructions validator into `quality.yml` so frontend pull requests now fail automatically when known React AI-risk guardrails or generic AI-triage guidance are missing from the runtime baseline
 - Dropped restoration of legacy cleartext and pre-v2 encrypted `auth_user` localStorage payloads; unsupported auth-storage records are now purged instead of being restored, and frontend test fixtures now seed authenticated state through the encrypted storage path only
+- Dropped the legacy `template_id` alias in the onboarding submission client so runtime writes now require `form_template_id` only, matching the current API contract during the project's `0.x` line
 
 ### Removed
 

--- a/src/services/onboardingApi.ts
+++ b/src/services/onboardingApi.ts
@@ -70,8 +70,7 @@ export interface OnboardingSubmission {
  * Onboarding submission create/update request
  */
 export interface OnboardingSubmissionData {
-  template_id?: string;
-  form_template_id?: string;
+  form_template_id: string;
   form_data: Record<string, unknown>;
   status?: "draft" | "submitted";
 }
@@ -352,9 +351,7 @@ export async function fetchOnboardingSubmissions(): Promise<
 export async function createOnboardingSubmission(
   data: OnboardingSubmissionData
 ): Promise<OnboardingSubmission> {
-  const formTemplateId = data.form_template_id ?? data.template_id;
-
-  if (!formTemplateId) {
+  if (!data.form_template_id) {
     throw new Error("Missing onboarding form template identifier");
   }
 
@@ -365,7 +362,7 @@ export async function createOnboardingSubmission(
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      form_template_id: formTemplateId,
+      form_template_id: data.form_template_id,
       form_data: data.form_data,
       status: data.status,
     }),

--- a/tests/unit/services/onboardingApi.test.ts
+++ b/tests/unit/services/onboardingApi.test.ts
@@ -432,7 +432,7 @@ describe("fetchOnboardingSubmissions", () => {
 });
 
 describe("createOnboardingSubmission", () => {
-  it("accepts the legacy template_id field and sends form_template_id to the runtime API", async () => {
+  it("requires form_template_id and sends it to the runtime API", async () => {
     vi.mocked(apiFetch).mockResolvedValueOnce(
       makeFetchResponse(201, {
         data: {
@@ -449,7 +449,7 @@ describe("createOnboardingSubmission", () => {
 
     await expect(
       createOnboardingSubmission({
-        template_id: "template-9",
+        form_template_id: "template-9",
         form_data: { tax_id: "DE123" },
         status: "draft",
       })
@@ -471,6 +471,18 @@ describe("createOnboardingSubmission", () => {
         }),
       })
     );
+  });
+
+  it("rejects the legacy template_id alias when form_template_id is missing", async () => {
+    await expect(
+      createOnboardingSubmission({
+        template_id: "template-9",
+        form_data: { tax_id: "DE123" },
+        status: "draft",
+      } as unknown as Parameters<typeof createOnboardingSubmission>[0])
+    ).rejects.toThrow("Missing onboarding form template identifier");
+
+    expect(apiFetch).not.toHaveBeenCalled();
   });
 
   it("fails fast when no onboarding form template identifier is provided", async () => {


### PR DESCRIPTION
## Summary

- remove the legacy `template_id` input alias from `createOnboardingSubmission()` so the frontend runtime requires `form_template_id` only
- tighten the onboarding API unit coverage to prove `form_template_id` is the only accepted create identifier and that the legacy alias now fails fast without calling the API
- record the under-0.x compatibility removal in `CHANGELOG.md`

## Validation

- `npx vitest run tests/unit/services/onboardingApi.test.ts`
- `npm run typecheck`
- `npx eslint src/services/onboardingApi.ts tests/unit/services/onboardingApi.test.ts`
- `npx markdownlint-cli2 CHANGELOG.md`

## Related

- Closes #913

## Checklist

- [x] Single topic
- [x] TDD via focused regression test first
- [x] CHANGELOG updated
