### PR TITLE
chore(deps): bump setup-chrome and align Lighthouse guard

### DIFF
--- a/.github/workflows/playwright-live-lighthouse.yml
+++ b/.github/workflows/playwright-live-lighthouse.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install stable Chrome
         id: setup-chrome
-        uses: browser-actions/setup-chrome@3ba2f2bc81ddf8088ecbacdea69d476631049f8b
+        uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded
         with:
           chrome-version: stable
           install-dependencies: true

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -126,7 +126,7 @@ describe("Build Configuration and Source Verification", () => {
       "name: Playwright Live Lighthouse"
     );
     expect(liveLighthouseWorkflow).toContain(
-      "browser-actions/setup-chrome@3ba2f2bc81ddf8088ecbacdea69d476631049f8b"
+      "browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded"
     );
     expect(liveLighthouseWorkflow).toContain("id: setup-chrome");
     expect(liveLighthouseWorkflow).toContain("chrome-version: stable");


### PR DESCRIPTION
## Summary
- bump the Playwright live Lighthouse workflow to `browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded`
- align the build guard so the workflow pin and the invariant test stay in sync
- supersede Dependabot PR #982 with a human-owned branch that carries the required guard update

## Validation
- `yamllint .github/workflows/playwright-live-lighthouse.yml`
- `vitest run tests/build.test.ts -t "keeps live Lighthouse CI provisioned with a stable Chrome binary" --reporter=verbose`
- `vitest run tests/build.test.ts --reporter=verbose`
