### PR TITLE
Fix protected-route browser-session rehydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Stopped browser-session auth from collapsing into an immediate frontend logout on protected routes when the local `auth_user` snapshot is missing or becomes unreadable after an `XSRF-TOKEN` rotation; bootstrap now falls back to `/v1/me` revalidation instead of treating client-side storage drift as a confirmed sign-out.
 - Hardened Playwright login setup for the live app by waiting for the health-gated submit button to become actionable before clicking, reusing that guard in mocked offline-auth flows, and requiring explicit `TEST_USER_EMAIL` / `TEST_USER_PASSWORD` whenever Playwright targets a remote HTTPS environment like `app.secpal.dev` so live E2E runs fail clearly instead of silently using invalid local placeholder credentials.
 - Expanded `app.secpal.dev` Digital Asset Links to publish both `delegate_permission/common.handle_all_urls` and `delegate_permission/common.get_login_creds`, matching Android Credential Manager's documented app-to-web trust prerequisites for passkey validation.
 - Reused a shared `buildEnvelopeMacPayload()` helper for auth-storage MAC construction in both runtime storage code and the Playwright passkey fixture, removing the duplicated inline field assembly that could drift and resolving frontend issue #917.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -98,7 +98,9 @@ describe("App", () => {
     i18n.load("en", {});
     i18n.activate("en");
     mockGetCurrentUser.mockRejectedValue(
-      new Error("No mock auth user available for bootstrap")
+      Object.assign(new Error("No mock auth user available for bootstrap"), {
+        code: "HTTP_401",
+      })
     );
   });
 
