### PR TITLE
fix(login): ignore transient health-check transport failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Stopped the login page from treating transient readiness-probe transport failures as a backend `not_ready` state, so sign-in now stays enabled unless the API explicitly reports `status: "not_ready"`, resolving frontend issue #991.
 - Localized the shared login-page passkey sign-in cancellation, timeout, provider-availability, and fallback messages so the Android native Credential Manager path no longer falls back to English on German devices after a cancelled passkey prompt, resolving frontend issue #978.
 - Limited Playwright Lighthouse audits to the desktop `chromium` project so strict all-project live E2E runs no longer fail in `mobile-chrome`, which lacks the fixed CDP port required by `playwright-lighthouse` for `app.secpal.dev` audits.
 - Split the live no-secret Playwright auth smoke away from the deterministic local invalid-credential and hard-login-redirect assertions, so `app.secpal.dev` now validates the shipped health-gated login state and browser-session protected-route recovery flow instead of failing on outdated assumptions, resolving frontend issue #975.

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -1714,24 +1714,32 @@ describe("Login", () => {
       expect(passwordInput).toBeDisabled();
     });
 
-    it("disables login and shows warning when health check fails with error", async () => {
-      vi.mocked(healthApi.checkHealth).mockRejectedValue(
-        new healthApi.HealthCheckError("Network error")
-      );
+    it("keeps login enabled and hides the warning when health check fails with a transport error", async () => {
+      vi.useFakeTimers();
+      try {
+        vi.mocked(healthApi.checkHealth).mockRejectedValue(
+          new healthApi.HealthCheckError("Network error")
+        );
 
-      renderLogin();
+        renderLogin();
 
-      // Wait for health check to complete and warning to appear
-      await waitFor(
-        () => {
-          expect(screen.getByText(/system not ready/i)).toBeInTheDocument();
-        },
-        { timeout: 8000 }
-      );
+        await act(async () => {
+          await vi.runAllTimersAsync();
+        });
 
-      // Button should be disabled
-      const submitButton = screen.getByRole("button", { name: /log in/i });
-      expect(submitButton).toBeDisabled();
+        expect(vi.mocked(healthApi.checkHealth)).toHaveBeenCalledTimes(3);
+        expect(screen.queryByText(/system not ready/i)).not.toBeInTheDocument();
+
+        const submitButton = screen.getByRole("button", { name: /log in/i });
+        const emailInput = screen.getByLabelText(/email/i);
+        const passwordInput = screen.getByLabelText(/password/i);
+
+        expect(submitButton).toBeEnabled();
+        expect(emailInput).toBeEnabled();
+        expect(passwordInput).toBeEnabled();
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("shows 'Checking system...' while health check is in progress", async () => {
@@ -2204,52 +2212,45 @@ describe("Login", () => {
       expect(submitButton).not.toBeDisabled();
     });
 
-    it("shows system not ready warning if health check fails after coming online", async () => {
+    it("keeps login enabled if the health check transport fails after coming online", async () => {
       // Start offline
       vi.mocked(useOnlineStatus).mockReturnValue(false);
       const mockCheckHealth = vi.mocked(healthApi.checkHealth);
 
       const { rerender } = renderLogin();
 
-      // Should show offline warning
-      await waitFor(() => {
-        expect(screen.getByText(/no internet connection/i)).toBeInTheDocument();
-      });
+      await screen.findByText(/no internet connection/i);
 
-      // Now go online but health check fails
-      vi.mocked(useOnlineStatus).mockReturnValue(true);
-      mockCheckHealth.mockRejectedValue(
-        new healthApi.HealthCheckError("Network error")
-      );
+      vi.useFakeTimers();
+      try {
+        // Now go online but the readiness probe keeps failing in transport.
+        vi.mocked(useOnlineStatus).mockReturnValue(true);
+        mockCheckHealth.mockRejectedValue(
+          new healthApi.HealthCheckError("Network error")
+        );
 
-      // Re-render to trigger online status change
-      rerender(
-        <MemoryRouter initialEntries={["/login"]}>
-          <I18nProvider i18n={i18n}>
-            <AuthProvider>
-              <Login />
-            </AuthProvider>
-          </I18nProvider>
-        </MemoryRouter>
-      );
+        rerender(
+          <MemoryRouter initialEntries={["/login"]}>
+            <I18nProvider i18n={i18n}>
+              <AuthProvider>
+                <Login />
+              </AuthProvider>
+            </I18nProvider>
+          </MemoryRouter>
+        );
 
-      // Should perform health check
-      await waitFor(() => {
-        expect(mockCheckHealth).toHaveBeenCalled();
-      });
+        await act(async () => {
+          await vi.runAllTimersAsync();
+        });
 
-      // Should now show system not ready warning
-      await waitFor(
-        () => {
-          expect(screen.getByText(/system not ready/i)).toBeInTheDocument();
-        },
-        { timeout: 8000 }
-      );
+        expect(mockCheckHealth).toHaveBeenCalledTimes(3);
+        expect(screen.queryByText(/system not ready/i)).not.toBeInTheDocument();
 
-      // Offline warning should be gone
-      expect(
-        screen.queryByText(/no internet connection/i)
-      ).not.toBeInTheDocument();
+        const submitButton = screen.getByRole("button", { name: /log in/i });
+        expect(submitButton).toBeEnabled();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -174,7 +174,6 @@ export function Login() {
   const [isVerifyingMfa, setIsVerifyingMfa] = useState(false);
   const [healthStatus, setHealthStatus] = useState<HealthStatus | null>(null);
   const [isHealthCheckLoading, setIsHealthCheckLoading] = useState(true);
-  const [healthCheckError, setHealthCheckError] = useState(false);
 
   // Check backend health on component mount and when online status changes
   useEffect(() => {
@@ -185,7 +184,6 @@ export function Login() {
       if (!isOnline) {
         if (isMounted) {
           setIsHealthCheckLoading(false);
-          setHealthCheckError(false);
         }
         return;
       }
@@ -194,7 +192,6 @@ export function Login() {
       if (isMounted) {
         setIsHealthCheckLoading(true);
         setHealthStatus(null);
-        setHealthCheckError(false);
       }
 
       try {
@@ -215,7 +212,6 @@ export function Login() {
 
             if (isMounted) {
               setHealthStatus(status);
-              setHealthCheckError(false);
             }
 
             return;
@@ -225,7 +221,6 @@ export function Login() {
 
             if (isMounted && isLastAttempt) {
               setHealthStatus(null);
-              setHealthCheckError(true);
             }
           }
         }
@@ -243,10 +238,8 @@ export function Login() {
     };
   }, [isOnline]); // Re-run when online status changes
 
-  // Determine if system is not ready (health check failed or backend reported not_ready)
-  // Only check health status when online; offline is handled separately
-  const isSystemNotReady =
-    isOnline && (healthCheckError || healthStatus?.status === "not_ready");
+  // Only an explicit backend not_ready result should block sign-in.
+  const isSystemNotReady = isOnline && healthStatus?.status === "not_ready";
 
   // Compute aria-describedby for inputs (combines error, lockout, and offline alerts)
   const ariaDescribedBy =


### PR DESCRIPTION
## Summary
- stop treating transport-level readiness probe failures as a login-blocking system-not-ready state
- keep login blocking scoped to explicit backend `status: "not_ready"` responses
- add focused regression coverage for both the direct transport-error path and the offline-to-online retry path

## Testing
- npx vitest run src/pages/Login.test.tsx
- npx eslint src/pages/Login.tsx src/pages/Login.test.tsx
- npm run typecheck

Closes #991
