### PR TITLE
test: guard live lighthouse browser requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Stopped live Playwright Lighthouse runs from failing with misleading 0-score threshold errors when they use the bundled Playwright Chromium snapshot against `app.secpal.dev`; live audits now require `CHROME_PATH` to point to a stable Chrome/Chromium binary and skip with an explicit capability message until that browser prerequisite is provided, keeping preview performance coverage intact while making issue #932 actionable.
 - Pinned Playwright CI preview builds to the preview origin so mocked browser-session E2E flows no longer drift onto the live API host, enabled Chromium's fixed CDP port for Lighthouse audits, mocked preview smoke auth-bootstrap endpoints so static-preview unauthenticated checks return deterministic 401/ready responses instead of 404 recovery screens, hardened the smoke CLS probe against SPA redirect timing, and corrected the missing Apple touch icon reference in `index.html`.
 - Hardened production API base URL resolution to reject loopback and preview-only origins such as `localhost`, `127.0.0.1`, and `::1`, so shipped frontend builds fail fast instead of deploying with a broken local-preview API endpoint.
 - Serialized remote Playwright workers for `https://app.secpal.dev` targets so Chromium runs that need the fixed Lighthouse CDP port no longer fail intermittently with `Address already in use (98)` during parallel browser launches.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,7 @@
 
 import { defineConfig, devices } from "@playwright/test";
 import {
+  getConfiguredLighthouseBrowserPath,
   LIGHTHOUSE_DEBUG_PORT,
   PREVIEW_BASE_URL,
   shouldEnableLighthouseBrowser,
@@ -53,10 +54,12 @@ const isRemoteTarget =
   process.env.PLAYWRIGHT_BASE_URL?.startsWith("https://") ?? false;
 
 const usesSingleWorker = shouldUseSingleWorker();
+const lighthouseExecutablePath = getConfiguredLighthouseBrowserPath();
 
 const chromiumLaunchOptions = shouldEnableLighthouseBrowser()
   ? {
       args: [`--remote-debugging-port=${LIGHTHOUSE_DEBUG_PORT}`],
+      executablePath: lighthouseExecutablePath,
     }
   : undefined;
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -59,7 +59,9 @@ const lighthouseExecutablePath = getConfiguredLighthouseBrowserPath();
 const chromiumLaunchOptions = shouldEnableLighthouseBrowser()
   ? {
       args: [`--remote-debugging-port=${LIGHTHOUSE_DEBUG_PORT}`],
-      executablePath: lighthouseExecutablePath,
+      ...(lighthouseExecutablePath !== undefined && {
+        executablePath: lighthouseExecutablePath,
+      }),
     }
   : undefined;
 

--- a/tests/e2e/performance-mode.ts
+++ b/tests/e2e/performance-mode.ts
@@ -3,6 +3,7 @@
 
 export const PREVIEW_BASE_URL = "http://localhost:4173";
 export const LIGHTHOUSE_DEBUG_PORT = 9222;
+export const LIGHTHOUSE_BROWSER_PATH_ENV_VAR = "CHROME_PATH";
 
 type PerformanceAuditMode = {
   baseUrl: string;
@@ -13,6 +14,15 @@ const hasExplicitLighthouseMode = () =>
   process.env.PLAYWRIGHT_LIGHTHOUSE === "1";
 
 const isLiveHttpsTarget = (baseUrl: string) => baseUrl.startsWith("https://");
+
+const isPlaywrightBundledChromiumPath = (browserPath: string) =>
+  /(^|[/\\])ms-playwright([/\\]|$)/.test(browserPath);
+
+export const getConfiguredLighthouseBrowserPath = () => {
+  const browserPath = process.env[LIGHTHOUSE_BROWSER_PATH_ENV_VAR]?.trim();
+
+  return browserPath ? browserPath : undefined;
+};
 
 export const shouldEnableLighthouseBrowser = () => hasExplicitLighthouseMode();
 
@@ -48,6 +58,24 @@ export const getPerformanceAuditMode = (): PerformanceAuditMode => {
       skipReason:
         "Live Lighthouse audits require PLAYWRIGHT_LIVE_LIGHTHOUSE=1 until issue #957 is resolved.",
     };
+  }
+
+  if (isLiveHttpsTarget(baseUrl)) {
+    const browserPath = getConfiguredLighthouseBrowserPath();
+
+    if (!browserPath) {
+      return {
+        baseUrl,
+        skipReason: `Live Lighthouse audits require ${LIGHTHOUSE_BROWSER_PATH_ENV_VAR} to point to a stable Chrome/Chromium binary because the bundled Playwright Chromium snapshot currently aborts with FAILED_DOCUMENT_REQUEST on app.secpal.dev.`,
+      };
+    }
+
+    if (isPlaywrightBundledChromiumPath(browserPath)) {
+      return {
+        baseUrl,
+        skipReason: `Live Lighthouse audits require ${LIGHTHOUSE_BROWSER_PATH_ENV_VAR} to point to a stable Chrome/Chromium binary instead of the bundled Playwright Chromium snapshot.`,
+      };
+    }
   }
 
   return { baseUrl, skipReason: undefined };

--- a/tests/e2e/performance-mode.ts
+++ b/tests/e2e/performance-mode.ts
@@ -66,7 +66,7 @@ export const getPerformanceAuditMode = (): PerformanceAuditMode => {
     if (!browserPath) {
       return {
         baseUrl,
-        skipReason: `Live Lighthouse audits require ${LIGHTHOUSE_BROWSER_PATH_ENV_VAR} to point to a stable Chrome/Chromium binary because the bundled Playwright Chromium snapshot currently aborts with FAILED_DOCUMENT_REQUEST on app.secpal.dev.`,
+        skipReason: `Live Lighthouse audits against ${baseUrl} require ${LIGHTHOUSE_BROWSER_PATH_ENV_VAR} to point to a stable Chrome/Chromium binary because the bundled Playwright Chromium snapshot does not support live HTTPS targets.`,
       };
     }
 

--- a/tests/performance-audit-mode.test.ts
+++ b/tests/performance-audit-mode.test.ts
@@ -69,7 +69,7 @@ describe("performance audit mode", () => {
     expect(getPerformanceAuditMode()).toEqual({
       baseUrl: "https://app.secpal.dev",
       skipReason:
-        "Live Lighthouse audits require CHROME_PATH to point to a stable Chrome/Chromium binary because the bundled Playwright Chromium snapshot currently aborts with FAILED_DOCUMENT_REQUEST on app.secpal.dev.",
+        "Live Lighthouse audits against https://app.secpal.dev require CHROME_PATH to point to a stable Chrome/Chromium binary because the bundled Playwright Chromium snapshot does not support live HTTPS targets.",
     });
   });
 

--- a/tests/performance-audit-mode.test.ts
+++ b/tests/performance-audit-mode.test.ts
@@ -43,12 +43,52 @@ describe("performance audit mode", () => {
     vi.stubEnv("PLAYWRIGHT_BASE_URL", "https://app.secpal.dev");
     vi.stubEnv("PLAYWRIGHT_LIGHTHOUSE", "1");
     vi.stubEnv("PLAYWRIGHT_LIVE_LIGHTHOUSE", "1");
+    vi.stubEnv("CHROME_PATH", "/usr/bin/google-chrome-stable");
+    vi.resetModules();
+    const { getConfiguredLighthouseBrowserPath, getPerformanceAuditMode } =
+      await import("./e2e/performance-mode");
+
+    expect(getPerformanceAuditMode()).toEqual({
+      baseUrl: "https://app.secpal.dev",
+      skipReason: undefined,
+    });
+    expect(getConfiguredLighthouseBrowserPath()).toBe(
+      "/usr/bin/google-chrome-stable"
+    );
+  });
+
+  it("requires an explicit Chrome path for live Lighthouse audits", async () => {
+    vi.stubEnv("CI", "");
+    vi.stubEnv("PLAYWRIGHT_BASE_URL", "https://app.secpal.dev");
+    vi.stubEnv("PLAYWRIGHT_LIGHTHOUSE", "1");
+    vi.stubEnv("PLAYWRIGHT_LIVE_LIGHTHOUSE", "1");
+    vi.stubEnv("CHROME_PATH", "");
     vi.resetModules();
     const { getPerformanceAuditMode } = await import("./e2e/performance-mode");
 
     expect(getPerformanceAuditMode()).toEqual({
       baseUrl: "https://app.secpal.dev",
-      skipReason: undefined,
+      skipReason:
+        "Live Lighthouse audits require CHROME_PATH to point to a stable Chrome/Chromium binary because the bundled Playwright Chromium snapshot currently aborts with FAILED_DOCUMENT_REQUEST on app.secpal.dev.",
+    });
+  });
+
+  it("rejects the bundled Playwright Chromium snapshot for live Lighthouse audits", async () => {
+    vi.stubEnv("CI", "");
+    vi.stubEnv("PLAYWRIGHT_BASE_URL", "https://app.secpal.dev");
+    vi.stubEnv("PLAYWRIGHT_LIGHTHOUSE", "1");
+    vi.stubEnv("PLAYWRIGHT_LIVE_LIGHTHOUSE", "1");
+    vi.stubEnv(
+      "CHROME_PATH",
+      "/home/secpal/.cache/ms-playwright/chromium-1217/chrome-linux64/chrome"
+    );
+    vi.resetModules();
+    const { getPerformanceAuditMode } = await import("./e2e/performance-mode");
+
+    expect(getPerformanceAuditMode()).toEqual({
+      baseUrl: "https://app.secpal.dev",
+      skipReason:
+        "Live Lighthouse audits require CHROME_PATH to point to a stable Chrome/Chromium binary instead of the bundled Playwright Chromium snapshot.",
     });
   });
 


### PR DESCRIPTION
## Summary
- guard live Playwright Lighthouse audits behind an explicit stable Chrome or Chromium path via `CHROME_PATH`
- keep preview Lighthouse coverage unchanged while preventing false live 0-score threshold failures from the bundled Playwright Chromium snapshot
- add focused regression coverage for the live audit mode guard and wire the configured browser path into Playwright launch options

## Validation
- `npx vitest run tests/performance-audit-mode.test.ts`
- `npm run typecheck`
- `npm run lint`
- `PLAYWRIGHT_BASE_URL=https://app.secpal.dev PLAYWRIGHT_LIGHTHOUSE=1 PLAYWRIGHT_LIVE_LIGHTHOUSE=1 PLAYWRIGHT_SKIP_GLOBAL_LOGIN=1 npx playwright test tests/e2e/performance.spec.ts --project=chromium`

## Issue Tracking
Closes #932
Refs #962
