### PR TITLE
Stabilize live offline Playwright coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Stabilized the live Playwright offline coverage by moving the flaky service-worker offline route assertions onto deterministic mocked auth and organizational-unit fixtures, correcting the offline banner expectation to the shipped copy, and marking the mocked offline-logout session as verified so the privacy flow reaches the profile page before logout.
 - Stopped browser-session auth from collapsing into an immediate frontend logout on protected routes when the local `auth_user` snapshot is missing or becomes unreadable after an `XSRF-TOKEN` rotation; bootstrap now falls back to `/v1/me` revalidation instead of treating client-side storage drift as a confirmed sign-out.
 - Hardened Playwright login setup for the live app by waiting for the health-gated submit button to become actionable before clicking, reusing that guard in mocked offline-auth flows, and requiring explicit `TEST_USER_EMAIL` / `TEST_USER_PASSWORD` whenever Playwright targets a remote HTTPS environment like `app.secpal.dev` so live E2E runs fail clearly instead of silently using invalid local placeholder credentials.
 - Expanded `app.secpal.dev` Digital Asset Links to publish both `delegate_permission/common.handle_all_urls` and `delegate_permission/common.get_login_creds`, matching Android Credential Manager's documented app-to-web trust prerequisites for passkey validation.

--- a/tests/e2e/offline-live-helpers.ts
+++ b/tests/e2e/offline-live-helpers.ts
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { expect, type BrowserContext, type Page } from "@playwright/test";
+import { waitForLoginFormReady } from "./auth-helpers";
+
+const MOCK_XSRF_TOKEN = "test-xsrf-token";
+
+async function ensureMockXsrfCookie(context: BrowserContext): Promise<void> {
+    await context.addCookies([
+        {
+            name: "XSRF-TOKEN",
+            value: MOCK_XSRF_TOKEN,
+            domain: "app.secpal.dev",
+            path: "/",
+            sameSite: "Lax",
+            secure: true,
+            httpOnly: false,
+        },
+    ]);
+}
+
+export const offlineLiveMockUser = {
+    id: "42",
+    name: "Jane Example",
+    email: "jane.example@secpal.app",
+    emailVerified: true,
+    roles: ["Manager"],
+    permissions: [],
+    hasOrganizationalScopes: true,
+    hasCustomerAccess: false,
+    hasSiteAccess: false,
+};
+
+export const offlineLiveMockOrganizationUnit = {
+    id: "org-root-1",
+    type: "holding",
+    name: "Headquarters Holding",
+    custom_type_name: null,
+    description: "Primary organizational root for offline live Playwright coverage.",
+    parent: null,
+    created_at: "2026-04-19T00:00:00Z",
+    updated_at: "2026-04-19T00:00:00Z",
+};
+
+export async function installMockAuthRoutes(
+    context: BrowserContext
+): Promise<void> {
+    await ensureMockXsrfCookie(context);
+
+    await context.route("**/health/ready", async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+                status: "ready",
+                checks: {
+                    database: "ok",
+                    tenant_keys: "ok",
+                    kek_file: "ok",
+                },
+                timestamp: new Date().toISOString(),
+            }),
+        });
+    });
+
+    await context.route("**/sanctum/csrf-cookie", async (route) => {
+        await ensureMockXsrfCookie(context);
+
+        await route.fulfill({
+            status: 204,
+            headers: {
+                "set-cookie": `XSRF-TOKEN=${MOCK_XSRF_TOKEN}; Path=/; SameSite=Lax; Secure`,
+            },
+            body: "",
+        });
+    });
+
+    await context.route("**/v1/auth/login", async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({ user: offlineLiveMockUser }),
+        });
+    });
+
+    await context.route("**/v1/me", async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(offlineLiveMockUser),
+        });
+    });
+
+    await context.route("**/v1/auth/logout", async (route) => {
+        await route.fulfill({
+            status: 204,
+            body: "",
+        });
+    });
+}
+
+export async function installMockOrganizationRoutes(
+    context: BrowserContext
+): Promise<void> {
+    await context.route("**/v1/organizational-units**", async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+                data: [offlineLiveMockOrganizationUnit],
+                meta: {
+                    current_page: 1,
+                    last_page: 1,
+                    per_page: 100,
+                    total: 1,
+                    root_unit_ids: [offlineLiveMockOrganizationUnit.id],
+                },
+            }),
+        });
+    });
+}
+
+export async function ensureActiveServiceWorker(page: Page): Promise<void> {
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(async () => {
+        if (!("serviceWorker" in navigator)) {
+            return;
+        }
+
+        await navigator.serviceWorker.ready;
+    });
+
+    const hasController = await page.evaluate(() => {
+        return (
+            "serviceWorker" in navigator &&
+            navigator.serviceWorker.controller !== null
+        );
+    });
+
+    if (!hasController) {
+        await page.reload();
+        await page.waitForLoadState("networkidle");
+    }
+}
+
+export async function loginWithMockedBrowserSession(page: Page): Promise<void> {
+    await page.goto("/login");
+    await ensureActiveServiceWorker(page);
+
+    await page.locator("#email").fill(offlineLiveMockUser.email);
+    await page.locator("#password").fill("password");
+    await waitForLoginFormReady(page);
+    await page
+        .getByRole("button", { name: /log in|anmelden|einloggen/i })
+        .click();
+
+    await expect(page).toHaveURL(/\/$/);
+}

