### PR TITLE
fix: honor authoritative login lockouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Mirrored backend `429` login lockouts into the frontend login rate limiter via `Retry-After` and added Playwright regression coverage, so the login UI now stays in the authoritative cooldown state instead of falling back to local failed-attempt tracking, resolving frontend issue #803.
 - Stopped the login page from treating transient readiness-probe transport failures as a backend `not_ready` state, so sign-in now stays enabled unless the API explicitly reports `status: "not_ready"`, resolving frontend issue #991.
 - Added a deploy-safe Digital Asset Links fallback by shipping `assetlinks.json` at the build root, serving `/.well-known/assetlinks.json` through an exact-match Nginx fallback, and adding a live smoke check so `app.secpal.dev` no longer regresses to the SPA shell or a stale DAL payload during Android passkey rollout, resolving frontend issue #925.
 - Localized the shared login-page passkey sign-in cancellation, timeout, provider-availability, and fallback messages so the Android native Credential Manager path no longer falls back to English on German devices after a cancelled passkey prompt, resolving frontend issue #978.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Mirrored backend `429` login lockouts into the frontend login rate limiter via `Retry-After` and added Playwright regression coverage, so the login UI now stays in the authoritative cooldown state instead of falling back to local failed-attempt tracking, resolving frontend issue #803.
+- Fixed RFC-correct handling of `Retry-After: 0` on `429` login responses; the header value is now parsed as valid rather than discarded, and `syncAuthoritativeLockout(0)` clears the local lockout state so the form remains immediately usable, matching the server's intent to allow an instant retry.
 - Stopped the login page from treating transient readiness-probe transport failures as a backend `not_ready` state, so sign-in now stays enabled unless the API explicitly reports `status: "not_ready"`, resolving frontend issue #991.
 - Added a deploy-safe Digital Asset Links fallback by shipping `assetlinks.json` at the build root, serving `/.well-known/assetlinks.json` through an exact-match Nginx fallback, and adding a live smoke check so `app.secpal.dev` no longer regresses to the SPA shell or a stale DAL payload during Android passkey rollout, resolving frontend issue #925.
 - Localized the shared login-page passkey sign-in cancellation, timeout, provider-availability, and fallback messages so the Android native Credential Manager path no longer falls back to English on German devices after a cancelled passkey prompt, resolving frontend issue #978.

--- a/src/hooks/useLoginRateLimiter.test.ts
+++ b/src/hooks/useLoginRateLimiter.test.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
@@ -160,6 +160,44 @@ describe("useLoginRateLimiter", () => {
 
       // Lockout end time should not change
       expect(result.current.lockoutEndTime).toBe(lockoutEnd);
+    });
+
+    it("keeps a server-authoritative lockout active for the retry-after window", () => {
+      const { result } = renderHook(() => useLoginRateLimiter());
+
+      act(() => {
+        result.current.syncAuthoritativeLockout(120);
+      });
+
+      expect(result.current.isLocked).toBe(true);
+      expect(result.current.remainingAttempts).toBe(0);
+      expect(result.current.remainingLockoutSeconds).toBeGreaterThanOrEqual(119);
+      expect(result.current.remainingLockoutSeconds).toBeLessThanOrEqual(120);
+
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}");
+      expect(stored.attempts).toBe(5);
+    });
+
+    it("does not shorten an active authoritative lockout when a weaker retry-after arrives", () => {
+      const { result } = renderHook(() => useLoginRateLimiter());
+
+      act(() => {
+        result.current.syncAuthoritativeLockout(120);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(10_000);
+      });
+
+      const lockoutEndTime = result.current.lockoutEndTime;
+
+      act(() => {
+        result.current.syncAuthoritativeLockout(30);
+      });
+
+      expect(result.current.lockoutEndTime).toBe(lockoutEndTime);
+      expect(result.current.remainingLockoutSeconds).toBeGreaterThanOrEqual(109);
+      expect(result.current.remainingLockoutSeconds).toBeLessThanOrEqual(110);
     });
   });
 

