### PR TITLE
fix: limit Lighthouse audits to desktop chromium project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Limited Playwright Lighthouse audits to the desktop `chromium` project so strict all-project live E2E runs no longer fail in `mobile-chrome`, which lacks the fixed CDP port required by `playwright-lighthouse` for `app.secpal.dev` audits.
 - Split the live no-secret Playwright auth smoke away from the deterministic local invalid-credential and hard-login-redirect assertions, so `app.secpal.dev` now validates the shipped health-gated login state and browser-session protected-route recovery flow instead of failing on outdated assumptions, resolving frontend issue #975.
 - Shifted the remote `onboarding-complete` Playwright suite from pure network-route mocks to a page-level fetch shim for the deterministic public onboarding endpoints, so live runs against `app.secpal.dev` no longer collapse into CSP-blocked `Failed to fetch` invalid-link screens when the deployed app points public onboarding traffic at a broken absolute API origin, resolving frontend issue #933.
 - Added a runtime guard for the live `app.secpal.dev` host so leaked preview-mode or loopback API bases such as `http://localhost:4173`, relative `/api`, or the SPA host itself now collapse back to the canonical `https://api.secpal.dev` origin instead of shipping CSP-blocked `/v1/me` bootstrap traffic, addressing frontend issue #973.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,7 @@
 
 import { defineConfig, devices } from "@playwright/test";
 import {
+  DESKTOP_CHROMIUM_PROJECT_NAME,
   getConfiguredLighthouseBrowserPath,
   LIGHTHOUSE_DEBUG_PORT,
   PREVIEW_BASE_URL,
@@ -111,7 +112,7 @@ export default defineConfig({
   // Configure projects - Chromium only for performance consistency
   projects: [
     {
-      name: "chromium",
+      name: DESKTOP_CHROMIUM_PROJECT_NAME,
       use: {
         ...devices["Desktop Chrome"],
         launchOptions: chromiumLaunchOptions,

--- a/tests/e2e/performance-mode.ts
+++ b/tests/e2e/performance-mode.ts
@@ -4,6 +4,7 @@
 export const PREVIEW_BASE_URL = "http://localhost:4173";
 export const LIGHTHOUSE_DEBUG_PORT = 9222;
 export const LIGHTHOUSE_BROWSER_PATH_ENV_VAR = "CHROME_PATH";
+export const DESKTOP_CHROMIUM_PROJECT_NAME = "chromium";
 
 export const DEFAULT_LIGHTHOUSE_THRESHOLDS = {
   performance: 90,
@@ -52,11 +53,11 @@ export const getPerformanceAuditProjectSkipReason = (
   projectName: string,
   browserName: string
 ) => {
-  if (browserName !== "chromium") {
+  if (browserName !== DESKTOP_CHROMIUM_PROJECT_NAME) {
     return "Lighthouse only works with Chromium";
   }
 
-  if (projectName !== "chromium") {
+  if (projectName !== DESKTOP_CHROMIUM_PROJECT_NAME) {
     return "Lighthouse audits only run in the desktop chromium project because mobile-chrome does not expose the fixed CDP port.";
   }
 

--- a/tests/e2e/performance-mode.ts
+++ b/tests/e2e/performance-mode.ts
@@ -48,6 +48,21 @@ export const shouldEnableLighthouseBrowser = () => hasExplicitLighthouseMode();
 export const shouldUseSingleWorker = () =>
   Boolean(process.env.CI) || hasExplicitLighthouseMode();
 
+export const getPerformanceAuditProjectSkipReason = (
+  projectName: string,
+  browserName: string
+) => {
+  if (browserName !== "chromium") {
+    return "Lighthouse only works with Chromium";
+  }
+
+  if (projectName !== "chromium") {
+    return "Lighthouse audits only run in the desktop chromium project because mobile-chrome does not expose the fixed CDP port.";
+  }
+
+  return undefined;
+};
+
 export const getPerformanceAuditMode = (): PerformanceAuditMode => {
   const baseUrl =
     process.env.PLAYWRIGHT_BASE_URL || (process.env.CI ? PREVIEW_BASE_URL : "");

--- a/tests/e2e/performance.spec.ts
+++ b/tests/e2e/performance.spec.ts
@@ -5,6 +5,7 @@ import { test, expect } from "./auth.setup";
 import { playAudit } from "playwright-lighthouse";
 import {
   getPerformanceAuditMode,
+  getPerformanceAuditProjectSkipReason,
   getPerformanceAuditThresholds,
   LIGHTHOUSE_DEBUG_PORT,
 } from "./performance-mode";
@@ -46,11 +47,14 @@ test.describe("Lighthouse Performance Audits", () => {
       "Performance audits require an explicit preview or live Lighthouse target"
   );
 
-  // Only run on chromium (Lighthouse requires Chrome DevTools Protocol)
-  test.skip(
-    ({ browserName }) => browserName !== "chromium",
-    "Lighthouse only works with Chromium"
-  );
+  test.beforeEach(({ browserName }, testInfo) => {
+    const projectSkipReason = getPerformanceAuditProjectSkipReason(
+      testInfo.project.name,
+      browserName
+    );
+
+    test.skip(Boolean(projectSkipReason), projectSkipReason);
+  });
 
   test("should meet performance thresholds on home page", async ({
     authenticatedPage: page,

--- a/tests/performance-audit-mode.test.ts
+++ b/tests/performance-audit-mode.test.ts
@@ -149,7 +149,10 @@ describe("performance audit mode", () => {
       )
     ).toBeUndefined();
     expect(
-      getPerformanceAuditProjectSkipReason("mobile-chrome", DESKTOP_CHROMIUM_PROJECT_NAME)
+      getPerformanceAuditProjectSkipReason(
+        "mobile-chrome",
+        DESKTOP_CHROMIUM_PROJECT_NAME
+      )
     ).toBe(
       "Lighthouse audits only run in the desktop chromium project because mobile-chrome does not expose the fixed CDP port."
     );

--- a/tests/performance-audit-mode.test.ts
+++ b/tests/performance-audit-mode.test.ts
@@ -137,14 +137,19 @@ describe("performance audit mode", () => {
 
   it("limits Lighthouse audits to the desktop chromium project", async () => {
     vi.resetModules();
-    const { getPerformanceAuditProjectSkipReason } =
-      await import("./e2e/performance-mode");
+    const {
+      DESKTOP_CHROMIUM_PROJECT_NAME,
+      getPerformanceAuditProjectSkipReason,
+    } = await import("./e2e/performance-mode");
 
     expect(
-      getPerformanceAuditProjectSkipReason("chromium", "chromium")
+      getPerformanceAuditProjectSkipReason(
+        DESKTOP_CHROMIUM_PROJECT_NAME,
+        DESKTOP_CHROMIUM_PROJECT_NAME
+      )
     ).toBeUndefined();
     expect(
-      getPerformanceAuditProjectSkipReason("mobile-chrome", "chromium")
+      getPerformanceAuditProjectSkipReason("mobile-chrome", DESKTOP_CHROMIUM_PROJECT_NAME)
     ).toBe(
       "Lighthouse audits only run in the desktop chromium project because mobile-chrome does not expose the fixed CDP port."
     );

--- a/tests/performance-audit-mode.test.ts
+++ b/tests/performance-audit-mode.test.ts
@@ -134,4 +134,23 @@ describe("performance audit mode", () => {
         "Performance audits require PLAYWRIGHT_LIGHTHOUSE=1 so Chromium exposes the Lighthouse CDP port.",
     });
   });
+
+  it("limits Lighthouse audits to the desktop chromium project", async () => {
+    vi.resetModules();
+    const { getPerformanceAuditProjectSkipReason } = await import(
+      "./e2e/performance-mode"
+    );
+
+    expect(
+      getPerformanceAuditProjectSkipReason("chromium", "chromium")
+    ).toBeUndefined();
+    expect(
+      getPerformanceAuditProjectSkipReason("mobile-chrome", "chromium")
+    ).toBe(
+      "Lighthouse audits only run in the desktop chromium project because mobile-chrome does not expose the fixed CDP port."
+    );
+    expect(
+      getPerformanceAuditProjectSkipReason("webkit", "webkit")
+    ).toBe("Lighthouse only works with Chromium");
+  });
 });

--- a/tests/performance-audit-mode.test.ts
+++ b/tests/performance-audit-mode.test.ts
@@ -137,9 +137,8 @@ describe("performance audit mode", () => {
 
   it("limits Lighthouse audits to the desktop chromium project", async () => {
     vi.resetModules();
-    const { getPerformanceAuditProjectSkipReason } = await import(
-      "./e2e/performance-mode"
-    );
+    const { getPerformanceAuditProjectSkipReason } =
+      await import("./e2e/performance-mode");
 
     expect(
       getPerformanceAuditProjectSkipReason("chromium", "chromium")
@@ -149,8 +148,8 @@ describe("performance audit mode", () => {
     ).toBe(
       "Lighthouse audits only run in the desktop chromium project because mobile-chrome does not expose the fixed CDP port."
     );
-    expect(
-      getPerformanceAuditProjectSkipReason("webkit", "webkit")
-    ).toBe("Lighthouse only works with Chromium");
+    expect(getPerformanceAuditProjectSkipReason("webkit", "webkit")).toBe(
+      "Lighthouse only works with Chromium"
+    );
   });
 });


### PR DESCRIPTION
## Summary
- limit Playwright Lighthouse audits to the desktop chromium project
- add regression coverage for the project skip decision
- record the strict all-project live E2E fix in the changelog

## Validation
- npx vitest run tests/performance-audit-mode.test.ts tests/playwright-config.test.ts
- TEST_USER_EMAIL=test@example.com TEST_USER_PASSWORD=password PLAYWRIGHT_BASE_URL=https://app.secpal.dev PLAYWRIGHT_API_BASE_URL=https://api.secpal.dev PLAYWRIGHT_LIVE_PASSKEY=1 PLAYWRIGHT_LIGHTHOUSE=1 PLAYWRIGHT_LIVE_LIGHTHOUSE=1 PLAYWRIGHT_SKIP_GLOBAL_LOGIN=1 CHROME_PATH=/usr/bin/chromium npx playwright test tests/e2e/performance.spec.ts
- TEST_USER_EMAIL=test@example.com TEST_USER_PASSWORD=password PLAYWRIGHT_BASE_URL=https://app.secpal.dev PLAYWRIGHT_API_BASE_URL=https://api.secpal.dev PLAYWRIGHT_LIVE_PASSKEY=1 PLAYWRIGHT_LIGHTHOUSE=1 PLAYWRIGHT_LIVE_LIGHTHOUSE=1 PLAYWRIGHT_SKIP_GLOBAL_LOGIN=1 CHROME_PATH=/usr/bin/chromium npx playwright test
- npm run lint
- npm run typecheck
