### PR TITLE
fix: harden live assetlinks delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dropped restoration of legacy cleartext and pre-v2 encrypted `auth_user` localStorage payloads; unsupported auth-storage records are now purged instead of being restored, and frontend test fixtures now seed authenticated state through the encrypted storage path only
 - Dropped the legacy `template_id` alias in the onboarding submission client so runtime writes now require `form_template_id` only, matching the current API contract during the project's `0.x` line
 - Renamed the build test suite from `Build Output Verification` to `Build Configuration and Source Verification` to match the JSDoc comment on the describe block
-- Replaced the `vite-plugin-static-copy` `rename: { stripBase: true }` option with `rename: "assetlinks.json"` to use the correct string-based API
+- Restored the documented `vite-plugin-static-copy` rename object for Digital Asset Links so the build flattens `config/assetlinks.json` to `assetlinks.json` instead of nesting it under `config/` in the output tree
 - Clarified the `manualChunks` comment in `vite.config.ts` to accurately describe the Rollup/Rolldown output API rather than attributing the requirement to Vite 8 specifically
 - Replaced `Buffer.from().toString("base64")` with a chunked `btoa` implementation in the Playwright auth storage utility for browser-compatible base64 encoding
 - Added `AUTH_STORAGE_KEY_MATERIAL_PREFIX` constant in the Playwright auth storage utility to avoid the `secpal-auth-storage:` magic string being duplicated between test utility and production code
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Stopped the login page from treating transient readiness-probe transport failures as a backend `not_ready` state, so sign-in now stays enabled unless the API explicitly reports `status: "not_ready"`, resolving frontend issue #991.
+- Added a deploy-safe Digital Asset Links fallback by shipping `assetlinks.json` at the build root, serving `/.well-known/assetlinks.json` through an exact-match Nginx fallback, and adding a live smoke check so `app.secpal.dev` no longer regresses to the SPA shell or a stale DAL payload during Android passkey rollout, resolving frontend issue #925.
 - Localized the shared login-page passkey sign-in cancellation, timeout, provider-availability, and fallback messages so the Android native Credential Manager path no longer falls back to English on German devices after a cancelled passkey prompt, resolving frontend issue #978.
 - Limited Playwright Lighthouse audits to the desktop `chromium` project so strict all-project live E2E runs no longer fail in `mobile-chrome`, which lacks the fixed CDP port required by `playwright-lighthouse` for `app.secpal.dev` audits.
 - Split the live no-secret Playwright auth smoke away from the deterministic local invalid-credential and hard-login-redirect assertions, so `app.secpal.dev` now validates the shipped health-gated login state and browser-session protected-route recovery flow instead of failing on outdated assumptions, resolving frontend issue #975.

--- a/deploy/nginx/app.secpal.dev.conf
+++ b/deploy/nginx/app.secpal.dev.conf
@@ -45,6 +45,25 @@ server {
     return 404;
   }
 
