### PR TITLE
fix: add App Links relation to Android asset links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Expanded `app.secpal.dev` Digital Asset Links to publish both `delegate_permission/common.handle_all_urls` and `delegate_permission/common.get_login_creds`, matching Android Credential Manager's documented app-to-web trust prerequisites for passkey validation.
 - Published `/.well-known/assetlinks.json` for `app.secpal.dev` and copied it through the Vite build so release-signed SecPal Android builds can complete Credential Manager passkey registration instead of falling through to the SPA shell at the Digital Asset Links endpoint.
 - Split the heavy `issue874-react-hooks-set-state-in-effect` lint regression into smaller tracked-file batches and gave each batch a dedicated 30-second timeout so `npm run test:coverage` no longer times out on one monolithic ESLint spawn under full-suite coverage load, resolving frontend issue #899.
 - Increased PBKDF2 iteration count from 5,000 to 600,000 (OWASP minimum for PBKDF2-HMAC-SHA256) for new auth-storage envelopes while preserving reads of legacy v1 envelopes during rollout, hardening key derivation without forcing deploy-time logouts.

--- a/config/assetlinks.json
+++ b/config/assetlinks.json
@@ -1,6 +1,9 @@
 [
   {
-    "relation": ["delegate_permission/common.get_login_creds"],
+    "relation": [
+      "delegate_permission/common.handle_all_urls",
+      "delegate_permission/common.get_login_creds"
+    ],
     "target": {
       "namespace": "android_app",
       "package_name": "app.secpal",

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -44,7 +44,10 @@ describe("Build Output Verification", () => {
 
     expect(assetLinks).toEqual([
       {
-        relation: ["delegate_permission/common.get_login_creds"],
+        relation: [
+          "delegate_permission/common.handle_all_urls",
+          "delegate_permission/common.get_login_creds",
+        ],
         target: {
           namespace: "android_app",
           package_name: "app.secpal",


### PR DESCRIPTION
## Summary
- add `delegate_permission/common.handle_all_urls` alongside `delegate_permission/common.get_login_creds` in `config/assetlinks.json`
- extend the focused build regression so the exact Digital Asset Links relation set stays pinned
- record the App Links follow-up in `CHANGELOG.md`

## Root cause
Real-device Android passkey registration still failed with `RP ID cannot be validated.` after the native Credential Manager dialog completed.

The live `app.secpal.dev/.well-known/assetlinks.json` currently advertises only `delegate_permission/common.get_login_creds`. Android's Credential Manager prerequisites document the app-to-site association using both:
- `delegate_permission/common.handle_all_urls`
- `delegate_permission/common.get_login_creds`

This PR adds the missing App Links relation as a focused follow-up on top of SecPal/frontend#921.

## Validation
- `/home/holger/code/SecPal/frontend/node_modules/.bin/vitest run /home/holger/code/SecPal/.worktrees/frontend-passkey-assetlinks/tests/build.test.ts`

## Dependencies
- Depends on SecPal/frontend#921
- Related: SecPal/android#163

## References
- Closes #922
