### PR TITLE
fix: harden Lingui Vite plugin interop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Hardened the Vite Lingui plugin wiring to resolve `lingui()` and `linguiTransformerBabelPreset()` from either named exports or a CommonJS `default` export, so frontend builds stay compatible with current Node/Vite CJS-interop behavior and issue #1003 is regression-covered.
 - Changed both `viteStaticCopy` `rename` options for `assetlinks.json` from the unsupported object form (`{ stripBase: true, name: "assetlinks.json" }`) to the correct string form (`"assetlinks.json"`); the object form was silently producing wrong output paths for Android Digital Asset Links at build time, resolving frontend issue #997.
 - Mirrored backend `429` login lockouts into the frontend login rate limiter via `Retry-After` and added Playwright regression coverage, so the login UI now stays in the authoritative cooldown state instead of falling back to local failed-attempt tracking, resolving frontend issue #803.
 - Fixed RFC-correct handling of `Retry-After: 0` on `429` login responses; the header value is now parsed as valid rather than discarded, and `syncAuthoritativeLockout(0)` clears the local lockout state so the form remains immediately usable, matching the server's intent to allow an instant retry.

--- a/linguiVitePluginInterop.ts
+++ b/linguiVitePluginInterop.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+type LinguiPluginFactory = (...args: unknown[]) => unknown;
+
+type LinguiVitePluginExports = {
+  lingui: LinguiPluginFactory;
+  linguiTransformerBabelPreset: LinguiPluginFactory;
+};
+
+function hasLinguiVitePluginExports(
+  value: unknown
+): value is LinguiVitePluginExports {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+
+  return (
+    typeof candidate.lingui === "function" &&
+    typeof candidate.linguiTransformerBabelPreset === "function"
+  );
+}
+
+export function resolveLinguiVitePluginExports(
+  moduleExports: unknown
+): LinguiVitePluginExports {
+  if (hasLinguiVitePluginExports(moduleExports)) {
+    return moduleExports;
+  }
+
+  if (
+    typeof moduleExports === "object" &&
+    moduleExports !== null &&
+    hasLinguiVitePluginExports(
+      (moduleExports as { default?: unknown }).default
+    )
+  ) {
+    return (moduleExports as { default: LinguiVitePluginExports }).default;
+  }
+
+  throw new TypeError(
+    "@lingui/vite-plugin did not expose usable lingui() and linguiTransformerBabelPreset() exports"
+  );
+}

--- a/linguiVitePluginInterop.ts
+++ b/linguiVitePluginInterop.ts
@@ -1,12 +1,10 @@
 // SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-type LinguiPluginFactory = (...args: unknown[]) => unknown;
