### PR TITLE
fix: publish Android Digital Asset Links for Android passkeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Published `/.well-known/assetlinks.json` for `app.secpal.dev` and copied it through the Vite build so release-signed SecPal Android builds can complete Credential Manager passkey registration instead of falling through to the SPA shell at the Digital Asset Links endpoint.
 - Split the heavy `issue874-react-hooks-set-state-in-effect` lint regression into smaller tracked-file batches and gave each batch a dedicated 30-second timeout so `npm run test:coverage` no longer times out on one monolithic ESLint spawn under full-suite coverage load, resolving frontend issue #899.
 - Increased PBKDF2 iteration count from 5,000 to 600,000 (OWASP minimum for PBKDF2-HMAC-SHA256) for new auth-storage envelopes while preserving reads of legacy v1 envelopes during rollout, hardening key derivation without forcing deploy-time logouts.
 - Replaced `Buffer.from` with `TextEncoder` in `Login.test.tsx` `textBytes` helper for cross-platform Web API compatibility.

--- a/config/assetlinks.json
+++ b/config/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.get_login_creds"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "app.secpal",
+      "sha256_cert_fingerprints": [
+        "C3:E9:FD:07:69:F3:34:9B:B0:B0:56:BA:E6:69:47:23:40:E1:CB:28:66:26:DE:30:C9:C9:FA:F9:5F:1E:47:B5"
+      ]
+    }
+  }
+]

--- a/config/assetlinks.json.license
+++ b/config/assetlinks.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 SecPal
+SPDX-License-Identifier: CC0-1.0

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -26,6 +26,36 @@ describe("Build Output Verification", () => {
     expect(existsSync(path.join(repoRoot, "index.html"))).toBe(true);
   });
 
+  it("ships Android Digital Asset Links for passkey trust on app.secpal.dev", () => {
+    const assetLinksPath = path.join(repoRoot, "config/assetlinks.json");
+
+    expect(existsSync(assetLinksPath)).toBe(true);
+
+    const assetLinks = JSON.parse(
+      readFileSync(assetLinksPath, "utf8")
+    ) as Array<{
+      relation: string[];
+      target: {
+        namespace: string;
+        package_name: string;
+        sha256_cert_fingerprints: string[];
+      };
+    }>;
+
+    expect(assetLinks).toEqual([
+      {
+        relation: ["delegate_permission/common.get_login_creds"],
+        target: {
+          namespace: "android_app",
+          package_name: "app.secpal",
+          sha256_cert_fingerprints: [
+            "C3:E9:FD:07:69:F3:34:9B:B0:B0:56:BA:E6:69:47:23:40:E1:CB:28:66:26:DE:30:C9:C9:FA:F9:5F:1E:47:B5",
+          ],
+        },
+      },
+    ]);
+  });
+
   it("ships a versioned Nginx config for app.secpal.dev", () => {
     expect(
       existsSync(path.join(repoRoot, "deploy/nginx/app.secpal.dev.conf"))
@@ -45,6 +75,9 @@ describe("Build Output Verification", () => {
     expect(viteConfig).toContain("vite-plugin-static-copy");
     expect(viteConfig).toContain('src: "public/.htaccess"');
     expect(viteConfig).toContain('dest: "."');
+    expect(viteConfig).toContain('src: "config/assetlinks.json"');
+    expect(viteConfig).toContain('dest: ".well-known"');
+    expect(viteConfig).toContain("stripBase: true");
   });
 
   it("hardens browser responses with the required security headers", () => {

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -27,7 +27,9 @@ describe("Build Output Verification", () => {
   });
 
   it("ships Android Digital Asset Links for passkey trust on app.secpal.dev", () => {
-    expect(existsSync(path.join(repoRoot, "config/assetlinks.json"))).toBe(true);
+    expect(existsSync(path.join(repoRoot, "config/assetlinks.json"))).toBe(
+      true
+    );
 
     const assetLinks = JSON.parse(
       readRepoFile("config/assetlinks.json")

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -27,12 +27,10 @@ describe("Build Output Verification", () => {
   });
 
   it("ships Android Digital Asset Links for passkey trust on app.secpal.dev", () => {
-    const assetLinksPath = path.join(repoRoot, "config/assetlinks.json");
-
-    expect(existsSync(assetLinksPath)).toBe(true);
+    expect(existsSync(path.join(repoRoot, "config/assetlinks.json"))).toBe(true);
 
     const assetLinks = JSON.parse(
-      readFileSync(assetLinksPath, "utf8")
+      readRepoFile("config/assetlinks.json")
     ) as Array<{
       relation: string[];
       target: {
@@ -75,6 +73,12 @@ describe("Build Output Verification", () => {
     expect(viteConfig).toContain("vite-plugin-static-copy");
     expect(viteConfig).toContain('src: "public/.htaccess"');
     expect(viteConfig).toContain('dest: "."');
+  });
+
+  it("keeps vite-plugin-static-copy configured for assetlinks.json", () => {
+    const viteConfig = readRepoFile("vite.config.ts");
+
+    expect(viteConfig).toContain("vite-plugin-static-copy");
     expect(viteConfig).toContain('src: "config/assetlinks.json"');
     expect(viteConfig).toContain('dest: ".well-known"');
     expect(viteConfig).toContain("stripBase: true");

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -58,7 +58,8 @@ export default defineConfig(({ mode }) => {
       }),
       lingui(),
       tailwindcss(),
-      // Copy .htaccess from public/ to dist/ (Vite ignores dotfiles by default)
+      // Copy static files that Vite ignores by default:
+      // - .htaccess (dotfile from public/) and assetlinks.json (Android Digital Asset Links)
       viteStaticCopy({
         targets: [
           {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -65,6 +65,11 @@ export default defineConfig(({ mode }) => {
             src: "public/.htaccess",
             dest: ".",
           },
+          {
+            src: "config/assetlinks.json",
+            dest: ".well-known",
+            rename: { stripBase: true },
+          },
         ],
       }),
       VitePWA({


### PR DESCRIPTION
## Summary
- publish Digital Asset Links for `app.secpal.dev` so the Android app can prove its relying-party binding to Credential Manager
- copy the assetlinks document into `/.well-known/assetlinks.json` during the Vite build
- add a regression test that guards the assetlinks source file and build-copy configuration

## Root cause
Android passkey creation relies on the live relying-party domain proving that the Android application package and signing certificate are trusted for that domain. The app bundles the frontend assets locally, but the OS-level trust check still resolves `https://app.secpal.dev/.well-known/assetlinks.json`. Without that document, passkey registration can fall through to a generic framework failure even when the UI and native bridge are wired correctly.

## Validation
- `vitest run tests/build.test.ts --reporter=verbose`
- frontend pre-push checks: formatting, REUSE, domain policy, lint, and typecheck