@@ -123,6 +125,33 @@ describe("App", () => {
   it("renders language switcher on login page", async () => {
     await renderWithI18n(<App />);
     expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("restores a valid browser session on a protected route even when no local auth snapshot is available", async () => {
+    window.history.replaceState({}, "", "/");
+
+    mockGetCurrentUser.mockResolvedValueOnce({
+      id: "1",
+      name: "Recovered Session User",
+      email: "recovered-session@secpal.dev",
+      emailVerified: true,
+      roles: [],
+      permissions: [],
+      hasOrganizationalScopes: false,
+      hasCustomerAccess: false,
+      hasSiteAccess: false,
+    });
+
+    await renderWithI18n(<App />);
+
+    expect(
+      await screen.findByRole(
+        "heading",
+        { name: /welcome to secpal/i },
+        { timeout: ROUTE_NAVIGATION_TIMEOUT_MS }
+      )
+    ).toBeInTheDocument();
+    expect(window.location.pathname).toBe("/");
   });
 
   it("shows not found for activity-logs when the user cannot discover that feature", async () => {

--- a/src/components/FeatureRoute.bootstrap.test.tsx
+++ b/src/components/FeatureRoute.bootstrap.test.tsx
@@ -11,93 +11,93 @@ import { AuthProvider } from "../contexts/AuthContext";
 
 const mockNavigate = vi.fn();
 const { mockGetCurrentUser } = vi.hoisted(() => ({
-    mockGetCurrentUser: vi.fn(),
+  mockGetCurrentUser: vi.fn(),
 }));
 
 vi.mock("../services/authApi", async () => {
-    const actual = await vi.importActual("../services/authApi");
-    return {
-        ...actual,
-        getCurrentUser: mockGetCurrentUser,
-    };
+  const actual = await vi.importActual("../services/authApi");
+  return {
+    ...actual,
+    getCurrentUser: mockGetCurrentUser,
+  };
 });
 
 vi.mock("react-router-dom", async () => {
-    const actual = await vi.importActual("react-router-dom");
-    return {
-        ...actual,
-        Navigate: ({ to }: { to: string }) => {
-            mockNavigate(to);
-            return <div>Redirected to {to}</div>;
-        },
-    };
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    Navigate: ({ to }: { to: string }) => {
+      mockNavigate(to);
+      return <div>Redirected to {to}</div>;
+    },
+  };
 });
 
 function setCsrfTokenCookie(value: string): void {
-    document.cookie = `XSRF-TOKEN=;expires=${new Date(0).toUTCString()};path=/`;
-    document.cookie = `XSRF-TOKEN=${encodeURIComponent(value)};path=/`;
+  document.cookie = `XSRF-TOKEN=;expires=${new Date(0).toUTCString()};path=/`;
+  document.cookie = `XSRF-TOKEN=${encodeURIComponent(value)};path=/`;
 }
 
 function renderEmployeesFeatureRoute() {
-    return render(
-        <BrowserRouter>
-            <I18nProvider i18n={i18n}>
-                <AuthProvider>
-                    <Routes>
-                        <Route
-                            path="/employees"
-                            element={
-                                <FeatureRoute feature="employees">
-                                    <div>Employees Content</div>
-                                </FeatureRoute>
-                            }
-                        />
-                    </Routes>
-                </AuthProvider>
-            </I18nProvider>
-        </BrowserRouter>
-    );
+  return render(
+    <BrowserRouter>
+      <I18nProvider i18n={i18n}>
+        <AuthProvider>
+          <Routes>
+            <Route
+              path="/employees"
+              element={
+                <FeatureRoute feature="employees">
+                  <div>Employees Content</div>
+                </FeatureRoute>
+              }
+            />
+          </Routes>
+        </AuthProvider>
+      </I18nProvider>
+    </BrowserRouter>
+  );
 }
 
 describe("FeatureRoute browser-session bootstrap", () => {
-    beforeEach(() => {
-        vi.resetAllMocks();
-        localStorage.clear();
-        window.history.replaceState({}, "", "/employees");
-        setCsrfTokenCookie("test-csrf-token");
-        i18n.load("en", {});
-        i18n.activate("en");
-        mockGetCurrentUser.mockRejectedValue(
-            Object.assign(new Error("Unauthorized"), {
-                code: "HTTP_401",
-            })
-        );
+  beforeEach(() => {
+    vi.resetAllMocks();
+    localStorage.clear();
+    window.history.replaceState({}, "", "/employees");
+    setCsrfTokenCookie("test-csrf-token");
+    i18n.load("en", {});
+    i18n.activate("en");
+    mockGetCurrentUser.mockRejectedValue(
+      Object.assign(new Error("Unauthorized"), {
+        code: "HTTP_401",
+      })
+    );
+  });
+
+  it("rehydrates a valid browser session on a deep-linked feature route without local auth storage", async () => {
+    mockGetCurrentUser.mockResolvedValueOnce({
+      id: "1",
+      name: "Employee Manager",
+      email: "manager@secpal.dev",
+      emailVerified: true,
+      hasOrganizationalScopes: true,
+      permissions: ["employees.read"],
+      roles: [],
     });
 
-    it("rehydrates a valid browser session on a deep-linked feature route without local auth storage", async () => {
-        mockGetCurrentUser.mockResolvedValueOnce({
-            id: "1",
-            name: "Employee Manager",
-            email: "manager@secpal.dev",
-            emailVerified: true,
-            hasOrganizationalScopes: true,
-            permissions: ["employees.read"],
-            roles: [],
-        });
+    renderEmployeesFeatureRoute();
 
-        renderEmployeesFeatureRoute();
+    expect(await screen.findByText("Employees Content")).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
 
-        expect(await screen.findByText("Employees Content")).toBeInTheDocument();
-        expect(mockNavigate).not.toHaveBeenCalled();
+  it("redirects to login on a deep-linked feature route when browser-session bootstrap confirms the session is unauthenticated", async () => {
+    renderEmployeesFeatureRoute();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/login");
     });
 
-    it("redirects to login on a deep-linked feature route when browser-session bootstrap confirms the session is unauthenticated", async () => {
-        renderEmployeesFeatureRoute();
-
-        await waitFor(() => {
-            expect(mockNavigate).toHaveBeenCalledWith("/login");
-        });
-
-        expect(screen.getByText(/redirected to \/login/i)).toBeInTheDocument();
-    });
+    expect(screen.getByText(/redirected to \/login/i)).toBeInTheDocument();
+  });
 });

--- a/src/components/FeatureRoute.bootstrap.test.tsx
+++ b/src/components/FeatureRoute.bootstrap.test.tsx
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { I18nProvider } from "@lingui/react";
+import { i18n } from "@lingui/core";
+import { FeatureRoute } from "./FeatureRoute";
+import { AuthProvider } from "../contexts/AuthContext";
+
+const mockNavigate = vi.fn();
+const { mockGetCurrentUser } = vi.hoisted(() => ({
+    mockGetCurrentUser: vi.fn(),
+}));
+
+vi.mock("../services/authApi", async () => {
+    const actual = await vi.importActual("../services/authApi");
+    return {
+        ...actual,
+        getCurrentUser: mockGetCurrentUser,
+    };
+});
+
+vi.mock("react-router-dom", async () => {
+    const actual = await vi.importActual("react-router-dom");
+    return {
+        ...actual,
+        Navigate: ({ to }: { to: string }) => {
+            mockNavigate(to);
+            return <div>Redirected to {to}</div>;
+        },
+    };
+});
+
+function setCsrfTokenCookie(value: string): void {
+    document.cookie = `XSRF-TOKEN=;expires=${new Date(0).toUTCString()};path=/`;
+    document.cookie = `XSRF-TOKEN=${encodeURIComponent(value)};path=/`;
+}
+
+function renderEmployeesFeatureRoute() {
+    return render(
+        <BrowserRouter>
+            <I18nProvider i18n={i18n}>
+                <AuthProvider>
+                    <Routes>
+                        <Route
+                            path="/employees"
+                            element={
+                                <FeatureRoute feature="employees">
+                                    <div>Employees Content</div>
+                                </FeatureRoute>
+                            }
+                        />
+                    </Routes>
+                </AuthProvider>
+            </I18nProvider>
+        </BrowserRouter>
+    );
+}
+
+describe("FeatureRoute browser-session bootstrap", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+        localStorage.clear();
+        window.history.replaceState({}, "", "/employees");
+        setCsrfTokenCookie("test-csrf-token");
+        i18n.load("en", {});
+        i18n.activate("en");
+        mockGetCurrentUser.mockRejectedValue(
+            Object.assign(new Error("Unauthorized"), {
+                code: "HTTP_401",
+            })
+        );
+    });
+
+    it("rehydrates a valid browser session on a deep-linked feature route without local auth storage", async () => {
+        mockGetCurrentUser.mockResolvedValueOnce({
+            id: "1",
+            name: "Employee Manager",
+            email: "manager@secpal.dev",
+            emailVerified: true,
+            hasOrganizationalScopes: true,
+            permissions: ["employees.read"],
+            roles: [],
+        });
+
+        renderEmployeesFeatureRoute();
+
+        expect(await screen.findByText("Employees Content")).toBeInTheDocument();
+        expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it("redirects to login on a deep-linked feature route when browser-session bootstrap confirms the session is unauthenticated", async () => {
+        renderEmployeesFeatureRoute();
+
+        await waitFor(() => {
+            expect(mockNavigate).toHaveBeenCalledWith("/login");
+        });
+
+        expect(screen.getByText(/redirected to \/login/i)).toBeInTheDocument();
+    });
+});

--- a/src/components/ProtectedRoute.test.tsx
+++ b/src/components/ProtectedRoute.test.tsx
@@ -117,12 +117,19 @@ describe("ProtectedRoute", () => {
     setCsrfTokenCookie("test-csrf-token");
     i18n.load("en", {});
     i18n.activate("en");
+    mockGetCurrentUser.mockRejectedValue(
+      Object.assign(new Error("Unauthorized"), {
+        code: "HTTP_401",
+      })
+    );
   });
 
-  it("redirects to login when not authenticated", () => {
+  it("redirects to login when not authenticated", async () => {
     renderProtectedRoute();
 
-    expect(mockNavigate).toHaveBeenCalledWith("/login");
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/login");
+    });
     expect(screen.getByText(/redirected to \/login/i)).toBeInTheDocument();
   });
 
@@ -194,6 +201,33 @@ describe("ProtectedRoute", () => {
     expect(screen.getByText(/redirected to \/login/i)).toBeInTheDocument();
   });
 
+  it("recovers browser-session auth when the persisted record becomes unreadable after CSRF rotation", async () => {
+    await persistAuthUser({
+      id: 1,
+      name: "Recovered User",
+      email: "recovered@secpal.dev",
+      emailVerified: true,
+    });
+
+    setCsrfTokenCookie("rotated-csrf-token");
+    mockGetCurrentUser.mockResolvedValueOnce({
+      id: 1,
+      name: "Recovered User",
+      email: "recovered@secpal.dev",
+      emailVerified: true,
+    });
+
+    renderProtectedRoute();
+
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("Protected Content")).toBeInTheDocument();
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
   it("shows a retry recovery state instead of spinning forever when bootstrap stalls", async () => {
     mockGetCurrentUser.mockReturnValueOnce(new Promise(() => undefined));
 
@@ -260,6 +294,8 @@ describe("ProtectedRoute", () => {
   });
 
   it("shows loading state initially", () => {
+    mockGetCurrentUser.mockReturnValueOnce(new Promise(() => undefined));
+
     const { container } = render(
       <BrowserRouter>
         <I18nProvider i18n={i18n}>
@@ -278,33 +314,21 @@ describe("ProtectedRoute", () => {
 
   describe("Accessibility", () => {
     it("loading state has role=status", () => {
-      // Temporarily remove token to trigger loading check
-      localStorage.clear();
+      mockGetCurrentUser.mockReturnValueOnce(new Promise(() => undefined));
       renderProtectedRoute();
 
-      // The loading div should have role="status"
-      // This will fail until we implement the ARIA attributes
-      const loadingElement = screen.queryByText("Loading...");
-      if (loadingElement) {
-        expect(loadingElement.closest("div")).toHaveAttribute("role", "status");
-      }
+      expect(screen.getByRole("status")).toHaveTextContent("Loading...");
     });
 
     it("loading state has aria-live=polite", () => {
-      localStorage.clear();
+      mockGetCurrentUser.mockReturnValueOnce(new Promise(() => undefined));
       renderProtectedRoute();
 
-      const loadingElement = screen.queryByText("Loading...");
-      if (loadingElement) {
-        expect(loadingElement.closest("div")).toHaveAttribute(
-          "aria-live",
-          "polite"
-        );
-      }
+      expect(screen.getByRole("status")).toHaveAttribute("aria-live", "polite");
     });
 
     it("loading text is visible to screen readers", () => {
-      localStorage.clear();
+      mockGetCurrentUser.mockReturnValueOnce(new Promise(() => undefined));
       renderProtectedRoute();
 
       const loadingText = screen.queryByText("Loading...");

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -25,7 +25,11 @@ import { analytics } from "../lib/analytics";
 export const BOOTSTRAP_REVALIDATION_TIMEOUT_MS = 3500;
 
 function isPublicUnauthenticatedRoute(pathname: string): boolean {
-  return pathname === "/login" || pathname === "/onboarding/complete";
+  const normalized =
+    pathname !== "/" && pathname.endsWith("/")
+      ? pathname.slice(0, -1)
+      : pathname;
+  return normalized === "/login" || normalized === "/onboarding/complete";
 }
 
 function shouldBootstrapBrowserSessionWithoutStoredUser(

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -24,6 +24,25 @@ import { analytics } from "../lib/analytics";
 
 export const BOOTSTRAP_REVALIDATION_TIMEOUT_MS = 3500;
 
+function isPublicUnauthenticatedRoute(pathname: string): boolean {
+  return pathname === "/login" || pathname === "/onboarding/complete";
+}
+
+function shouldBootstrapBrowserSessionWithoutStoredUser(
+  authTransportKind: string,
+  hasLogoutBarrier: boolean
+): boolean {
+  if (authTransportKind !== "browser-session" || hasLogoutBarrier) {
+    return false;
+  }
+
+  if (!isOnline() || typeof window === "undefined") {
+    return false;
+  }
+
+  return !isPublicUnauthenticatedRoute(window.location.pathname);
+}
+
 function getBootstrapErrorCode(error: unknown): string | null {
   if (typeof error !== "object" || error === null || !("code" in error)) {
     return null;
@@ -85,8 +104,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     authStorage.getUserSnapshot()
   );
   const [isLoading, setIsLoading] = useState(() => {
+    const hasLogoutBarrier = authStorage.hasLogoutBarrier();
+
     if (!authStorage.hasStoredUser()) {
-      return false;
+      return shouldBootstrapBrowserSessionWithoutStoredUser(
+        authTransport.kind,
+        hasLogoutBarrier
+      );
     }
 
     if (
@@ -343,6 +367,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
 
     const restoreAndRevalidate = async () => {
+      const hadStoredUser = authStorage.hasStoredUser();
       const storedUser = await authStorage.getUser();
 
       if (!isActive || bootstrapRequestVersionRef.current !== requestVersion) {
@@ -350,6 +375,29 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
 
       if (!storedUser) {
+        if (authTransport.kind === "browser-session" && hadStoredUser) {
+          if (!isOnline()) {
+            setBootstrapRecoveryReason(null);
+            setUser(null);
+            setIsLoading(false);
+            syncOfflineAuthState(false);
+            return;
+          }
+
+          startBootstrapRevalidation();
+          return;
+        }
+
+        if (
+          shouldBootstrapBrowserSessionWithoutStoredUser(
+            authTransport.kind,
+            hasLogoutBarrierRef.current
+          )
+        ) {
+          startBootstrapRevalidation();
+          return;
+        }
+
         setBootstrapRecoveryReason(null);
         setUser(null);
         setIsLoading(false);

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -108,8 +108,8 @@ describe("useAuth", () => {
     mockGetCurrentUser.mockReset();
     vi.mocked(syncOfflineSessionAccess).mockReset();
     vi.mocked(clearSensitiveClientState).mockReset();
-    vi.spyOn(console, "error").mockImplementation(() => { });
-    vi.spyOn(console, "log").mockImplementation(() => { });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
     sessionEvents.reset();
     mockGetCurrentUser.mockResolvedValue({
       id: 1,

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -442,6 +442,40 @@ describe("useAuth", () => {
     onLineSpy.mockRestore();
   });
 
+  it("collapses to logged-out state when stored user becomes unreadable while offline", async () => {
+    const mockUser = {
+      id: "1",
+      name: "Test User",
+      email: "test@secpal.dev",
+      emailVerified: false,
+    };
+
+    await persistAuthUser(mockUser);
+
+    // Rotate the CSRF token so the stored MAC becomes invalid — getUser() returns null
+    setCsrfTokenCookie("rotated-csrf-token");
+
+    const onLineSpy = vi
+      .spyOn(window.navigator, "onLine", "get")
+      .mockReturnValue(false);
+
+    try {
+      const { result } = renderHook(() => useAuth(), {
+        wrapper: AuthProvider,
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.user).toBeNull();
+      expect(result.current.isAuthenticated).toBe(false);
+      expect(mockGetCurrentUser).not.toHaveBeenCalled();
+    } finally {
+      onLineSpy.mockRestore();
+    }
+  });
+
   it("handles corrupted user data in localStorage", () => {
     localStorage.setItem("auth_user", "invalid-json");
 

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -102,13 +102,14 @@ async function expectEncryptedStoredUser(
 describe("useAuth", () => {
   beforeEach(() => {
     localStorage.clear();
+    window.history.replaceState({}, "", "/login");
     setCsrfTokenCookie("test-csrf-token");
     vi.clearAllMocks();
     mockGetCurrentUser.mockReset();
     vi.mocked(syncOfflineSessionAccess).mockReset();
     vi.mocked(clearSensitiveClientState).mockReset();
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => { });
+    vi.spyOn(console, "log").mockImplementation(() => { });
     sessionEvents.reset();
     mockGetCurrentUser.mockResolvedValue({
       id: 1,
@@ -134,6 +135,28 @@ describe("useAuth", () => {
     expect(result.current.isAuthenticated).toBe(false);
     expect(result.current.isLoading).toBe(false);
     expect(mockGetCurrentUser).not.toHaveBeenCalled();
+  });
+
+  it("bootstraps a protected browser-session route even when local auth storage is empty", async () => {
+    window.history.replaceState({}, "", "/");
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(true);
+    });
+
+    expect(result.current.user).toEqual({
+      id: "1",
+      name: "Bootstrap User",
+      email: "bootstrap@secpal.dev",
+      emailVerified: false,
+    });
+    expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
   });
 
   it("revalidates a stored user before completing bootstrap", async () => {

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -159,6 +159,22 @@ describe("useAuth", () => {
     expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
   });
 
+  it("skips bootstrap revalidation on the login route with a trailing slash", async () => {
+    window.history.replaceState({}, "", "/login/");
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.user).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(mockGetCurrentUser).not.toHaveBeenCalled();
+  });
+
   it("revalidates a stored user before completing bootstrap", async () => {
     const mockUser = {
       id: 1,

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -503,7 +503,7 @@ describe("Login", () => {
       )
     ).rejects.toThrow("Passkeys are not available in this browser.");
 
-    vi.stubGlobal("PublicKeyCredential", class PublicKeyCredentialMock { });
+    vi.stubGlobal("PublicKeyCredential", class PublicKeyCredentialMock {});
     Object.defineProperty(navigator, "credentials", {
       configurable: true,
       value: {
@@ -1180,7 +1180,7 @@ describe("Login", () => {
     const mockVerifyMfaChallenge = vi.mocked(authApi.verifyMfaChallenge);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => { });
+      .mockImplementation(() => {});
 
     mockLogin.mockResolvedValueOnce({
       challenge: {
@@ -1256,7 +1256,7 @@ describe("Login", () => {
   it("shows an error when MFA challenge response has an unexpected mode", async () => {
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => { });
+      .mockImplementation(() => {});
     vi.mocked(authApi.verifyMfaChallenge).mockResolvedValueOnce({
       user: createAuthUser(),
       authentication: {
@@ -1317,7 +1317,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => { });
+      .mockImplementation(() => {});
 
     mockLogin.mockRejectedValueOnce(
       new authApi.AuthApiError("Server Error", undefined, 500)
@@ -1357,7 +1357,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => { });
+      .mockImplementation(() => {});
     mockLogin.mockRejectedValueOnce(new Error("Network error"));
 
     renderLogin();
@@ -1391,7 +1391,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => { });
+      .mockImplementation(() => {});
     mockLogin.mockRejectedValueOnce("string error");
 
     renderLogin();

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -137,6 +137,7 @@ describe("Login", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    window.history.replaceState({}, "", "/login");
     i18n.load("en", {});
     i18n.activate("en");
     // Default: health check passes
@@ -502,7 +503,7 @@ describe("Login", () => {
       )
     ).rejects.toThrow("Passkeys are not available in this browser.");
 
-    vi.stubGlobal("PublicKeyCredential", class PublicKeyCredentialMock {});
+    vi.stubGlobal("PublicKeyCredential", class PublicKeyCredentialMock { });
     Object.defineProperty(navigator, "credentials", {
       configurable: true,
       value: {
@@ -1179,7 +1180,7 @@ describe("Login", () => {
     const mockVerifyMfaChallenge = vi.mocked(authApi.verifyMfaChallenge);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => {});
+      .mockImplementation(() => { });
 
     mockLogin.mockResolvedValueOnce({
       challenge: {
@@ -1255,7 +1256,7 @@ describe("Login", () => {
   it("shows an error when MFA challenge response has an unexpected mode", async () => {
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => {});
+      .mockImplementation(() => { });
     vi.mocked(authApi.verifyMfaChallenge).mockResolvedValueOnce({
       user: createAuthUser(),
       authentication: {
@@ -1316,7 +1317,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => {});
+      .mockImplementation(() => { });
 
     mockLogin.mockRejectedValueOnce(
       new authApi.AuthApiError("Server Error", undefined, 500)
@@ -1356,7 +1357,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => {});
+      .mockImplementation(() => { });
     mockLogin.mockRejectedValueOnce(new Error("Network error"));
 
     renderLogin();
@@ -1390,7 +1391,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => {});
+      .mockImplementation(() => { });
     mockLogin.mockRejectedValueOnce("string error");
 
     renderLogin();

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -81,6 +81,26 @@ test.describe("Authentication", () => {
     expect(page.url()).not.toContain("/login");
   });
 
+  test("should stay authenticated when deep-linking to a protected route and reloading it", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/customers");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page).toHaveURL(/\/customers$/);
+    await expect(page.getByRole("button", { name: /user menu/i })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+
+    await expect(page).toHaveURL(/\/customers$/);
+    await expect(page.getByRole("button", { name: /user menu/i })).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
   test("should redirect to login when accessing protected route without auth", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary
- rehydrate browser-session auth on protected routes via `/v1/me` even when local `auth_user` state is missing or unreadable
- keep redirects to `/login` limited to confirmed unauthenticated sessions instead of pre-bootstrap local-storage misses
- add regression coverage for AuthContext, ProtectedRoute, App routing, FeatureRoute deep links, and Playwright auth reload behaviour

Closes #927

## Validation
- `npx vitest run src/components/FeatureRoute.bootstrap.test.tsx src/components/ProtectedRoute.test.tsx src/hooks/useAuth.test.ts src/App.test.tsx`
- `npm run typecheck`
- `npx eslint src/contexts/AuthContext.tsx src/components/ProtectedRoute.test.tsx src/components/FeatureRoute.bootstrap.test.tsx src/App.test.tsx src/hooks/useAuth.test.ts tests/e2e/auth.spec.ts`

## Notes
- added a Playwright regression in `tests/e2e/auth.spec.ts` for deep-link plus reload on `/customers`
- the new E2E spec was linted but not executed locally in this session