-
-type LinguiVitePluginExports = {
-  lingui: LinguiPluginFactory;
-  linguiTransformerBabelPreset: LinguiPluginFactory;
-};
+type LinguiVitePluginExports = Pick<
+  typeof import("@lingui/vite-plugin"),
+  "lingui" | "linguiTransformerBabelPreset"
+>;
 
 function hasLinguiVitePluginExports(
   value: unknown

--- a/linguiVitePluginInterop.ts
+++ b/linguiVitePluginInterop.ts
@@ -33,9 +33,7 @@ export function resolveLinguiVitePluginExports(
   if (
     typeof moduleExports === "object" &&
     moduleExports !== null &&
-    hasLinguiVitePluginExports(
-      (moduleExports as { default?: unknown }).default
-    )
+    hasLinguiVitePluginExports((moduleExports as { default?: unknown }).default)
   ) {
     return (moduleExports as { default: LinguiVitePluginExports }).default;
   }

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -171,6 +171,23 @@ describe("Build Configuration and Source Verification", () => {
     expect(viteConfig).not.toMatch(/@lingui\/babel-plugin-lingui-macro/);
   });
 
+  it("loads Lingui Vite exports through CJS-safe interop wiring", () => {
+    const viteConfig = readRepoFile("vite.config.ts");
+
+    expect(viteConfig).toContain(
+      'import * as linguiVitePlugin from "@lingui/vite-plugin";'
+    );
+    expect(viteConfig).toContain(
+      'import { resolveLinguiVitePluginExports } from "./linguiVitePluginInterop";'
+    );
+    expect(viteConfig).toContain(
+      "resolveLinguiVitePluginExports(linguiVitePlugin)"
+    );
+    expect(viteConfig).not.toContain(
+      'import { lingui, linguiTransformerBabelPreset } from "@lingui/vite-plugin";'
+    );
+  });
+
   it("keeps nginx serving Digital Asset Links even when hidden directories are skipped during deploy", () => {
     const nginxConfig = readRepoFile("deploy/nginx/app.secpal.dev.conf");
 

--- a/tests/unit/linguiVitePluginInterop.test.ts
+++ b/tests/unit/linguiVitePluginInterop.test.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it, vi } from "vitest";
+import { resolveLinguiVitePluginExports } from "../../linguiVitePluginInterop";
+
+describe("resolveLinguiVitePluginExports", () => {
+  it("falls back to CommonJS default exports when named exports are unavailable", () => {
+    const lingui = vi.fn();
+    const linguiTransformerBabelPreset = vi.fn();
+
+    expect(
+      resolveLinguiVitePluginExports({
+        default: {
+          lingui,
+          linguiTransformerBabelPreset,
+        },
+      })
+    ).toEqual({
+      lingui,
+      linguiTransformerBabelPreset,
+    });
+  });
+
+  it("throws when neither named exports nor default exports expose the required Lingui functions", () => {
+    expect(() => resolveLinguiVitePluginExports({})).toThrow(
+      "@lingui/vite-plugin did not expose usable lingui() and linguiTransformerBabelPreset() exports"
+    );
+  });
+});

--- a/tests/unit/linguiVitePluginInterop.test.ts
+++ b/tests/unit/linguiVitePluginInterop.test.ts
@@ -5,6 +5,15 @@ import { describe, expect, it, vi } from "vitest";
 import { resolveLinguiVitePluginExports } from "../../linguiVitePluginInterop";
 
 describe("resolveLinguiVitePluginExports", () => {
+  it("returns named exports directly when they are present", () => {
+    const lingui = vi.fn();
+    const linguiTransformerBabelPreset = vi.fn();
+
+    expect(
+      resolveLinguiVitePluginExports({ lingui, linguiTransformerBabelPreset })
+    ).toEqual({ lingui, linguiTransformerBabelPreset });
+  });
+
   it("falls back to CommonJS default exports when named exports are unavailable", () => {
     const lingui = vi.fn();
     const linguiTransformerBabelPreset = vi.fn();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,17 +4,20 @@
 import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import babel from "@rolldown/plugin-babel";
-import { lingui, linguiTransformerBabelPreset } from "@lingui/vite-plugin";
+import * as linguiVitePlugin from "@lingui/vite-plugin";
 import tailwindcss from "@tailwindcss/vite";
 import { VitePWA } from "vite-plugin-pwa";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import { visualizer } from "rollup-plugin-visualizer";
 import path from "path";
 import { fileURLToPath } from "url";
+import { resolveLinguiVitePluginExports } from "./linguiVitePluginInterop";
 import { applyInjectManifestCodeSplittingFix } from "./src/lib/pwaInjectManifestBuildConfig";
 import { buildPwaRuntimeCaching } from "./src/lib/pwaRuntimeCaching";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const { lingui, linguiTransformerBabelPreset } =
+  resolveLinguiVitePluginExports(linguiVitePlugin);
 
 const vendorChunkPackages: Record<string, string[]> = {
   "vendor-react": ["react", "react-dom", "react-router-dom"],


### PR DESCRIPTION
## Summary
- harden the Lingui Vite plugin wiring so `vite.config.ts` can resolve `lingui()` and `linguiTransformerBabelPreset()` from either named exports or a CommonJS `default` export
- add regression coverage for the config wiring and the fallback export resolution path
- document the fix in the changelog

## Validation
- npx vitest run tests/build.test.ts tests/unit/linguiVitePluginInterop.test.ts
- npm run typecheck
- npm run lint
- npm run build

Closes #1003
