### PR TITLE
test(auth): align live smoke with auth runtime

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -70,7 +70,8 @@ jobs:
         run: npm run test:coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v5
+        # v5
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
         with:
           # Token is optional for public repos (tokenless uploads supported)
           # Dependabot PRs cannot access secrets, so token may be empty
@@ -111,5 +112,5 @@ jobs:
           PLAYWRIGHT_SKIP_GLOBAL_LOGIN: "1"
         run: >-
           npx playwright test tests/e2e/auth.spec.ts --project=chromium --grep
-          "should reject invalid credentials|should redirect to login when
-          accessing protected route without auth"
+          "should surface the current login readiness state on live targets|should
+          resolve protected route auth bootstrap on live targets"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -51,6 +51,7 @@ jobs:
   vitest:
     name: Vitest Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: ${{ !startsWith(github.head_ref, 'spike/') && !startsWith(github.ref, 'refs/heads/spike/') }}
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Split the live no-secret Playwright auth smoke away from the deterministic local invalid-credential and hard-login-redirect assertions, so `app.secpal.dev` now validates the shipped health-gated login state and browser-session protected-route recovery flow instead of failing on outdated assumptions, resolving frontend issue #975.
 - Rebased the live `app.secpal.dev` Lighthouse performance threshold from 90 to 85 while keeping the stricter preview threshold and the existing accessibility, best-practices, and Core Web Vitals assertions unchanged, so repeated stable-Chrome live audits no longer fail on borderline 87-90 scores, resolving frontend issue #970.
 - Added a dedicated Playwright live-Lighthouse workflow that provisions a stable Chrome binary, exports `CHROME_PATH`, and runs the guarded `app.secpal.dev` performance suite so live Lighthouse can collect real scores in CI instead of skipping on the bundled Playwright Chromium snapshot, resolving frontend issue #962.
 - Stopped live Playwright Lighthouse runs from failing with misleading 0-score threshold errors when they use the bundled Playwright Chromium snapshot against `app.secpal.dev`; live audits now require `CHROME_PATH` to point to a stable Chrome/Chromium binary and skip with an explicit capability message until that browser prerequisite is provided, keeping preview performance coverage intact while making issue #932 actionable.

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -90,8 +90,11 @@ test.describe("Authentication", () => {
       } catch (error) {
         const blockingReason = error instanceof Error ? error.message : "";
 
+        if (!blockingReason.includes("health gate")) {
+          throw error;
+        }
+
         await expect(page.locator("#health-warning")).toBeVisible();
-        expect(blockingReason).toContain("health gate");
         return;
       }
 

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { test, expect, loginViaUI } from "./auth.setup";
@@ -158,12 +158,12 @@ test.describe("Authentication", () => {
         return;
       }
 
-      await expect(
-        page.locator('[data-route-guard-state="bootstrap-recovery"]')
-      ).toBeVisible();
-      await expect(
-        page.getByRole("button", { name: /go to login/i })
-      ).toBeVisible();
+      const bootstrapRecovery = page.locator(
+        '[data-route-guard-state="bootstrap-recovery"]'
+      );
+
+      await expect(bootstrapRecovery).toBeVisible();
+      await expect(bootstrapRecovery.locator("button").first()).toBeVisible();
     });
   });
 

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { test, expect, loginViaUI } from "./auth.setup";
-import { isRemoteE2ETarget, waitForLoginFormReady } from "./auth-helpers";
+import {
+  isRemoteE2ETarget,
+  waitForAuthResolution,
+  waitForLoginFormReady,
+} from "./auth-helpers";
 import { installMockAuthRoutes } from "./offline-live-helpers";
 
 /**
@@ -42,6 +46,11 @@ test.describe("Authentication", () => {
     });
 
     test("should reject invalid credentials", async ({ page }) => {
+      test.skip(
+        isRemoteE2ETarget(),
+        "Live targets use a dedicated no-secret smoke assertion for the current login gate state."
+      );
+
       await page.goto("/login");
       await page.waitForLoadState("networkidle");
 
@@ -60,6 +69,35 @@ test.describe("Authentication", () => {
       await expect(
         page.getByText(/invalid|incorrect|falsch|ungültig|credentials/i)
       ).toBeVisible({ timeout: 10_000 });
+    });
+
+    test("should surface the current login readiness state on live targets", async ({
+      page,
+    }) => {
+      test.skip(
+        !isRemoteE2ETarget(),
+        "Only relevant for the live no-secret auth smoke on app.secpal.dev."
+      );
+
+      await page.goto("/login");
+      await page.waitForLoadState("networkidle");
+
+      await expect(page.locator("#email")).toBeVisible();
+      await expect(page.locator("#password")).toBeVisible();
+
+      try {
+        await waitForLoginFormReady(page);
+      } catch (error) {
+        const blockingReason = error instanceof Error ? error.message : "";
+
+        await expect(page.locator("#health-warning")).toBeVisible();
+        expect(blockingReason).toContain("health gate");
+        return;
+      }
+
+      await expect(
+        page.getByRole("button", { name: /log in|anmelden|einloggen/i })
+      ).toBeEnabled();
     });
 
     test("should logout successfully", async ({ page }) => {
@@ -87,12 +125,45 @@ test.describe("Authentication", () => {
     test("should redirect to login when accessing protected route without auth", async ({
       page,
     }) => {
+      test.skip(
+        isRemoteE2ETarget(),
+        "Live targets can legitimately resolve protected browser-session routes through recovery instead of an immediate login redirect."
+      );
+
       // Try to access protected route directly
       await page.goto("/organization");
       await page.waitForLoadState("networkidle");
 
       // Should redirect to login
       await expect(page).toHaveURL(/\/login/);
+    });
+
+    test("should resolve protected route auth bootstrap on live targets", async ({
+      page,
+    }) => {
+      test.skip(
+        !isRemoteE2ETarget(),
+        "Only relevant for the live no-secret auth smoke on app.secpal.dev."
+      );
+
+      await page.goto("/organization");
+      await page.waitForLoadState("networkidle");
+
+      const authResolution = await waitForAuthResolution(page);
+
+      expect(["login", "recovery"]).toContain(authResolution);
+
+      if (authResolution === "login") {
+        await expect(page).toHaveURL(/\/login/);
+        return;
+      }
+
+      await expect(
+        page.locator('[data-route-guard-state="bootstrap-recovery"]')
+      ).toBeVisible();
+      await expect(
+        page.getByRole("button", { name: /go to login/i })
+      ).toBeVisible();
     });
   });
 


### PR DESCRIPTION
## Summary
- align the live no-secret Playwright auth smoke with the shipped browser-session runtime on app.secpal.dev
- keep the deterministic local invalid-credential and login-redirect assertions strict, but move the live smoke onto dedicated expectations for the health-gated login state and protected-route bootstrap recovery
- update the quality workflow grep so CI executes the live-specific auth smoke assertions instead of the outdated local-only assumptions

## Testing
- npx playwright test tests/e2e/auth.spec.ts --project=chromium --grep "should reject invalid credentials|should redirect to login when accessing protected route without auth"
- PLAYWRIGHT_BASE_URL=https://app.secpal.dev PLAYWRIGHT_SKIP_GLOBAL_LOGIN=1 npx playwright test tests/e2e/auth.spec.ts --project=chromium --grep "should surface the current login readiness state on live targets|should resolve protected route auth bootstrap on live targets"
- npx eslint tests/e2e/auth.spec.ts
- npm run typecheck
- yamllint .github/workflows/quality.yml

## Notes
- this resolves the current live auth smoke mismatch tracked in #975
- once merged, PR #974 should be re-run because its failing `Playwright Live Smoke` job is blocked by this exact outdated auth-smoke expectation

Closes #975
