### PR TITLE
fix(frontend): restore Lingui Vite build interop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Reframed the frontend `README.md` around the currently shipped workforce-operations routes and runtime guidance, removing stale Secrets-era password-vault, attachment-encryption, and migration-status sections that no longer matched the live app surface, resolving frontend issue #531.
-- Switched the Vite Lingui macro transform from an unfiltered Babel plugin run to Lingui's filtered `linguiTransformerBabelPreset()`, reducing unnecessary production-build plugin work and hardening the frontend against renewed Rolldown `PLUGIN_TIMINGS` warnings during `npm run build` (frontend issue #901).
+- Switched the Vite Lingui macro transform from an unfiltered Babel plugin run to a filtered Rolldown Babel preset around `@lingui/babel-plugin-lingui-macro`, reducing unnecessary production-build plugin work and hardening the frontend against renewed Rolldown `PLUGIN_TIMINGS` warnings during `npm run build` (frontend issue #901).
 - Migrated the frontend Lingui toolchain to the v6-compatible formatter and split macro entry points (`@lingui/core/macro`, `@lingui/react/macro`) so Dependabot Lingui update PRs no longer fail CI on mixed-version `I18n` types, stale `@lingui/macro` extraction, or the removed `format: "po"` setting.
 - Wired the central Copilot-instructions validator into `quality.yml` so frontend pull requests now fail automatically when known React AI-risk guardrails or generic AI-triage guidance are missing from the runtime baseline
 - Dropped restoration of legacy cleartext and pre-v2 encrypted `auth_user` localStorage payloads; unsupported auth-storage records are now purged instead of being restored, and frontend test fixtures now seed authenticated state through the encrypted storage path only
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Hardened the Vite Lingui plugin wiring to resolve `lingui()` and `linguiTransformerBabelPreset()` from either named exports or a CommonJS `default` export, so frontend builds stay compatible with current Node/Vite CJS-interop behavior and issue #1003 is regression-covered.
+- Hardened the Vite Lingui plugin wiring to resolve `lingui()` from either named exports or a CommonJS `default` export, and paired it with a filtered local Rolldown preset for Lingui macros, so frontend builds stay compatible with the current Node/Vite CJS-interop behavior and issue #1003 is regression-covered.
 - Changed both `viteStaticCopy` `rename` options for `assetlinks.json` from the unsupported object form (`{ stripBase: true, name: "assetlinks.json" }`) to the correct string form (`"assetlinks.json"`); the object form was silently producing wrong output paths for Android Digital Asset Links at build time, resolving frontend issue #997.
 - Mirrored backend `429` login lockouts into the frontend login rate limiter via `Retry-After` and added Playwright regression coverage, so the login UI now stays in the authoritative cooldown state instead of falling back to local failed-attempt tracking, resolving frontend issue #803.
 - Fixed RFC-correct handling of `Retry-After: 0` on `429` login responses; the header value is now parsed as valid rather than discarded, and `syncAuthoritativeLockout(0)` clears the local lockout state so the form remains immediately usable, matching the server's intent to allow an instant retry.

--- a/linguiVitePluginInterop.ts
+++ b/linguiVitePluginInterop.ts
@@ -3,7 +3,7 @@
 
 type LinguiVitePluginExports = Pick<
   typeof import("@lingui/vite-plugin"),
-  "lingui" | "linguiTransformerBabelPreset"
+  "lingui"
 >;
 
 function hasLinguiVitePluginExports(
@@ -15,10 +15,7 @@ function hasLinguiVitePluginExports(
 
   const candidate = value as Record<string, unknown>;
 
-  return (
-    typeof candidate.lingui === "function" &&
-    typeof candidate.linguiTransformerBabelPreset === "function"
-  );
+  return typeof candidate.lingui === "function";
 }
 
 export function resolveLinguiVitePluginExports(
@@ -37,6 +34,6 @@ export function resolveLinguiVitePluginExports(
   }
 
   throw new TypeError(
-    "@lingui/vite-plugin did not expose usable lingui() and linguiTransformerBabelPreset() exports"
+    "@lingui/vite-plugin did not expose a usable lingui() export"
   );
 }

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -167,6 +167,9 @@ describe("Build Configuration and Source Verification", () => {
     expect(viteConfig).toContain("defineRolldownBabelPreset");
     expect(viteConfig).toContain("linguiMacroBabelPreset");
     expect(viteConfig).toContain("@lingui\\/(?:core|react)\\/macro");
+    expect(viteConfig).toMatch(/rolldown\s*:\s*\{\s*filter\s*:\s*\{/);
+    expect(viteConfig).toMatch(/filter\s*:\s*\{[\s\S]*\bid\s*:/);
+    expect(viteConfig).toMatch(/filter\s*:\s*\{[\s\S]*\bcode\s*:/);
     expect(viteConfig).toMatch(
       /presets\s*:\s*\[\s*linguiMacroBabelPreset\s*\]/
     );

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -170,7 +170,7 @@ describe("Build Configuration and Source Verification", () => {
     expect(viteConfig).toMatch(
       /presets\s*:\s*\[\s*linguiMacroBabelPreset\s*\]/
     );
-    expect(viteConfig).toContain('@lingui/babel-plugin-lingui-macro');
+    expect(viteConfig).toContain("@lingui/babel-plugin-lingui-macro");
   });
 
   it("loads Lingui Vite exports through CJS-safe interop wiring", () => {

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -164,15 +164,18 @@ describe("Build Configuration and Source Verification", () => {
   it("scopes the Lingui macro Babel transform to files that import Lingui macros", () => {
     const viteConfig = readRepoFile("vite.config.ts");
 
-    expect(viteConfig).toMatch(/\blinguiTransformerBabelPreset\b/);
+    expect(viteConfig).toContain("defineRolldownBabelPreset");
+    expect(viteConfig).toContain("linguiMacroBabelPreset");
+    expect(viteConfig).toContain("@lingui\\/(?:core|react)\\/macro");
     expect(viteConfig).toMatch(
-      /presets\s*:\s*\[\s*linguiTransformerBabelPreset\(\)\s*\]/
+      /presets\s*:\s*\[\s*linguiMacroBabelPreset\s*\]/
     );
-    expect(viteConfig).not.toMatch(/@lingui\/babel-plugin-lingui-macro/);
+    expect(viteConfig).toContain('@lingui/babel-plugin-lingui-macro');
   });
 
   it("loads Lingui Vite exports through CJS-safe interop wiring", () => {
     const viteConfig = readRepoFile("vite.config.ts");
+    const interopHelper = readRepoFile("linguiVitePluginInterop.ts");
 
     expect(viteConfig).toContain(
       'import * as linguiVitePlugin from "@lingui/vite-plugin";'
@@ -186,6 +189,8 @@ describe("Build Configuration and Source Verification", () => {
     expect(viteConfig).not.toContain(
       'import { lingui, linguiTransformerBabelPreset } from "@lingui/vite-plugin";'
     );
+    expect(interopHelper).toContain('"lingui"');
+    expect(interopHelper).not.toContain('"linguiTransformerBabelPreset"');
   });
 
   it("keeps nginx serving Digital Asset Links even when hidden directories are skipped during deploy", () => {

--- a/tests/unit/linguiVitePluginInterop.test.ts
+++ b/tests/unit/linguiVitePluginInterop.test.ts
@@ -5,35 +5,27 @@ import { describe, expect, it, vi } from "vitest";
 import { resolveLinguiVitePluginExports } from "../../linguiVitePluginInterop";
 
 describe("resolveLinguiVitePluginExports", () => {
-  it("returns named exports directly when they are present", () => {
+  it("returns the named lingui export directly when it is present", () => {
     const lingui = vi.fn();
-    const linguiTransformerBabelPreset = vi.fn();
 
-    expect(
-      resolveLinguiVitePluginExports({ lingui, linguiTransformerBabelPreset })
-    ).toEqual({ lingui, linguiTransformerBabelPreset });
+    expect(resolveLinguiVitePluginExports({ lingui })).toEqual({ lingui });
   });
 
-  it("falls back to CommonJS default exports when named exports are unavailable", () => {
+  it("falls back to CommonJS default exports when the named lingui export is unavailable", () => {
     const lingui = vi.fn();
-    const linguiTransformerBabelPreset = vi.fn();
 
     expect(
       resolveLinguiVitePluginExports({
         default: {
           lingui,
-          linguiTransformerBabelPreset,
         },
       })
-    ).toEqual({
-      lingui,
-      linguiTransformerBabelPreset,
-    });
+    ).toEqual({ lingui });
   });
 
-  it("throws when neither named exports nor default exports expose the required Lingui functions", () => {
+  it("throws when neither named exports nor default exports expose a usable lingui function", () => {
     expect(() => resolveLinguiVitePluginExports({})).toThrow(
-      "@lingui/vite-plugin did not expose usable lingui() and linguiTransformerBabelPreset() exports"
+      "@lingui/vite-plugin did not expose a usable lingui() export"
     );
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,8 @@
 
 import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
-import babel from "@rolldown/plugin-babel";
+import babel, { defineRolldownBabelPreset } from "@rolldown/plugin-babel";
+import linguiMacroBabelPlugin from "@lingui/babel-plugin-lingui-macro";
 import * as linguiVitePlugin from "@lingui/vite-plugin";
 import tailwindcss from "@tailwindcss/vite";
 import { VitePWA } from "vite-plugin-pwa";
@@ -16,8 +17,21 @@ import { applyInjectManifestCodeSplittingFix } from "./src/lib/pwaInjectManifest
 import { buildPwaRuntimeCaching } from "./src/lib/pwaRuntimeCaching";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const { lingui, linguiTransformerBabelPreset } =
-  resolveLinguiVitePluginExports(linguiVitePlugin);
+const { lingui } = resolveLinguiVitePluginExports(linguiVitePlugin);
+const linguiMacroImportPattern = /@lingui\/(?:core|react)\/macro/;
+const linguiMacroBabelPreset = defineRolldownBabelPreset({
+  preset: [
+    () => ({
+      plugins: [linguiMacroBabelPlugin],
+    }),
+  ],
+  rolldown: {
+    filter: {
+      id: /\.[jt]sx?$/,
+      code: linguiMacroImportPattern,
+    },
+  },
+});
 
 const vendorChunkPackages: Record<string, string[]> = {
   "vendor-react": ["react", "react-dom", "react-router-dom"],
@@ -57,7 +71,7 @@ export default defineConfig(({ mode }) => {
     plugins: [
       react({}),
       babel({
-        presets: [linguiTransformerBabelPreset()],
+        presets: [linguiMacroBabelPreset],
       }),
       lingui(),
       tailwindcss(),


### PR DESCRIPTION
## Summary
Restore frontend builds under the current Node/Vite toolchain by switching the Lingui Vite wiring to the exports that actually exist in the installed package set and keeping the macro transform narrowly filtered.

## Validation
- `npx vitest run tests/unit/linguiVitePluginInterop.test.ts tests/build.test.ts`
- `npx eslint vite.config.ts linguiVitePluginInterop.ts tests/unit/linguiVitePluginInterop.test.ts tests/build.test.ts`
- `npm run build`

## Issues
- Closes #1003