### PR TITLE
fix: harden live Playwright auth setup

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: CC0-1.0
 
+---
 name: Quality Checks
 
 on:
@@ -81,3 +82,34 @@ jobs:
         # Allow step to succeed even if upload fails for dependabot
         # This prevents blocking the PR when CODECOV_TOKEN is unavailable
         continue-on-error: ${{ contains(fromJSON('["dependabot[bot]", "renovate[bot]"]'), github.actor) }}
+
+  playwright-live-smoke:
+    name: Playwright Live Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: ${{ !startsWith(github.head_ref, 'spike/') && !startsWith(github.ref, 'refs/heads/spike/') }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run live auth smoke against app.secpal.dev
+        env:
+          PLAYWRIGHT_BASE_URL: https://app.secpal.dev
+          PLAYWRIGHT_SKIP_GLOBAL_LOGIN: "1"
+        run: >-
+          npx playwright test tests/e2e/auth.spec.ts --project=chromium --grep
+          "should reject invalid credentials|should redirect to login when
+          accessing protected route without auth"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Hardened Playwright login setup for the live app by waiting for the health-gated submit button to become actionable before clicking, reusing that guard in mocked offline-auth flows, and requiring explicit `TEST_USER_EMAIL` / `TEST_USER_PASSWORD` whenever Playwright targets a remote HTTPS environment like `app.secpal.dev` so live E2E runs fail clearly instead of silently using invalid local placeholder credentials.
 - Expanded `app.secpal.dev` Digital Asset Links to publish both `delegate_permission/common.handle_all_urls` and `delegate_permission/common.get_login_creds`, matching Android Credential Manager's documented app-to-web trust prerequisites for passkey validation.
 - Reused a shared `buildEnvelopeMacPayload()` helper for auth-storage MAC construction in both runtime storage code and the Playwright passkey fixture, removing the duplicated inline field assembly that could drift and resolving frontend issue #917.
 - Published `/.well-known/assetlinks.json` for `app.secpal.dev` and copied it through the Vite build so release-signed SecPal Android builds can complete Credential Manager passkey registration instead of falling through to the SPA shell at the Digital Asset Links endpoint.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,7 +10,7 @@ import { defineConfig, devices } from "@playwright/test";
  *
  * 1. Local Development (default):
  *    - Uses Vite dev server (http://localhost:5173)
- *    - Proxies API to DDEV backend
+ *    - Uses the repository's current Vite/API wiring for local development
  *    - Full authentication and API integration
  *    - Command: `npx playwright test`
  *

--- a/tests/auth-e2e-helpers.test.ts
+++ b/tests/auth-e2e-helpers.test.ts
@@ -6,6 +6,7 @@ import {
   buildTestUser,
   describeAuthResolutionState,
   describeLoginBlockingState,
+  getConfiguredTestUserOrThrow,
   isRemoteE2ETarget,
   type LoginSubmitState,
 } from "./e2e/auth-helpers";
@@ -61,6 +62,7 @@ describe("auth E2E helpers", () => {
         text: "Checking system...",
         healthWarning: "System not ready",
         offlineWarning: null,
+        lockoutWarning: null,
         error: null,
       };
 
@@ -74,10 +76,39 @@ describe("auth E2E helpers", () => {
         text: "Log in",
         healthWarning: null,
         offlineWarning: "No internet connection",
+        lockoutWarning: null,
         error: null,
       };
 
       expect(describeLoginBlockingState(state)).toContain("offline gate");
+    });
+
+    it("explains rate-limit lockout states", () => {
+      const state: LoginSubmitState = {
+        disabled: true,
+        ariaDisabled: "true",
+        text: "Log in",
+        healthWarning: null,
+        offlineWarning: null,
+        lockoutWarning: "Too many attempts. Try again in 10 minutes.",
+        error: null,
+      };
+
+      expect(describeLoginBlockingState(state)).toContain("lockout");
+    });
+
+    it("explains login-error blocking states", () => {
+      const state: LoginSubmitState = {
+        disabled: true,
+        ariaDisabled: "true",
+        text: "Log in",
+        healthWarning: null,
+        offlineWarning: null,
+        lockoutWarning: null,
+        error: "Invalid credentials",
+      };
+
+      expect(describeLoginBlockingState(state)).toContain("visible error");
     });
 
     it("returns null when the submit button is actionable", () => {
@@ -87,10 +118,38 @@ describe("auth E2E helpers", () => {
         text: "Log in",
         healthWarning: null,
         offlineWarning: null,
+        lockoutWarning: null,
         error: null,
       };
 
       expect(describeLoginBlockingState(state)).toBeNull();
+    });
+  });
+
+  describe("getConfiguredTestUserOrThrow", () => {
+    it("returns credentials when targeting a remote environment with credentials set", () => {
+      const result = getConfiguredTestUserOrThrow(
+        {
+          TEST_USER_EMAIL: "guard@secpal.dev",
+          TEST_USER_PASSWORD: "correct-horse-battery-staple",
+          PLAYWRIGHT_BASE_URL: "https://app.secpal.dev",
+        },
+        "https://app.secpal.dev"
+      );
+
+      expect(result).toEqual({
+        email: "guard@secpal.dev",
+        password: "correct-horse-battery-staple",
+      });
+    });
+
+    it("throws when targeting a remote environment without credentials", () => {
+      expect(() =>
+        getConfiguredTestUserOrThrow(
+          { PLAYWRIGHT_BASE_URL: "https://app.secpal.dev" },
+          "https://app.secpal.dev"
+        )
+      ).toThrow("TEST_USER_EMAIL and TEST_USER_PASSWORD must be set");
     });
   });
 

--- a/tests/auth-e2e-helpers.test.ts
+++ b/tests/auth-e2e-helpers.test.ts
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import {
+  buildTestUser,
+  describeAuthResolutionState,
+  describeLoginBlockingState,
+  isRemoteE2ETarget,
+  type LoginSubmitState,
+} from "./e2e/auth-helpers";
+
+describe("auth E2E helpers", () => {
+  describe("isRemoteE2ETarget", () => {
+    it("treats https targets as remote", () => {
+      expect(isRemoteE2ETarget("https://app.secpal.dev")).toBe(true);
+    });
+
+    it("treats local and missing targets as non-remote", () => {
+      expect(isRemoteE2ETarget("http://localhost:5173")).toBe(false);
+      expect(isRemoteE2ETarget(undefined)).toBe(false);
+    });
+  });
+
+  describe("buildTestUser", () => {
+    it("uses local development defaults for non-remote targets", () => {
+      expect(buildTestUser({}, undefined)).toEqual({
+        email: "test@secpal.dev",
+        password: "password",
+      });
+    });
+
+    it("requires explicit credentials for remote targets", () => {
+      expect(buildTestUser({}, "https://app.secpal.dev")).toEqual({
+        email: "",
+        password: "",
+      });
+    });
+
+    it("prefers explicitly configured credentials for remote targets", () => {
+      expect(
+        buildTestUser(
+          {
+            TEST_USER_EMAIL: "guard@secpal.dev",
+            TEST_USER_PASSWORD: "correct horse battery staple",
+          },
+          "https://app.secpal.dev"
+        )
+      ).toEqual({
+        email: "guard@secpal.dev",
+        password: "correct horse battery staple",
+      });
+    });
+  });
+
+  describe("describeLoginBlockingState", () => {
+    it("explains health-gated login states", () => {
+      const state: LoginSubmitState = {
+        disabled: true,
+        ariaDisabled: "true",
+        text: "Checking system...",
+        healthWarning: "System not ready",
+        offlineWarning: null,
+        error: null,
+      };
+
+      expect(describeLoginBlockingState(state)).toContain("health gate");
+    });
+
+    it("explains offline login states", () => {
+      const state: LoginSubmitState = {
+        disabled: true,
+        ariaDisabled: "true",
+        text: "Log in",
+        healthWarning: null,
+        offlineWarning: "No internet connection",
+        error: null,
+      };
+
+      expect(describeLoginBlockingState(state)).toContain("offline gate");
+    });
+
+    it("returns null when the submit button is actionable", () => {
+      const state: LoginSubmitState = {
+        disabled: false,
+        ariaDisabled: "false",
+        text: "Log in",
+        healthWarning: null,
+        offlineWarning: null,
+        error: null,
+      };
+
+      expect(describeLoginBlockingState(state)).toBeNull();
+    });
+  });
+
+  describe("describeAuthResolutionState", () => {
+    it("returns authenticated when the user menu is visible", () => {
+      expect(
+        describeAuthResolutionState({
+          pathname: "/",
+          hasUserMenu: true,
+        })
+      ).toBe("authenticated");
+    });
+
+    it("returns login when the app resolved to the login route", () => {
+      expect(
+        describeAuthResolutionState({
+          pathname: "/login",
+          hasUserMenu: false,
+        })
+      ).toBe("login");
+    });
+
+    it("returns unresolved while neither login nor authenticated shell is visible", () => {
+      expect(
+        describeAuthResolutionState({
+          pathname: "/",
+          hasUserMenu: false,
+        })
+      ).toBe("unresolved");
+    });
+  });
+});

--- a/tests/e2e/auth-helpers.ts
+++ b/tests/e2e/auth-helpers.ts
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { expect, type Page } from "@playwright/test";
+
+export interface TestUserCredentials {
+  email: string;
+  password: string;
+}
+
+export interface LoginSubmitState {
+  disabled: boolean;
+  ariaDisabled: string | null;
+  text: string | null;
+  healthWarning: string | null;
+  offlineWarning: string | null;
+  error: string | null;
+}
+
+export interface AuthResolutionState {
+  pathname: string;
+  hasUserMenu: boolean;
+}
+
+const DEFAULT_LOCAL_TEST_USER: TestUserCredentials = {
+  email: "test@secpal.dev",
+  password: "password",
+};
+
+const LOGIN_READY_TIMEOUT_MS = 15_000;
+const AUTH_RESOLUTION_TIMEOUT_MS = 15_000;
+
+export function isRemoteE2ETarget(baseUrl = process.env.PLAYWRIGHT_BASE_URL) {
+  return typeof baseUrl === "string" && /^https:\/\//i.test(baseUrl);
+}
+
+export function buildTestUser(
+  env: NodeJS.ProcessEnv = process.env,
+  baseUrl = env.PLAYWRIGHT_BASE_URL
+): TestUserCredentials {
+  const email = env.TEST_USER_EMAIL?.trim() ?? "";
+  const password = env.TEST_USER_PASSWORD?.trim() ?? "";
+
+  if (isRemoteE2ETarget(baseUrl)) {
+    return {
+      email,
+      password,
+    };
+  }
+
+  return {
+    email: email || DEFAULT_LOCAL_TEST_USER.email,
+    password: password || DEFAULT_LOCAL_TEST_USER.password,
+  };
+}
+
+export function getConfiguredTestUserOrThrow(
+  env: NodeJS.ProcessEnv = process.env,
+  baseUrl = env.PLAYWRIGHT_BASE_URL
+): TestUserCredentials {
+  const testUser = buildTestUser(env, baseUrl);
+
+  if (testUser.email && testUser.password) {
+    return testUser;
+  }
+
+  throw new Error(
+    "TEST_USER_EMAIL and TEST_USER_PASSWORD must be set when Playwright targets a remote environment such as app.secpal.dev."
+  );
+}
+
+export function describeLoginBlockingState(
+  state: LoginSubmitState
+): string | null {
+  if (!state.disabled) {
+    return null;
+  }
+
+  if (state.healthWarning) {
+    return `Login blocked by health gate: ${state.healthWarning}`;
+  }
+
+  if (state.offlineWarning) {
+    return `Login blocked by offline gate: ${state.offlineWarning}`;
+  }
+
+  if (state.error) {
+    return `Login blocked with visible error: ${state.error}`;
+  }
+
+  if (state.text) {
+    return `Login submit is still disabled (${state.text}).`;
+  }
+
+  return "Login submit is still disabled.";
+}
+
+export function describeAuthResolutionState(
+  state: AuthResolutionState
+): "authenticated" | "login" | "unresolved" {
+  if (state.hasUserMenu) {
+    return "authenticated";
+  }
+
+  if (state.pathname.includes("/login")) {
+    return "login";
+  }
+
+  return "unresolved";
+}
+
+export async function readLoginSubmitState(
+  page: Page
+): Promise<LoginSubmitState> {
+  return page.evaluate(() => {
+    const submitButton = document.querySelector("button[type='submit']");
+
+    return {
+      disabled: submitButton?.hasAttribute("disabled") ?? false,
+      ariaDisabled: submitButton?.getAttribute("aria-disabled") ?? null,
+      text: submitButton?.textContent?.trim() ?? null,
+      healthWarning:
+        document.querySelector("#health-warning")?.textContent?.trim() ?? null,
+      offlineWarning:
+        document.querySelector("#offline-warning")?.textContent?.trim() ?? null,
+      error:
+        document.querySelector("#login-error")?.textContent?.trim() ?? null,
+    };
+  });
+}
+
+export async function waitForLoginFormReady(
+  page: Page,
+  timeout = LOGIN_READY_TIMEOUT_MS
+): Promise<void> {
+  await expect(page.locator("#email")).toBeVisible();
+  await expect(page.locator("#password")).toBeVisible();
+
+  await page.waitForFunction(
+    () => {
+      const submitButton = document.querySelector("button[type='submit']");
+
+      return Boolean(
+        (submitButton && !submitButton.hasAttribute("disabled")) ||
+        document.querySelector("#health-warning") ||
+        document.querySelector("#offline-warning")
+      );
+    },
+    { timeout }
+  );
+
+  const state = await readLoginSubmitState(page);
+  const reason = describeLoginBlockingState(state);
+
+  if (reason) {
+    throw new Error(reason);
+  }
+}
+
+export async function readAuthResolutionState(
+  page: Page
+): Promise<AuthResolutionState> {
+  return page.evaluate(() => ({
+    pathname: window.location.pathname,
+    hasUserMenu:
+      document.querySelector('button[aria-label="User menu"]') !== null,
+  }));
+}
+
+export async function waitForAuthResolution(
+  page: Page,
+  timeout = AUTH_RESOLUTION_TIMEOUT_MS
+): Promise<"authenticated" | "login" | "unresolved"> {
+  await page
+    .waitForFunction(
+      () =>
+        window.location.pathname.includes("/login") ||
+        document.querySelector('button[aria-label="User menu"]') !== null,
+      { timeout }
+    )
+    .catch(() => undefined);
+
+  const state = await readAuthResolutionState(page);
+
+  return describeAuthResolutionState(state);
+}

--- a/tests/e2e/auth-helpers.ts
+++ b/tests/e2e/auth-helpers.ts
@@ -14,6 +14,7 @@ export interface LoginSubmitState {
   text: string | null;
   healthWarning: string | null;
   offlineWarning: string | null;
+  lockoutWarning: string | null;
   error: string | null;
 }
 
@@ -84,6 +85,10 @@ export function describeLoginBlockingState(
     return `Login blocked by offline gate: ${state.offlineWarning}`;
   }
 
+  if (state.lockoutWarning) {
+    return `Login blocked by rate-limit lockout: ${state.lockoutWarning}`;
+  }
+
   if (state.error) {
     return `Login blocked with visible error: ${state.error}`;
   }
@@ -123,6 +128,8 @@ export async function readLoginSubmitState(
         document.querySelector("#health-warning")?.textContent?.trim() ?? null,
       offlineWarning:
         document.querySelector("#offline-warning")?.textContent?.trim() ?? null,
+      lockoutWarning:
+        document.querySelector("#lockout-warning")?.textContent?.trim() ?? null,
       error:
         document.querySelector("#login-error")?.textContent?.trim() ?? null,
     };
@@ -143,7 +150,9 @@ export async function waitForLoginFormReady(
       return Boolean(
         (submitButton && !submitButton.hasAttribute("disabled")) ||
         document.querySelector("#health-warning") ||
-        document.querySelector("#offline-warning")
+        document.querySelector("#offline-warning") ||
+        document.querySelector("#lockout-warning") ||
+        document.querySelector("#login-error")
       );
     },
     { timeout }

--- a/tests/e2e/auth.setup.ts
+++ b/tests/e2e/auth.setup.ts
@@ -2,6 +2,12 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { test as base, expect, type Page } from "@playwright/test";
+import {
+  buildTestUser,
+  getConfiguredTestUserOrThrow,
+  waitForAuthResolution,
+  waitForLoginFormReady,
+} from "./auth-helpers";
 
 /**
  * Test Credentials
@@ -10,8 +16,7 @@ import { test as base, expect, type Page } from "@playwright/test";
  * In CI, these can be overridden via environment variables.
  */
 export const TEST_USER = {
-  email: process.env.TEST_USER_EMAIL || "test@secpal.dev",
-  password: process.env.TEST_USER_PASSWORD || "password",
+  ...buildTestUser(),
 };
 
 /**
@@ -22,15 +27,20 @@ export const TEST_USER = {
  */
 export async function loginViaUI(
   page: Page,
-  email = TEST_USER.email,
-  password = TEST_USER.password
+  email?: string,
+  password?: string
 ): Promise<void> {
+  const configuredTestUser =
+    email && password ? { email, password } : getConfiguredTestUserOrThrow();
+
   await page.goto("/login");
   await page.waitForLoadState("networkidle");
 
   // Fill in credentials using ID selectors (matching Login.tsx)
-  await page.locator("#email").fill(email);
-  await page.locator("#password").fill(password);
+  await page.locator("#email").fill(configuredTestUser.email);
+  await page.locator("#password").fill(configuredTestUser.password);
+
+  await waitForLoginFormReady(page);
 
   // Submit form - "Log in" in English, "Anmelden" or similar in German
   await page
@@ -56,6 +66,8 @@ const AUTH_FILE = "./tests/e2e/.auth/user.json";
  */
 export const test = base.extend<{ authenticatedPage: Page }>({
   authenticatedPage: async ({ browser }, runTest) => {
+    const configuredTestUser = getConfiguredTestUserOrThrow();
+
     // Try to use saved auth state
     let context;
     try {
@@ -67,13 +79,24 @@ export const test = base.extend<{ authenticatedPage: Page }>({
 
     const page = await context.newPage();
 
-    // If no valid session, perform login
+    // Resolve whether the reused storage state still results in the authenticated shell.
     await page.goto("/");
-    if (page.url().includes("/login")) {
-      await loginViaUI(page);
+    await page.waitForLoadState("networkidle");
+
+    const authResolution = await waitForAuthResolution(page);
+
+    if (authResolution !== "authenticated") {
+      await loginViaUI(
+        page,
+        configuredTestUser.email,
+        configuredTestUser.password
+      );
     }
 
-    // Verify we're logged in
+    // Verify we're logged in with the actual authenticated application shell.
+    await expect(page.getByRole("button", { name: /user menu/i })).toBeVisible({
+      timeout: 15_000,
+    });
     expect(page.url()).not.toContain("/login");
 
     // Run the test with authenticated page

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2025 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, loginViaUI, TEST_USER } from "./auth.setup";
+import { test, expect, loginViaUI } from "./auth.setup";
+import { waitForLoginFormReady } from "./auth-helpers";
 
 /**
  * Authentication Flow Tests
@@ -35,8 +36,9 @@ test.describe("Authentication", () => {
     await page.waitForLoadState("networkidle");
 
     // Try to login with wrong password
-    await page.locator("#email").fill(TEST_USER.email);
+    await page.locator("#email").fill("wrong-user@secpal.dev");
     await page.locator("#password").fill("wrongpassword");
+    await waitForLoginFormReady(page);
     await page
       .getByRole("button", { name: /log in|anmelden|einloggen/i })
       .click();

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { chromium, type FullConfig } from "@playwright/test";
-import { TEST_USER } from "./auth.setup";
+import {
+  getConfiguredTestUserOrThrow,
+  waitForLoginFormReady,
+} from "./auth-helpers";
 import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
@@ -44,6 +47,8 @@ async function globalSetup(config: FullConfig) {
 
   console.log("🔐 Performing global login setup...");
 
+  const testUser = getConfiguredTestUserOrThrow();
+
   const baseURL = config.projects[0]?.use?.baseURL || "http://localhost:5173";
 
   const browser = await chromium.launch();
@@ -56,8 +61,10 @@ async function globalSetup(config: FullConfig) {
     await page.waitForLoadState("networkidle");
 
     // Fill in credentials
-    await page.locator("#email").fill(TEST_USER.email);
-    await page.locator("#password").fill(TEST_USER.password);
+    await page.locator("#email").fill(testUser.email);
+    await page.locator("#password").fill(testUser.password);
+
+    await waitForLoginFormReady(page);
 
     // Submit form
     await page

--- a/tests/e2e/offline-logout.spec.ts
+++ b/tests/e2e/offline-logout.spec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { expect, test, type BrowserContext, type Page } from "@playwright/test";
+import { waitForLoginFormReady } from "./auth-helpers";
 
 const supportsServiceWorkerOfflineFlows =
   Boolean(process.env.CI) ||
@@ -112,6 +113,7 @@ test.describe("Offline Logout Privacy", () => {
 
     await page.locator("#email").fill(offlineLogoutMockUser.email);
     await page.locator("#password").fill("password");
+    await waitForLoginFormReady(page);
     await page
       .getByRole("button", { name: /log in|anmelden|einloggen/i })
       .click();


### PR DESCRIPTION
## Summary

- harden Playwright live auth setup by centralizing remote credential resolution, waiting for the health-gated login form to become actionable, and verifying reused auth state against the authenticated shell instead of trusting the URL alone
- add focused regression coverage for the new auth E2E helpers and wire a no-secret live smoke job into the quality workflow
- keep the remaining non-auth live Playwright failures out of scope for this PR because they are tracked separately in #929, #930, #931, #932, and #933

## Testing

- npm run test -- tests/auth-e2e-helpers.test.ts
- npm run typecheck
- npm exec -- eslint playwright.config.ts tests/e2e/auth.setup.ts tests/e2e/auth.spec.ts tests/e2e/global-setup.ts tests/e2e/offline-logout.spec.ts tests/auth-e2e-helpers.test.ts tests/e2e/auth-helpers.ts
- yamllint .github/workflows/quality.yml
- PLAYWRIGHT_BASE_URL=https://app.secpal.dev TEST_USER_EMAIL=test@example.com TEST_USER_PASSWORD=password npx playwright test tests/e2e/auth.spec.ts --project=chromium

## Related

- Closes #928
- Related: #929
- Related: #930
- Related: #931
- Related: #932
- Related: #933

## Checklist

- [x] Single topic
- [x] CHANGELOG updated
- [x] Smallest relevant validation passed locally
- [x] Remaining out-of-scope failures tracked as issues