--- a/src/hooks/useLoginRateLimiter.test.ts
+++ b/src/hooks/useLoginRateLimiter.test.ts
@@ -171,7 +171,9 @@ describe("useLoginRateLimiter", () => {
 
       expect(result.current.isLocked).toBe(true);
       expect(result.current.remainingAttempts).toBe(0);
-      expect(result.current.remainingLockoutSeconds).toBeGreaterThanOrEqual(119);
+      expect(result.current.remainingLockoutSeconds).toBeGreaterThanOrEqual(
+        119
+      );
       expect(result.current.remainingLockoutSeconds).toBeLessThanOrEqual(120);
 
       const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}");
@@ -196,7 +198,9 @@ describe("useLoginRateLimiter", () => {
       });
 
       expect(result.current.lockoutEndTime).toBe(lockoutEndTime);
-      expect(result.current.remainingLockoutSeconds).toBeGreaterThanOrEqual(109);
+      expect(result.current.remainingLockoutSeconds).toBeGreaterThanOrEqual(
+        109
+      );
       expect(result.current.remainingLockoutSeconds).toBeLessThanOrEqual(110);
     });
   });

--- a/src/hooks/useLoginRateLimiter.test.ts
+++ b/src/hooks/useLoginRateLimiter.test.ts
@@ -180,6 +180,17 @@ describe("useLoginRateLimiter", () => {
       expect(stored.attempts).toBe(5);
     });
 
