### PR TITLE
ci: provision stable chrome for live lighthouse

### DIFF
--- a/.github/workflows/playwright-live-lighthouse.yml
+++ b/.github/workflows/playwright-live-lighthouse.yml
@@ -47,6 +47,6 @@ jobs:
         env:
           CI: "true"
           CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
-          TEST_USER_EMAIL: test@example.com
-          TEST_USER_PASSWORD: password
+          TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
+          TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
         run: npm run test:e2e:performance:staging

--- a/.github/workflows/playwright-live-lighthouse.yml
+++ b/.github/workflows/playwright-live-lighthouse.yml
@@ -1,0 +1,52 @@
+---
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: CC0-1.0
+
+name: Playwright Live Lighthouse
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  playwright-live-lighthouse:
+    name: Playwright Live Lighthouse
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: ${{ !startsWith(github.head_ref, 'spike/') && !startsWith(github.ref, 'refs/heads/spike/') }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install stable Chrome
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@3ba2f2bc81ddf8088ecbacdea69d476631049f8b
+        with:
+          chrome-version: stable
+          install-dependencies: true
+
+      - name: Report installed Chrome
+        run: ${{ steps.setup-chrome.outputs.chrome-path }} --version
+
+      - name: Run live Lighthouse against app.secpal.dev
+        env:
+          CI: "true"
+          CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
+          TEST_USER_EMAIL: test@example.com
+          TEST_USER_PASSWORD: password
+        run: npm run test:e2e:performance:staging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Added a dedicated Playwright live-Lighthouse workflow that provisions a stable Chrome binary, exports `CHROME_PATH`, and runs the guarded `app.secpal.dev` performance suite so live Lighthouse can collect real scores in CI instead of skipping on the bundled Playwright Chromium snapshot, resolving frontend issue #962.
 - Stopped live Playwright Lighthouse runs from failing with misleading 0-score threshold errors when they use the bundled Playwright Chromium snapshot against `app.secpal.dev`; live audits now require `CHROME_PATH` to point to a stable Chrome/Chromium binary and skip with an explicit capability message until that browser prerequisite is provided, keeping preview performance coverage intact while making issue #932 actionable.
 - Pinned Playwright CI preview builds to the preview origin so mocked browser-session E2E flows no longer drift onto the live API host, enabled Chromium's fixed CDP port for Lighthouse audits, mocked preview smoke auth-bootstrap endpoints so static-preview unauthenticated checks return deterministic 401/ready responses instead of 404 recovery screens, hardened the smoke CLS probe against SPA redirect timing, and corrected the missing Apple touch icon reference in `index.html`.
 - Hardened production API base URL resolution to reject loopback and preview-only origins such as `localhost`, `127.0.0.1`, and `::1`, so shipped frontend builds fail fast instead of deploying with a broken local-preview API endpoint.

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -117,6 +117,31 @@ describe("Build Configuration and Source Verification", () => {
     );
   });
 
+  it("keeps live Lighthouse CI provisioned with a stable Chrome binary", () => {
+    const liveLighthouseWorkflow = readRepoFile(
+      ".github/workflows/playwright-live-lighthouse.yml"
+    );
+
+    expect(liveLighthouseWorkflow).toContain(
+      "name: Playwright Live Lighthouse"
+    );
+    expect(liveLighthouseWorkflow).toContain(
+      "browser-actions/setup-chrome@3ba2f2bc81ddf8088ecbacdea69d476631049f8b"
+    );
+    expect(liveLighthouseWorkflow).toContain("id: setup-chrome");
+    expect(liveLighthouseWorkflow).toContain("chrome-version: stable");
+    expect(liveLighthouseWorkflow).toContain(
+      "CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}"
+    );
+    expect(liveLighthouseWorkflow).toContain(
+      "TEST_USER_EMAIL: test@example.com"
+    );
+    expect(liveLighthouseWorkflow).toContain("TEST_USER_PASSWORD: password");
+    expect(liveLighthouseWorkflow).toContain(
+      "npm run test:e2e:performance:staging"
+    );
+  });
+
   it("keeps vite-plugin-static-copy configured for assetlinks.json", () => {
     const viteConfig = readRepoFile("vite.config.ts");
 

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -134,9 +134,11 @@ describe("Build Configuration and Source Verification", () => {
       "CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}"
     );
     expect(liveLighthouseWorkflow).toContain(
-      "TEST_USER_EMAIL: test@example.com"
+      "TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}"
     );
-    expect(liveLighthouseWorkflow).toContain("TEST_USER_PASSWORD: password");
+    expect(liveLighthouseWorkflow).toContain(
+      "TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}"
+    );
     expect(liveLighthouseWorkflow).toContain(
       "npm run test:e2e:performance:staging"
     );


### PR DESCRIPTION
## Summary
- add a dedicated Playwright live-Lighthouse workflow that installs a stable Chrome binary and exports `CHROME_PATH` into the guarded staging performance suite
- keep a repo-level build test that locks the workflow pin and `CHROME_PATH` wiring in place
- record the CI provisioning change in the changelog

## Validation
- `npx vitest run tests/build.test.ts tests/playwright-config.test.ts tests/performance-audit-mode.test.ts`
- `npm run lint`
- `npm run typecheck`
- `yamllint .github/workflows/playwright-live-lighthouse.yml`
- `CI=true CHROME_PATH=/tmp/secpal-stable-chrome/chrome/linux-147.0.7727.57/chrome-linux64/chrome TEST_USER_EMAIL=test@example.com TEST_USER_PASSWORD=password PLAYWRIGHT_BASE_URL=https://app.secpal.dev PLAYWRIGHT_LIGHTHOUSE=1 PLAYWRIGHT_LIVE_LIGHTHOUSE=1 PLAYWRIGHT_SKIP_GLOBAL_LOGIN=1 npx playwright test tests/e2e/performance.spec.ts --project=chromium`

## Issue Tracking
Closes #962
Refs #970
