### PR TITLE
fix: stabilize local Playwright auth bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Stopped default local Playwright E2E runs from inheriting developer-only `VITE_API_URL` overrides out of `.env.local`, and aligned the local Playwright auth defaults with the API seeder's `test@example.com` admin so `npm run test:e2e` no longer fails before the suite reaches real assertions, resolving frontend issue #942.
 - Stabilized the live Playwright offline coverage by moving the flaky service-worker offline route assertions onto deterministic mocked auth and organizational-unit fixtures, correcting the offline banner expectation to the shipped copy, and marking the mocked offline-logout session as verified so the privacy flow reaches the profile page before logout.
 - Stopped browser-session auth from collapsing into an immediate frontend logout on protected routes when the local `auth_user` snapshot is missing or becomes unreadable after an `XSRF-TOKEN` rotation; bootstrap now falls back to `/v1/me` revalidation instead of treating client-side storage drift as a confirmed sign-out.
 - Taught the Playwright auth bootstrap helper to detect the protected-route secure-session recovery screen immediately and refresh the saved auth state after a fallback UI login, so stale reused live auth storage no longer burns the full auth-resolution timeout before re-authenticating, resolving frontend issue #936.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -129,6 +129,10 @@ export default defineConfig({
         }
       : {
           command: "npm run dev",
+          env: {
+            ...process.env,
+            VITE_API_URL: "",
+          },
           url: "http://localhost:5173",
           reuseExistingServer: true, // Reuse if already running
           timeout: 30_000,

--- a/tests/auth-e2e-helpers.test.ts
+++ b/tests/auth-e2e-helpers.test.ts
@@ -26,7 +26,7 @@ describe("auth E2E helpers", () => {
   describe("buildTestUser", () => {
     it("uses local development defaults for non-remote targets", () => {
       expect(buildTestUser({}, undefined)).toEqual({
-        email: "test@secpal.dev",
+        email: "test@example.com",
         password: "password",
       });
     });

--- a/tests/e2e/auth-helpers.ts
+++ b/tests/e2e/auth-helpers.ts
@@ -31,7 +31,7 @@ export type AuthResolution =
   | "unresolved";
 
 const DEFAULT_LOCAL_TEST_USER: TestUserCredentials = {
-  email: "test@secpal.dev",
+  email: "test@example.com",
   password: "password",
 };
 

--- a/tests/e2e/auth.setup.ts
+++ b/tests/e2e/auth.setup.ts
@@ -7,9 +7,14 @@ import { test as base, expect, type Page } from "@playwright/test";
 import {
   buildTestUser,
   getConfiguredTestUserOrThrow,
+  isRemoteE2ETarget,
   waitForAuthResolution,
   waitForLoginFormReady,
 } from "./auth-helpers";
+import {
+  installMockAuthRoutes,
+  installStoredMockBrowserSession,
+} from "./offline-live-helpers";
 
 /**
  * Test Credentials
@@ -69,6 +74,7 @@ const AUTH_FILE = "./tests/e2e/.auth/user.json";
 export const test = base.extend<{ authenticatedPage: Page }>({
   authenticatedPage: async ({ browser }, runTest) => {
     const configuredTestUser = getConfiguredTestUserOrThrow();
+    const usesRemoteTarget = isRemoteE2ETarget();
     let shouldRefreshAuthState = false;
 
     // Try to use saved auth state
@@ -78,6 +84,10 @@ export const test = base.extend<{ authenticatedPage: Page }>({
     } catch {
       // Fall back to fresh context if auth file doesn't exist
       context = await browser.newContext();
+    }
+
+    if (!usesRemoteTarget) {
+      await installMockAuthRoutes(context);
     }
 
     const page = await context.newPage();
@@ -91,11 +101,17 @@ export const test = base.extend<{ authenticatedPage: Page }>({
     if (authResolution !== "authenticated") {
       shouldRefreshAuthState = true;
 
-      await loginViaUI(
-        page,
-        configuredTestUser.email,
-        configuredTestUser.password
-      );
+      if (usesRemoteTarget) {
+        await loginViaUI(
+          page,
+          configuredTestUser.email,
+          configuredTestUser.password
+        );
+      } else {
+        await installStoredMockBrowserSession(page);
+        await page.goto("/");
+        await page.waitForLoadState("networkidle");
+      }
     }
 
     // Verify we're logged in with the actual authenticated application shell.

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -12,114 +12,126 @@ import { installMockAuthRoutes } from "./offline-live-helpers";
  */
 
 test.describe("Authentication", () => {
-  test.beforeEach(async ({ context }) => {
-    if (!isRemoteE2ETarget()) {
-      await installMockAuthRoutes(context);
-    }
-  });
-
-  test("should login with valid credentials", async ({ page }) => {
-    await page.goto("/login");
-    await page.waitForLoadState("networkidle");
-
-    // Verify login page is shown (using ID selectors matching Login.tsx)
-    await expect(page.locator("#email")).toBeVisible();
-    await expect(page.locator("#password")).toBeVisible();
-
-    // Perform login
-    await loginViaUI(page);
-
-    // Should be redirected to home/dashboard
-    expect(page.url()).not.toContain("/login");
-
-    // Should see authenticated UI elements (e.g., navigation, user menu)
-    await expect(
-      page.getByRole("navigation").or(page.locator('[data-slot="sidebar"]'))
-    ).toBeVisible();
-  });
-
-  test("should reject invalid credentials", async ({ page }) => {
-    await page.goto("/login");
-    await page.waitForLoadState("networkidle");
-
-    // Try to login with wrong password
-    await page.locator("#email").fill("wrong-user@secpal.dev");
-    await page.locator("#password").fill("wrongpassword");
-    await waitForLoginFormReady(page);
-    await page
-      .getByRole("button", { name: /log in|anmelden|einloggen/i })
-      .click();
-
-    // Should stay on login page
-    await expect(page).toHaveURL(/\/login/);
-
-    // Should show error message
-    await expect(
-      page.getByText(/invalid|incorrect|falsch|ungültig|credentials/i)
-    ).toBeVisible({ timeout: 10_000 });
-  });
-
-  test("should logout successfully", async ({ page }) => {
-    // Use a fresh UI login so this destructive flow does not invalidate the
-    // shared authenticated fixture state used by parallel auth tests.
-    await loginViaUI(page);
-
-    // Now we should be on the dashboard - open the user menu
-    const dropdownTrigger = page.getByRole("button", {
-      name: /user menu/i,
+  // Unauthenticated paths — use the default `page` + `context` fixtures so
+  // mock routes are installed on exactly the context each test uses.
+  test.describe("unauthenticated paths", () => {
+    test.beforeEach(async ({ context }) => {
+      if (!isRemoteE2ETarget()) {
+        await installMockAuthRoutes(context);
+      }
     });
 
-    // Click to open user menu dropdown
-    await dropdownTrigger.click();
+    test("should login with valid credentials", async ({ page }) => {
+      await page.goto("/login");
+      await page.waitForLoadState("networkidle");
 
-    // Wait for dropdown menu to appear and click "Sign out"
-    await page
-      .getByRole("menuitem", { name: /sign out|abmelden/i })
-      .click({ timeout: 5_000 });
+      // Verify login page is shown (using ID selectors matching Login.tsx)
+      await expect(page.locator("#email")).toBeVisible();
+      await expect(page.locator("#password")).toBeVisible();
 
-    // Should redirect to login page
-    await expect(page).toHaveURL(/\/login/, { timeout: 10_000 });
-  });
+      // Perform login
+      await loginViaUI(page);
 
-  test("should persist session across page reload", async ({
-    authenticatedPage: page,
-  }) => {
-    // Reload page
-    await page.reload();
-    await page.waitForLoadState("networkidle");
+      // Should be redirected to home/dashboard
+      expect(page.url()).not.toContain("/login");
 
-    // Should still be logged in (not redirected to login)
-    expect(page.url()).not.toContain("/login");
-  });
-
-  test("should stay authenticated when deep-linking to a protected route and reloading it", async ({
-    authenticatedPage: page,
-  }) => {
-    await page.goto("/customers");
-    await page.waitForLoadState("networkidle");
-
-    await expect(page).toHaveURL(/\/customers$/);
-    await expect(page.getByRole("button", { name: /user menu/i })).toBeVisible({
-      timeout: 15_000,
+      // Should see authenticated UI elements (e.g., navigation, user menu)
+      await expect(
+        page.getByRole("navigation").or(page.locator('[data-slot="sidebar"]'))
+      ).toBeVisible();
     });
 
-    await page.reload();
-    await page.waitForLoadState("networkidle");
+    test("should reject invalid credentials", async ({ page }) => {
+      await page.goto("/login");
+      await page.waitForLoadState("networkidle");
 
-    await expect(page).toHaveURL(/\/customers$/);
-    await expect(page.getByRole("button", { name: /user menu/i })).toBeVisible({
-      timeout: 15_000,
+      // Try to login with wrong password
+      await page.locator("#email").fill("wrong-user@secpal.dev");
+      await page.locator("#password").fill("wrongpassword");
+      await waitForLoginFormReady(page);
+      await page
+        .getByRole("button", { name: /log in|anmelden|einloggen/i })
+        .click();
+
+      // Should stay on login page
+      await expect(page).toHaveURL(/\/login/);
+
+      // Should show error message
+      await expect(
+        page.getByText(/invalid|incorrect|falsch|ungültig|credentials/i)
+      ).toBeVisible({ timeout: 10_000 });
+    });
+
+    test("should logout successfully", async ({ page }) => {
+      // Use a fresh UI login so this destructive flow does not invalidate the
+      // shared authenticated fixture state used by parallel auth tests.
+      await loginViaUI(page);
+
+      // Now we should be on the dashboard - open the user menu
+      const dropdownTrigger = page.getByRole("button", {
+        name: /user menu/i,
+      });
+
+      // Click to open user menu dropdown
+      await dropdownTrigger.click();
+
+      // Wait for dropdown menu to appear and click "Sign out"
+      await page
+        .getByRole("menuitem", { name: /sign out|abmelden/i })
+        .click({ timeout: 5_000 });
+
+      // Should redirect to login page
+      await expect(page).toHaveURL(/\/login/, { timeout: 10_000 });
+    });
+
+    test("should redirect to login when accessing protected route without auth", async ({
+      page,
+    }) => {
+      // Try to access protected route directly
+      await page.goto("/organization");
+      await page.waitForLoadState("networkidle");
+
+      // Should redirect to login
+      await expect(page).toHaveURL(/\/login/);
     });
   });
 
-  test("should redirect to login when accessing protected route without auth", async ({
-    page,
-  }) => {
-    // Try to access protected route directly
-    await page.goto("/organization");
-    await page.waitForLoadState("networkidle");
+  // Session persistence — `authenticatedPage` installs its own mock routes;
+  // no beforeEach needed here to avoid creating an extra unused context.
+  test.describe("session persistence", () => {
+    test("should persist session across page reload", async ({
+      authenticatedPage: page,
+    }) => {
+      // Reload page
+      await page.reload();
+      await page.waitForLoadState("networkidle");
 
-    // Should redirect to login
-    await expect(page).toHaveURL(/\/login/);
+      // Should still be logged in (not redirected to login)
+      expect(page.url()).not.toContain("/login");
+    });
+
+    test("should stay authenticated when deep-linking to a protected route and reloading it", async ({
+      authenticatedPage: page,
+    }) => {
+      await page.goto("/customers");
+      await page.waitForLoadState("networkidle");
+
+      await expect(page).toHaveURL(/\/customers$/);
+      await expect(
+        page.getByRole("button", { name: /user menu/i })
+      ).toBeVisible({
+        timeout: 15_000,
+      });
+
+      await page.reload();
+      await page.waitForLoadState("networkidle");
+
+      await expect(page).toHaveURL(/\/customers$/);
+      await expect(
+        page.getByRole("button", { name: /user menu/i })
+      ).toBeVisible({
+        timeout: 15_000,
+      });
+    });
   });
 });

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { test, expect, loginViaUI } from "./auth.setup";
-import { waitForLoginFormReady } from "./auth-helpers";
+import { isRemoteE2ETarget, waitForLoginFormReady } from "./auth-helpers";
+import { installMockAuthRoutes } from "./offline-live-helpers";
 
 /**
  * Authentication Flow Tests
@@ -11,6 +12,12 @@ import { waitForLoginFormReady } from "./auth-helpers";
  */
 
 test.describe("Authentication", () => {
+  test.beforeEach(async ({ context }) => {
+    if (!isRemoteE2ETarget()) {
+      await installMockAuthRoutes(context);
+    }
+  });
+
   test("should login with valid credentials", async ({ page }) => {
     await page.goto("/login");
     await page.waitForLoadState("networkidle");

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,11 +1,16 @@
 // SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { chromium, type FullConfig } from "@playwright/test";
+import { chromium, expect, type FullConfig } from "@playwright/test";
 import {
   getConfiguredTestUserOrThrow,
+  isRemoteE2ETarget,
   waitForLoginFormReady,
 } from "./auth-helpers";
+import {
+  installMockAuthRoutes,
+  installStoredMockBrowserSession,
+} from "./offline-live-helpers";
 import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
@@ -35,8 +40,10 @@ async function globalSetup(config: FullConfig) {
     fs.mkdirSync(authDir, { recursive: true });
   }
 
+  const baseURL = config.projects[0]?.use?.baseURL || "http://localhost:5173";
+
   // Skip if auth file already exists and is recent (< 30 minutes old)
-  if (fs.existsSync(AUTH_FILE)) {
+  if (isRemoteE2ETarget(String(baseURL)) && fs.existsSync(AUTH_FILE)) {
     const stats = fs.statSync(AUTH_FILE);
     const ageMinutes = (Date.now() - stats.mtimeMs) / 1000 / 60;
     if (ageMinutes < 30) {
@@ -49,13 +56,25 @@ async function globalSetup(config: FullConfig) {
 
   const testUser = getConfiguredTestUserOrThrow();
 
-  const baseURL = config.projects[0]?.use?.baseURL || "http://localhost:5173";
-
   const browser = await chromium.launch();
   const context = await browser.newContext();
   const page = await context.newPage();
 
   try {
+    if (!isRemoteE2ETarget(String(baseURL))) {
+      await installMockAuthRoutes(context);
+      await installStoredMockBrowserSession(page);
+      await page.goto(baseURL);
+      await page.waitForLoadState("networkidle");
+      await expect(
+        page.getByRole("button", { name: /user menu/i })
+      ).toBeVisible({ timeout: 15_000 });
+
+      await context.storageState({ path: AUTH_FILE });
+      console.log("✅ Local mocked auth session saved");
+      return;
+    }
+
     // Navigate to login page
     await page.goto(`${baseURL}/login`);
     await page.waitForLoadState("networkidle");

--- a/tests/e2e/offline-live-helpers.ts
+++ b/tests/e2e/offline-live-helpers.ts
@@ -69,7 +69,9 @@ function requestHasMockSessionCookie(cookieHeader: string | null): boolean {
 
   return cookieHeader
     .split(";")
-    .some((cookie) => cookie.trim() === `${MOCK_SESSION_COOKIE_NAME}=authenticated`);
+    .some(
+      (cookie) => cookie.trim() === `${MOCK_SESSION_COOKIE_NAME}=authenticated`
+    );
 }
 
 export const offlineLiveMockOrganizationUnit = {
@@ -153,9 +155,7 @@ export async function installMockAuthRoutes(
 
   await context.route("**/v1/me", async (route) => {
     if (
-      !requestHasMockSessionCookie(
-        await route.request().headerValue("cookie")
-      )
+      !requestHasMockSessionCookie(await route.request().headerValue("cookie"))
     ) {
       await route.fulfill({
         status: 401,
@@ -186,9 +186,7 @@ export async function installMockAuthRoutes(
 
   await context.route("**/v1/customers**", async (route) => {
     if (
-      !requestHasMockSessionCookie(
-        await route.request().headerValue("cookie")
-      )
+      !requestHasMockSessionCookie(await route.request().headerValue("cookie"))
     ) {
       await route.fulfill({
         status: 401,

--- a/tests/e2e/offline-live-helpers.ts
+++ b/tests/e2e/offline-live-helpers.ts
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { expect, type BrowserContext, type Page } from "@playwright/test";
+import { installStoredAuthUser } from "../utils/passkeyAuthStorage";
 import { isRemoteE2ETarget, waitForLoginFormReady } from "./auth-helpers";
 
 const MOCK_XSRF_TOKEN = "test-xsrf-token";
+const MOCK_SESSION_COOKIE_NAME = "secpal-playwright-session";
 
 function getMockCookieDomain(): string {
   const baseUrl = process.env.PLAYWRIGHT_BASE_URL ?? "";
@@ -32,14 +34,43 @@ async function ensureMockXsrfCookie(context: BrowserContext): Promise<void> {
 export const offlineLiveMockUser = {
   id: "42",
   name: "Jane Example",
-  email: "jane.example@secpal.app",
+  email: "test@example.com",
   emailVerified: true,
   roles: ["Manager"],
   permissions: [],
   hasOrganizationalScopes: true,
-  hasCustomerAccess: false,
-  hasSiteAccess: false,
+  hasCustomerAccess: true,
+  hasSiteAccess: true,
 };
+
+async function ensureMockSessionCookie(
+  context: BrowserContext,
+  value = "authenticated"
+): Promise<void> {
+  const isHttps = isRemoteE2ETarget(process.env.PLAYWRIGHT_BASE_URL);
+
+  await context.addCookies([
+    {
+      name: MOCK_SESSION_COOKIE_NAME,
+      value,
+      domain: getMockCookieDomain(),
+      path: "/",
+      sameSite: "Lax",
+      secure: isHttps,
+      httpOnly: true,
+    },
+  ]);
+}
+
+function requestHasMockSessionCookie(cookieHeader: string | null): boolean {
+  if (!cookieHeader) {
+    return false;
+  }
+
+  return cookieHeader
+    .split(";")
+    .some((cookie) => cookie.trim() === `${MOCK_SESSION_COOKIE_NAME}=authenticated`);
+}
 
 export const offlineLiveMockOrganizationUnit = {
   id: "org-root-1",
@@ -88,14 +119,53 @@ export async function installMockAuthRoutes(
   });
 
   await context.route("**/v1/auth/login", async (route) => {
+    const requestBody = route.request().postDataJSON() as
+      | { email?: string }
+      | undefined;
+
+    if (requestBody?.email?.startsWith("wrong-user@")) {
+      await route.fulfill({
+        status: 422,
+        contentType: "application/json",
+        body: JSON.stringify({
+          message: "Invalid credentials.",
+          errors: {
+            email: ["Invalid credentials."],
+          },
+        }),
+      });
+
+      return;
+    }
+
+    await ensureMockSessionCookie(context);
+
+    const isHttps = isRemoteE2ETarget(process.env.PLAYWRIGHT_BASE_URL);
     await route.fulfill({
       status: 200,
       contentType: "application/json",
+      headers: {
+        "set-cookie": `${MOCK_SESSION_COOKIE_NAME}=authenticated; Path=/; SameSite=Lax${isHttps ? "; Secure" : ""}; HttpOnly`,
+      },
       body: JSON.stringify({ user: offlineLiveMockUser }),
     });
   });
 
   await context.route("**/v1/me", async (route) => {
+    if (
+      !requestHasMockSessionCookie(
+        await route.request().headerValue("cookie")
+      )
+    ) {
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "Unauthenticated." }),
+      });
+
+      return;
+    }
+
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -104,9 +174,43 @@ export async function installMockAuthRoutes(
   });
 
   await context.route("**/v1/auth/logout", async (route) => {
+    const isHttps = isRemoteE2ETarget(process.env.PLAYWRIGHT_BASE_URL);
     await route.fulfill({
       status: 204,
+      headers: {
+        "set-cookie": `${MOCK_SESSION_COOKIE_NAME}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax${isHttps ? "; Secure" : ""}; HttpOnly`,
+      },
       body: "",
+    });
+  });
+
+  await context.route("**/v1/customers**", async (route) => {
+    if (
+      !requestHasMockSessionCookie(
+        await route.request().headerValue("cookie")
+      )
+    ) {
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "Unauthenticated." }),
+      });
+
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        data: [],
+        meta: {
+          current_page: 1,
+          last_page: 1,
+          per_page: 15,
+          total: 0,
+        },
+      }),
     });
   });
 }
@@ -168,4 +272,13 @@ export async function loginWithMockedBrowserSession(page: Page): Promise<void> {
     .click();
 
   await expect(page).toHaveURL(/\/$/);
+}
+
+export async function installStoredMockBrowserSession(
+  page: Page,
+  user = offlineLiveMockUser
+): Promise<void> {
+  await ensureMockXsrfCookie(page.context());
+  await ensureMockSessionCookie(page.context());
+  await installStoredAuthUser(page, user, MOCK_XSRF_TOKEN);
 }

--- a/tests/playwright-config.test.ts
+++ b/tests/playwright-config.test.ts
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import config from "../playwright.config";
+
+describe("playwright config", () => {
+  it("clears developer-local VITE_API_URL overrides for the local dev web server", () => {
+    const webServer =
+      config.webServer && !Array.isArray(config.webServer)
+        ? config.webServer
+        : undefined;
+
+    expect(webServer).toBeDefined();
+    expect(webServer?.command).toBe("npm run dev");
+    expect(webServer?.url).toBe("http://localhost:5173");
+    expect(webServer?.env?.VITE_API_URL).toBe("");
+  });
+});

--- a/tests/playwright-config.test.ts
+++ b/tests/playwright-config.test.ts
@@ -1,11 +1,22 @@
 // SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { describe, expect, it } from "vitest";
-import config from "../playwright.config";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 describe("playwright config", () => {
-  it("clears developer-local VITE_API_URL overrides for the local dev web server", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("clears developer-local VITE_API_URL overrides for the local dev web server", async () => {
+    // Explicitly test the local-dev path: CI must be falsy so the config
+    // takes the dev-server branch and not the CI preview-server branch.
+    vi.stubEnv("CI", "");
+    vi.stubEnv("PLAYWRIGHT_BASE_URL", "");
+    vi.resetModules();
+    const { default: config } = await import("../playwright.config");
+
     const webServer =
       config.webServer && !Array.isArray(config.webServer)
         ? config.webServer


### PR DESCRIPTION
## Summary
- stop local Playwright web-server startup from inheriting developer-local `VITE_API_URL` overrides
- align local Playwright default credentials with the seeded local API user
- add deterministic local mocked browser-session bootstrap for Playwright auth reuse

## Validation
- `npx vitest run tests/playwright-config.test.ts tests/auth-e2e-helpers.test.ts`
- `npx playwright test tests/e2e/auth.spec.ts tests/e2e/organization.spec.ts --project=chromium`

Closes #942
