### PR TITLE
fix: scope Lingui build transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Switched the Vite Lingui macro transform from an unfiltered Babel plugin run to Lingui's filtered `linguiTransformerBabelPreset()`, reducing unnecessary production-build plugin work and hardening the frontend against renewed Rolldown `PLUGIN_TIMINGS` warnings during `npm run build` (frontend issue #901).
 - Migrated the frontend Lingui toolchain to the v6-compatible formatter and split macro entry points (`@lingui/core/macro`, `@lingui/react/macro`) so Dependabot Lingui update PRs no longer fail CI on mixed-version `I18n` types, stale `@lingui/macro` extraction, or the removed `format: "po"` setting.
 - Wired the central Copilot-instructions validator into `quality.yml` so frontend pull requests now fail automatically when known React AI-risk guardrails or generic AI-triage guidance are missing from the runtime baseline
 - Dropped restoration of legacy cleartext and pre-v2 encrypted `auth_user` localStorage payloads; unsupported auth-storage records are now purged instead of being restored, and frontend test fixtures now seed authenticated state through the encrypted storage path only

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -167,11 +167,11 @@ describe("Build Configuration and Source Verification", () => {
   it("scopes the Lingui macro Babel transform to files that import Lingui macros", () => {
     const viteConfig = readRepoFile("vite.config.ts");
 
-    expect(viteConfig).toContain("linguiTransformerBabelPreset");
-    expect(viteConfig).toContain("presets: [linguiTransformerBabelPreset()]");
-    expect(viteConfig).not.toContain(
-      'plugins: ["@lingui/babel-plugin-lingui-macro"]'
+    expect(viteConfig).toMatch(/\blinguiTransformerBabelPreset\b/);
+    expect(viteConfig).toMatch(
+      /presets\s*:\s*\[\s*linguiTransformerBabelPreset\(\)\s*\]/
     );
+    expect(viteConfig).not.toMatch(/@lingui\/babel-plugin-lingui-macro/);
   });
 
   it("keeps nginx serving Digital Asset Links even when hidden directories are skipped during deploy", () => {

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -164,6 +164,16 @@ describe("Build Configuration and Source Verification", () => {
     ).toBe(2);
   });
 
+  it("scopes the Lingui macro Babel transform to files that import Lingui macros", () => {
+    const viteConfig = readRepoFile("vite.config.ts");
+
+    expect(viteConfig).toContain("linguiTransformerBabelPreset");
+    expect(viteConfig).toContain("presets: [linguiTransformerBabelPreset()]");
+    expect(viteConfig).not.toContain(
+      'plugins: ["@lingui/babel-plugin-lingui-macro"]'
+    );
+  });
+
   it("keeps nginx serving Digital Asset Links even when hidden directories are skipped during deploy", () => {
     const nginxConfig = readRepoFile("deploy/nginx/app.secpal.dev.conf");
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@
 import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import babel from "@rolldown/plugin-babel";
-import { lingui } from "@lingui/vite-plugin";
+import { lingui, linguiTransformerBabelPreset } from "@lingui/vite-plugin";
 import tailwindcss from "@tailwindcss/vite";
 import { VitePWA } from "vite-plugin-pwa";
 import { viteStaticCopy } from "vite-plugin-static-copy";
@@ -54,7 +54,7 @@ export default defineConfig(({ mode }) => {
     plugins: [
       react({}),
       babel({
-        plugins: ["@lingui/babel-plugin-lingui-macro"],
+        presets: [linguiTransformerBabelPreset()],
       }),
       lingui(),
       tailwindcss(),


### PR DESCRIPTION
## Summary
- switch the Vite Lingui macro transform to `linguiTransformerBabelPreset()` so Rolldown Babel only processes files that actually import Lingui macros
- add a build configuration guard test that keeps the filtered Lingui preset in place
- document the build-pipeline hardening in `CHANGELOG.md`

## Validation
- npx vitest run tests/build.test.ts
- npx eslint vite.config.ts tests/build.test.ts
- npm run build

## Notes
- `npm run build` on current `main` no longer reproduced the historical `PLUGIN_TIMINGS` warning from issue #901; this change still removes unnecessary plugin work and guards the intended filtered configuration going forward

Closes #901.