--- a/tests/e2e/offline-live-helpers.ts
+++ b/tests/e2e/offline-live-helpers.ts
@@ -7,154 +7,155 @@ import { waitForLoginFormReady } from "./auth-helpers";
 const MOCK_XSRF_TOKEN = "test-xsrf-token";
 
 async function ensureMockXsrfCookie(context: BrowserContext): Promise<void> {
-    await context.addCookies([
-        {
-            name: "XSRF-TOKEN",
-            value: MOCK_XSRF_TOKEN,
-            domain: "app.secpal.dev",
-            path: "/",
-            sameSite: "Lax",
-            secure: true,
-            httpOnly: false,
-        },
-    ]);
+  await context.addCookies([
+    {
+      name: "XSRF-TOKEN",
+      value: MOCK_XSRF_TOKEN,
+      domain: "app.secpal.dev",
+      path: "/",
+      sameSite: "Lax",
+      secure: true,
+      httpOnly: false,
+    },
+  ]);
 }
 
 export const offlineLiveMockUser = {
-    id: "42",
-    name: "Jane Example",
-    email: "jane.example@secpal.app",
-    emailVerified: true,
-    roles: ["Manager"],
-    permissions: [],
-    hasOrganizationalScopes: true,
-    hasCustomerAccess: false,
-    hasSiteAccess: false,
+  id: "42",
+  name: "Jane Example",
+  email: "jane.example@secpal.app",
+  emailVerified: true,
+  roles: ["Manager"],
+  permissions: [],
+  hasOrganizationalScopes: true,
+  hasCustomerAccess: false,
+  hasSiteAccess: false,
 };
 
 export const offlineLiveMockOrganizationUnit = {
-    id: "org-root-1",
-    type: "holding",
-    name: "Headquarters Holding",
-    custom_type_name: null,
-    description: "Primary organizational root for offline live Playwright coverage.",
-    parent: null,
-    created_at: "2026-04-19T00:00:00Z",
-    updated_at: "2026-04-19T00:00:00Z",
+  id: "org-root-1",
+  type: "holding",
+  name: "Headquarters Holding",
+  custom_type_name: null,
+  description:
+    "Primary organizational root for offline live Playwright coverage.",
+  parent: null,
+  created_at: "2026-04-19T00:00:00Z",
+  updated_at: "2026-04-19T00:00:00Z",
 };
 
 export async function installMockAuthRoutes(
-    context: BrowserContext
+  context: BrowserContext
 ): Promise<void> {
+  await ensureMockXsrfCookie(context);
+
+  await context.route("**/health/ready", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        status: "ready",
+        checks: {
+          database: "ok",
+          tenant_keys: "ok",
+          kek_file: "ok",
+        },
+        timestamp: new Date().toISOString(),
+      }),
+    });
+  });
+
+  await context.route("**/sanctum/csrf-cookie", async (route) => {
     await ensureMockXsrfCookie(context);
 
-    await context.route("**/health/ready", async (route) => {
-        await route.fulfill({
-            status: 200,
-            contentType: "application/json",
-            body: JSON.stringify({
-                status: "ready",
-                checks: {
-                    database: "ok",
-                    tenant_keys: "ok",
-                    kek_file: "ok",
-                },
-                timestamp: new Date().toISOString(),
-            }),
-        });
+    await route.fulfill({
+      status: 204,
+      headers: {
+        "set-cookie": `XSRF-TOKEN=${MOCK_XSRF_TOKEN}; Path=/; SameSite=Lax; Secure`,
+      },
+      body: "",
     });
+  });
 
-    await context.route("**/sanctum/csrf-cookie", async (route) => {
-        await ensureMockXsrfCookie(context);
-
-        await route.fulfill({
-            status: 204,
-            headers: {
-                "set-cookie": `XSRF-TOKEN=${MOCK_XSRF_TOKEN}; Path=/; SameSite=Lax; Secure`,
-            },
-            body: "",
-        });
+  await context.route("**/v1/auth/login", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ user: offlineLiveMockUser }),
     });
+  });
 