+    it("does not lock out when Retry-After: 0 (retry immediately)", () => {
+      const { result } = renderHook(() => useLoginRateLimiter());
+
+      act(() => {
+        result.current.syncAuthoritativeLockout(0);
+      });
+
+      expect(result.current.isLocked).toBe(false);
+      expect(result.current.canAttemptLogin()).toBe(true);
+    });
+
     it("does not shorten an active authoritative lockout when a weaker retry-after arrives", () => {
       const { result } = renderHook(() => useLoginRateLimiter());
 

--- a/src/hooks/useLoginRateLimiter.ts
+++ b/src/hooks/useLoginRateLimiter.ts
@@ -118,6 +118,20 @@ export function useLoginRateLimiter(): UseLoginRateLimiterResult {
   const syncAuthoritativeLockout = useCallback(
     (retryAfterSeconds?: number) => {
       const currentTime = Date.now();
+
+      // Retry-After: 0 means "retry immediately" — clear any client-side lockout
+      if (retryAfterSeconds === 0) {
+        const clearedState: RateLimitState = {
+          attempts: 0,
+          lockoutEndTime: null,
+          lastAttemptTime: currentTime,
+        };
+        setNow(currentTime);
+        setState(clearedState);
+        saveState(clearedState);
+        return;
+      }
+
       const retryAfterMs =
         typeof retryAfterSeconds === "number" && retryAfterSeconds > 0
           ? retryAfterSeconds * 1000

--- a/src/hooks/useLoginRateLimiter.ts
+++ b/src/hooks/useLoginRateLimiter.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { useState, useEffect, useCallback, useRef } from "react";
@@ -7,6 +7,7 @@ const STORAGE_KEY = "login_rate_limit";
 const MAX_ATTEMPTS = 5;
 const LOCKOUT_DURATION_MS = 30 * 1000; // 30 seconds
 const ATTEMPT_RESET_DURATION_MS = 15 * 60 * 1000; // 15 minutes
+const DEFAULT_AUTHORITATIVE_LOCKOUT_DURATION_MS = 60 * 1000; // 60 seconds
 
 interface RateLimitState {
   attempts: number;
@@ -27,6 +28,8 @@ interface UseLoginRateLimiterResult {
   canAttemptLogin: () => boolean;
   /** Record a failed login attempt */
   recordFailedAttempt: () => void;
+  /** Mirror a server-authoritative lockout from a 429 response */
+  syncAuthoritativeLockout: (retryAfterSeconds?: number) => void;
   /** Reset all attempts (call after successful login) */
   resetAttempts: () => void;
 }
@@ -112,6 +115,34 @@ export function useLoginRateLimiter(): UseLoginRateLimiterResult {
     saveState(newState);
   }, [state.attempts, state.lockoutEndTime]);
 
+  const syncAuthoritativeLockout = useCallback(
+    (retryAfterSeconds?: number) => {
+      const currentTime = Date.now();
+      const retryAfterMs =
+        typeof retryAfterSeconds === "number" && retryAfterSeconds > 0
+          ? retryAfterSeconds * 1000
+          : DEFAULT_AUTHORITATIVE_LOCKOUT_DURATION_MS;
+      const requestedLockoutEndTime = currentTime + retryAfterMs;
+      const currentLockoutEndTime =
+        state.lockoutEndTime && state.lockoutEndTime > currentTime
+          ? state.lockoutEndTime
+          : null;
+
+      const newState: RateLimitState = {
+        attempts: MAX_ATTEMPTS,
+        lockoutEndTime: currentLockoutEndTime
+          ? Math.max(currentLockoutEndTime, requestedLockoutEndTime)
+          : requestedLockoutEndTime,
+        lastAttemptTime: currentTime,
+      };
+
+      setNow(currentTime);
+      setState(newState);
+      saveState(newState);
+    },
+    [state.lockoutEndTime]
+  );
+
   const resetAttempts = useCallback(() => {
     setState({
       attempts: 0,
@@ -128,6 +159,7 @@ export function useLoginRateLimiter(): UseLoginRateLimiterResult {
     remainingLockoutSeconds,
     canAttemptLogin,
     recordFailedAttempt,
+    syncAuthoritativeLockout,
     resetAttempts,
   };
 }

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -639,7 +639,7 @@ describe("Login", () => {
       )
     ).rejects.toThrow("Passkeys are not available in this browser.");
 
-    vi.stubGlobal("PublicKeyCredential", class PublicKeyCredentialMock {});
+    vi.stubGlobal("PublicKeyCredential", class PublicKeyCredentialMock { });
     Object.defineProperty(navigator, "credentials", {
       configurable: true,
       value: {
@@ -1316,7 +1316,7 @@ describe("Login", () => {
     const mockVerifyMfaChallenge = vi.mocked(authApi.verifyMfaChallenge);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => {});
+      .mockImplementation(() => { });
 
     mockLogin.mockResolvedValueOnce({
       challenge: {
@@ -1392,7 +1392,7 @@ describe("Login", () => {
   it("shows an error when MFA challenge response has an unexpected mode", async () => {
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => {});
+      .mockImplementation(() => { });
     vi.mocked(authApi.verifyMfaChallenge).mockResolvedValueOnce({
       user: createAuthUser(),
       authentication: {
@@ -1453,7 +1453,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => {});
+      .mockImplementation(() => { });
 
     mockLogin.mockRejectedValueOnce(
       new authApi.AuthApiError("Server Error", undefined, 500)
@@ -1493,7 +1493,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => {});
+      .mockImplementation(() => { });
     mockLogin.mockRejectedValueOnce(new Error("Network error"));
 
     renderLogin();
@@ -1527,7 +1527,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => {});
+      .mockImplementation(() => { });
     mockLogin.mockRejectedValueOnce("string error");
 
     renderLogin();
@@ -1934,6 +1934,53 @@ describe("Login", () => {
           screen.getByText(/too many failed attempts/i)
         ).toBeInTheDocument();
       });
+    });
+
+    it("applies a server-authoritative lockout when login returns 429 with retry-after", async () => {
+      const mockLogin = vi.mocked(authApi.login);
+      mockLogin.mockRejectedValueOnce(
+        new authApi.AuthApiError(
+          "Too many login attempts. Please try again later.",
+          undefined,
+          429,
+          undefined,
+          120
+        )
+      );
+
+      renderLogin();
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /log in/i })
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByLabelText(/email/i), {
+        target: { value: "test@secpal.dev" },
+      });
+      fireEvent.change(screen.getByLabelText(/password/i), {
+        target: { value: "wrong" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /log in/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/too many failed attempts/i)
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByText(/too many login attempts\. please try again later\./i)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /locked \(120s\)|locked \(119s\)/i })
+      ).toBeDisabled();
+
+      const stored = JSON.parse(
+        localStorage.getItem("login_rate_limit") || "{}"
+      );
+      expect(stored.attempts).toBe(5);
     });
 
     it("disables form inputs and button during lockout", async () => {

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -639,7 +639,7 @@ describe("Login", () => {
       )
     ).rejects.toThrow("Passkeys are not available in this browser.");
 
-    vi.stubGlobal("PublicKeyCredential", class PublicKeyCredentialMock { });
+    vi.stubGlobal("PublicKeyCredential", class PublicKeyCredentialMock {});
     Object.defineProperty(navigator, "credentials", {
       configurable: true,
       value: {
@@ -1316,7 +1316,7 @@ describe("Login", () => {
     const mockVerifyMfaChallenge = vi.mocked(authApi.verifyMfaChallenge);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => { });
+      .mockImplementation(() => {});
 
     mockLogin.mockResolvedValueOnce({
       challenge: {
@@ -1392,7 +1392,7 @@ describe("Login", () => {
   it("shows an error when MFA challenge response has an unexpected mode", async () => {
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => { });
+      .mockImplementation(() => {});
     vi.mocked(authApi.verifyMfaChallenge).mockResolvedValueOnce({
       user: createAuthUser(),
       authentication: {
@@ -1453,7 +1453,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => { });
+      .mockImplementation(() => {});
 
     mockLogin.mockRejectedValueOnce(
       new authApi.AuthApiError("Server Error", undefined, 500)
@@ -1493,7 +1493,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => { });
+      .mockImplementation(() => {});
     mockLogin.mockRejectedValueOnce(new Error("Network error"));
 
     renderLogin();
@@ -1527,7 +1527,7 @@ describe("Login", () => {
     const mockLogin = vi.mocked(authApi.login);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
-      .mockImplementation(() => { });
+      .mockImplementation(() => {});
     mockLogin.mockRejectedValueOnce("string error");
 
     renderLogin();

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -1974,13 +1974,56 @@ describe("Login", () => {
         screen.getByText(/too many login attempts\. please try again later\./i)
       ).toBeInTheDocument();
       expect(
-        screen.getByRole("button", { name: /locked \(120s\)|locked \(119s\)/i })
+        screen.getByRole("button", { name: /locked \(\d+s\)/i })
       ).toBeDisabled();
 
       const stored = JSON.parse(
         localStorage.getItem("login_rate_limit") || "{}"
       );
       expect(stored.attempts).toBe(5);
+    });
+
+    it("does not lock out when login returns 429 with Retry-After: 0", async () => {
+      const mockLogin = vi.mocked(authApi.login);
+      mockLogin.mockRejectedValueOnce(
+        new authApi.AuthApiError(
+          "Too many login attempts. Please try again later.",
+          undefined,
+          429,
+          undefined,
+          0
+        )
+      );
+
+      renderLogin();
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /log in/i })
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByLabelText(/email/i), {
+        target: { value: "test@secpal.dev" },
+      });
+      fireEvent.change(screen.getByLabelText(/password/i), {
+        target: { value: "wrong" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /log in/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            /too many login attempts\. please try again later\./i
+          )
+        ).toBeInTheDocument();
+      });
+
+      // Retry-After: 0 means retry immediately — form must remain enabled
+      expect(
+        screen.getByRole("button", { name: /log in/i })
+      ).not.toBeDisabled();
+      expect(screen.getByLabelText(/email/i)).not.toBeDisabled();
     });
 
     it("disables form inputs and button during lockout", async () => {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -155,6 +155,7 @@ export function Login() {
     remainingLockoutSeconds,
     canAttemptLogin,
     recordFailedAttempt,
+    syncAuthoritativeLockout,
     resetAttempts,
   } = useLoginRateLimiter();
   const isOnline = useOnlineStatus();
@@ -281,6 +282,12 @@ export function Login() {
       if (err instanceof AuthApiError) {
         if ((err.status ?? 0) >= 500) {
           setError(TEMPORARY_LOGIN_UNAVAILABLE_MESSAGE);
+          return;
+        }
+
+        if (err.status === 429) {
+          syncAuthoritativeLockout(err.retryAfterSeconds);
+          setError(err.message);
           return;
         }
 

--- a/src/services/authApi.test.ts
+++ b/src/services/authApi.test.ts
@@ -321,6 +321,32 @@ describe("authApi", () => {
         });
       }
     });
+
+    it("captures retry-after metadata on 429 login errors", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+      } as Response);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        headers: new Headers({
+          "Content-Type": "application/json",
+          "Retry-After": "120",
+        }),
+        json: async () => ({
+          message: "Too many login attempts. Please try again later.",
+        }),
+      } as Response);
+
+      await expect(
+        login({ email: "test@secpal.dev", password: "wrong" })
+      ).rejects.toMatchObject({
+        message: "Too many login attempts. Please try again later.",
+        status: 429,
+        retryAfterSeconds: 120,
+      });
+    });
   });
 
   describe("logout", () => {
@@ -1204,6 +1230,18 @@ describe("authApi", () => {
 
       expect(error.status).toBe(409);
       expect(error.code).toBe("CONFLICT");
+    });
+
+    it("stores optional retry-after metadata", () => {
+      const error = new AuthApiError(
+        "Rate limited",
+        undefined,
+        429,
+        undefined,
+        90
+      );
+
+      expect(error.retryAfterSeconds).toBe(90);
     });
   });
 });

--- a/src/services/authApi.test.ts
+++ b/src/services/authApi.test.ts
@@ -347,6 +347,32 @@ describe("authApi", () => {
         retryAfterSeconds: 120,
       });
     });
+
+    it("treats Retry-After: 0 as valid (retry immediately) on 429 login errors", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+      } as Response);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        headers: new Headers({
+          "Content-Type": "application/json",
+          "Retry-After": "0",
+        }),
+        json: async () => ({
+          message: "Too many login attempts. Please try again later.",
+        }),
+      } as Response);
+
+      await expect(
+        login({ email: "test@secpal.dev", password: "wrong" })
+      ).rejects.toMatchObject({
+        message: "Too many login attempts. Please try again later.",
+        status: 429,
+        retryAfterSeconds: 0,
+      });
+    });
   });
 
   describe("logout", () => {

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -82,12 +82,32 @@ async function parseJsonError(response: Response): Promise<ApiError | null> {
   }
 }
 
+function parseRetryAfterSeconds(response: Response): number | undefined {
+  if (
+    !("headers" in response) ||
+    !response.headers ||
+    typeof response.headers.get !== "function"
+  ) {
+    return undefined;
+  }
+
+  const retryAfterHeader = response.headers.get("Retry-After");
+  const retryAfterSeconds = retryAfterHeader
+    ? Number.parseInt(retryAfterHeader, 10)
+    : Number.NaN;
+
+  return Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
+    ? retryAfterSeconds
+    : undefined;
+}
+
 export class AuthApiError extends Error {
   constructor(
     message: string,
     public errors?: Record<string, string[]>,
     public status?: number,
-    public code?: string
+    public code?: string,
+    public retryAfterSeconds?: number
   ) {
     super(message);
     this.name = "AuthApiError";
@@ -100,16 +120,24 @@ async function createAuthApiError(
   nonJsonMessage = `${defaultMessage}: ${response.status} ${response.statusText}`
 ): Promise<AuthApiError> {
   const error = await parseJsonError(response);
+  const retryAfterSeconds = parseRetryAfterSeconds(response);
 
   if (!error) {
-    return new AuthApiError(nonJsonMessage, undefined, response.status);
+    return new AuthApiError(
+      nonJsonMessage,
+      undefined,
+      response.status,
+      undefined,
+      retryAfterSeconds
+    );
   }
 
   return new AuthApiError(
     error.message || defaultMessage,
     error.errors,
     response.status,
-    error.code
+    error.code,
+    retryAfterSeconds
   );
 }
 

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -96,7 +96,7 @@ function parseRetryAfterSeconds(response: Response): number | undefined {
     ? Number.parseInt(retryAfterHeader, 10)
     : Number.NaN;
 
-  return Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
+  return Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0
     ? retryAfterSeconds
     : undefined;
 }

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -135,7 +135,7 @@ test.describe("Authentication", () => {
         page.getByText(/too many login attempts\. please try again later\./i)
       ).toBeVisible();
       await expect(
-        page.getByRole("button", { name: /locked \(120s\)|locked \(119s\)/i })
+        page.getByRole("button", { name: /locked \(\d+s\)/i })
       ).toBeDisabled();
       await expect(page.locator("#email")).toBeDisabled();
       await expect(page.locator("#password")).toBeDisabled();

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -71,6 +71,76 @@ test.describe("Authentication", () => {
       ).toBeVisible({ timeout: 10_000 });
     });
 
+    test("should honor a server-authoritative login lockout after a 429 response", async ({
+      page,
+      context,
+    }) => {
+      test.skip(
+        isRemoteE2ETarget(),
+        "Deterministic server-lockout coverage uses local mocked auth routes only."
+      );
+
+      await context.unroute("**/v1/auth/login");
+      await context.route("**/v1/auth/login", async (route) => {
+        const requestBody = route.request().postDataJSON() as
+          | { email?: string }
+          | undefined;
+
+        if (requestBody?.email === "lockout-user@secpal.dev") {
+          await route.fulfill({
+            status: 429,
+            contentType: "application/json",
+            headers: {
+              "Retry-After": "120",
+            },
+            body: JSON.stringify({
+              message: "Too many login attempts. Please try again later.",
+            }),
+          });
+
+          return;
+        }
+
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            user: {
+              id: "42",
+              name: "Jane Example",
+              email: "test@example.com",
+              emailVerified: true,
+              roles: ["Manager"],
+              permissions: [],
+              hasOrganizationalScopes: true,
+              hasCustomerAccess: true,
+              hasSiteAccess: true,
+            },
+          }),
+        });
+      });
+
+      await page.goto("/login");
+      await page.waitForLoadState("networkidle");
+      await waitForLoginFormReady(page);
+
+      await page.locator("#email").fill("lockout-user@secpal.dev");
+      await page.locator("#password").fill("wrongpassword");
+      await page
+        .getByRole("button", { name: /log in|anmelden|einloggen/i })
+        .click();
+
+      await expect(page.locator("#lockout-warning")).toBeVisible();
+      await expect(
+        page.getByText(/too many login attempts\. please try again later\./i)
+      ).toBeVisible();
+      await expect(
+        page.getByRole("button", { name: /locked \(120s\)|locked \(119s\)/i })
+      ).toBeDisabled();
+      await expect(page.locator("#email")).toBeDisabled();
+      await expect(page.locator("#password")).toBeDisabled();
+    });
+
     test("should surface the current login readiness state on live targets", async ({
       page,
     }) => {


### PR DESCRIPTION
## Summary

- mirror backend `429` login lockouts into the frontend login rate limiter via `Retry-After` so the UI stays in the authoritative cooldown state
- add focused regression coverage in `authApi`, `useLoginRateLimiter`, `Login`, and Playwright auth E2E coverage for the server-authoritative lockout path
- update the frontend changelog for issue #803

## Testing

- `npm exec -- vitest run src/services/authApi.test.ts src/hooks/useLoginRateLimiter.test.ts src/pages/Login.test.tsx`
- `PLAYWRIGHT_SKIP_GLOBAL_LOGIN=1 npm exec -- playwright test tests/e2e/auth.spec.ts --project=chromium --grep "server-authoritative login lockout"`
- `npm run typecheck`
- `npm exec -- eslint src/services/authApi.ts src/services/authApi.test.ts src/hooks/useLoginRateLimiter.ts src/hooks/useLoginRateLimiter.test.ts src/pages/Login.tsx src/pages/Login.test.tsx tests/e2e/auth.spec.ts`
- `npm exec -- playwright test`
- `npm run build`

## Related

- Closes #803

## Checklist

- [x] Single topic
- [x] CHANGELOG updated
- [x] Relevant local validation passed
- [x] Full Playwright E2E suite passed locally (`80 passed`, `24 skipped`)