+  # Keep Digital Asset Links reachable even if a deployment transport skips
+  # hidden directories like .well-known and only uploads root files.
+  location = /.well-known/assetlinks.json {
+    default_type application/json;
+    add_header Content-Security-Policy $secpal_csp always;
+    add_header Permissions-Policy $secpal_permissions_policy always;
+    add_header Strict-Transport-Security $secpal_hsts always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "0" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    add_header Cross-Origin-Resource-Policy "same-origin" always;
+    add_header Origin-Agent-Cluster "?1" always;
+    add_header X-Permitted-Cross-Domain-Policies "none" always;
+    add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+    try_files $uri /assetlinks.json =404;
+  }
+
   # Nginx does not inherit add_header directives into locations that declare
   # their own headers, so the PWA-critical exact matches repeat the baseline.
   location = / {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test:e2e:live:passkeys": "cross-env PLAYWRIGHT_BASE_URL=https://app.secpal.dev PLAYWRIGHT_API_BASE_URL=https://api.secpal.dev PLAYWRIGHT_LIVE_PASSKEY=1 PLAYWRIGHT_SKIP_GLOBAL_LOGIN=1 playwright test tests/e2e/passkeys.live.spec.ts --project=chromium",
     "test:e2e:offline-logout": "cross-env CI=true PLAYWRIGHT_SKIP_GLOBAL_LOGIN=1 playwright test tests/e2e/offline-logout.spec.ts --project=chromium --project=mobile-chrome",
     "test:e2e:offline-logout:staging": "cross-env PLAYWRIGHT_BASE_URL=https://app.secpal.dev PLAYWRIGHT_SKIP_GLOBAL_LOGIN=1 playwright test tests/e2e/offline-logout.spec.ts --project=chromium --project=mobile-chrome",
+    "test:live:assetlinks": "bash ./scripts/check-live-assetlinks.sh",
     "test:live:auth-routes": "bash ./scripts/check-live-auth-route-separation.sh",
     "test:live:pwa-headers": "bash ./scripts/check-live-pwa-headers.sh",
     "format": "prettier --write --cache '**/*.{md,yml,yaml,json,ts,tsx,js,jsx}'",

--- a/scripts/check-live-assetlinks.sh
+++ b/scripts/check-live-assetlinks.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+APP_URL="${APP_URL:-https://app.secpal.dev}"
+ASSETLINKS_URL="${APP_URL%/}/.well-known/assetlinks.json"
+EXPECTED_PACKAGE_NAME="${EXPECTED_PACKAGE_NAME:-app.secpal}"
+EXPECTED_FINGERPRINT="${EXPECTED_FINGERPRINT:-C3:E9:FD:07:69:F3:34:9B:B0:B0:56:BA:E6:69:47:23:40:E1:CB:28:66:26:DE:30:C9:C9:FA:F9:5F:1E:47:B5}"
+
+last_response_headers() {
+    local raw="$1"
+
+    printf '%s\n' "$raw" | awk '
+        /^HTTP\/[0-9.]+ / { block = "" }
+        { block = block "\n" $0 }
+        END { print block }
+    '
+}
+
+get_header_value() {
+    local headers="$1"
+    local header_name="$2"
+
+    printf '%s\n' "$headers" | awk -v target="$header_name" '
+        BEGIN {
+            FS = ": "
+        }
+        tolower($1) == tolower(target) {
+            gsub(/\r/, "", $2)
+            print $2
+            exit
+        }
+    '
+}
+
+get_status_code() {
+    local headers="$1"
+
+    printf '%s\n' "$headers" | awk '/^HTTP\/[0-9.]+ / { code = $2 } END { if (code != "") print code }'
+}
+
+tmp_headers="$(mktemp)"
+tmp_body="$(mktemp)"
+trap 'rm -f "$tmp_headers" "$tmp_body"' EXIT
+
+if ! curl --silent --show-error --location --retry 2 --retry-delay 2 \
+    --header 'Accept: application/json' \
+    --dump-header "$tmp_headers" \
+    --output "$tmp_body" \
+    "$ASSETLINKS_URL"; then
+    echo "ERROR: request failed for ${ASSETLINKS_URL}"
+    exit 1
+fi
+
+raw_headers="$(cat "$tmp_headers")"
+headers="$(last_response_headers "$raw_headers")"
+status="$(get_status_code "$raw_headers")"
+content_type="$(get_header_value "$headers" 'Content-Type')"
+
+if [[ "$status" != "200" ]]; then
+    echo "ERROR: expected HTTP 200 for ${ASSETLINKS_URL}"
+    echo "  actual status: ${status:-<missing>}"
+    exit 1
+fi
+
+if [[ "$content_type" != application/json* ]]; then
+    echo "ERROR: ${ASSETLINKS_URL} did not return JSON"
+    echo "  expected: application/json"
+    echo "  actual:   ${content_type:-<missing>}"
+    exit 1
+fi
+
+node - "$tmp_body" "$EXPECTED_PACKAGE_NAME" "$EXPECTED_FINGERPRINT" <<'NODE'
+const fs = require('node:fs');
+
+const [, , filePath, expectedPackageName, expectedFingerprint] = process.argv;
+const payload = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+
+if (!Array.isArray(payload) || payload.length !== 1) {
+  console.error('ERROR: assetlinks payload must contain exactly one statement');
+  process.exit(1);
+}
+
+const [statement] = payload;
+const relations = new Set(Array.isArray(statement.relation) ? statement.relation : []);
+const target = statement.target ?? {};
+const fingerprints = new Set(
+  Array.isArray(target.sha256_cert_fingerprints)
+    ? target.sha256_cert_fingerprints
+    : []
+);
+
+for (const relation of [
+  'delegate_permission/common.handle_all_urls',
+  'delegate_permission/common.get_login_creds',
+]) {
+  if (!relations.has(relation)) {
+    console.error(`ERROR: missing relation ${relation}`);
+    process.exit(1);
+  }
+}
+
+if (target.namespace !== 'android_app') {
+  console.error(`ERROR: unexpected target namespace ${String(target.namespace)}`);
+  process.exit(1);
+}
+
+if (target.package_name !== expectedPackageName) {
+  console.error(`ERROR: unexpected package_name ${String(target.package_name)}`);
+  process.exit(1);
+}
+
+if (!fingerprints.has(expectedFingerprint)) {
+  console.error('ERROR: expected signing fingerprint missing from assetlinks payload');
+  process.exit(1);
+}
+NODE
+
+echo "Live assetlinks delivery smoke test passed"

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -152,7 +152,12 @@ describe("Build Configuration and Source Verification", () => {
       2
     );
     expect(viteConfig).toContain('dest: ".well-known"');
-    expect(viteConfig).toContain('dest: "."');
+    expect(
+      viteConfig
+        .split('src: "config/assetlinks.json"')
+        .slice(1)
+        .some((block) => block.includes('dest: "."'))
+    ).toBe(true);
     expect(
       viteConfig.split('rename: { stripBase: true, name: "assetlinks.json" }')
         .length - 1

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -154,9 +154,8 @@ describe("Build Configuration and Source Verification", () => {
     expect(viteConfig).toContain('dest: ".well-known"');
     expect(viteConfig).toContain('dest: "."');
     expect(
-      viteConfig.split(
-        'rename: { stripBase: true, name: "assetlinks.json" }'
-      ).length - 1
+      viteConfig.split('rename: { stripBase: true, name: "assetlinks.json" }')
+        .length - 1
     ).toBe(2);
   });
 

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -148,9 +148,24 @@ describe("Build Configuration and Source Verification", () => {
     const viteConfig = readRepoFile("vite.config.ts");
 
     expect(viteConfig).toContain("vite-plugin-static-copy");
-    expect(viteConfig).toContain('src: "config/assetlinks.json"');
+    expect(viteConfig.split('src: "config/assetlinks.json"').length - 1).toBe(
+      2
+    );
     expect(viteConfig).toContain('dest: ".well-known"');
-    expect(viteConfig).toContain('rename: "assetlinks.json"');
+    expect(viteConfig).toContain('dest: "."');
+    expect(
+      viteConfig.split(
+        'rename: { stripBase: true, name: "assetlinks.json" }'
+      ).length - 1
+    ).toBe(2);
+  });
+
+  it("keeps nginx serving Digital Asset Links even when hidden directories are skipped during deploy", () => {
+    const nginxConfig = readRepoFile("deploy/nginx/app.secpal.dev.conf");
+
+    expect(nginxConfig).toContain("location = /.well-known/assetlinks.json");
+    expect(nginxConfig).toContain("default_type application/json");
+    expect(nginxConfig).toContain("try_files $uri /assetlinks.json =404;");
   });
 
   it("hardens browser responses with the required security headers", () => {
@@ -234,6 +249,18 @@ describe("Build Configuration and Source Verification", () => {
 
     expect(packageJson).toContain(
       '"test:live:pwa-headers": "bash ./scripts/check-live-pwa-headers.sh"'
+    );
+  });
+
+  it("ships a live smoke check for deployed assetlinks delivery", () => {
+    expect(
+      existsSync(path.join(repoRoot, "scripts/check-live-assetlinks.sh"))
+    ).toBe(true);
+
+    const packageJson = readRepoFile("package.json");
+
+    expect(packageJson).toContain(
+      '"test:live:assetlinks": "bash ./scripts/check-live-assetlinks.sh"'
     );
   });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -69,7 +69,12 @@ export default defineConfig(({ mode }) => {
           {
             src: "config/assetlinks.json",
             dest: ".well-known",
-            rename: "assetlinks.json",
+            rename: { stripBase: true, name: "assetlinks.json" },
+          },
+          {
+            src: "config/assetlinks.json",
+            dest: ".",
+            rename: { stripBase: true, name: "assetlinks.json" },
           },
         ],
       }),


### PR DESCRIPTION
## Summary
- fix the Digital Asset Links build copy so assetlinks.json is flattened instead of being emitted under config/
- ship a deploy-safe root fallback plus an exact-match Nginx location for /.well-known/assetlinks.json
- add live smoke coverage and regression tests for assetlinks delivery

## Validation
- npx vitest run tests/build.test.ts
- npx eslint vite.config.ts tests/build.test.ts
- npm run build

## Runtime note
- Reproduced the current live failure on 2026-04-24: https://app.secpal.dev/.well-known/assetlinks.json returned the SPA HTML shell instead of JSON before this fix.

Closes #925