-    await context.route("**/v1/auth/login", async (route) => {
-        await route.fulfill({
-            status: 200,
-            contentType: "application/json",
-            body: JSON.stringify({ user: offlineLiveMockUser }),
-        });
+  await context.route("**/v1/me", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(offlineLiveMockUser),
     });
+  });
 
-    await context.route("**/v1/me", async (route) => {
-        await route.fulfill({
-            status: 200,
-            contentType: "application/json",
-            body: JSON.stringify(offlineLiveMockUser),
-        });
+  await context.route("**/v1/auth/logout", async (route) => {
+    await route.fulfill({
+      status: 204,
+      body: "",
     });
-
-    await context.route("**/v1/auth/logout", async (route) => {
-        await route.fulfill({
-            status: 204,
-            body: "",
-        });
-    });
+  });
 }
 
 export async function installMockOrganizationRoutes(
-    context: BrowserContext
+  context: BrowserContext
 ): Promise<void> {
-    await context.route("**/v1/organizational-units**", async (route) => {
-        await route.fulfill({
-            status: 200,
-            contentType: "application/json",
-            body: JSON.stringify({
-                data: [offlineLiveMockOrganizationUnit],
-                meta: {
-                    current_page: 1,
-                    last_page: 1,
-                    per_page: 100,
-                    total: 1,
-                    root_unit_ids: [offlineLiveMockOrganizationUnit.id],
-                },
-            }),
-        });
+  await context.route("**/v1/organizational-units**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        data: [offlineLiveMockOrganizationUnit],
+        meta: {
+          current_page: 1,
+          last_page: 1,
+          per_page: 100,
+          total: 1,
+          root_unit_ids: [offlineLiveMockOrganizationUnit.id],
+        },
+      }),
     });
+  });
 }
 
 export async function ensureActiveServiceWorker(page: Page): Promise<void> {
-    await page.waitForLoadState("networkidle");
+  await page.waitForLoadState("networkidle");
 
-    await page.evaluate(async () => {
-        if (!("serviceWorker" in navigator)) {
-            return;
-        }
-
-        await navigator.serviceWorker.ready;
-    });
-
-    const hasController = await page.evaluate(() => {
-        return (
-            "serviceWorker" in navigator &&
-            navigator.serviceWorker.controller !== null
-        );
-    });
-
-    if (!hasController) {
-        await page.reload();
-        await page.waitForLoadState("networkidle");
+  await page.evaluate(async () => {
+    if (!("serviceWorker" in navigator)) {
+      return;
     }
+
+    await navigator.serviceWorker.ready;
+  });
+
+  const hasController = await page.evaluate(() => {
+    return (
+      "serviceWorker" in navigator &&
+      navigator.serviceWorker.controller !== null
+    );
+  });
+
+  if (!hasController) {
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+  }
 }
 
 export async function loginWithMockedBrowserSession(page: Page): Promise<void> {
-    await page.goto("/login");
-    await ensureActiveServiceWorker(page);
+  await page.goto("/login");
+  await ensureActiveServiceWorker(page);
 
-    await page.locator("#email").fill(offlineLiveMockUser.email);
-    await page.locator("#password").fill("password");
-    await waitForLoginFormReady(page);
-    await page
-        .getByRole("button", { name: /log in|anmelden|einloggen/i })
-        .click();
+  await page.locator("#email").fill(offlineLiveMockUser.email);
+  await page.locator("#password").fill("password");
+  await waitForLoginFormReady(page);
+  await page
+    .getByRole("button", { name: /log in|anmelden|einloggen/i })
+    .click();
 
-    await expect(page).toHaveURL(/\/$/);
+  await expect(page).toHaveURL(/\/$/);
 }

--- a/tests/e2e/offline-live-helpers.ts
+++ b/tests/e2e/offline-live-helpers.ts
@@ -2,19 +2,28 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { expect, type BrowserContext, type Page } from "@playwright/test";
-import { waitForLoginFormReady } from "./auth-helpers";
+import { isRemoteE2ETarget, waitForLoginFormReady } from "./auth-helpers";
 
 const MOCK_XSRF_TOKEN = "test-xsrf-token";
 
+function getMockCookieDomain(): string {
+  const baseUrl = process.env.PLAYWRIGHT_BASE_URL ?? "";
+  if (isRemoteE2ETarget(baseUrl)) {
+    return new URL(baseUrl).hostname;
+  }
+  return "localhost";
+}
+
 async function ensureMockXsrfCookie(context: BrowserContext): Promise<void> {
+  const isHttps = isRemoteE2ETarget(process.env.PLAYWRIGHT_BASE_URL);
   await context.addCookies([
     {
       name: "XSRF-TOKEN",
       value: MOCK_XSRF_TOKEN,
-      domain: "app.secpal.dev",
+      domain: getMockCookieDomain(),
       path: "/",
       sameSite: "Lax",
-      secure: true,
+      secure: isHttps,
       httpOnly: false,
     },
   ]);
@@ -68,10 +77,11 @@ export async function installMockAuthRoutes(
   await context.route("**/sanctum/csrf-cookie", async (route) => {
     await ensureMockXsrfCookie(context);
 
+    const isHttps = isRemoteE2ETarget(process.env.PLAYWRIGHT_BASE_URL);
     await route.fulfill({
       status: 204,
       headers: {
-        "set-cookie": `XSRF-TOKEN=${MOCK_XSRF_TOKEN}; Path=/; SameSite=Lax; Secure`,
+        "set-cookie": `XSRF-TOKEN=${MOCK_XSRF_TOKEN}; Path=/; SameSite=Lax${isHttps ? "; Secure" : ""}`,
       },
       body: "",
     });

--- a/tests/e2e/offline-logout.spec.ts
+++ b/tests/e2e/offline-logout.spec.ts
@@ -1,100 +1,18 @@
 // SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { expect, test, type BrowserContext, type Page } from "@playwright/test";
-import { waitForLoginFormReady } from "./auth-helpers";
+import { expect, test } from "@playwright/test";
+import {
+  installMockAuthRoutes,
+  loginWithMockedBrowserSession,
+  offlineLiveMockUser,
+} from "./offline-live-helpers";
 
 const supportsServiceWorkerOfflineFlows =
   Boolean(process.env.CI) ||
   (process.env.PLAYWRIGHT_BASE_URL?.startsWith("https://") ?? false);
 
-const offlineLogoutMockUser = {
-  id: 42,
-  name: "Jane Example",
-  email: "jane.example@secpal.app",
-  roles: ["Employee"],
-  permissions: [],
-  hasOrganizationalScopes: false,
-  hasCustomerAccess: false,
-  hasSiteAccess: false,
-};
-
 const OFFLINE_SESSION_STATE_PATH = "/__session-state__";
-
-async function installMockAuthRoutes(context: BrowserContext): Promise<void> {
-  await context.route("**/health/ready", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        status: "ready",
-        checks: {
-          database: "ok",
-          tenant_keys: "ok",
-          kek_file: "ok",
-        },
-        timestamp: new Date().toISOString(),
-      }),
-    });
-  });
-
-  await context.route("**/sanctum/csrf-cookie", async (route) => {
-    await route.fulfill({
-      status: 204,
-      headers: {
-        "set-cookie": "XSRF-TOKEN=test-xsrf-token; Path=/; SameSite=Lax",
-      },
-      body: "",
-    });
-  });
-
-  await context.route("**/v1/auth/login", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({ user: offlineLogoutMockUser }),
-    });
-  });
-
-  await context.route("**/v1/me", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify(offlineLogoutMockUser),
-    });
-  });
-
-  await context.route("**/v1/auth/logout", async (route) => {
-    await route.fulfill({
-      status: 204,
-      body: "",
-    });
-  });
-}
-
-async function ensureActiveServiceWorker(page: Page): Promise<void> {
-  await page.waitForLoadState("networkidle");
-
-  await page.evaluate(async () => {
-    if (!("serviceWorker" in navigator)) {
-      return;
-    }
-
-    await navigator.serviceWorker.ready;
-  });
-
-  const hasController = await page.evaluate(() => {
-    return (
-      "serviceWorker" in navigator &&
-      navigator.serviceWorker.controller !== null
-    );
-  });
-
-  if (!hasController) {
-    await page.reload();
-    await page.waitForLoadState("networkidle");
-  }
-}
 
 test.describe("Offline Logout Privacy", () => {
   test("should block offline access to the cached profile page after logout", async ({
@@ -107,18 +25,7 @@ test.describe("Offline Logout Privacy", () => {
     );
 
     await installMockAuthRoutes(context);
-
-    await page.goto("/login");
-    await ensureActiveServiceWorker(page);
-
-    await page.locator("#email").fill(offlineLogoutMockUser.email);
-    await page.locator("#password").fill("password");
-    await waitForLoginFormReady(page);
-    await page
-      .getByRole("button", { name: /log in|anmelden|einloggen/i })
-      .click();
-
-    await expect(page).toHaveURL(/\/$/);
+    await loginWithMockedBrowserSession(page);
 
     await page.goto("/profile");
     await page.waitForLoadState("networkidle");
@@ -127,10 +34,10 @@ test.describe("Offline Logout Privacy", () => {
       page.getByRole("heading", { name: /my profile/i })
     ).toBeVisible();
     await expect(
-      page.getByText(offlineLogoutMockUser.name).first()
+      page.getByText(offlineLiveMockUser.name).first()
     ).toBeVisible();
     await expect(
-      page.getByText(offlineLogoutMockUser.email).first()
+      page.getByText(offlineLiveMockUser.email).first()
     ).toBeVisible();
 
     await context.setOffline(true);
@@ -141,10 +48,10 @@ test.describe("Offline Logout Privacy", () => {
       page.getByRole("heading", { name: /my profile/i })
     ).toBeVisible();
     await expect(
-      page.getByText(offlineLogoutMockUser.name).first()
+      page.getByText(offlineLiveMockUser.name).first()
     ).toBeVisible();
     await expect(
-      page.getByText(offlineLogoutMockUser.email).first()
+      page.getByText(offlineLiveMockUser.email).first()
     ).toBeVisible();
 
     await page.evaluate(() => {
@@ -219,10 +126,10 @@ test.describe("Offline Logout Privacy", () => {
     await expect(page.locator("#email")).toBeVisible();
     await expect(page.locator("#password")).toBeVisible();
     await expect(
-      page.getByText(offlineLogoutMockUser.name).first()
+      page.getByText(offlineLiveMockUser.name).first()
     ).not.toBeVisible();
     await expect(
-      page.getByText(offlineLogoutMockUser.email).first()
+      page.getByText(offlineLiveMockUser.email).first()
     ).not.toBeVisible();
 
     await page.goto("/settings").catch(() => undefined);

--- a/tests/e2e/offline.spec.ts
+++ b/tests/e2e/offline.spec.ts
@@ -213,8 +213,12 @@ test.describe("Offline Functionality", () => {
       await expect(
         page.getByRole("heading", { name: /My Profile/i })
       ).toBeVisible();
-      await expect(page.getByText(offlineLiveMockUser.name).first()).toBeVisible();
-      await expect(page.getByText(offlineLiveMockUser.email).first()).toBeVisible();
+      await expect(
+        page.getByText(offlineLiveMockUser.name).first()
+      ).toBeVisible();
+      await expect(
+        page.getByText(offlineLiveMockUser.email).first()
+      ).toBeVisible();
 
       // Step 2: Go offline
       await page.context().setOffline(true);
@@ -238,8 +242,12 @@ test.describe("Offline Functionality", () => {
       await expect(
         page.getByRole("heading", { name: /My Profile/i })
       ).toBeVisible();
-      await expect(page.getByText(offlineLiveMockUser.name).first()).toBeVisible();
-      await expect(page.getByText(offlineLiveMockUser.email).first()).toBeVisible();
+      await expect(
+        page.getByText(offlineLiveMockUser.name).first()
+      ).toBeVisible();
+      await expect(
+        page.getByText(offlineLiveMockUser.email).first()
+      ).toBeVisible();
 
       // Step 5: Navigate back to Organization using nav links
       const orgNavLink = page.getByRole("link", { name: /Organization/i });

--- a/tests/e2e/offline.spec.ts
+++ b/tests/e2e/offline.spec.ts
@@ -2,6 +2,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { test, expect } from "./auth.setup";
+import {
+  installMockAuthRoutes,
+  installMockOrganizationRoutes,
+  loginWithMockedBrowserSession,
+  offlineLiveMockOrganizationUnit,
+  offlineLiveMockUser,
+} from "./offline-live-helpers";
 
 const supportsServiceWorkerOfflineFlows =
   Boolean(process.env.CI) ||
@@ -23,12 +30,17 @@ const supportsServiceWorkerOfflineFlows =
 test.describe("Offline Functionality", () => {
   test.describe("Organization Page Offline", () => {
     test("should display cached organizational units when offline", async ({
-      authenticatedPage: page,
+      page,
+      context,
     }) => {
       test.skip(
         !supportsServiceWorkerOfflineFlows,
         "Requires preview/staging mode with an active service worker."
       );
+
+      await installMockAuthRoutes(context);
+      await installMockOrganizationRoutes(context);
+      await loginWithMockedBrowserSession(page);
 
       // Step 1: Load page online to populate cache
       await page.goto("/organization");
@@ -37,6 +49,9 @@ test.describe("Offline Functionality", () => {
       // Wait for units to load
       await expect(
         page.getByRole("heading", { name: /Organization Structure/i })
+      ).toBeVisible();
+      await expect(
+        page.getByText(offlineLiveMockOrganizationUnit.name).first()
       ).toBeVisible();
 
       // Step 2: Go offline
@@ -50,10 +65,13 @@ test.describe("Offline Functionality", () => {
       await expect(
         page.getByRole("heading", { name: /Organization Structure/i })
       ).toBeVisible();
+      await expect(
+        page.getByText(offlineLiveMockOrganizationUnit.name).first()
+      ).toBeVisible();
 
       // Should show offline indicator banner
       await expect(
-        page.getByText(/You're offline.*Viewing cached/i)
+        page.getByText(/You're offline - showing cached data/i)
       ).toBeVisible();
 
       // Go back online
@@ -168,12 +186,17 @@ test.describe("Offline Functionality", () => {
 
   test.describe("Offline Navigation", () => {
     test("should navigate between Organization and Profile while offline", async ({
-      authenticatedPage: page,
+      page,
+      context,
     }) => {
       test.skip(
         !supportsServiceWorkerOfflineFlows,
         "Requires preview/staging mode with an active service worker."
       );
+
+      await installMockAuthRoutes(context);
+      await installMockOrganizationRoutes(context);
+      await loginWithMockedBrowserSession(page);
 
       // Step 1: Visit both pages online to cache them
       await page.goto("/organization");
@@ -181,12 +204,17 @@ test.describe("Offline Functionality", () => {
       await expect(
         page.getByRole("heading", { name: /Organization Structure/i })
       ).toBeVisible();
+      await expect(
+        page.getByText(offlineLiveMockOrganizationUnit.name).first()
+      ).toBeVisible();
 
       await page.goto("/profile");
       await page.waitForLoadState("networkidle");
       await expect(
         page.getByRole("heading", { name: /My Profile/i })
       ).toBeVisible();
+      await expect(page.getByText(offlineLiveMockUser.name).first()).toBeVisible();
+      await expect(page.getByText(offlineLiveMockUser.email).first()).toBeVisible();
 
       // Step 2: Go offline
       await page.context().setOffline(true);
@@ -198,7 +226,10 @@ test.describe("Offline Functionality", () => {
         page.getByRole("heading", { name: /Organization Structure/i })
       ).toBeVisible();
       await expect(
-        page.getByText(/You're offline.*Viewing cached/i)
+        page.getByText(/You're offline - showing cached data/i)
+      ).toBeVisible();
+      await expect(
+        page.getByText(offlineLiveMockOrganizationUnit.name).first()
       ).toBeVisible();
 
       // Step 4: Navigate to Profile
@@ -207,6 +238,8 @@ test.describe("Offline Functionality", () => {
       await expect(
         page.getByRole("heading", { name: /My Profile/i })
       ).toBeVisible();
+      await expect(page.getByText(offlineLiveMockUser.name).first()).toBeVisible();
+      await expect(page.getByText(offlineLiveMockUser.email).first()).toBeVisible();
 
       // Step 5: Navigate back to Organization using nav links
       const orgNavLink = page.getByRole("link", { name: /Organization/i });
@@ -215,6 +248,9 @@ test.describe("Offline Functionality", () => {
         await page.waitForLoadState("networkidle");
         await expect(
           page.getByRole("heading", { name: /Organization Structure/i })
+        ).toBeVisible();
+        await expect(
+          page.getByText(offlineLiveMockOrganizationUnit.name).first()
         ).toBeVisible();
       }
 


### PR DESCRIPTION
## Summary
- stabilize the live Playwright offline coverage by moving the flaky service-worker offline route assertions onto deterministic mocked auth and organizational-unit fixtures
- persist the mocked XSRF cookie in the browser context so mocked browser-session logins actually write and restore encrypted auth storage across offline reloads
- mark the mocked offline logout user as verified so the privacy flow reaches the cached profile page before logout and then proves offline access is blocked afterward

Closes #930

## Validation
- `npx eslint tests/e2e/offline-live-helpers.ts tests/e2e/offline.spec.ts tests/e2e/offline-logout.spec.ts --max-warnings 0`
- `npm run typecheck`
- `PLAYWRIGHT_BASE_URL=https://app.secpal.dev TEST_USER_EMAIL=test@example.com TEST_USER_PASSWORD=password PLAYWRIGHT_SKIP_GLOBAL_LOGIN=1 npx playwright test tests/e2e/offline.spec.ts tests/e2e/offline-logout.spec.ts --project=chromium`

## Notes
- this PR intentionally keeps the service worker and live app shell real while mocking the auth and organizational-unit data required for deterministic offline assertions
- the remaining non-offline live Playwright clusters stay tracked separately under #931, #932, and #933
