### PR TITLE
fix(frontend): add encrypted offline vault baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Added the Phase-2 offline-vault baseline for persisted frontend PII: the authenticated profile now moves out of `auth_user` localStorage into wrapped vault-backed IndexedDB storage, legacy encrypted `auth_user` records are migrated one-way into the vault, and long-term offline analytics plus organizational-unit cache records now persist encrypted at rest with focused regression coverage for frontend issue #1005.
 - Updated the transitive `basic-ftp` dependency from `5.2.2` to `5.3.0` in `package-lock.json`, clearing the high-severity `GHSA-rp42-5vxx-qpwr` npm audit finding tracked in issue #893.
 
 ### Fixed

--- a/src/components/ProtectedRoute.test.tsx
+++ b/src/components/ProtectedRoute.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
 import {
   act,
   fireEvent,
@@ -20,6 +20,8 @@ import {
 import { AuthApiError } from "../services/authApi";
 import { sanitizePersistedAuthUser } from "../services/authState";
 import { authStorage } from "../services/storage";
+import { db } from "../lib/db";
+import { clearOfflineVaultSession } from "../lib/offlineVault";
 
 const mockNavigate = vi.fn();
 const { mockGetCurrentUser, mockSendVerificationNotification } = vi.hoisted(
@@ -109,11 +111,22 @@ async function waitForProtectedRoute(
 const waitFor = waitForProtectedRoute;
 
 describe("ProtectedRoute", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     // resetAllMocks clears implementations too, preventing leftover mockReturnValueOnce
     // entries from failed tests from leaking into subsequent tests.
     vi.resetAllMocks();
+    if (!db.isOpen()) {
+      await db.open();
+    }
+    await Promise.all([
+      db.analytics.clear(),
+      db.organizationalUnitCache.clear(),
+      db.vaultProfile.clear(),
+      db.vaultAnalytics.clear(),
+      db.vaultOrganizationalUnitCache.clear(),
+    ]);
     localStorage.clear();
+    clearOfflineVaultSession();
     setCsrfTokenCookie("test-csrf-token");
     i18n.load("en", {});
     i18n.activate("en");
@@ -122,6 +135,10 @@ describe("ProtectedRoute", () => {
         code: "HTTP_401",
       })
     );
+  });
+
+  afterEach(() => {
+    clearOfflineVaultSession();
   });
 
   it("redirects to login when not authenticated", async () => {

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -27,6 +27,11 @@ import * as authApi from "../services/authApi";
 import { sanitizePersistedAuthUser } from "../services/authState";
 import { authStorage } from "../services/storage";
 import { clearSensitiveClientState } from "../lib/clientStateCleanup";
+import { db } from "../lib/db";
+import {
+  AUTH_VAULT_STORAGE_KEY,
+  clearOfflineVaultSession,
+} from "../lib/offlineVault";
 import { messages as deMessages } from "../locales/de/messages.mjs";
 
 type AuthenticatedUser = Awaited<ReturnType<typeof authApi.getCurrentUser>>;
@@ -37,6 +42,15 @@ vi.mock("../lib/clientStateCleanup", () => ({
 }));
 
 const QUERY_TIMEOUT = 15000;
+
+function setCsrfTokenCookie(value: string): void {
+  document.cookie = `XSRF-TOKEN=;expires=${new Date(0).toUTCString()};path=/`;
+  document.cookie = `XSRF-TOKEN=${encodeURIComponent(value)};path=/`;
+}
+
+function getStoredAuthState(): string | null {
+  return localStorage.getItem(AUTH_VAULT_STORAGE_KEY);
+}
 
 // Mock ResizeObserver for HeadlessUI Menu component
 beforeAll(() => {
@@ -72,11 +86,20 @@ async function seedAuthenticatedUser(user: Record<string, unknown>) {
 
   const authenticatedUser: AuthenticatedUser = {
     ...persistedUser,
-    roles: [],
-    permissions: [],
-    hasOrganizationalScopes: false,
-    hasCustomerAccess: false,
-    hasSiteAccess: false,
+    roles: Array.isArray(user.roles) ? (user.roles as string[]) : [],
+    permissions: Array.isArray(user.permissions)
+      ? (user.permissions as string[])
+      : [],
+    hasOrganizationalScopes:
+      typeof user.hasOrganizationalScopes === "boolean"
+        ? user.hasOrganizationalScopes
+        : false,
+    hasCustomerAccess:
+      typeof user.hasCustomerAccess === "boolean"
+        ? user.hasCustomerAccess
+        : false,
+    hasSiteAccess:
+      typeof user.hasSiteAccess === "boolean" ? user.hasSiteAccess : false,
     emailVerified: persistedUser.emailVerified ?? false,
   };
 
@@ -112,11 +135,24 @@ describe("ApplicationLayout", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    await Promise.all([
+      db.analytics.clear(),
+      db.organizationalUnitCache.clear(),
+      db.vaultProfile.clear(),
+      db.vaultAnalytics.clear(),
+      db.vaultOrganizationalUnitCache.clear(),
+    ]);
     localStorage.clear();
+    clearOfflineVaultSession();
+    setCsrfTokenCookie("test-csrf-token");
     i18n.load("en", {});
     i18n.activate("en");
 
     await seedAuthenticatedUser(authenticatedUser);
+  });
+
+  afterEach(() => {
+    clearOfflineVaultSession();
   });
 
   describe("rendering", () => {
@@ -337,7 +373,7 @@ describe("ApplicationLayout", () => {
       });
 
       // User should be cleared from localStorage
-      expect(localStorage.getItem("auth_user")).toBeNull();
+      expect(getStoredAuthState()).toBeNull();
       expect(clearSensitiveClientState).toHaveBeenCalledTimes(1);
     });
 
@@ -347,7 +383,7 @@ describe("ApplicationLayout", () => {
       const mockLogout = vi.mocked(authApi.logout);
       mockLogout.mockImplementation(async () => {
         wasLocalStorageClearedBeforeApiCall =
-          localStorage.getItem("auth_user") === null;
+          getStoredAuthState() === null;
       });
 
       renderWithProviders(
@@ -401,7 +437,7 @@ describe("ApplicationLayout", () => {
       });
 
       // User should still be cleared from localStorage
-      expect(localStorage.getItem("auth_user")).toBeNull();
+      expect(getStoredAuthState()).toBeNull();
 
       consoleSpy.mockRestore();
     });
@@ -430,12 +466,12 @@ describe("ApplicationLayout", () => {
         fireEvent.click(signOutButton);
 
         expect(mockLogout).toHaveBeenCalledTimes(1);
-        expect(localStorage.getItem("auth_user")).not.toBeNull();
+        expect(getStoredAuthState()).not.toBeNull();
 
         await act(async () => {
           await vi.advanceTimersByTimeAsync(7999);
         });
-        expect(localStorage.getItem("auth_user")).not.toBeNull();
+        expect(getStoredAuthState()).not.toBeNull();
 
         await act(async () => {
           await vi.advanceTimersByTimeAsync(1);
@@ -449,7 +485,7 @@ describe("ApplicationLayout", () => {
               error.message.includes("timed out after 8000ms")
           )
         ).toBe(true);
-        expect(localStorage.getItem("auth_user")).toBeNull();
+        expect(getStoredAuthState()).toBeNull();
         expect(clearSensitiveClientState).toHaveBeenCalledTimes(1);
       } finally {
         vi.useRealTimers();

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -382,8 +382,7 @@ describe("ApplicationLayout", () => {
 
       const mockLogout = vi.mocked(authApi.logout);
       mockLogout.mockImplementation(async () => {
-        wasLocalStorageClearedBeforeApiCall =
-          getStoredAuthState() === null;
+        wasLocalStorageClearedBeforeApiCall = getStoredAuthState() === null;
       });
 
       renderWithProviders(

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -6,6 +6,7 @@ import { render, screen, act, waitFor } from "@testing-library/react";
 import { AuthProvider } from "./AuthContext";
 import { useAuth } from "../hooks/useAuth";
 import { sanitizePersistedAuthUser } from "../services/authState";
+import { clearOfflineVaultSession } from "../lib/offlineVault";
 import { authStorage } from "../services/storage";
 
 vi.mock("../services/authApi", () => ({
@@ -63,8 +64,13 @@ async function seedStoredUser(user: Record<string, unknown>) {
 describe("AuthContext", () => {
   beforeEach(() => {
     localStorage.clear();
+    clearOfflineVaultSession();
     document.cookie = `XSRF-TOKEN=;expires=${new Date(0).toUTCString()};path=/`;
     document.cookie = "XSRF-TOKEN=test-csrf-token;path=/";
+  });
+
+  afterEach(() => {
+    clearOfflineVaultSession();
   });
 
   describe("hasRole", () => {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -476,10 +476,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         return;
       }
 
-      if (
-        event.key !== "auth_user" &&
-        event.key !== AUTH_VAULT_STORAGE_KEY
-      ) {
+      if (event.key !== "auth_user" && event.key !== AUTH_VAULT_STORAGE_KEY) {
         return;
       }
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -19,6 +19,7 @@ import { authStorage } from "../services/storage";
 import { sessionEvents, isOnline } from "../services/sessionEvents";
 import { clearSensitiveClientState } from "../lib/clientStateCleanup";
 import { hasUserPermission, hasUserRole } from "../lib/capabilities";
+import { AUTH_VAULT_STORAGE_KEY } from "../lib/offlineVault";
 import { syncOfflineSessionAccess } from "../lib/serviceWorkerSession";
 import { analytics } from "../lib/analytics";
 
@@ -466,11 +467,27 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     const handleStorage = (event: StorageEvent) => {
-      if (event.storageArea !== localStorage || event.key !== "auth_user") {
+      if (event.storageArea !== localStorage) {
         return;
       }
 
-      if (event.newValue === null) {
+      if (event.key === "auth_logout_barrier" && event.newValue !== null) {
+        clearAuthenticatedState(true);
+        return;
+      }
+
+      if (
+        event.key !== "auth_user" &&
+        event.key !== AUTH_VAULT_STORAGE_KEY
+      ) {
+        return;
+      }
+
+      if (
+        event.newValue === null &&
+        localStorage.getItem("auth_user") === null &&
+        localStorage.getItem(AUTH_VAULT_STORAGE_KEY) === null
+      ) {
         clearAuthenticatedState(true);
         return;
       }

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -272,7 +272,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     let isActive = true;
     let didTimeout = false;
-    let timeoutId: number | null = null;
+    let timeoutId: ReturnType<typeof globalThis.setTimeout> | null = null;
     const requestVersion = bootstrapRequestVersionRef.current + 1;
     bootstrapRequestVersionRef.current = requestVersion;
     const snapshotUser = authStorage.getUserSnapshot();
@@ -287,7 +287,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
 
     const startBootstrapRevalidation = () => {
-      timeoutId = window.setTimeout(() => {
+      timeoutId = globalThis.setTimeout(() => {
         if (
           !isActive ||
           bootstrapRequestVersionRef.current !== requestVersion ||
@@ -308,7 +308,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         .getCurrentUser()
         .then(async (currentUser) => {
           if (timeoutId !== null) {
-            window.clearTimeout(timeoutId);
+            globalThis.clearTimeout(timeoutId);
           }
 
           if (
@@ -341,7 +341,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         })
         .catch((error: unknown) => {
           if (timeoutId !== null) {
-            window.clearTimeout(timeoutId);
+            globalThis.clearTimeout(timeoutId);
           }
 
           if (
@@ -455,7 +455,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     return () => {
       isActive = false;
       if (timeoutId !== null) {
-        window.clearTimeout(timeoutId);
+        globalThis.clearTimeout(timeoutId);
       }
     };
   }, [

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { afterEach, describe, it, expect, beforeEach, vi } from "vitest";
 import {
   renderHook,
   act,
@@ -16,6 +16,10 @@ import { sanitizePersistedAuthUser } from "../services/authState";
 import { authStorage } from "../services/storage";
 import { sessionEvents } from "../services/sessionEvents";
 import { clearSensitiveClientState } from "../lib/clientStateCleanup";
+import {
+  AUTH_VAULT_STORAGE_KEY,
+  clearOfflineVaultSession,
+} from "../lib/offlineVault";
 import { syncOfflineSessionAccess } from "../lib/serviceWorkerSession";
 
 const { mockGetCurrentUser } = vi.hoisted(() => ({
@@ -66,11 +70,16 @@ async function persistAuthUser(user: Record<string, unknown>): Promise<string> {
 
   await authStorage.setUser(persistedUser);
   mockGetCurrentUser.mockResolvedValue(persistedUser);
-  const storedUser = localStorage.getItem("auth_user");
+  const storedUser = localStorage.getItem(AUTH_VAULT_STORAGE_KEY);
 
   expect(storedUser).not.toBeNull();
 
   return storedUser as string;
+}
+
+function expectNoStoredAuthState(): void {
+  expect(localStorage.getItem("auth_user")).toBeNull();
+  expect(localStorage.getItem(AUTH_VAULT_STORAGE_KEY)).toBeNull();
 }
 
 async function waitForAuthState(
@@ -87,7 +96,7 @@ const waitFor = waitForAuthState;
 async function expectEncryptedStoredUser(
   expectedUser: Record<string, unknown>
 ): Promise<void> {
-  const storedUser = localStorage.getItem("auth_user");
+  const storedUser = localStorage.getItem(AUTH_VAULT_STORAGE_KEY);
 
   expect(storedUser).not.toBeNull();
 
@@ -102,6 +111,7 @@ async function expectEncryptedStoredUser(
 describe("useAuth", () => {
   beforeEach(() => {
     localStorage.clear();
+    clearOfflineVaultSession();
     window.history.replaceState({}, "", "/login");
     setCsrfTokenCookie("test-csrf-token");
     vi.clearAllMocks();
@@ -118,6 +128,10 @@ describe("useAuth", () => {
     });
     vi.mocked(clearSensitiveClientState).mockResolvedValue(undefined);
     vi.mocked(syncOfflineSessionAccess).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    clearOfflineVaultSession();
   });
 
   it("throws error when used outside AuthProvider", () => {
@@ -250,7 +264,7 @@ describe("useAuth", () => {
     });
 
     expect(result.current.user).toBeNull();
-    expect(localStorage.getItem("auth_user")).toBeNull();
+    expectNoStoredAuthState();
 
     await act(async () => {
       deferred.resolve(revalidatedUser);
@@ -259,7 +273,7 @@ describe("useAuth", () => {
 
     expect(result.current.user).toBeNull();
     expect(result.current.isAuthenticated).toBe(false);
-    expect(localStorage.getItem("auth_user")).toBeNull();
+    expectNoStoredAuthState();
     expect(clearSensitiveClientState).toHaveBeenCalledTimes(1);
   });
 
@@ -289,7 +303,7 @@ describe("useAuth", () => {
 
     expect(result.current.user).toBeNull();
     expect(result.current.isAuthenticated).toBe(false);
-    expect(localStorage.getItem("auth_user")).toBeNull();
+    expectNoStoredAuthState();
     expect(clearSensitiveClientState).toHaveBeenCalledTimes(1);
   });
 
@@ -543,7 +557,7 @@ describe("useAuth", () => {
 
     expect(result.current.user).toBeNull();
     expect(result.current.isAuthenticated).toBe(false);
-    expect(localStorage.getItem("auth_user")).toBeNull();
+    expectNoStoredAuthState();
     expect(clearSensitiveClientState).toHaveBeenCalledTimes(1);
   });
 
@@ -612,7 +626,7 @@ describe("useAuth", () => {
 
     expect(result.current.isAuthenticated).toBe(false);
     expect(result.current.user).toBeNull();
-    expect(localStorage.getItem("auth_user")).toBeNull();
+    expectNoStoredAuthState();
     expect(clearSensitiveClientState).toHaveBeenCalledTimes(1);
   });
 
@@ -645,10 +659,10 @@ describe("useAuth", () => {
     });
 
     act(() => {
-      localStorage.removeItem("auth_user");
+      localStorage.removeItem(AUTH_VAULT_STORAGE_KEY);
       const crossTabLogoutEvent = new Event("storage");
       Object.defineProperties(crossTabLogoutEvent, {
-        key: { value: "auth_user" },
+        key: { value: AUTH_VAULT_STORAGE_KEY },
         oldValue: { value: storedUser },
         newValue: { value: null },
         storageArea: { value: localStorage },
@@ -678,7 +692,7 @@ describe("useAuth", () => {
     });
 
     act(() => {
-      localStorage.removeItem("auth_user");
+      localStorage.removeItem(AUTH_VAULT_STORAGE_KEY);
       window.dispatchEvent(
         new PageTransitionEvent("pageshow", { persisted: true })
       );
@@ -717,7 +731,7 @@ describe("useAuth", () => {
       const newStoredValue = await persistAuthUser(mockUser);
       const staleAuthEvent = new Event("storage");
       Object.defineProperties(staleAuthEvent, {
-        key: { value: "auth_user" },
+        key: { value: AUTH_VAULT_STORAGE_KEY },
         oldValue: { value: null },
         newValue: { value: newStoredValue },
         storageArea: { value: localStorage },
@@ -731,8 +745,9 @@ describe("useAuth", () => {
 
     expect(result.current.user).toBeNull();
     await waitFor(() => {
-      expect(localStorage.getItem("auth_user")).toBeNull();
+      expect(localStorage.getItem(AUTH_VAULT_STORAGE_KEY)).toBeNull();
     });
+    expect(localStorage.getItem("auth_user")).toBeNull();
   });
 
   it("rejects BFCache-style auth restoration after explicit logout", async () => {
@@ -769,8 +784,9 @@ describe("useAuth", () => {
 
     expect(result.current.user).toBeNull();
     await waitFor(() => {
-      expect(localStorage.getItem("auth_user")).toBeNull();
+      expect(localStorage.getItem(AUTH_VAULT_STORAGE_KEY)).toBeNull();
     });
+    expect(localStorage.getItem("auth_user")).toBeNull();
   });
 
   it("does not bootstrap /v1/me when a logout barrier blocks stale auth storage", async () => {
@@ -786,11 +802,11 @@ describe("useAuth", () => {
     expect(result.current.user).toBeNull();
     expect(result.current.isAuthenticated).toBe(false);
     expect(result.current.isLoading).toBe(false);
-    expect(localStorage.getItem("auth_user")).toBeNull();
+    expectNoStoredAuthState();
     expect(mockGetCurrentUser).not.toHaveBeenCalled();
   });
 
-  it("ignores storage events for keys other than auth_user", async () => {
+  it("ignores storage events for keys other than supported auth storage keys", async () => {
     const { result } = renderHook(() => useAuth(), {
       wrapper: AuthProvider,
     });
@@ -829,7 +845,7 @@ describe("useAuth", () => {
       const storedUser = await persistAuthUser(newUser);
       const crossTabLoginEvent = new Event("storage");
       Object.defineProperties(crossTabLoginEvent, {
-        key: { value: "auth_user" },
+        key: { value: AUTH_VAULT_STORAGE_KEY },
         oldValue: { value: null },
         newValue: { value: storedUser },
         storageArea: { value: localStorage },
@@ -861,10 +877,10 @@ describe("useAuth", () => {
     act(() => {
       // Write the corrupt value so localStorage matches the event (real browser
       // cross-tab writes keep newValue and the actual storage in sync).
-      localStorage.setItem("auth_user", "{invalid json{{");
+      localStorage.setItem(AUTH_VAULT_STORAGE_KEY, "{invalid json{{");
       const invalidJsonEvent = new Event("storage");
       Object.defineProperties(invalidJsonEvent, {
-        key: { value: "auth_user" },
+        key: { value: AUTH_VAULT_STORAGE_KEY },
         oldValue: { value: storedUser },
         newValue: { value: "{invalid json{{" },
         storageArea: { value: localStorage },

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -33,9 +33,9 @@ vi.mock("./offlineVault", () => ({
 describe("OfflineAnalytics", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.spyOn(console, "error").mockImplementation(() => { });
-    vi.spyOn(console, "log").mockImplementation(() => { });
-    vi.spyOn(console, "warn").mockImplementation(() => { });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
   afterEach(() => {

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -3,26 +3,22 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { analytics } from "./analytics";
-import { db } from "./db";
+import {
+  clearOldVaultAnalyticsEvents,
+  clearVaultAnalytics,
+  listUnsyncedVaultAnalyticsRecordIds,
+  listVaultAnalyticsEvents,
+  markVaultAnalyticsEventsSynced,
+  storeVaultAnalyticsEvent,
+} from "./offlineVault";
 
-// Mock IndexedDB
-vi.mock("./db", () => ({
-  db: {
-    analytics: {
-      add: vi.fn().mockResolvedValue(1),
-      clear: vi.fn().mockResolvedValue(undefined),
-      where: vi.fn(() => ({
-        equals: vi.fn(() => ({
-          toArray: vi.fn().mockResolvedValue([]),
-          and: vi.fn(() => ({
-            delete: vi.fn().mockResolvedValue(0),
-          })),
-        })),
-      })),
-      toArray: vi.fn().mockResolvedValue([]),
-      bulkUpdate: vi.fn().mockResolvedValue(0),
-    },
-  },
+vi.mock("./offlineVault", () => ({
+  storeVaultAnalyticsEvent: vi.fn().mockResolvedValue(1),
+  clearVaultAnalytics: vi.fn().mockResolvedValue(undefined),
+  listUnsyncedVaultAnalyticsRecordIds: vi.fn().mockResolvedValue([]),
+  markVaultAnalyticsEventsSynced: vi.fn().mockResolvedValue(undefined),
+  listVaultAnalyticsEvents: vi.fn().mockResolvedValue([]),
+  clearOldVaultAnalyticsEvents: vi.fn().mockResolvedValue(undefined),
 }));
 
 // NOTE: Singleton persistence across tests is intentional
@@ -37,9 +33,9 @@ vi.mock("./db", () => ({
 describe("OfflineAnalytics", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => { });
+    vi.spyOn(console, "log").mockImplementation(() => { });
+    vi.spyOn(console, "warn").mockImplementation(() => { });
   });
 
   afterEach(() => {
@@ -127,7 +123,7 @@ describe("OfflineAnalytics", () => {
 
       await analytics!.track("page_view", "navigation", "view_home");
 
-      expect(db.analytics!.add).toHaveBeenCalledWith(
+      expect(storeVaultAnalyticsEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "page_view",
           category: "navigation",
@@ -148,7 +144,7 @@ describe("OfflineAnalytics", () => {
         metadata: { page: "/login" },
       });
 
-      expect(db.analytics!.add).toHaveBeenCalledWith(
+      expect(storeVaultAnalyticsEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "button_click",
           category: "interaction",
@@ -165,7 +161,7 @@ describe("OfflineAnalytics", () => {
 
       await analytics!.track("page_view", "navigation", "view_dashboard");
 
-      expect(db.analytics!.add).toHaveBeenCalledWith(
+      expect(storeVaultAnalyticsEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           userId: "user-456",
         })
@@ -177,7 +173,7 @@ describe("OfflineAnalytics", () => {
 
       const consoleWarn = vi.mocked(console.warn);
       const error = new Error("Database error");
-      vi.mocked(db.analytics!.add).mockRejectedValueOnce(error);
+      vi.mocked(storeVaultAnalyticsEvent).mockRejectedValueOnce(error);
 
       await analytics!.track("page_view", "test", "test");
 
@@ -194,7 +190,7 @@ describe("OfflineAnalytics", () => {
 
       await analytics!.trackPageView("/dashboard", "Dashboard");
 
-      expect(db.analytics!.add).toHaveBeenCalledWith(
+      expect(storeVaultAnalyticsEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "page_view",
           category: "navigation",
@@ -210,7 +206,7 @@ describe("OfflineAnalytics", () => {
 
       await analytics!.trackClick("submit-button", { form: "login" });
 
-      expect(db.analytics!.add).toHaveBeenCalledWith(
+      expect(storeVaultAnalyticsEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "button_click",
           category: "interaction",
@@ -226,7 +222,7 @@ describe("OfflineAnalytics", () => {
 
       await analytics!.trackFormSubmit("login-form", true, { method: "email" });
 
-      expect(db.analytics!.add).toHaveBeenCalledWith(
+      expect(storeVaultAnalyticsEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "form_submit",
           category: "interaction",
@@ -243,7 +239,7 @@ describe("OfflineAnalytics", () => {
 
       await analytics!.trackFormSubmit("login-form", false);
 
-      expect(db.analytics!.add).toHaveBeenCalledWith(
+      expect(storeVaultAnalyticsEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           value: 0,
         })
@@ -256,7 +252,7 @@ describe("OfflineAnalytics", () => {
       const error = new Error("Test error");
       await analytics!.trackError(error, { component: "LoginForm" });
 
-      expect(db.analytics!.add).toHaveBeenCalledWith(
+      expect(storeVaultAnalyticsEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "error",
           category: "error",
@@ -269,7 +265,7 @@ describe("OfflineAnalytics", () => {
       );
 
       // Ensure stack is NOT included by default
-      const call = vi.mocked(db.analytics!.add).mock.calls[0]?.[0];
+      const call = vi.mocked(storeVaultAnalyticsEvent).mock.calls[0]?.[0];
       expect(call?.metadata).not.toHaveProperty("stack");
     });
 
@@ -279,7 +275,7 @@ describe("OfflineAnalytics", () => {
       const error = new Error("Test error with stack");
       await analytics!.trackError(error, { component: "LoginForm" }, true);
 
-      expect(db.analytics!.add).toHaveBeenCalledWith(
+      expect(storeVaultAnalyticsEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "error",
           category: "error",
@@ -298,7 +294,7 @@ describe("OfflineAnalytics", () => {
 
       await analytics!.trackPerformance("page_load", 1234, { page: "/home" });
 
-      expect(db.analytics!.add).toHaveBeenCalledWith(
+      expect(storeVaultAnalyticsEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "performance",
           category: "performance",
@@ -314,7 +310,7 @@ describe("OfflineAnalytics", () => {
 
       await analytics!.trackFeatureUsage("dark-mode", { enabled: true });
 
-      expect(db.analytics!.add).toHaveBeenCalledWith(
+      expect(storeVaultAnalyticsEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "feature_usage",
           category: "feature",
@@ -330,72 +326,38 @@ describe("OfflineAnalytics", () => {
     it("should sync unsynced events when online", async () => {
       analytics!.resumeAuthenticatedSession("test-user-123");
 
-      const mockEvents = [
-        {
-          id: 1,
-          type: "page_view",
-          category: "test",
-          action: "test",
-          synced: false,
-          timestamp: Date.now(),
-          sessionId: "test",
-        },
-        {
-          id: 2,
-          type: "button_click",
-          category: "test",
-          action: "test",
-          synced: false,
-          timestamp: Date.now(),
-          sessionId: "test",
-        },
-      ];
-
-      vi.mocked(db.analytics!.where).mockReturnValue({
-        equals: vi.fn().mockReturnValue({
-          toArray: vi.fn().mockResolvedValue(mockEvents),
-          and: vi.fn(),
-        }),
-      } as never);
+      vi.mocked(listUnsyncedVaultAnalyticsRecordIds).mockResolvedValue([1, 2]);
 
       await analytics!.syncEvents();
 
-      expect(db.analytics!.bulkUpdate).toHaveBeenCalledWith([
-        { key: 1, changes: { synced: true } },
-        { key: 2, changes: { synced: true } },
-      ]);
+      expect(markVaultAnalyticsEventsSynced).toHaveBeenCalledWith([1, 2]);
     });
 
     it("clears persisted analytics state and disables tracking on logout reset", async () => {
       analytics!.resumeAuthenticatedSession("user-456");
 
       await analytics!.trackPageView("/dashboard", "Dashboard");
-      expect(db.analytics!.add).toHaveBeenCalledTimes(1);
+      expect(storeVaultAnalyticsEvent).toHaveBeenCalledTimes(1);
 
       vi.clearAllMocks();
 
       await analytics!.resetForLogout();
 
-      expect(db.analytics!.clear).toHaveBeenCalledTimes(1);
+      expect(clearVaultAnalytics).toHaveBeenCalledTimes(1);
 
       await analytics!.trackPageView("/login", "Login");
 
-      expect(db.analytics!.add).not.toHaveBeenCalled();
+      expect(storeVaultAnalyticsEvent).not.toHaveBeenCalled();
     });
 
     it("should not sync when no unsynced events", async () => {
       analytics!.resumeAuthenticatedSession("test-user-123");
 
-      vi.mocked(db.analytics!.where).mockReturnValue({
-        equals: vi.fn().mockReturnValue({
-          toArray: vi.fn().mockResolvedValue([]),
-          and: vi.fn(),
-        }),
-      } as never);
+      vi.mocked(listUnsyncedVaultAnalyticsRecordIds).mockResolvedValue([]);
 
       await analytics!.syncEvents();
 
-      expect(db.analytics!.bulkUpdate).not.toHaveBeenCalled();
+      expect(markVaultAnalyticsEventsSynced).not.toHaveBeenCalled();
     });
 
     it("should handle sync errors gracefully", async () => {
@@ -403,7 +365,7 @@ describe("OfflineAnalytics", () => {
 
       const consoleWarn = vi.mocked(console.warn);
       const error = new Error("Sync failed");
-      vi.mocked(db.analytics!.where).mockImplementation(() => {
+      vi.mocked(listUnsyncedVaultAnalyticsRecordIds).mockImplementation(() => {
         throw error;
       });
 
@@ -441,24 +403,7 @@ describe("OfflineAnalytics", () => {
     it("should not create duplicate syncs from debounce and manual trigger", async () => {
       analytics!.resumeAuthenticatedSession("test-user-123");
 
-      const mockEvents = [
-        {
-          id: 1,
-          type: "page_view",
-          category: "test",
-          action: "test",
-          synced: false,
-          timestamp: Date.now(),
-          sessionId: "test",
-        },
-      ];
-
-      vi.mocked(db.analytics!.where).mockReturnValue({
-        equals: vi.fn().mockReturnValue({
-          toArray: vi.fn().mockResolvedValue(mockEvents),
-          and: vi.fn(),
-        }),
-      } as never);
+      vi.mocked(listUnsyncedVaultAnalyticsRecordIds).mockResolvedValue([1]);
 
       // Track an event (schedules debounced sync)
       await analytics!.trackPageView("/test", "Test");
@@ -467,13 +412,13 @@ describe("OfflineAnalytics", () => {
       await analytics!.syncEvents();
 
       // Verify sync was called (via bulkUpdate)
-      expect(db.analytics!.bulkUpdate).toHaveBeenCalledTimes(1);
+      expect(markVaultAnalyticsEventsSynced).toHaveBeenCalledTimes(1);
 
       // Wait for debounce timeout to potentially fire
       await new Promise((resolve) => setTimeout(resolve, 1100));
 
       // Verify sync was NOT called again (debounce was cancelled)
-      expect(db.analytics!.bulkUpdate).toHaveBeenCalledTimes(1);
+      expect(markVaultAnalyticsEventsSynced).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -509,7 +454,7 @@ describe("OfflineAnalytics", () => {
         },
       ];
 
-      vi.mocked(db.analytics!.toArray).mockResolvedValue(mockEvents);
+      vi.mocked(listVaultAnalyticsEvents).mockResolvedValue(mockEvents);
 
       const stats = await analytics!.getStats();
 
@@ -525,7 +470,7 @@ describe("OfflineAnalytics", () => {
     });
 
     it("should return empty stats when no events", async () => {
-      vi.mocked(db.analytics!.toArray).mockResolvedValue([]);
+      vi.mocked(listVaultAnalyticsEvents).mockResolvedValue([]);
 
       const stats = await analytics!.getStats();
 
@@ -540,20 +485,11 @@ describe("OfflineAnalytics", () => {
 
   describe("clearOldEvents", () => {
     it("should delete old synced events", async () => {
-      const mockDelete = vi.fn().mockResolvedValue(5);
-
-      vi.mocked(db.analytics!.where).mockReturnValue({
-        equals: vi.fn().mockReturnValue({
-          and: vi.fn().mockReturnValue({
-            delete: mockDelete,
-          }),
-          toArray: vi.fn(),
-        }),
-      } as never);
-
       await analytics!.clearOldEvents();
 
-      expect(db.analytics!.where).toHaveBeenCalledWith("synced");
+      expect(clearOldVaultAnalyticsEvents).toHaveBeenCalledWith(
+        expect.any(Number)
+      );
     });
   });
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,7 +1,15 @@
 // SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { db, type AnalyticsEvent, type AnalyticsEventType } from "./db";
+import type { AnalyticsEvent, AnalyticsEventType } from "./db";
+import {
+  clearOldVaultAnalyticsEvents,
+  clearVaultAnalytics,
+  listUnsyncedVaultAnalyticsRecordIds,
+  listVaultAnalyticsEvents,
+  markVaultAnalyticsEventsSynced,
+  storeVaultAnalyticsEvent,
+} from "./offlineVault";
 
 // Re-export types for external use
 export type { AnalyticsEvent, AnalyticsEventType };
@@ -102,7 +110,7 @@ class OfflineAnalytics {
       this.syncTimeout = undefined;
     }
 
-    await db.analytics.clear();
+    await clearVaultAnalytics();
   }
 
   /**
@@ -145,8 +153,7 @@ class OfflineAnalytics {
     };
 
     try {
-      // Store event in IndexedDB
-      await db.analytics.add(event);
+      await storeVaultAnalyticsEvent(event);
 
       // If online, debounce sync to avoid excessive syncing
       if (this.isOnline) {
@@ -351,12 +358,9 @@ class OfflineAnalytics {
 
     try {
       // Get all unsynced events
-      const unsyncedEvents = await db.analytics
-        .where("synced")
-        .equals(0)
-        .toArray();
+      const unsyncedEventIds = await listUnsyncedVaultAnalyticsRecordIds();
 
-      if (unsyncedEvents.length === 0) {
+      if (unsyncedEventIds.length === 0) {
         this.isSyncing = false;
         return;
       }
@@ -366,21 +370,9 @@ class OfflineAnalytics {
       // For now, we just mark them as synced for local testing
 
       // Simulate network request
-      console.log(`Syncing ${unsyncedEvents.length} analytics events...`);
-
-      // Mark events as synced - single-pass bulk update with proper type narrowing
-      const eventsWithId = unsyncedEvents.filter(
-        (e): e is AnalyticsEvent & { id: number } => e.id !== undefined
-      );
-
-      await db.analytics.bulkUpdate(
-        eventsWithId.map((e) => ({
-          key: e.id,
-          changes: { synced: true },
-        }))
-      );
-
-      console.log(`Successfully synced ${eventsWithId.length} events`);
+      console.log(`Syncing ${unsyncedEventIds.length} analytics events...`);
+      await markVaultAnalyticsEventsSynced(unsyncedEventIds);
+      console.log(`Successfully synced ${unsyncedEventIds.length} events`);
     } catch (error) {
       // Non-critical: Sync will be retried automatically
       console.warn("Failed to sync analytics events:", error);
@@ -398,7 +390,7 @@ class OfflineAnalytics {
     unsynced: number;
     byType: Record<AnalyticsEventType, number>;
   }> {
-    const allEvents = await db.analytics.toArray();
+    const allEvents = await listVaultAnalyticsEvents();
     const syncedEvents = allEvents.filter((e) => e.synced);
     const unsyncedEvents = allEvents.filter((e) => !e.synced);
 
@@ -425,11 +417,7 @@ class OfflineAnalytics {
   async clearOldEvents(): Promise<void> {
     const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
 
-    await db.analytics
-      .where("synced")
-      .equals(1)
-      .and((event) => event.timestamp < thirtyDaysAgo)
-      .delete();
+    await clearOldVaultAnalyticsEvents(thirtyDaysAgo);
   }
 }
 

--- a/src/lib/clientStateCleanup.test.ts
+++ b/src/lib/clientStateCleanup.test.ts
@@ -7,6 +7,7 @@ import {
   clearSensitiveClientState,
   SENSITIVE_CACHE_NAMES,
 } from "./clientStateCleanup";
+import { AUTH_VAULT_STORAGE_KEY } from "./offlineVault";
 
 const mockCaches = {
   keys: vi.fn(),
@@ -39,6 +40,10 @@ describe("clearSensitiveClientState", () => {
     localStorage.setItem(
       "secpal-notification-preferences",
       JSON.stringify([{ category: "alerts", enabled: false }])
+    );
+    localStorage.setItem(
+      AUTH_VAULT_STORAGE_KEY,
+      JSON.stringify({ scheme: "pbkdf2-aes-cbc-hmac-sha256-vault" })
     );
     localStorage.setItem("locale", "de");
     sessionStorage.setItem("share-draft", "pending");
@@ -75,6 +80,7 @@ describe("clearSensitiveClientState", () => {
     expect(localStorage.getItem("auth_user")).toBeNull();
     expect(localStorage.getItem("auth_token")).toBeNull();
     expect(localStorage.getItem("secpal-notification-preferences")).toBeNull();
+    expect(localStorage.getItem(AUTH_VAULT_STORAGE_KEY)).toBeNull();
     expect(localStorage.getItem("locale")).toBe("de");
     expect(sessionStorage.length).toBe(0);
 

--- a/src/lib/clientStateCleanup.ts
+++ b/src/lib/clientStateCleanup.ts
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { db } from "./db";
+import {
+  AUTH_VAULT_STORAGE_KEY,
+  clearOfflineVaultSession,
+} from "./offlineVault";
 
 export const SENSITIVE_CACHE_NAMES = [
   "api-cache",
@@ -13,6 +17,7 @@ const USER_SCOPED_LOCAL_STORAGE_KEYS = [
   "auth_user",
   "auth_token",
   "secpal-notification-preferences",
+  AUTH_VAULT_STORAGE_KEY,
 ] as const;
 
 async function clearSensitiveCaches(): Promise<void> {
@@ -55,6 +60,8 @@ async function clearSensitiveIndexedDbState(): Promise<void> {
 }
 
 export async function clearSensitiveClientState(): Promise<void> {
+  clearOfflineVaultSession();
+
   for (const key of USER_SCOPED_LOCAL_STORAGE_KEYS) {
     localStorage.removeItem(key);
   }

--- a/src/lib/clientStateCleanup.ts
+++ b/src/lib/clientStateCleanup.ts
@@ -47,6 +47,9 @@ async function clearSensitiveIndexedDbState(): Promise<void> {
     await Promise.all([
       db.analytics.clear(),
       db.organizationalUnitCache.clear(),
+      db.vaultProfile.clear(),
+      db.vaultAnalytics.clear(),
+      db.vaultOrganizationalUnitCache.clear(),
     ]);
   }
 }

--- a/src/lib/db-constants.ts
+++ b/src/lib/db-constants.ts
@@ -24,4 +24,4 @@ export const DB_NAME = "SecPalDB";
  * 1. Update this constant
  * 2. Update the single version() block in db.ts
  */
-export const DB_VERSION = 10;
+export const DB_VERSION = 11;

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -10,6 +10,9 @@ describe("IndexedDB Database", () => {
     // Clear all tables before each test
     await db.analytics.clear();
     await db.organizationalUnitCache.clear();
+    await db.vaultProfile.clear();
+    await db.vaultAnalytics.clear();
+    await db.vaultOrganizationalUnitCache.clear();
   });
 
   describe("Database Metadata", () => {
@@ -26,6 +29,9 @@ describe("IndexedDB Database", () => {
 
       expect(tableNames).toContain("analytics");
       expect(tableNames).toContain("organizationalUnitCache");
+      expect(tableNames).toContain("vaultProfile");
+      expect(tableNames).toContain("vaultAnalytics");
+      expect(tableNames).toContain("vaultOrganizationalUnitCache");
       expect(tableNames).not.toContain("guards");
       expect(tableNames).not.toContain("syncQueue");
       expect(tableNames).not.toContain("apiCache");

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -78,8 +78,7 @@ export interface VaultAnalyticsRecord extends EncryptedVaultRecord {
   timestamp: number;
 }
 
-export interface VaultOrganizationalUnitCacheRecord
-  extends EncryptedVaultRecord {
+export interface VaultOrganizationalUnitCacheRecord extends EncryptedVaultRecord {
   id: string;
   cachedAt: Date;
   lastSynced: Date;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -60,6 +60,31 @@ export interface OrganizationalUnitCacheEntry {
   lastSynced: Date;
 }
 
+export interface EncryptedVaultRecord {
+  recordId: string;
+  version: number;
+  ciphertext: string;
+  iv: string;
+  authTag: string;
+}
+
+export interface EncryptedProfileRecord extends EncryptedVaultRecord {
+  id: "profile";
+}
+
+export interface VaultAnalyticsRecord extends EncryptedVaultRecord {
+  id?: number;
+  synced: boolean;
+  timestamp: number;
+}
+
+export interface VaultOrganizationalUnitCacheRecord
+  extends EncryptedVaultRecord {
+  id: string;
+  cachedAt: Date;
+  lastSynced: Date;
+}
+
 /**
  * SecPal IndexedDB database
  *
@@ -70,11 +95,20 @@ export interface OrganizationalUnitCacheEntry {
 export const db = new Dexie(DB_NAME) as Dexie & {
   analytics: EntityTable<AnalyticsEvent, "id">;
   organizationalUnitCache: EntityTable<OrganizationalUnitCacheEntry, "id">;
+  vaultProfile: EntityTable<EncryptedProfileRecord, "id">;
+  vaultAnalytics: EntityTable<VaultAnalyticsRecord, "id">;
+  vaultOrganizationalUnitCache: EntityTable<
+    VaultOrganizationalUnitCacheRecord,
+    "id"
+  >;
 };
 
-// Schema version 10 - Current offline storage only
+// Schema version 11 - Adds encrypted vault-backed offline stores for long-term PII.
 // 0.x keeps the IndexedDB schema focused on the currently supported offline data.
 db.version(DB_VERSION).stores({
   analytics: "++id, synced, timestamp, sessionId, type",
   organizationalUnitCache: "id, type, parent_id, updated_at, cachedAt",
+  vaultProfile: "id",
+  vaultAnalytics: "++id, synced, timestamp",
+  vaultOrganizationalUnitCache: "id, cachedAt, lastSynced",
 });

--- a/src/lib/offlineVault.test.ts
+++ b/src/lib/offlineVault.test.ts
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { PersistedAuthUser } from "../services/authState";
+import { db, type OrganizationalUnitCacheEntry } from "./db";
+import {
+  AUTH_VAULT_STORAGE_KEY,
+  clearOfflineVaultSession,
+  initializeOfflineVault,
+  listVaultAnalyticsEvents,
+  listVaultOrganizationalUnits,
+  readPersistedAuthUserFromVault,
+} from "./offlineVault";
+
+function setCsrfTokenCookie(value: string): void {
+  document.cookie = `XSRF-TOKEN=;expires=${new Date(0).toUTCString()};path=/`;
+  document.cookie = `XSRF-TOKEN=${encodeURIComponent(value)};path=/`;
+}
+
+describe("offlineVault", () => {
+  const persistedUser: PersistedAuthUser = {
+    id: "user-1",
+    name: "Vault User",
+    email: "vault@secpal.dev",
+    emailVerified: false,
+    roles: ["Admin"],
+  };
+
+  beforeEach(async () => {
+    await db.delete();
+    await db.open();
+    localStorage.clear();
+    sessionStorage.clear();
+    setCsrfTokenCookie("test-csrf-token");
+    clearOfflineVaultSession();
+  });
+
+  afterEach(() => {
+    clearOfflineVaultSession();
+  });
+
+  it("stores the persisted profile in the encrypted vault and keeps auth_user out of localStorage", async () => {
+    await initializeOfflineVault(persistedUser);
+
+    expect(localStorage.getItem("auth_user")).toBeNull();
+    expect(localStorage.getItem(AUTH_VAULT_STORAGE_KEY)).not.toBeNull();
+    await expect(readPersistedAuthUserFromVault()).resolves.toEqual(
+      persistedUser
+    );
+
+    const storedProfile = await db.vaultProfile.get("profile");
+
+    expect(storedProfile).toEqual(
+      expect.objectContaining({
+        id: "profile",
+        ciphertext: expect.any(String),
+        iv: expect.any(String),
+        authTag: expect.any(String),
+      })
+    );
+  });
+
+  it("migrates legacy IndexedDB PII into vault-backed stores and clears plaintext records", async () => {
+    await db.analytics.add({
+      type: "page_view",
+      category: "navigation",
+      action: "view_dashboard",
+      timestamp: Date.now(),
+      synced: false,
+      sessionId: "session-1",
+      userId: persistedUser.id,
+    });
+
+    const organizationalUnit: OrganizationalUnitCacheEntry = {
+      id: "org-1",
+      type: "company",
+      name: "SecPal GmbH",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-02T00:00:00Z",
+      cachedAt: new Date("2026-01-03T00:00:00Z"),
+      lastSynced: new Date("2026-01-03T00:00:00Z"),
+      parent_id: null,
+      parent: null,
+    };
+
+    await db.organizationalUnitCache.put(organizationalUnit);
+
+    await initializeOfflineVault(persistedUser);
+
+    expect(await db.analytics.count()).toBe(0);
+    expect(await db.organizationalUnitCache.count()).toBe(0);
+
+    await expect(listVaultAnalyticsEvents()).resolves.toEqual([
+      expect.objectContaining({
+        type: "page_view",
+        userId: persistedUser.id,
+        sessionId: "session-1",
+      }),
+    ]);
+    await expect(listVaultOrganizationalUnits()).resolves.toEqual([
+      expect.objectContaining({
+        id: "org-1",
+        name: "SecPal GmbH",
+      }),
+    ]);
+  });
+});

--- a/src/lib/offlineVault.test.ts
+++ b/src/lib/offlineVault.test.ts
@@ -11,6 +11,7 @@ import {
   listVaultAnalyticsEvents,
   listVaultOrganizationalUnits,
   readPersistedAuthUserFromVault,
+  clearOfflineVaultTables,
 } from "./offlineVault";
 
 function setCsrfTokenCookie(value: string): void {
@@ -104,5 +105,44 @@ describe("offlineVault", () => {
         name: "SecPal GmbH",
       }),
     ]);
+  });
+
+  it("removes invalid vault state from localStorage when JSON is malformed", async () => {
+    localStorage.setItem(AUTH_VAULT_STORAGE_KEY, "not-valid-json{{{");
+
+    // initializeOfflineVault will trigger getStoredVaultState
+    await initializeOfflineVault(persistedUser);
+
+    // Vault should now be initialized fresh (old invalid key replaced)
+    expect(localStorage.getItem(AUTH_VAULT_STORAGE_KEY)).not.toBeNull();
+    await expect(readPersistedAuthUserFromVault()).resolves.toEqual(
+      persistedUser
+    );
+  });
+
+  it("clears vault state and legacy tables when profile record is missing from vault", async () => {
+    await initializeOfflineVault(persistedUser);
+    expect(await db.vaultProfile.count()).toBe(1);
+
+    // Simulate a corrupted vault: clear only the profile table, leave vault state
+    await clearOfflineVaultTables();
+    clearOfflineVaultSession();
+
+    // Add legacy data to verify it gets cleared too
+    await db.analytics.add({
+      type: "page_view",
+      category: "navigation",
+      action: "open",
+      timestamp: Date.now(),
+      synced: false,
+      sessionId: "test-session",
+    });
+
+    const result = await readPersistedAuthUserFromVault();
+
+    expect(result).toBeNull();
+    expect(localStorage.getItem(AUTH_VAULT_STORAGE_KEY)).toBeNull();
+    expect(await db.vaultProfile.count()).toBe(0);
+    expect(await db.analytics.count()).toBe(0);
   });
 });

--- a/src/lib/offlineVault.ts
+++ b/src/lib/offlineVault.ts
@@ -160,7 +160,7 @@ async function ensureVaultDatabaseOpen(): Promise<void> {
   }
 }
 
-async function clearOfflineVaultTables(): Promise<void> {
+export async function clearOfflineVaultTables(): Promise<void> {
   await ensureVaultDatabaseOpen();
 
   await Promise.all([
@@ -894,7 +894,11 @@ export async function getVaultOrganizationalUnit(
     return undefined;
   }
 
-  return decryptedRecord;
+  return {
+    ...decryptedRecord,
+    cachedAt: record.cachedAt,
+    lastSynced: record.lastSynced,
+  };
 }
 
 export async function listVaultOrganizationalUnits(): Promise<
@@ -926,7 +930,11 @@ export async function listVaultOrganizationalUnits(): Promise<
         return null;
       }
 
-      return decryptedRecord;
+      return {
+        ...decryptedRecord,
+        cachedAt: record.cachedAt,
+        lastSynced: record.lastSynced,
+      };
     })
   );
 

--- a/src/lib/offlineVault.ts
+++ b/src/lib/offlineVault.ts
@@ -1,0 +1,912 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { PersistedAuthUser } from "../services/authState";
+import { sanitizePersistedAuthUser } from "../services/authState";
+import { getCsrfTokenFromCookie } from "../services/csrf";
+import {
+    db,
+    type AnalyticsEvent,
+    type EncryptedProfileRecord,
+    type EncryptedVaultRecord,
+    type OrganizationalUnitCacheEntry,
+    type VaultAnalyticsRecord,
+    type VaultOrganizationalUnitCacheRecord,
+} from "./db";
+
+const AUTH_VAULT_SCHEME = "pbkdf2-aes-cbc-hmac-sha256-vault";
+const AUTH_VAULT_VERSION = 1;
+const AUTH_VAULT_PBKDF2_ITERATIONS = 600_000;
+const AUTH_VAULT_SALT_BYTES = 16;
+const AUTH_VAULT_IV_BYTES = 16;
+const AUTH_VAULT_HALF_KEY_BYTES = 32;
+const AUTH_VAULT_DERIVED_KEY_BYTES = AUTH_VAULT_HALF_KEY_BYTES * 2;
+const VAULT_RECORD_IV_BYTES = 12;
+const VAULT_RECORD_TAG_BYTES = 16;
+const PROFILE_RECORD_ID = "profile";
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+export const AUTH_VAULT_STORAGE_KEY = "auth_vault_state";
+
+type AuthVaultVersion = typeof AUTH_VAULT_VERSION;
+
+interface AuthVaultStateEnvelope {
+    scheme: typeof AUTH_VAULT_SCHEME;
+    version: AuthVaultVersion;
+    salt: string;
+    iv: string;
+    ciphertext: string;
+    mac: string;
+    subjectHash: string;
+}
+
+interface VaultSession {
+    rootKeyBytes: Uint8Array;
+    subjectHash: string;
+    wrapperKeyMaterial: string | null;
+}
+
+type VaultAnalyticsPayload = Omit<AnalyticsEvent, "id" | "synced" | "timestamp">;
+
+let activeVaultSession: VaultSession | null = null;
+
+function isAuthVaultVersion(value: unknown): value is AuthVaultVersion {
+    return value === AUTH_VAULT_VERSION;
+}
+
+function isAuthVaultStateEnvelope(
+    value: unknown
+): value is AuthVaultStateEnvelope {
+    if (typeof value !== "object" || value === null) {
+        return false;
+    }
+
+    const candidate = value as Record<string, unknown>;
+
+    return (
+        candidate.scheme === AUTH_VAULT_SCHEME &&
+        isAuthVaultVersion(candidate.version) &&
+        typeof candidate.salt === "string" &&
+        typeof candidate.iv === "string" &&
+        typeof candidate.ciphertext === "string" &&
+        typeof candidate.mac === "string" &&
+        typeof candidate.subjectHash === "string"
+    );
+}
+
+function getAuthVaultKeyMaterial(): string | null {
+    const csrfToken = getCsrfTokenFromCookie();
+
+    if (!csrfToken) {
+        return null;
+    }
+
+    return `secpal-auth-vault:${csrfToken}`;
+}
+
+function encodeBase64(bytes: Uint8Array): string {
+    let binary = "";
+
+    for (let index = 0; index < bytes.length; index += 0x8000) {
+        const chunk = bytes.subarray(index, index + 0x8000);
+        binary += String.fromCharCode(...chunk);
+    }
+
+    return btoa(binary);
+}
+
+function decodeBase64(value: string): Uint8Array {
+    const binary = atob(value);
+    const bytes = new Uint8Array(binary.length);
+
+    for (let index = 0; index < binary.length; index += 1) {
+        bytes[index] = binary.charCodeAt(index);
+    }
+
+    return bytes;
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+    return bytes.buffer.slice(
+        bytes.byteOffset,
+        bytes.byteOffset + bytes.byteLength
+    ) as ArrayBuffer;
+}
+
+function createRandomBytes(length: number): Uint8Array {
+    return crypto.getRandomValues(new Uint8Array(length));
+}
+
+function getStoredVaultState(): AuthVaultStateEnvelope | null {
+    const storedState = localStorage.getItem(AUTH_VAULT_STORAGE_KEY);
+
+    if (!storedState) {
+        return null;
+    }
+
+    try {
+        const parsedState = JSON.parse(storedState) as unknown;
+        return isAuthVaultStateEnvelope(parsedState) ? parsedState : null;
+    } catch {
+        return null;
+    }
+}
+
+function setStoredVaultState(state: AuthVaultStateEnvelope): void {
+    localStorage.setItem(AUTH_VAULT_STORAGE_KEY, JSON.stringify(state));
+}
+
+export function clearOfflineVaultSession(): void {
+    if (activeVaultSession) {
+        activeVaultSession.rootKeyBytes.fill(0);
+    }
+
+    activeVaultSession = null;
+}
+
+export function clearStoredOfflineVaultState(): void {
+    localStorage.removeItem(AUTH_VAULT_STORAGE_KEY);
+    clearOfflineVaultSession();
+}
+
+async function clearOfflineVaultTables(): Promise<void> {
+    await Promise.all([
+        db.vaultProfile.clear(),
+        db.vaultAnalytics.clear(),
+        db.vaultOrganizationalUnitCache.clear(),
+    ]);
+}
+
+async function clearInvalidOfflineVaultArtifacts(): Promise<void> {
+    clearStoredOfflineVaultState();
+    await clearOfflineVaultTables();
+}
+
+async function deriveVaultWrapperKeys(
+    keyMaterial: string,
+    salt: Uint8Array
+): Promise<{ encryptionKey: CryptoKey; macKey: CryptoKey }> {
+    const baseKey = await crypto.subtle.importKey(
+        "raw",
+        textEncoder.encode(keyMaterial),
+        "PBKDF2",
+        false,
+        ["deriveBits"]
+    );
+
+    const derivedKeyBits = await crypto.subtle.deriveBits(
+        {
+            name: "PBKDF2",
+            hash: "SHA-256",
+            salt: toArrayBuffer(salt),
+            iterations: AUTH_VAULT_PBKDF2_ITERATIONS,
+        },
+        baseKey,
+        AUTH_VAULT_DERIVED_KEY_BYTES * 8
+    );
+    const derivedKey = new Uint8Array(derivedKeyBits);
+
+    if (derivedKey.byteLength !== AUTH_VAULT_DERIVED_KEY_BYTES) {
+        throw new Error("Derived auth vault key has an unexpected length.");
+    }
+
+    const encryptionKeyBytes = derivedKey.slice(0, AUTH_VAULT_HALF_KEY_BYTES);
+    const macKeyBytes = derivedKey.slice(AUTH_VAULT_HALF_KEY_BYTES);
+
+    const [encryptionKey, macKey] = await Promise.all([
+        crypto.subtle.importKey(
+            "raw",
+            encryptionKeyBytes,
+            {
+                name: "AES-CBC",
+                length: AUTH_VAULT_HALF_KEY_BYTES * 8,
+            },
+            false,
+            ["encrypt", "decrypt"]
+        ),
+        crypto.subtle.importKey(
+            "raw",
+            macKeyBytes,
+            {
+                name: "HMAC",
+                hash: "SHA-256",
+            },
+            false,
+            ["sign", "verify"]
+        ),
+    ]);
+
+    return { encryptionKey, macKey };
+}
+
+function buildAuthVaultMacPayload(
+    envelope: Omit<AuthVaultStateEnvelope, "mac">
+): string {
+    return [
+        envelope.scheme,
+        String(envelope.version),
+        envelope.subjectHash,
+        envelope.salt,
+        envelope.iv,
+        envelope.ciphertext,
+    ].join(":");
+}
+
+async function signAuthVaultMac(
+    envelope: Omit<AuthVaultStateEnvelope, "mac">,
+    macKey: CryptoKey
+): Promise<string> {
+    const mac = await crypto.subtle.sign(
+        "HMAC",
+        macKey,
+        textEncoder.encode(buildAuthVaultMacPayload(envelope))
+    );
+
+    return encodeBase64(new Uint8Array(mac));
+}
+
+async function verifyAuthVaultMac(
+    envelope: Omit<AuthVaultStateEnvelope, "mac">,
+    mac: string,
+    macKey: CryptoKey
+): Promise<boolean> {
+    return await crypto.subtle.verify(
+        "HMAC",
+        macKey,
+        toArrayBuffer(decodeBase64(mac)),
+        textEncoder.encode(buildAuthVaultMacPayload(envelope))
+    );
+}
+
+async function encryptVaultRootKeyBytes(
+    rootKeyBytes: Uint8Array,
+    subjectHash: string
+): Promise<AuthVaultStateEnvelope | null> {
+    const keyMaterial = getAuthVaultKeyMaterial();
+
+    if (!keyMaterial) {
+        return null;
+    }
+
+    const salt = createRandomBytes(AUTH_VAULT_SALT_BYTES);
+    const iv = createRandomBytes(AUTH_VAULT_IV_BYTES);
+    const { encryptionKey, macKey } = await deriveVaultWrapperKeys(
+        keyMaterial,
+        salt
+    );
+    const ciphertext = new Uint8Array(
+        await crypto.subtle.encrypt(
+            {
+                name: "AES-CBC",
+                iv: toArrayBuffer(iv),
+            },
+            encryptionKey,
+            textEncoder.encode(encodeBase64(rootKeyBytes))
+        )
+    );
+
+    const envelopeWithoutMac = {
+        scheme: AUTH_VAULT_SCHEME,
+        version: AUTH_VAULT_VERSION,
+        salt: encodeBase64(salt),
+        iv: encodeBase64(iv),
+        ciphertext: encodeBase64(ciphertext),
+        subjectHash,
+    } satisfies Omit<AuthVaultStateEnvelope, "mac">;
+
+    return {
+        ...envelopeWithoutMac,
+        mac: await signAuthVaultMac(envelopeWithoutMac, macKey),
+    };
+}
+
+async function decryptVaultRootKeyBytes(
+    state: AuthVaultStateEnvelope
+): Promise<Uint8Array | null> {
+    const keyMaterial = getAuthVaultKeyMaterial();
+
+    if (!keyMaterial) {
+        return null;
+    }
+
+    const envelopeWithoutMac = {
+        scheme: state.scheme,
+        version: state.version,
+        salt: state.salt,
+        iv: state.iv,
+        ciphertext: state.ciphertext,
+        subjectHash: state.subjectHash,
+    } satisfies Omit<AuthVaultStateEnvelope, "mac">;
+    const { encryptionKey, macKey } = await deriveVaultWrapperKeys(
+        keyMaterial,
+        decodeBase64(state.salt)
+    );
+    const isMacValid = await verifyAuthVaultMac(
+        envelopeWithoutMac,
+        state.mac,
+        macKey
+    );
+
+    if (!isMacValid) {
+        return null;
+    }
+
+    try {
+        const decrypted = await crypto.subtle.decrypt(
+            {
+                name: "AES-CBC",
+                iv: toArrayBuffer(decodeBase64(state.iv)),
+            },
+            encryptionKey,
+            toArrayBuffer(decodeBase64(state.ciphertext))
+        );
+
+        const rootKeyBytes = decodeBase64(textDecoder.decode(decrypted));
+
+        return rootKeyBytes.byteLength === 32 ? rootKeyBytes : null;
+    } catch {
+        return null;
+    }
+}
+
+async function computeSubjectHash(userId: string): Promise<string> {
+    const digest = await crypto.subtle.digest(
+        "SHA-256",
+        textEncoder.encode(userId)
+    );
+
+    return encodeBase64(new Uint8Array(digest));
+}
+
+function createVaultRecordId(prefix: string): string {
+    if (typeof crypto.randomUUID === "function") {
+        return `${prefix}:${crypto.randomUUID()}`;
+    }
+
+    return `${prefix}:${encodeBase64(createRandomBytes(12))}`;
+}
+
+async function deriveVaultStoreKey(
+    rootKeyBytes: Uint8Array,
+    storeName: string
+): Promise<CryptoKey> {
+    const hkdfKey = await crypto.subtle.importKey(
+        "raw",
+        toArrayBuffer(rootKeyBytes),
+        "HKDF",
+        false,
+        ["deriveKey"]
+    );
+
+    return await crypto.subtle.deriveKey(
+        {
+            name: "HKDF",
+            hash: "SHA-256",
+            salt: toArrayBuffer(new Uint8Array(0)),
+            info: textEncoder.encode(`secpal-offline-vault:${storeName}`),
+        },
+        hkdfKey,
+        {
+            name: "AES-GCM",
+            length: 256,
+        },
+        false,
+        ["encrypt", "decrypt"]
+    );
+}
+
+function buildVaultAdditionalData(
+    storeName: string,
+    recordId: string,
+    subjectHash: string
+): Uint8Array {
+    return textEncoder.encode(
+        JSON.stringify({
+            version: AUTH_VAULT_VERSION,
+            storeName,
+            recordId,
+            subjectHash,
+        })
+    );
+}
+
+async function encryptVaultRecord(
+    payload: unknown,
+    storeName: string,
+    recordId: string,
+    session: VaultSession
+): Promise<EncryptedVaultRecord> {
+    const key = await deriveVaultStoreKey(session.rootKeyBytes, storeName);
+    const iv = createRandomBytes(VAULT_RECORD_IV_BYTES);
+    const encrypted = new Uint8Array(
+        await crypto.subtle.encrypt(
+            {
+                name: "AES-GCM",
+                iv: toArrayBuffer(iv),
+                tagLength: 128,
+                additionalData: toArrayBuffer(
+                    buildVaultAdditionalData(storeName, recordId, session.subjectHash)
+                ),
+            },
+            key,
+            toArrayBuffer(textEncoder.encode(JSON.stringify(payload)))
+        )
+    );
+    const ciphertext = encrypted.slice(0, encrypted.length - VAULT_RECORD_TAG_BYTES);
+    const authTag = encrypted.slice(encrypted.length - VAULT_RECORD_TAG_BYTES);
+
+    return {
+        recordId,
+        version: AUTH_VAULT_VERSION,
+        ciphertext: encodeBase64(ciphertext),
+        iv: encodeBase64(iv),
+        authTag: encodeBase64(authTag),
+    };
+}
+
+async function decryptVaultRecord<T>(
+    record: EncryptedVaultRecord,
+    storeName: string,
+    session: VaultSession
+): Promise<T | null> {
+    try {
+        const key = await deriveVaultStoreKey(session.rootKeyBytes, storeName);
+        const ciphertext = decodeBase64(record.ciphertext);
+        const authTag = decodeBase64(record.authTag);
+        const combined = new Uint8Array(ciphertext.length + authTag.length);
+
+        combined.set(ciphertext, 0);
+        combined.set(authTag, ciphertext.length);
+
+        const decrypted = await crypto.subtle.decrypt(
+            {
+                name: "AES-GCM",
+                iv: toArrayBuffer(decodeBase64(record.iv)),
+                tagLength: 128,
+                additionalData: toArrayBuffer(
+                    buildVaultAdditionalData(
+                        storeName,
+                        record.recordId,
+                        session.subjectHash
+                    )
+                ),
+            },
+            key,
+            toArrayBuffer(combined)
+        );
+
+        return JSON.parse(textDecoder.decode(decrypted)) as T;
+    } catch {
+        return null;
+    }
+}
+
+async function ensureOfflineVaultSession(): Promise<VaultSession | null> {
+    const currentKeyMaterial = getAuthVaultKeyMaterial();
+
+    if (activeVaultSession) {
+        if (activeVaultSession.wrapperKeyMaterial === currentKeyMaterial) {
+            return activeVaultSession;
+        }
+
+        clearOfflineVaultSession();
+    }
+
+    const storedState = getStoredVaultState();
+
+    if (!storedState) {
+        return null;
+    }
+
+    const rootKeyBytes = await decryptVaultRootKeyBytes(storedState);
+
+    if (!rootKeyBytes) {
+        await clearInvalidOfflineVaultArtifacts();
+        return null;
+    }
+
+    activeVaultSession = {
+        rootKeyBytes,
+        subjectHash: storedState.subjectHash,
+        wrapperKeyMaterial: currentKeyMaterial,
+    };
+
+    return activeVaultSession;
+}
+
+async function ensureVaultSessionForUser(
+    user: PersistedAuthUser
+): Promise<VaultSession> {
+    const subjectHash = await computeSubjectHash(user.id);
+    const currentSession = await ensureOfflineVaultSession();
+
+    if (currentSession && currentSession.subjectHash === subjectHash) {
+        return currentSession;
+    }
+
+    if (currentSession && currentSession.subjectHash !== subjectHash) {
+        await clearOfflineVaultTables();
+        clearStoredOfflineVaultState();
+    }
+
+    const rootKeyBytes = createRandomBytes(32);
+    const storedState = await encryptVaultRootKeyBytes(rootKeyBytes, subjectHash);
+
+    if (!storedState) {
+        throw new Error(
+            "Failed to derive auth vault key due to missing CSRF token/session context."
+        );
+    }
+
+    setStoredVaultState(storedState);
+    activeVaultSession = {
+        rootKeyBytes,
+        subjectHash,
+        wrapperKeyMaterial: getAuthVaultKeyMaterial(),
+    };
+
+    return activeVaultSession;
+}
+
+async function persistProfileRecord(
+    user: PersistedAuthUser,
+    session: VaultSession
+): Promise<void> {
+    const encryptedRecord = await encryptVaultRecord(
+        user,
+        "profile",
+        PROFILE_RECORD_ID,
+        session
+    );
+
+    await db.vaultProfile.put({
+        id: PROFILE_RECORD_ID,
+        ...encryptedRecord,
+    } satisfies EncryptedProfileRecord);
+}
+
+async function migrateLegacyAnalyticsRecords(
+    session: VaultSession
+): Promise<void> {
+    const legacyRecords = await db.analytics.toArray();
+
+    if (legacyRecords.length === 0) {
+        return;
+    }
+
+    const encryptedRecords = await Promise.all(
+        legacyRecords.map(async (record) => {
+            const { synced, timestamp, ...payloadWithId } = record;
+            const payload = { ...payloadWithId };
+
+            delete payload.id;
+
+            const recordId =
+                typeof record.id === "number"
+                    ? `legacy:${record.id}`
+                    : createVaultRecordId("analytics");
+            const encryptedPayload = await encryptVaultRecord(
+                payload,
+                "analytics",
+                recordId,
+                session
+            );
+
+            return {
+                synced,
+                timestamp,
+                ...encryptedPayload,
+            } satisfies Omit<VaultAnalyticsRecord, "id">;
+        })
+    );
+
+    await db.vaultAnalytics.bulkPut(encryptedRecords);
+    await db.analytics.clear();
+}
+
+async function migrateLegacyOrganizationalUnitRecords(
+    session: VaultSession
+): Promise<void> {
+    const legacyRecords = await db.organizationalUnitCache.toArray();
+
+    if (legacyRecords.length === 0) {
+        return;
+    }
+
+    const encryptedRecords = await Promise.all(
+        legacyRecords.map(async (record) => {
+            const encryptedPayload = await encryptVaultRecord(
+                record,
+                "organizationalUnitCache",
+                record.id,
+                session
+            );
+
+            return {
+                id: record.id,
+                cachedAt: record.cachedAt,
+                lastSynced: record.lastSynced,
+                ...encryptedPayload,
+            } satisfies VaultOrganizationalUnitCacheRecord;
+        })
+    );
+
+    await db.vaultOrganizationalUnitCache.bulkPut(encryptedRecords);
+    await db.organizationalUnitCache.clear();
+}
+
+export async function initializeOfflineVault(
+    user: PersistedAuthUser
+): Promise<void> {
+    const session = await ensureVaultSessionForUser(user);
+
+    await persistProfileRecord(user, session);
+    await Promise.all([
+        migrateLegacyAnalyticsRecords(session),
+        migrateLegacyOrganizationalUnitRecords(session),
+    ]);
+
+    localStorage.removeItem("auth_user");
+}
+
+export async function readPersistedAuthUserFromVault(): Promise<PersistedAuthUser | null> {
+    const session = await ensureOfflineVaultSession();
+
+    if (!session) {
+        return null;
+    }
+
+    const storedProfile = await db.vaultProfile.get(PROFILE_RECORD_ID);
+
+    if (!storedProfile) {
+        return null;
+    }
+
+    const decryptedUser = await decryptVaultRecord<unknown>(
+        storedProfile,
+        "profile",
+        session
+    );
+    const sanitizedUser = sanitizePersistedAuthUser(decryptedUser);
+
+    if (!sanitizedUser) {
+        console.error(
+            "Failed to parse stored user data:",
+            new SyntaxError("Invalid encrypted vault profile payload.")
+        );
+        await clearInvalidOfflineVaultArtifacts();
+        return null;
+    }
+
+    return sanitizedUser;
+}
+
+export async function storeVaultAnalyticsEvent(
+    event: AnalyticsEvent
+): Promise<number> {
+    const session = await ensureOfflineVaultSession();
+
+    if (!session) {
+        throw new Error("Offline vault is not available.");
+    }
+
+    const recordId = createVaultRecordId("analytics");
+    const { synced, timestamp, ...payloadWithId } = event;
+    const payload = { ...payloadWithId };
+
+    delete payload.id;
+
+    const encryptedPayload = await encryptVaultRecord(
+        payload satisfies VaultAnalyticsPayload,
+        "analytics",
+        recordId,
+        session
+    );
+
+    const insertedId = await db.vaultAnalytics.add({
+        synced,
+        timestamp,
+        ...encryptedPayload,
+    });
+
+    if (typeof insertedId !== "number") {
+        throw new Error("Vault analytics record was created without a numeric ID.");
+    }
+
+    return insertedId;
+}
+
+export async function listVaultAnalyticsEvents(): Promise<AnalyticsEvent[]> {
+    const session = await ensureOfflineVaultSession();
+
+    if (!session) {
+        return [];
+    }
+
+    await migrateLegacyAnalyticsRecords(session);
+
+    const records = await db.vaultAnalytics.toArray();
+    const invalidIds: number[] = [];
+    const decryptedEvents = await Promise.all(
+        records.map(async (record) => {
+            const payload = await decryptVaultRecord<VaultAnalyticsPayload>(
+                record,
+                "analytics",
+                session
+            );
+
+            if (!payload) {
+                if (record.id !== undefined) {
+                    invalidIds.push(record.id);
+                }
+
+                return null;
+            }
+
+            const event: AnalyticsEvent = {
+                synced: record.synced,
+                timestamp: record.timestamp,
+                ...payload,
+            };
+
+            if (record.id !== undefined) {
+                event.id = record.id;
+            }
+
+            return event;
+        })
+    );
+
+    if (invalidIds.length > 0) {
+        await db.vaultAnalytics.bulkDelete(invalidIds);
+    }
+
+    return decryptedEvents.flatMap((event) => (event ? [event] : []));
+}
+
+export async function listUnsyncedVaultAnalyticsRecordIds(): Promise<number[]> {
+    const records = await db.vaultAnalytics.where("synced").equals(0).toArray();
+
+    return records.flatMap((record) =>
+        record.id === undefined ? [] : [record.id]
+    );
+}
+
+export async function markVaultAnalyticsEventsSynced(
+    ids: number[]
+): Promise<void> {
+    if (ids.length === 0) {
+        return;
+    }
+
+    await db.vaultAnalytics.bulkUpdate(
+        ids.map((id) => ({
+            key: id,
+            changes: { synced: true },
+        }))
+    );
+}
+
+export async function clearVaultAnalytics(): Promise<void> {
+    await db.vaultAnalytics.clear();
+}
+
+export async function clearOldVaultAnalyticsEvents(
+    olderThanTimestamp: number
+): Promise<void> {
+    await db.vaultAnalytics
+        .where("synced")
+        .equals(1)
+        .and((record) => record.timestamp < olderThanTimestamp)
+        .delete();
+}
+
+export async function saveVaultOrganizationalUnit(
+    unit: OrganizationalUnitCacheEntry
+): Promise<void> {
+    const session = await ensureOfflineVaultSession();
+
+    if (!session) {
+        throw new Error("Offline vault is not available.");
+    }
+
+    const encryptedPayload = await encryptVaultRecord(
+        unit,
+        "organizationalUnitCache",
+        unit.id,
+        session
+    );
+
+    await db.vaultOrganizationalUnitCache.put({
+        id: unit.id,
+        cachedAt: unit.cachedAt,
+        lastSynced: unit.lastSynced,
+        ...encryptedPayload,
+    });
+}
+
+export async function getVaultOrganizationalUnit(
+    id: string
+): Promise<OrganizationalUnitCacheEntry | undefined> {
+    const session = await ensureOfflineVaultSession();
+
+    if (!session) {
+        return undefined;
+    }
+
+    await migrateLegacyOrganizationalUnitRecords(session);
+
+    const record = await db.vaultOrganizationalUnitCache.get(id);
+
+    if (!record) {
+        return undefined;
+    }
+
+    const decryptedRecord = await decryptVaultRecord<OrganizationalUnitCacheEntry>(
+        record,
+        "organizationalUnitCache",
+        session
+    );
+
+    if (!decryptedRecord) {
+        await db.vaultOrganizationalUnitCache.delete(id);
+        return undefined;
+    }
+
+    return decryptedRecord;
+}
+
+export async function listVaultOrganizationalUnits(): Promise<
+    OrganizationalUnitCacheEntry[]
+> {
+    const session = await ensureOfflineVaultSession();
+
+    if (!session) {
+        return [];
+    }
+
+    await migrateLegacyOrganizationalUnitRecords(session);
+
+    const records = await db.vaultOrganizationalUnitCache.toArray();
+    const invalidIds: string[] = [];
+    const decryptedRecords = await Promise.all(
+        records.map(async (record) => {
+            const decryptedRecord = await decryptVaultRecord<OrganizationalUnitCacheEntry>(
+                record,
+                "organizationalUnitCache",
+                session
+            );
+
+            if (!decryptedRecord) {
+                invalidIds.push(record.id);
+                return null;
+            }
+
+            return decryptedRecord;
+        })
+    );
+
+    if (invalidIds.length > 0) {
+        await db.vaultOrganizationalUnitCache.bulkDelete(invalidIds);
+    }
+
+    return decryptedRecords.filter(
+        (record): record is OrganizationalUnitCacheEntry => record !== null
+    );
+}
+
+export async function deleteVaultOrganizationalUnit(id: string): Promise<void> {
+    await Promise.all([
+        db.vaultOrganizationalUnitCache.delete(id),
+        db.organizationalUnitCache.delete(id),
+    ]);
+}
+
+export async function clearVaultOrganizationalUnits(): Promise<void> {
+    await Promise.all([
+        db.vaultOrganizationalUnitCache.clear(),
+        db.organizationalUnitCache.clear(),
+    ]);
+}

--- a/src/lib/offlineVault.ts
+++ b/src/lib/offlineVault.ts
@@ -5,13 +5,13 @@ import type { PersistedAuthUser } from "../services/authState";
 import { sanitizePersistedAuthUser } from "../services/authState";
 import { getCsrfTokenFromCookie } from "../services/csrf";
 import {
-    db,
-    type AnalyticsEvent,
-    type EncryptedProfileRecord,
-    type EncryptedVaultRecord,
-    type OrganizationalUnitCacheEntry,
-    type VaultAnalyticsRecord,
-    type VaultOrganizationalUnitCacheRecord,
+  db,
+  type AnalyticsEvent,
+  type EncryptedProfileRecord,
+  type EncryptedVaultRecord,
+  type OrganizationalUnitCacheEntry,
+  type VaultAnalyticsRecord,
+  type VaultOrganizationalUnitCacheRecord,
 } from "./db";
 
 const AUTH_VAULT_SCHEME = "pbkdf2-aes-cbc-hmac-sha256-vault";
@@ -33,880 +33,888 @@ export const AUTH_VAULT_STORAGE_KEY = "auth_vault_state";
 type AuthVaultVersion = typeof AUTH_VAULT_VERSION;
 
 interface AuthVaultStateEnvelope {
-    scheme: typeof AUTH_VAULT_SCHEME;
-    version: AuthVaultVersion;
-    salt: string;
-    iv: string;
-    ciphertext: string;
-    mac: string;
-    subjectHash: string;
+  scheme: typeof AUTH_VAULT_SCHEME;
+  version: AuthVaultVersion;
+  salt: string;
+  iv: string;
+  ciphertext: string;
+  mac: string;
+  subjectHash: string;
 }
 
 interface VaultSession {
-    rootKeyBytes: Uint8Array;
-    subjectHash: string;
-    wrapperKeyMaterial: string | null;
+  rootKeyBytes: Uint8Array;
+  subjectHash: string;
+  wrapperKeyMaterial: string | null;
 }
 
-type VaultAnalyticsPayload = Omit<AnalyticsEvent, "id" | "synced" | "timestamp">;
+type VaultAnalyticsPayload = Omit<
+  AnalyticsEvent,
+  "id" | "synced" | "timestamp"
+>;
 
 let activeVaultSession: VaultSession | null = null;
 
 function isAuthVaultVersion(value: unknown): value is AuthVaultVersion {
-    return value === AUTH_VAULT_VERSION;
+  return value === AUTH_VAULT_VERSION;
 }
 
 function isAuthVaultStateEnvelope(
-    value: unknown
+  value: unknown
 ): value is AuthVaultStateEnvelope {
-    if (typeof value !== "object" || value === null) {
-        return false;
-    }
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
 
-    const candidate = value as Record<string, unknown>;
+  const candidate = value as Record<string, unknown>;
 
-    return (
-        candidate.scheme === AUTH_VAULT_SCHEME &&
-        isAuthVaultVersion(candidate.version) &&
-        typeof candidate.salt === "string" &&
-        typeof candidate.iv === "string" &&
-        typeof candidate.ciphertext === "string" &&
-        typeof candidate.mac === "string" &&
-        typeof candidate.subjectHash === "string"
-    );
+  return (
+    candidate.scheme === AUTH_VAULT_SCHEME &&
+    isAuthVaultVersion(candidate.version) &&
+    typeof candidate.salt === "string" &&
+    typeof candidate.iv === "string" &&
+    typeof candidate.ciphertext === "string" &&
+    typeof candidate.mac === "string" &&
+    typeof candidate.subjectHash === "string"
+  );
 }
 
 function getAuthVaultKeyMaterial(): string | null {
-    const csrfToken = getCsrfTokenFromCookie();
+  const csrfToken = getCsrfTokenFromCookie();
 
-    if (!csrfToken) {
-        return null;
-    }
+  if (!csrfToken) {
+    return null;
+  }
 
-    return `secpal-auth-vault:${csrfToken}`;
+  return `secpal-auth-vault:${csrfToken}`;
 }
 
 function encodeBase64(bytes: Uint8Array): string {
-    let binary = "";
+  let binary = "";
 
-    for (let index = 0; index < bytes.length; index += 0x8000) {
-        const chunk = bytes.subarray(index, index + 0x8000);
-        binary += String.fromCharCode(...chunk);
-    }
+  for (let index = 0; index < bytes.length; index += 0x8000) {
+    const chunk = bytes.subarray(index, index + 0x8000);
+    binary += String.fromCharCode(...chunk);
+  }
 
-    return btoa(binary);
+  return btoa(binary);
 }
 
 function decodeBase64(value: string): Uint8Array {
-    const binary = atob(value);
-    const bytes = new Uint8Array(binary.length);
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
 
-    for (let index = 0; index < binary.length; index += 1) {
-        bytes[index] = binary.charCodeAt(index);
-    }
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
 
-    return bytes;
+  return bytes;
 }
 
 function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
-    return bytes.buffer.slice(
-        bytes.byteOffset,
-        bytes.byteOffset + bytes.byteLength
-    ) as ArrayBuffer;
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength
+  ) as ArrayBuffer;
 }
 
 function createRandomBytes(length: number): Uint8Array {
-    return crypto.getRandomValues(new Uint8Array(length));
+  return crypto.getRandomValues(new Uint8Array(length));
 }
 
 function getStoredVaultState(): AuthVaultStateEnvelope | null {
-    const storedState = localStorage.getItem(AUTH_VAULT_STORAGE_KEY);
+  const storedState = localStorage.getItem(AUTH_VAULT_STORAGE_KEY);
 
-    if (!storedState) {
-        return null;
-    }
+  if (!storedState) {
+    return null;
+  }
 
-    try {
-        const parsedState = JSON.parse(storedState) as unknown;
-        return isAuthVaultStateEnvelope(parsedState) ? parsedState : null;
-    } catch {
-        return null;
-    }
+  try {
+    const parsedState = JSON.parse(storedState) as unknown;
+    return isAuthVaultStateEnvelope(parsedState) ? parsedState : null;
+  } catch {
+    return null;
+  }
 }
 
 function setStoredVaultState(state: AuthVaultStateEnvelope): void {
-    localStorage.setItem(AUTH_VAULT_STORAGE_KEY, JSON.stringify(state));
+  localStorage.setItem(AUTH_VAULT_STORAGE_KEY, JSON.stringify(state));
 }
 
 export function clearOfflineVaultSession(): void {
-    if (activeVaultSession) {
-        activeVaultSession.rootKeyBytes.fill(0);
-    }
+  if (activeVaultSession) {
+    activeVaultSession.rootKeyBytes.fill(0);
+  }
 
-    activeVaultSession = null;
+  activeVaultSession = null;
 }
 
 export function clearStoredOfflineVaultState(): void {
-    localStorage.removeItem(AUTH_VAULT_STORAGE_KEY);
-    clearOfflineVaultSession();
+  localStorage.removeItem(AUTH_VAULT_STORAGE_KEY);
+  clearOfflineVaultSession();
 }
 
 async function clearOfflineVaultTables(): Promise<void> {
-    await Promise.all([
-        db.vaultProfile.clear(),
-        db.vaultAnalytics.clear(),
-        db.vaultOrganizationalUnitCache.clear(),
-    ]);
+  await Promise.all([
+    db.vaultProfile.clear(),
+    db.vaultAnalytics.clear(),
+    db.vaultOrganizationalUnitCache.clear(),
+  ]);
 }
 
 async function clearInvalidOfflineVaultArtifacts(): Promise<void> {
-    clearStoredOfflineVaultState();
-    await clearOfflineVaultTables();
+  clearStoredOfflineVaultState();
+  await clearOfflineVaultTables();
 }
 
 async function deriveVaultWrapperKeys(
-    keyMaterial: string,
-    salt: Uint8Array
+  keyMaterial: string,
+  salt: Uint8Array
 ): Promise<{ encryptionKey: CryptoKey; macKey: CryptoKey }> {
-    const baseKey = await crypto.subtle.importKey(
-        "raw",
-        textEncoder.encode(keyMaterial),
-        "PBKDF2",
-        false,
-        ["deriveBits"]
-    );
+  const baseKey = await crypto.subtle.importKey(
+    "raw",
+    textEncoder.encode(keyMaterial),
+    "PBKDF2",
+    false,
+    ["deriveBits"]
+  );
 
-    const derivedKeyBits = await crypto.subtle.deriveBits(
-        {
-            name: "PBKDF2",
-            hash: "SHA-256",
-            salt: toArrayBuffer(salt),
-            iterations: AUTH_VAULT_PBKDF2_ITERATIONS,
-        },
-        baseKey,
-        AUTH_VAULT_DERIVED_KEY_BYTES * 8
-    );
-    const derivedKey = new Uint8Array(derivedKeyBits);
+  const derivedKeyBits = await crypto.subtle.deriveBits(
+    {
+      name: "PBKDF2",
+      hash: "SHA-256",
+      salt: toArrayBuffer(salt),
+      iterations: AUTH_VAULT_PBKDF2_ITERATIONS,
+    },
+    baseKey,
+    AUTH_VAULT_DERIVED_KEY_BYTES * 8
+  );
+  const derivedKey = new Uint8Array(derivedKeyBits);
 
-    if (derivedKey.byteLength !== AUTH_VAULT_DERIVED_KEY_BYTES) {
-        throw new Error("Derived auth vault key has an unexpected length.");
-    }
+  if (derivedKey.byteLength !== AUTH_VAULT_DERIVED_KEY_BYTES) {
+    throw new Error("Derived auth vault key has an unexpected length.");
+  }
 
-    const encryptionKeyBytes = derivedKey.slice(0, AUTH_VAULT_HALF_KEY_BYTES);
-    const macKeyBytes = derivedKey.slice(AUTH_VAULT_HALF_KEY_BYTES);
+  const encryptionKeyBytes = derivedKey.slice(0, AUTH_VAULT_HALF_KEY_BYTES);
+  const macKeyBytes = derivedKey.slice(AUTH_VAULT_HALF_KEY_BYTES);
 
-    const [encryptionKey, macKey] = await Promise.all([
-        crypto.subtle.importKey(
-            "raw",
-            encryptionKeyBytes,
-            {
-                name: "AES-CBC",
-                length: AUTH_VAULT_HALF_KEY_BYTES * 8,
-            },
-            false,
-            ["encrypt", "decrypt"]
-        ),
-        crypto.subtle.importKey(
-            "raw",
-            macKeyBytes,
-            {
-                name: "HMAC",
-                hash: "SHA-256",
-            },
-            false,
-            ["sign", "verify"]
-        ),
-    ]);
+  const [encryptionKey, macKey] = await Promise.all([
+    crypto.subtle.importKey(
+      "raw",
+      encryptionKeyBytes,
+      {
+        name: "AES-CBC",
+        length: AUTH_VAULT_HALF_KEY_BYTES * 8,
+      },
+      false,
+      ["encrypt", "decrypt"]
+    ),
+    crypto.subtle.importKey(
+      "raw",
+      macKeyBytes,
+      {
+        name: "HMAC",
+        hash: "SHA-256",
+      },
+      false,
+      ["sign", "verify"]
+    ),
+  ]);
 
-    return { encryptionKey, macKey };
+  return { encryptionKey, macKey };
 }
 
 function buildAuthVaultMacPayload(
-    envelope: Omit<AuthVaultStateEnvelope, "mac">
+  envelope: Omit<AuthVaultStateEnvelope, "mac">
 ): string {
-    return [
-        envelope.scheme,
-        String(envelope.version),
-        envelope.subjectHash,
-        envelope.salt,
-        envelope.iv,
-        envelope.ciphertext,
-    ].join(":");
+  return [
+    envelope.scheme,
+    String(envelope.version),
+    envelope.subjectHash,
+    envelope.salt,
+    envelope.iv,
+    envelope.ciphertext,
+  ].join(":");
 }
 
 async function signAuthVaultMac(
-    envelope: Omit<AuthVaultStateEnvelope, "mac">,
-    macKey: CryptoKey
+  envelope: Omit<AuthVaultStateEnvelope, "mac">,
+  macKey: CryptoKey
 ): Promise<string> {
-    const mac = await crypto.subtle.sign(
-        "HMAC",
-        macKey,
-        textEncoder.encode(buildAuthVaultMacPayload(envelope))
-    );
+  const mac = await crypto.subtle.sign(
+    "HMAC",
+    macKey,
+    textEncoder.encode(buildAuthVaultMacPayload(envelope))
+  );
 
-    return encodeBase64(new Uint8Array(mac));
+  return encodeBase64(new Uint8Array(mac));
 }
 
 async function verifyAuthVaultMac(
-    envelope: Omit<AuthVaultStateEnvelope, "mac">,
-    mac: string,
-    macKey: CryptoKey
+  envelope: Omit<AuthVaultStateEnvelope, "mac">,
+  mac: string,
+  macKey: CryptoKey
 ): Promise<boolean> {
-    return await crypto.subtle.verify(
-        "HMAC",
-        macKey,
-        toArrayBuffer(decodeBase64(mac)),
-        textEncoder.encode(buildAuthVaultMacPayload(envelope))
-    );
+  return await crypto.subtle.verify(
+    "HMAC",
+    macKey,
+    toArrayBuffer(decodeBase64(mac)),
+    textEncoder.encode(buildAuthVaultMacPayload(envelope))
+  );
 }
 
 async function encryptVaultRootKeyBytes(
-    rootKeyBytes: Uint8Array,
-    subjectHash: string
+  rootKeyBytes: Uint8Array,
+  subjectHash: string
 ): Promise<AuthVaultStateEnvelope | null> {
-    const keyMaterial = getAuthVaultKeyMaterial();
+  const keyMaterial = getAuthVaultKeyMaterial();
 
-    if (!keyMaterial) {
-        return null;
-    }
+  if (!keyMaterial) {
+    return null;
+  }
 
-    const salt = createRandomBytes(AUTH_VAULT_SALT_BYTES);
-    const iv = createRandomBytes(AUTH_VAULT_IV_BYTES);
-    const { encryptionKey, macKey } = await deriveVaultWrapperKeys(
-        keyMaterial,
-        salt
-    );
-    const ciphertext = new Uint8Array(
-        await crypto.subtle.encrypt(
-            {
-                name: "AES-CBC",
-                iv: toArrayBuffer(iv),
-            },
-            encryptionKey,
-            textEncoder.encode(encodeBase64(rootKeyBytes))
-        )
-    );
+  const salt = createRandomBytes(AUTH_VAULT_SALT_BYTES);
+  const iv = createRandomBytes(AUTH_VAULT_IV_BYTES);
+  const { encryptionKey, macKey } = await deriveVaultWrapperKeys(
+    keyMaterial,
+    salt
+  );
+  const ciphertext = new Uint8Array(
+    await crypto.subtle.encrypt(
+      {
+        name: "AES-CBC",
+        iv: toArrayBuffer(iv),
+      },
+      encryptionKey,
+      textEncoder.encode(encodeBase64(rootKeyBytes))
+    )
+  );
 
-    const envelopeWithoutMac = {
-        scheme: AUTH_VAULT_SCHEME,
-        version: AUTH_VAULT_VERSION,
-        salt: encodeBase64(salt),
-        iv: encodeBase64(iv),
-        ciphertext: encodeBase64(ciphertext),
-        subjectHash,
-    } satisfies Omit<AuthVaultStateEnvelope, "mac">;
+  const envelopeWithoutMac = {
+    scheme: AUTH_VAULT_SCHEME,
+    version: AUTH_VAULT_VERSION,
+    salt: encodeBase64(salt),
+    iv: encodeBase64(iv),
+    ciphertext: encodeBase64(ciphertext),
+    subjectHash,
+  } satisfies Omit<AuthVaultStateEnvelope, "mac">;
 
-    return {
-        ...envelopeWithoutMac,
-        mac: await signAuthVaultMac(envelopeWithoutMac, macKey),
-    };
+  return {
+    ...envelopeWithoutMac,
+    mac: await signAuthVaultMac(envelopeWithoutMac, macKey),
+  };
 }
 
 async function decryptVaultRootKeyBytes(
-    state: AuthVaultStateEnvelope
+  state: AuthVaultStateEnvelope
 ): Promise<Uint8Array | null> {
-    const keyMaterial = getAuthVaultKeyMaterial();
+  const keyMaterial = getAuthVaultKeyMaterial();
 
-    if (!keyMaterial) {
-        return null;
-    }
+  if (!keyMaterial) {
+    return null;
+  }
 
-    const envelopeWithoutMac = {
-        scheme: state.scheme,
-        version: state.version,
-        salt: state.salt,
-        iv: state.iv,
-        ciphertext: state.ciphertext,
-        subjectHash: state.subjectHash,
-    } satisfies Omit<AuthVaultStateEnvelope, "mac">;
-    const { encryptionKey, macKey } = await deriveVaultWrapperKeys(
-        keyMaterial,
-        decodeBase64(state.salt)
+  const envelopeWithoutMac = {
+    scheme: state.scheme,
+    version: state.version,
+    salt: state.salt,
+    iv: state.iv,
+    ciphertext: state.ciphertext,
+    subjectHash: state.subjectHash,
+  } satisfies Omit<AuthVaultStateEnvelope, "mac">;
+  const { encryptionKey, macKey } = await deriveVaultWrapperKeys(
+    keyMaterial,
+    decodeBase64(state.salt)
+  );
+  const isMacValid = await verifyAuthVaultMac(
+    envelopeWithoutMac,
+    state.mac,
+    macKey
+  );
+
+  if (!isMacValid) {
+    return null;
+  }
+
+  try {
+    const decrypted = await crypto.subtle.decrypt(
+      {
+        name: "AES-CBC",
+        iv: toArrayBuffer(decodeBase64(state.iv)),
+      },
+      encryptionKey,
+      toArrayBuffer(decodeBase64(state.ciphertext))
     );
-    const isMacValid = await verifyAuthVaultMac(
-        envelopeWithoutMac,
-        state.mac,
-        macKey
-    );
 
-    if (!isMacValid) {
-        return null;
-    }
+    const rootKeyBytes = decodeBase64(textDecoder.decode(decrypted));
 
-    try {
-        const decrypted = await crypto.subtle.decrypt(
-            {
-                name: "AES-CBC",
-                iv: toArrayBuffer(decodeBase64(state.iv)),
-            },
-            encryptionKey,
-            toArrayBuffer(decodeBase64(state.ciphertext))
-        );
-
-        const rootKeyBytes = decodeBase64(textDecoder.decode(decrypted));
-
-        return rootKeyBytes.byteLength === 32 ? rootKeyBytes : null;
-    } catch {
-        return null;
-    }
+    return rootKeyBytes.byteLength === 32 ? rootKeyBytes : null;
+  } catch {
+    return null;
+  }
 }
 
 async function computeSubjectHash(userId: string): Promise<string> {
-    const digest = await crypto.subtle.digest(
-        "SHA-256",
-        textEncoder.encode(userId)
-    );
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    textEncoder.encode(userId)
+  );
 
-    return encodeBase64(new Uint8Array(digest));
+  return encodeBase64(new Uint8Array(digest));
 }
 
 function createVaultRecordId(prefix: string): string {
-    if (typeof crypto.randomUUID === "function") {
-        return `${prefix}:${crypto.randomUUID()}`;
-    }
+  if (typeof crypto.randomUUID === "function") {
+    return `${prefix}:${crypto.randomUUID()}`;
+  }
 
-    return `${prefix}:${encodeBase64(createRandomBytes(12))}`;
+  return `${prefix}:${encodeBase64(createRandomBytes(12))}`;
 }
 
 async function deriveVaultStoreKey(
-    rootKeyBytes: Uint8Array,
-    storeName: string
+  rootKeyBytes: Uint8Array,
+  storeName: string
 ): Promise<CryptoKey> {
-    const hkdfKey = await crypto.subtle.importKey(
-        "raw",
-        toArrayBuffer(rootKeyBytes),
-        "HKDF",
-        false,
-        ["deriveKey"]
-    );
+  const hkdfKey = await crypto.subtle.importKey(
+    "raw",
+    toArrayBuffer(rootKeyBytes),
+    "HKDF",
+    false,
+    ["deriveKey"]
+  );
 
-    return await crypto.subtle.deriveKey(
-        {
-            name: "HKDF",
-            hash: "SHA-256",
-            salt: toArrayBuffer(new Uint8Array(0)),
-            info: textEncoder.encode(`secpal-offline-vault:${storeName}`),
-        },
-        hkdfKey,
-        {
-            name: "AES-GCM",
-            length: 256,
-        },
-        false,
-        ["encrypt", "decrypt"]
-    );
+  return await crypto.subtle.deriveKey(
+    {
+      name: "HKDF",
+      hash: "SHA-256",
+      salt: toArrayBuffer(new Uint8Array(0)),
+      info: textEncoder.encode(`secpal-offline-vault:${storeName}`),
+    },
+    hkdfKey,
+    {
+      name: "AES-GCM",
+      length: 256,
+    },
+    false,
+    ["encrypt", "decrypt"]
+  );
 }
 
 function buildVaultAdditionalData(
-    storeName: string,
-    recordId: string,
-    subjectHash: string
+  storeName: string,
+  recordId: string,
+  subjectHash: string
 ): Uint8Array {
-    return textEncoder.encode(
-        JSON.stringify({
-            version: AUTH_VAULT_VERSION,
-            storeName,
-            recordId,
-            subjectHash,
-        })
-    );
+  return textEncoder.encode(
+    JSON.stringify({
+      version: AUTH_VAULT_VERSION,
+      storeName,
+      recordId,
+      subjectHash,
+    })
+  );
 }
 
 async function encryptVaultRecord(
-    payload: unknown,
-    storeName: string,
-    recordId: string,
-    session: VaultSession
+  payload: unknown,
+  storeName: string,
+  recordId: string,
+  session: VaultSession
 ): Promise<EncryptedVaultRecord> {
-    const key = await deriveVaultStoreKey(session.rootKeyBytes, storeName);
-    const iv = createRandomBytes(VAULT_RECORD_IV_BYTES);
-    const encrypted = new Uint8Array(
-        await crypto.subtle.encrypt(
-            {
-                name: "AES-GCM",
-                iv: toArrayBuffer(iv),
-                tagLength: 128,
-                additionalData: toArrayBuffer(
-                    buildVaultAdditionalData(storeName, recordId, session.subjectHash)
-                ),
-            },
-            key,
-            toArrayBuffer(textEncoder.encode(JSON.stringify(payload)))
-        )
-    );
-    const ciphertext = encrypted.slice(0, encrypted.length - VAULT_RECORD_TAG_BYTES);
-    const authTag = encrypted.slice(encrypted.length - VAULT_RECORD_TAG_BYTES);
+  const key = await deriveVaultStoreKey(session.rootKeyBytes, storeName);
+  const iv = createRandomBytes(VAULT_RECORD_IV_BYTES);
+  const encrypted = new Uint8Array(
+    await crypto.subtle.encrypt(
+      {
+        name: "AES-GCM",
+        iv: toArrayBuffer(iv),
+        tagLength: 128,
+        additionalData: toArrayBuffer(
+          buildVaultAdditionalData(storeName, recordId, session.subjectHash)
+        ),
+      },
+      key,
+      toArrayBuffer(textEncoder.encode(JSON.stringify(payload)))
+    )
+  );
+  const ciphertext = encrypted.slice(
+    0,
+    encrypted.length - VAULT_RECORD_TAG_BYTES
+  );
+  const authTag = encrypted.slice(encrypted.length - VAULT_RECORD_TAG_BYTES);
 
-    return {
-        recordId,
-        version: AUTH_VAULT_VERSION,
-        ciphertext: encodeBase64(ciphertext),
-        iv: encodeBase64(iv),
-        authTag: encodeBase64(authTag),
-    };
+  return {
+    recordId,
+    version: AUTH_VAULT_VERSION,
+    ciphertext: encodeBase64(ciphertext),
+    iv: encodeBase64(iv),
+    authTag: encodeBase64(authTag),
+  };
 }
 
 async function decryptVaultRecord<T>(
-    record: EncryptedVaultRecord,
-    storeName: string,
-    session: VaultSession
+  record: EncryptedVaultRecord,
+  storeName: string,
+  session: VaultSession
 ): Promise<T | null> {
-    try {
-        const key = await deriveVaultStoreKey(session.rootKeyBytes, storeName);
-        const ciphertext = decodeBase64(record.ciphertext);
-        const authTag = decodeBase64(record.authTag);
-        const combined = new Uint8Array(ciphertext.length + authTag.length);
+  try {
+    const key = await deriveVaultStoreKey(session.rootKeyBytes, storeName);
+    const ciphertext = decodeBase64(record.ciphertext);
+    const authTag = decodeBase64(record.authTag);
+    const combined = new Uint8Array(ciphertext.length + authTag.length);
 
-        combined.set(ciphertext, 0);
-        combined.set(authTag, ciphertext.length);
+    combined.set(ciphertext, 0);
+    combined.set(authTag, ciphertext.length);
 
-        const decrypted = await crypto.subtle.decrypt(
-            {
-                name: "AES-GCM",
-                iv: toArrayBuffer(decodeBase64(record.iv)),
-                tagLength: 128,
-                additionalData: toArrayBuffer(
-                    buildVaultAdditionalData(
-                        storeName,
-                        record.recordId,
-                        session.subjectHash
-                    )
-                ),
-            },
-            key,
-            toArrayBuffer(combined)
-        );
+    const decrypted = await crypto.subtle.decrypt(
+      {
+        name: "AES-GCM",
+        iv: toArrayBuffer(decodeBase64(record.iv)),
+        tagLength: 128,
+        additionalData: toArrayBuffer(
+          buildVaultAdditionalData(
+            storeName,
+            record.recordId,
+            session.subjectHash
+          )
+        ),
+      },
+      key,
+      toArrayBuffer(combined)
+    );
 
-        return JSON.parse(textDecoder.decode(decrypted)) as T;
-    } catch {
-        return null;
-    }
+    return JSON.parse(textDecoder.decode(decrypted)) as T;
+  } catch {
+    return null;
+  }
 }
 
 async function ensureOfflineVaultSession(): Promise<VaultSession | null> {
-    const currentKeyMaterial = getAuthVaultKeyMaterial();
+  const currentKeyMaterial = getAuthVaultKeyMaterial();
 
-    if (activeVaultSession) {
-        if (activeVaultSession.wrapperKeyMaterial === currentKeyMaterial) {
-            return activeVaultSession;
-        }
-
-        clearOfflineVaultSession();
+  if (activeVaultSession) {
+    if (activeVaultSession.wrapperKeyMaterial === currentKeyMaterial) {
+      return activeVaultSession;
     }
 
-    const storedState = getStoredVaultState();
+    clearOfflineVaultSession();
+  }
 
-    if (!storedState) {
-        return null;
-    }
+  const storedState = getStoredVaultState();
 
-    const rootKeyBytes = await decryptVaultRootKeyBytes(storedState);
+  if (!storedState) {
+    return null;
+  }
 
-    if (!rootKeyBytes) {
-        await clearInvalidOfflineVaultArtifacts();
-        return null;
-    }
+  const rootKeyBytes = await decryptVaultRootKeyBytes(storedState);
 
-    activeVaultSession = {
-        rootKeyBytes,
-        subjectHash: storedState.subjectHash,
-        wrapperKeyMaterial: currentKeyMaterial,
-    };
+  if (!rootKeyBytes) {
+    await clearInvalidOfflineVaultArtifacts();
+    return null;
+  }
 
-    return activeVaultSession;
+  activeVaultSession = {
+    rootKeyBytes,
+    subjectHash: storedState.subjectHash,
+    wrapperKeyMaterial: currentKeyMaterial,
+  };
+
+  return activeVaultSession;
 }
 
 async function ensureVaultSessionForUser(
-    user: PersistedAuthUser
+  user: PersistedAuthUser
 ): Promise<VaultSession> {
-    const subjectHash = await computeSubjectHash(user.id);
-    const currentSession = await ensureOfflineVaultSession();
+  const subjectHash = await computeSubjectHash(user.id);
+  const currentSession = await ensureOfflineVaultSession();
 
-    if (currentSession && currentSession.subjectHash === subjectHash) {
-        return currentSession;
-    }
+  if (currentSession && currentSession.subjectHash === subjectHash) {
+    return currentSession;
+  }
 
-    if (currentSession && currentSession.subjectHash !== subjectHash) {
-        await clearOfflineVaultTables();
-        clearStoredOfflineVaultState();
-    }
+  if (currentSession && currentSession.subjectHash !== subjectHash) {
+    await clearOfflineVaultTables();
+    clearStoredOfflineVaultState();
+  }
 
-    const rootKeyBytes = createRandomBytes(32);
-    const storedState = await encryptVaultRootKeyBytes(rootKeyBytes, subjectHash);
+  const rootKeyBytes = createRandomBytes(32);
+  const storedState = await encryptVaultRootKeyBytes(rootKeyBytes, subjectHash);
 
-    if (!storedState) {
-        throw new Error(
-            "Failed to derive auth vault key due to missing CSRF token/session context."
-        );
-    }
+  if (!storedState) {
+    throw new Error(
+      "Failed to derive auth vault key due to missing CSRF token/session context."
+    );
+  }
 
-    setStoredVaultState(storedState);
-    activeVaultSession = {
-        rootKeyBytes,
-        subjectHash,
-        wrapperKeyMaterial: getAuthVaultKeyMaterial(),
-    };
+  setStoredVaultState(storedState);
+  activeVaultSession = {
+    rootKeyBytes,
+    subjectHash,
+    wrapperKeyMaterial: getAuthVaultKeyMaterial(),
+  };
 
-    return activeVaultSession;
+  return activeVaultSession;
 }
 
 async function persistProfileRecord(
-    user: PersistedAuthUser,
-    session: VaultSession
+  user: PersistedAuthUser,
+  session: VaultSession
 ): Promise<void> {
-    const encryptedRecord = await encryptVaultRecord(
-        user,
-        "profile",
-        PROFILE_RECORD_ID,
-        session
-    );
+  const encryptedRecord = await encryptVaultRecord(
+    user,
+    "profile",
+    PROFILE_RECORD_ID,
+    session
+  );
 
-    await db.vaultProfile.put({
-        id: PROFILE_RECORD_ID,
-        ...encryptedRecord,
-    } satisfies EncryptedProfileRecord);
+  await db.vaultProfile.put({
+    id: PROFILE_RECORD_ID,
+    ...encryptedRecord,
+  } satisfies EncryptedProfileRecord);
 }
 
 async function migrateLegacyAnalyticsRecords(
-    session: VaultSession
+  session: VaultSession
 ): Promise<void> {
-    const legacyRecords = await db.analytics.toArray();
+  const legacyRecords = await db.analytics.toArray();
 
-    if (legacyRecords.length === 0) {
-        return;
-    }
+  if (legacyRecords.length === 0) {
+    return;
+  }
 
-    const encryptedRecords = await Promise.all(
-        legacyRecords.map(async (record) => {
-            const { synced, timestamp, ...payloadWithId } = record;
-            const payload = { ...payloadWithId };
+  const encryptedRecords = await Promise.all(
+    legacyRecords.map(async (record) => {
+      const { synced, timestamp, ...payloadWithId } = record;
+      const payload = { ...payloadWithId };
 
-            delete payload.id;
+      delete payload.id;
 
-            const recordId =
-                typeof record.id === "number"
-                    ? `legacy:${record.id}`
-                    : createVaultRecordId("analytics");
-            const encryptedPayload = await encryptVaultRecord(
-                payload,
-                "analytics",
-                recordId,
-                session
-            );
-
-            return {
-                synced,
-                timestamp,
-                ...encryptedPayload,
-            } satisfies Omit<VaultAnalyticsRecord, "id">;
-        })
-    );
-
-    await db.vaultAnalytics.bulkPut(encryptedRecords);
-    await db.analytics.clear();
-}
-
-async function migrateLegacyOrganizationalUnitRecords(
-    session: VaultSession
-): Promise<void> {
-    const legacyRecords = await db.organizationalUnitCache.toArray();
-
-    if (legacyRecords.length === 0) {
-        return;
-    }
-
-    const encryptedRecords = await Promise.all(
-        legacyRecords.map(async (record) => {
-            const encryptedPayload = await encryptVaultRecord(
-                record,
-                "organizationalUnitCache",
-                record.id,
-                session
-            );
-
-            return {
-                id: record.id,
-                cachedAt: record.cachedAt,
-                lastSynced: record.lastSynced,
-                ...encryptedPayload,
-            } satisfies VaultOrganizationalUnitCacheRecord;
-        })
-    );
-
-    await db.vaultOrganizationalUnitCache.bulkPut(encryptedRecords);
-    await db.organizationalUnitCache.clear();
-}
-
-export async function initializeOfflineVault(
-    user: PersistedAuthUser
-): Promise<void> {
-    const session = await ensureVaultSessionForUser(user);
-
-    await persistProfileRecord(user, session);
-    await Promise.all([
-        migrateLegacyAnalyticsRecords(session),
-        migrateLegacyOrganizationalUnitRecords(session),
-    ]);
-
-    localStorage.removeItem("auth_user");
-}
-
-export async function readPersistedAuthUserFromVault(): Promise<PersistedAuthUser | null> {
-    const session = await ensureOfflineVaultSession();
-
-    if (!session) {
-        return null;
-    }
-
-    const storedProfile = await db.vaultProfile.get(PROFILE_RECORD_ID);
-
-    if (!storedProfile) {
-        return null;
-    }
-
-    const decryptedUser = await decryptVaultRecord<unknown>(
-        storedProfile,
-        "profile",
-        session
-    );
-    const sanitizedUser = sanitizePersistedAuthUser(decryptedUser);
-
-    if (!sanitizedUser) {
-        console.error(
-            "Failed to parse stored user data:",
-            new SyntaxError("Invalid encrypted vault profile payload.")
-        );
-        await clearInvalidOfflineVaultArtifacts();
-        return null;
-    }
-
-    return sanitizedUser;
-}
-
-export async function storeVaultAnalyticsEvent(
-    event: AnalyticsEvent
-): Promise<number> {
-    const session = await ensureOfflineVaultSession();
-
-    if (!session) {
-        throw new Error("Offline vault is not available.");
-    }
-
-    const recordId = createVaultRecordId("analytics");
-    const { synced, timestamp, ...payloadWithId } = event;
-    const payload = { ...payloadWithId };
-
-    delete payload.id;
-
-    const encryptedPayload = await encryptVaultRecord(
-        payload satisfies VaultAnalyticsPayload,
+      const recordId =
+        typeof record.id === "number"
+          ? `legacy:${record.id}`
+          : createVaultRecordId("analytics");
+      const encryptedPayload = await encryptVaultRecord(
+        payload,
         "analytics",
         recordId,
         session
-    );
+      );
 
-    const insertedId = await db.vaultAnalytics.add({
+      return {
         synced,
         timestamp,
         ...encryptedPayload,
-    });
+      } satisfies Omit<VaultAnalyticsRecord, "id">;
+    })
+  );
 
-    if (typeof insertedId !== "number") {
-        throw new Error("Vault analytics record was created without a numeric ID.");
-    }
+  await db.vaultAnalytics.bulkPut(encryptedRecords);
+  await db.analytics.clear();
+}
 
-    return insertedId;
+async function migrateLegacyOrganizationalUnitRecords(
+  session: VaultSession
+): Promise<void> {
+  const legacyRecords = await db.organizationalUnitCache.toArray();
+
+  if (legacyRecords.length === 0) {
+    return;
+  }
+
+  const encryptedRecords = await Promise.all(
+    legacyRecords.map(async (record) => {
+      const encryptedPayload = await encryptVaultRecord(
+        record,
+        "organizationalUnitCache",
+        record.id,
+        session
+      );
+
+      return {
+        id: record.id,
+        cachedAt: record.cachedAt,
+        lastSynced: record.lastSynced,
+        ...encryptedPayload,
+      } satisfies VaultOrganizationalUnitCacheRecord;
+    })
+  );
+
+  await db.vaultOrganizationalUnitCache.bulkPut(encryptedRecords);
+  await db.organizationalUnitCache.clear();
+}
+
+export async function initializeOfflineVault(
+  user: PersistedAuthUser
+): Promise<void> {
+  const session = await ensureVaultSessionForUser(user);
+
+  await persistProfileRecord(user, session);
+  await Promise.all([
+    migrateLegacyAnalyticsRecords(session),
+    migrateLegacyOrganizationalUnitRecords(session),
+  ]);
+
+  localStorage.removeItem("auth_user");
+}
+
+export async function readPersistedAuthUserFromVault(): Promise<PersistedAuthUser | null> {
+  const session = await ensureOfflineVaultSession();
+
+  if (!session) {
+    return null;
+  }
+
+  const storedProfile = await db.vaultProfile.get(PROFILE_RECORD_ID);
+
+  if (!storedProfile) {
+    return null;
+  }
+
+  const decryptedUser = await decryptVaultRecord<unknown>(
+    storedProfile,
+    "profile",
+    session
+  );
+  const sanitizedUser = sanitizePersistedAuthUser(decryptedUser);
+
+  if (!sanitizedUser) {
+    console.error(
+      "Failed to parse stored user data:",
+      new SyntaxError("Invalid encrypted vault profile payload.")
+    );
+    await clearInvalidOfflineVaultArtifacts();
+    return null;
+  }
+
+  return sanitizedUser;
+}
+
+export async function storeVaultAnalyticsEvent(
+  event: AnalyticsEvent
+): Promise<number> {
+  const session = await ensureOfflineVaultSession();
+
+  if (!session) {
+    throw new Error("Offline vault is not available.");
+  }
+
+  const recordId = createVaultRecordId("analytics");
+  const { synced, timestamp, ...payloadWithId } = event;
+  const payload = { ...payloadWithId };
+
+  delete payload.id;
+
+  const encryptedPayload = await encryptVaultRecord(
+    payload satisfies VaultAnalyticsPayload,
+    "analytics",
+    recordId,
+    session
+  );
+
+  const insertedId = await db.vaultAnalytics.add({
+    synced,
+    timestamp,
+    ...encryptedPayload,
+  });
+
+  if (typeof insertedId !== "number") {
+    throw new Error("Vault analytics record was created without a numeric ID.");
+  }
+
+  return insertedId;
 }
 
 export async function listVaultAnalyticsEvents(): Promise<AnalyticsEvent[]> {
-    const session = await ensureOfflineVaultSession();
+  const session = await ensureOfflineVaultSession();
 
-    if (!session) {
-        return [];
-    }
+  if (!session) {
+    return [];
+  }
 
-    await migrateLegacyAnalyticsRecords(session);
+  await migrateLegacyAnalyticsRecords(session);
 
-    const records = await db.vaultAnalytics.toArray();
-    const invalidIds: number[] = [];
-    const decryptedEvents = await Promise.all(
-        records.map(async (record) => {
-            const payload = await decryptVaultRecord<VaultAnalyticsPayload>(
-                record,
-                "analytics",
-                session
-            );
+  const records = await db.vaultAnalytics.toArray();
+  const invalidIds: number[] = [];
+  const decryptedEvents = await Promise.all(
+    records.map(async (record) => {
+      const payload = await decryptVaultRecord<VaultAnalyticsPayload>(
+        record,
+        "analytics",
+        session
+      );
 
-            if (!payload) {
-                if (record.id !== undefined) {
-                    invalidIds.push(record.id);
-                }
+      if (!payload) {
+        if (record.id !== undefined) {
+          invalidIds.push(record.id);
+        }
 
-                return null;
-            }
+        return null;
+      }
 
-            const event: AnalyticsEvent = {
-                synced: record.synced,
-                timestamp: record.timestamp,
-                ...payload,
-            };
+      const event: AnalyticsEvent = {
+        synced: record.synced,
+        timestamp: record.timestamp,
+        ...payload,
+      };
 
-            if (record.id !== undefined) {
-                event.id = record.id;
-            }
+      if (record.id !== undefined) {
+        event.id = record.id;
+      }
 
-            return event;
-        })
-    );
+      return event;
+    })
+  );
 
-    if (invalidIds.length > 0) {
-        await db.vaultAnalytics.bulkDelete(invalidIds);
-    }
+  if (invalidIds.length > 0) {
+    await db.vaultAnalytics.bulkDelete(invalidIds);
+  }
 
-    return decryptedEvents.flatMap((event) => (event ? [event] : []));
+  return decryptedEvents.flatMap((event) => (event ? [event] : []));
 }
 
 export async function listUnsyncedVaultAnalyticsRecordIds(): Promise<number[]> {
-    const records = await db.vaultAnalytics.where("synced").equals(0).toArray();
+  const records = await db.vaultAnalytics.where("synced").equals(0).toArray();
 
-    return records.flatMap((record) =>
-        record.id === undefined ? [] : [record.id]
-    );
+  return records.flatMap((record) =>
+    record.id === undefined ? [] : [record.id]
+  );
 }
 
 export async function markVaultAnalyticsEventsSynced(
-    ids: number[]
+  ids: number[]
 ): Promise<void> {
-    if (ids.length === 0) {
-        return;
-    }
+  if (ids.length === 0) {
+    return;
+  }
 
-    await db.vaultAnalytics.bulkUpdate(
-        ids.map((id) => ({
-            key: id,
-            changes: { synced: true },
-        }))
-    );
+  await db.vaultAnalytics.bulkUpdate(
+    ids.map((id) => ({
+      key: id,
+      changes: { synced: true },
+    }))
+  );
 }
 
 export async function clearVaultAnalytics(): Promise<void> {
-    await db.vaultAnalytics.clear();
+  await db.vaultAnalytics.clear();
 }
 
 export async function clearOldVaultAnalyticsEvents(
-    olderThanTimestamp: number
+  olderThanTimestamp: number
 ): Promise<void> {
-    await db.vaultAnalytics
-        .where("synced")
-        .equals(1)
-        .and((record) => record.timestamp < olderThanTimestamp)
-        .delete();
+  await db.vaultAnalytics
+    .where("synced")
+    .equals(1)
+    .and((record) => record.timestamp < olderThanTimestamp)
+    .delete();
 }
 
 export async function saveVaultOrganizationalUnit(
-    unit: OrganizationalUnitCacheEntry
+  unit: OrganizationalUnitCacheEntry
 ): Promise<void> {
-    const session = await ensureOfflineVaultSession();
+  const session = await ensureOfflineVaultSession();
 
-    if (!session) {
-        throw new Error("Offline vault is not available.");
-    }
+  if (!session) {
+    throw new Error("Offline vault is not available.");
+  }
 
-    const encryptedPayload = await encryptVaultRecord(
-        unit,
-        "organizationalUnitCache",
-        unit.id,
-        session
-    );
+  const encryptedPayload = await encryptVaultRecord(
+    unit,
+    "organizationalUnitCache",
+    unit.id,
+    session
+  );
 
-    await db.vaultOrganizationalUnitCache.put({
-        id: unit.id,
-        cachedAt: unit.cachedAt,
-        lastSynced: unit.lastSynced,
-        ...encryptedPayload,
-    });
+  await db.vaultOrganizationalUnitCache.put({
+    id: unit.id,
+    cachedAt: unit.cachedAt,
+    lastSynced: unit.lastSynced,
+    ...encryptedPayload,
+  });
 }
 
 export async function getVaultOrganizationalUnit(
-    id: string
+  id: string
 ): Promise<OrganizationalUnitCacheEntry | undefined> {
-    const session = await ensureOfflineVaultSession();
+  const session = await ensureOfflineVaultSession();
 
-    if (!session) {
-        return undefined;
-    }
+  if (!session) {
+    return undefined;
+  }
 
-    await migrateLegacyOrganizationalUnitRecords(session);
+  await migrateLegacyOrganizationalUnitRecords(session);
 
-    const record = await db.vaultOrganizationalUnitCache.get(id);
+  const record = await db.vaultOrganizationalUnitCache.get(id);
 
-    if (!record) {
-        return undefined;
-    }
+  if (!record) {
+    return undefined;
+  }
 
-    const decryptedRecord = await decryptVaultRecord<OrganizationalUnitCacheEntry>(
-        record,
-        "organizationalUnitCache",
-        session
+  const decryptedRecord =
+    await decryptVaultRecord<OrganizationalUnitCacheEntry>(
+      record,
+      "organizationalUnitCache",
+      session
     );
 
-    if (!decryptedRecord) {
-        await db.vaultOrganizationalUnitCache.delete(id);
-        return undefined;
-    }
+  if (!decryptedRecord) {
+    await db.vaultOrganizationalUnitCache.delete(id);
+    return undefined;
+  }
 
-    return decryptedRecord;
+  return decryptedRecord;
 }
 
 export async function listVaultOrganizationalUnits(): Promise<
-    OrganizationalUnitCacheEntry[]
+  OrganizationalUnitCacheEntry[]
 > {
-    const session = await ensureOfflineVaultSession();
+  const session = await ensureOfflineVaultSession();
 
-    if (!session) {
-        return [];
-    }
+  if (!session) {
+    return [];
+  }
 
-    await migrateLegacyOrganizationalUnitRecords(session);
+  await migrateLegacyOrganizationalUnitRecords(session);
 
-    const records = await db.vaultOrganizationalUnitCache.toArray();
-    const invalidIds: string[] = [];
-    const decryptedRecords = await Promise.all(
-        records.map(async (record) => {
-            const decryptedRecord = await decryptVaultRecord<OrganizationalUnitCacheEntry>(
-                record,
-                "organizationalUnitCache",
-                session
-            );
+  const records = await db.vaultOrganizationalUnitCache.toArray();
+  const invalidIds: string[] = [];
+  const decryptedRecords = await Promise.all(
+    records.map(async (record) => {
+      const decryptedRecord =
+        await decryptVaultRecord<OrganizationalUnitCacheEntry>(
+          record,
+          "organizationalUnitCache",
+          session
+        );
 
-            if (!decryptedRecord) {
-                invalidIds.push(record.id);
-                return null;
-            }
+      if (!decryptedRecord) {
+        invalidIds.push(record.id);
+        return null;
+      }
 
-            return decryptedRecord;
-        })
-    );
+      return decryptedRecord;
+    })
+  );
 
-    if (invalidIds.length > 0) {
-        await db.vaultOrganizationalUnitCache.bulkDelete(invalidIds);
-    }
+  if (invalidIds.length > 0) {
+    await db.vaultOrganizationalUnitCache.bulkDelete(invalidIds);
+  }
 
-    return decryptedRecords.filter(
-        (record): record is OrganizationalUnitCacheEntry => record !== null
-    );
+  return decryptedRecords.filter(
+    (record): record is OrganizationalUnitCacheEntry => record !== null
+  );
 }
 
 export async function deleteVaultOrganizationalUnit(id: string): Promise<void> {
-    await Promise.all([
-        db.vaultOrganizationalUnitCache.delete(id),
-        db.organizationalUnitCache.delete(id),
-    ]);
+  await Promise.all([
+    db.vaultOrganizationalUnitCache.delete(id),
+    db.organizationalUnitCache.delete(id),
+  ]);
 }
 
 export async function clearVaultOrganizationalUnits(): Promise<void> {
-    await Promise.all([
-        db.vaultOrganizationalUnitCache.clear(),
-        db.organizationalUnitCache.clear(),
-    ]);
+  await Promise.all([
+    db.vaultOrganizationalUnitCache.clear(),
+    db.organizationalUnitCache.clear(),
+  ]);
 }

--- a/src/lib/offlineVault.ts
+++ b/src/lib/offlineVault.ts
@@ -154,7 +154,15 @@ export function clearStoredOfflineVaultState(): void {
   clearOfflineVaultSession();
 }
 
+async function ensureVaultDatabaseOpen(): Promise<void> {
+  if (!db.isOpen()) {
+    await db.open();
+  }
+}
+
 async function clearOfflineVaultTables(): Promise<void> {
+  await ensureVaultDatabaseOpen();
+
   await Promise.all([
     db.vaultProfile.clear(),
     db.vaultAnalytics.clear(),
@@ -491,16 +499,19 @@ async function decryptVaultRecord<T>(
 
 async function ensureOfflineVaultSession(): Promise<VaultSession | null> {
   const currentKeyMaterial = getAuthVaultKeyMaterial();
+  const storedState = getStoredVaultState();
 
   if (activeVaultSession) {
-    if (activeVaultSession.wrapperKeyMaterial === currentKeyMaterial) {
+    if (
+      storedState &&
+      activeVaultSession.wrapperKeyMaterial === currentKeyMaterial &&
+      activeVaultSession.subjectHash === storedState.subjectHash
+    ) {
       return activeVaultSession;
     }
 
     clearOfflineVaultSession();
   }
-
-  const storedState = getStoredVaultState();
 
   if (!storedState) {
     return null;
@@ -560,6 +571,8 @@ async function persistProfileRecord(
   user: PersistedAuthUser,
   session: VaultSession
 ): Promise<void> {
+  await ensureVaultDatabaseOpen();
+
   const encryptedRecord = await encryptVaultRecord(
     user,
     "profile",
@@ -576,6 +589,8 @@ async function persistProfileRecord(
 async function migrateLegacyAnalyticsRecords(
   session: VaultSession
 ): Promise<void> {
+  await ensureVaultDatabaseOpen();
+
   const legacyRecords = await db.analytics.toArray();
 
   if (legacyRecords.length === 0) {
@@ -615,6 +630,8 @@ async function migrateLegacyAnalyticsRecords(
 async function migrateLegacyOrganizationalUnitRecords(
   session: VaultSession
 ): Promise<void> {
+  await ensureVaultDatabaseOpen();
+
   const legacyRecords = await db.organizationalUnitCache.toArray();
 
   if (legacyRecords.length === 0) {
@@ -664,6 +681,8 @@ export async function readPersistedAuthUserFromVault(): Promise<PersistedAuthUse
     return null;
   }
 
+  await ensureVaultDatabaseOpen();
+
   const storedProfile = await db.vaultProfile.get(PROFILE_RECORD_ID);
 
   if (!storedProfile) {
@@ -697,6 +716,8 @@ export async function storeVaultAnalyticsEvent(
   if (!session) {
     throw new Error("Offline vault is not available.");
   }
+
+  await ensureVaultDatabaseOpen();
 
   const recordId = createVaultRecordId("analytics");
   const { synced, timestamp, ...payloadWithId } = event;
@@ -773,6 +794,8 @@ export async function listVaultAnalyticsEvents(): Promise<AnalyticsEvent[]> {
 }
 
 export async function listUnsyncedVaultAnalyticsRecordIds(): Promise<number[]> {
+  await ensureVaultDatabaseOpen();
+
   const records = await db.vaultAnalytics.where("synced").equals(0).toArray();
 
   return records.flatMap((record) =>
@@ -787,6 +810,8 @@ export async function markVaultAnalyticsEventsSynced(
     return;
   }
 
+  await ensureVaultDatabaseOpen();
+
   await db.vaultAnalytics.bulkUpdate(
     ids.map((id) => ({
       key: id,
@@ -796,12 +821,15 @@ export async function markVaultAnalyticsEventsSynced(
 }
 
 export async function clearVaultAnalytics(): Promise<void> {
+  await ensureVaultDatabaseOpen();
   await db.vaultAnalytics.clear();
 }
 
 export async function clearOldVaultAnalyticsEvents(
   olderThanTimestamp: number
 ): Promise<void> {
+  await ensureVaultDatabaseOpen();
+
   await db.vaultAnalytics
     .where("synced")
     .equals(1)
@@ -817,6 +845,8 @@ export async function saveVaultOrganizationalUnit(
   if (!session) {
     throw new Error("Offline vault is not available.");
   }
+
+  await ensureVaultDatabaseOpen();
 
   const encryptedPayload = await encryptVaultRecord(
     unit,
@@ -841,6 +871,8 @@ export async function getVaultOrganizationalUnit(
   if (!session) {
     return undefined;
   }
+
+  await ensureVaultDatabaseOpen();
 
   await migrateLegacyOrganizationalUnitRecords(session);
 
@@ -874,6 +906,8 @@ export async function listVaultOrganizationalUnits(): Promise<
     return [];
   }
 
+  await ensureVaultDatabaseOpen();
+
   await migrateLegacyOrganizationalUnitRecords(session);
 
   const records = await db.vaultOrganizationalUnitCache.toArray();
@@ -906,6 +940,8 @@ export async function listVaultOrganizationalUnits(): Promise<
 }
 
 export async function deleteVaultOrganizationalUnit(id: string): Promise<void> {
+  await ensureVaultDatabaseOpen();
+
   await Promise.all([
     db.vaultOrganizationalUnitCache.delete(id),
     db.organizationalUnitCache.delete(id),
@@ -913,6 +949,8 @@ export async function deleteVaultOrganizationalUnit(id: string): Promise<void> {
 }
 
 export async function clearVaultOrganizationalUnits(): Promise<void> {
+  await ensureVaultDatabaseOpen();
+
   await Promise.all([
     db.vaultOrganizationalUnitCache.clear(),
     db.organizationalUnitCache.clear(),

--- a/src/lib/offlineVault.ts
+++ b/src/lib/offlineVault.ts
@@ -131,8 +131,17 @@ function getStoredVaultState(): AuthVaultStateEnvelope | null {
 
   try {
     const parsedState = JSON.parse(storedState) as unknown;
-    return isAuthVaultStateEnvelope(parsedState) ? parsedState : null;
+
+    if (isAuthVaultStateEnvelope(parsedState)) {
+      return parsedState;
+    }
+
+    localStorage.removeItem(AUTH_VAULT_STORAGE_KEY);
+    clearOfflineVaultSession();
+    return null;
   } catch {
+    localStorage.removeItem(AUTH_VAULT_STORAGE_KEY);
+    clearOfflineVaultSession();
     return null;
   }
 }
@@ -172,7 +181,11 @@ export async function clearOfflineVaultTables(): Promise<void> {
 
 async function clearInvalidOfflineVaultArtifacts(): Promise<void> {
   clearStoredOfflineVaultState();
-  await clearOfflineVaultTables();
+  await Promise.all([
+    clearOfflineVaultTables(),
+    db.analytics.clear(),
+    db.organizationalUnitCache.clear(),
+  ]);
 }
 
 async function deriveVaultWrapperKeys(
@@ -686,6 +699,7 @@ export async function readPersistedAuthUserFromVault(): Promise<PersistedAuthUse
   const storedProfile = await db.vaultProfile.get(PROFILE_RECORD_ID);
 
   if (!storedProfile) {
+    await clearInvalidOfflineVaultArtifacts();
     return null;
   }
 

--- a/src/lib/organizationalUnitStore.test.ts
+++ b/src/lib/organizationalUnitStore.test.ts
@@ -16,6 +16,15 @@ import {
   searchOrganizationalUnits,
   clearOrganizationalUnitCache,
 } from "./organizationalUnitStore";
+import {
+  clearOfflineVaultSession,
+  initializeOfflineVault,
+} from "./offlineVault";
+
+function setCsrfTokenCookie(value: string): void {
+  document.cookie = `XSRF-TOKEN=;expires=${new Date(0).toUTCString()};path=/`;
+  document.cookie = `XSRF-TOKEN=${encodeURIComponent(value)};path=/`;
+}
 
 describe("buildOrganizationalUnitCacheEntry", () => {
   const baseUnit: OrganizationalUnit = {
@@ -107,6 +116,15 @@ describe("OrganizationalUnitStore", () => {
     // Clear database before each test
     await db.delete();
     await db.open();
+    localStorage.clear();
+    clearOfflineVaultSession();
+    setCsrfTokenCookie("test-csrf-token");
+    await initializeOfflineVault({
+      id: "user-1",
+      name: "Vault User",
+      email: "vault@secpal.dev",
+      emailVerified: false,
+    });
   });
 
   describe("saveOrganizationalUnit", () => {
@@ -123,7 +141,7 @@ describe("OrganizationalUnitStore", () => {
 
       await saveOrganizationalUnit(unit);
 
-      const saved = await db.organizationalUnitCache.get("unit-1");
+      const saved = await getOrganizationalUnit("unit-1");
       expect(saved).toBeDefined();
       expect(saved?.name).toBe("Berlin Branch");
       expect(saved?.type).toBe("branch");
@@ -151,12 +169,12 @@ describe("OrganizationalUnitStore", () => {
 
       await saveOrganizationalUnit(updated);
 
-      const saved = await db.organizationalUnitCache.get("unit-1");
+      const saved = await getOrganizationalUnit("unit-1");
       expect(saved?.name).toBe("Berlin Branch (Updated)");
       expect(saved?.updated_at).toBe("2025-01-11T00:00:00Z");
 
       // Should still have only one entry
-      const allUnits = await db.organizationalUnitCache.toArray();
+      const allUnits = await listOrganizationalUnits();
       expect(allUnits).toHaveLength(1);
     });
   });
@@ -249,10 +267,10 @@ describe("OrganizationalUnitStore", () => {
       };
 
       await db.organizationalUnitCache.put(unit);
-      expect(await db.organizationalUnitCache.get("unit-1")).toBeDefined();
+      expect(await getOrganizationalUnit("unit-1")).toBeDefined();
 
       await deleteOrganizationalUnit("unit-1");
-      expect(await db.organizationalUnitCache.get("unit-1")).toBeUndefined();
+      expect(await getOrganizationalUnit("unit-1")).toBeUndefined();
     });
 
     it("should not throw error when deleting non-existent unit", async () => {
@@ -470,10 +488,10 @@ describe("OrganizationalUnitStore", () => {
       await Promise.all(
         units.map((unit) => db.organizationalUnitCache.put(unit))
       );
-      expect(await db.organizationalUnitCache.count()).toBe(2);
+      expect((await listOrganizationalUnits()).length).toBe(2);
 
       await clearOrganizationalUnitCache();
-      expect(await db.organizationalUnitCache.count()).toBe(0);
+      expect(await listOrganizationalUnits()).toEqual([]);
     });
   });
 });

--- a/src/lib/organizationalUnitStore.test.ts
+++ b/src/lib/organizationalUnitStore.test.ts
@@ -128,6 +128,34 @@ describe("OrganizationalUnitStore", () => {
   });
 
   describe("saveOrganizationalUnit", () => {
+    it("returns Date instances for cachedAt and lastSynced after vault round-trip", async () => {
+      const cachedAt = new Date("2025-01-10T00:00:00Z");
+      const lastSynced = new Date("2025-01-10T00:00:00Z");
+      const unit: OrganizationalUnitCacheEntry = {
+        id: "unit-date-roundtrip",
+        type: "branch",
+        name: "Round-trip Branch",
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+        cachedAt,
+        lastSynced,
+      };
+
+      await saveOrganizationalUnit(unit);
+
+      const saved = await getOrganizationalUnit("unit-date-roundtrip");
+      expect(saved).toBeDefined();
+      expect(saved?.cachedAt).toBeInstanceOf(Date);
+      expect(saved?.lastSynced).toBeInstanceOf(Date);
+      expect(saved?.cachedAt.getTime()).toBe(cachedAt.getTime());
+      expect(saved?.lastSynced.getTime()).toBe(lastSynced.getTime());
+
+      const listed = await listOrganizationalUnits();
+      const listedUnit = listed.find((u) => u.id === "unit-date-roundtrip");
+      expect(listedUnit?.cachedAt).toBeInstanceOf(Date);
+      expect(listedUnit?.lastSynced).toBeInstanceOf(Date);
+    });
+
     it("should save an organizational unit to IndexedDB", async () => {
       const unit: OrganizationalUnitCacheEntry = {
         id: "unit-1",

--- a/src/lib/organizationalUnitStore.ts
+++ b/src/lib/organizationalUnitStore.ts
@@ -1,9 +1,15 @@
 // SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { db } from "./db";
 import type { OrganizationalUnitCacheEntry } from "./db";
 import type { OrganizationalUnit } from "../types/organizational";
+import {
+  clearVaultOrganizationalUnits,
+  deleteVaultOrganizationalUnit,
+  getVaultOrganizationalUnit,
+  listVaultOrganizationalUnits,
+  saveVaultOrganizationalUnit,
+} from "./offlineVault";
 
 export function buildOrganizationalUnitCacheEntry(
   unit: OrganizationalUnit,
@@ -50,7 +56,7 @@ export function buildOrganizationalUnitCacheEntry(
 export async function saveOrganizationalUnit(
   unit: OrganizationalUnitCacheEntry
 ): Promise<void> {
-  await db.organizationalUnitCache.put(unit);
+  await saveVaultOrganizationalUnit(unit);
 }
 
 /**
@@ -70,7 +76,7 @@ export async function saveOrganizationalUnit(
 export async function getOrganizationalUnit(
   id: string
 ): Promise<OrganizationalUnitCacheEntry | undefined> {
-  return db.organizationalUnitCache.get(id);
+  return await getVaultOrganizationalUnit(id);
 }
 
 /**
@@ -87,7 +93,7 @@ export async function getOrganizationalUnit(
 export async function listOrganizationalUnits(): Promise<
   OrganizationalUnitCacheEntry[]
 > {
-  const units = await db.organizationalUnitCache.toArray();
+  const units = await listVaultOrganizationalUnits();
 
   // Sort by name ascending
   return units.sort((a, b) => a.name.localeCompare(b.name));
@@ -104,7 +110,7 @@ export async function listOrganizationalUnits(): Promise<
  * ```
  */
 export async function deleteOrganizationalUnit(id: string): Promise<void> {
-  await db.organizationalUnitCache.delete(id);
+  await deleteVaultOrganizationalUnit(id);
 }
 
 /**
@@ -121,10 +127,9 @@ export async function deleteOrganizationalUnit(id: string): Promise<void> {
 export async function getOrganizationalUnitsByType(
   type: OrganizationalUnitCacheEntry["type"]
 ): Promise<OrganizationalUnitCacheEntry[]> {
-  const units = await db.organizationalUnitCache
-    .where("type")
-    .equals(type)
-    .toArray();
+  const units = (await listVaultOrganizationalUnits()).filter(
+    (unit) => unit.type === type
+  );
 
   return units.sort((a, b) => a.name.localeCompare(b.name));
 }
@@ -144,20 +149,13 @@ export async function getOrganizationalUnitsByType(
 export async function getOrganizationalUnitsByParent(
   parentId: string | null
 ): Promise<OrganizationalUnitCacheEntry[]> {
-  let units: OrganizationalUnitCacheEntry[];
-
-  if (parentId === null) {
-    // For root units, we need to filter where parent_id is null or undefined
-    const allUnits = await db.organizationalUnitCache.toArray();
-    units = allUnits.filter(
-      (unit) => unit.parent_id === null || unit.parent_id === undefined
-    );
-  } else {
-    units = await db.organizationalUnitCache
-      .where("parent_id")
-      .equals(parentId)
-      .toArray();
-  }
+  const allUnits = await listVaultOrganizationalUnits();
+  const units =
+    parentId === null
+      ? allUnits.filter(
+          (unit) => unit.parent_id === null || unit.parent_id === undefined
+        )
+      : allUnits.filter((unit) => unit.parent_id === parentId);
 
   return units.sort((a, b) => a.name.localeCompare(b.name));
 }
@@ -177,9 +175,9 @@ export async function searchOrganizationalUnits(
   query: string
 ): Promise<OrganizationalUnitCacheEntry[]> {
   const lowerQuery = query.toLowerCase();
-  const units = await db.organizationalUnitCache
-    .filter((unit) => unit.name.toLowerCase().includes(lowerQuery))
-    .toArray();
+  const units = (await listVaultOrganizationalUnits()).filter((unit) =>
+    unit.name.toLowerCase().includes(lowerQuery)
+  );
 
   return units.sort((a, b) => a.name.localeCompare(b.name));
 }
@@ -193,5 +191,5 @@ export async function searchOrganizationalUnits(
  * ```
  */
 export async function clearOrganizationalUnitCache(): Promise<void> {
-  await db.organizationalUnitCache.clear();
+  await clearVaultOrganizationalUnits();
 }

--- a/src/services/organizationalUnitApi.test.ts
+++ b/src/services/organizationalUnitApi.test.ts
@@ -24,6 +24,7 @@ import type {
 // Mock apiFetch (central API wrapper)
 vi.mock("./csrf", () => ({
   apiFetch: vi.fn(),
+  getCsrfTokenFromCookie: vi.fn(() => "test-csrf-token"),
 }));
 
 import { apiFetch } from "./csrf";

--- a/src/services/organizationalUnitApi.ts
+++ b/src/services/organizationalUnitApi.ts
@@ -37,10 +37,7 @@ async function cacheOrganizationalUnit(
   try {
     await saveToCache(buildOrganizationalUnitCacheEntry(unit));
   } catch (error) {
-    console.warn(
-      "Failed to cache organizational unit for offline use:",
-      error
-    );
+    console.warn("Failed to cache organizational unit for offline use:", error);
   }
 }
 

--- a/src/services/organizationalUnitApi.ts
+++ b/src/services/organizationalUnitApi.ts
@@ -34,7 +34,25 @@ import type {
 async function cacheOrganizationalUnit(
   unit: OrganizationalUnit
 ): Promise<void> {
-  await saveToCache(buildOrganizationalUnitCacheEntry(unit));
+  try {
+    await saveToCache(buildOrganizationalUnitCacheEntry(unit));
+  } catch (error) {
+    console.warn(
+      "Failed to cache organizational unit for offline use:",
+      error
+    );
+  }
+}
+
+async function removeCachedOrganizationalUnit(id: string): Promise<void> {
+  try {
+    await deleteFromCache(id);
+  } catch (error) {
+    console.warn(
+      "Failed to remove cached organizational unit for offline use:",
+      error
+    );
+  }
 }
 
 /**
@@ -220,7 +238,7 @@ export async function deleteOrganizationalUnit(id: string): Promise<void> {
   }
 
   // Delete from cache immediately
-  await deleteFromCache(id);
+  await removeCachedOrganizationalUnit(id);
 }
 
 /**

--- a/src/services/storage.test.ts
+++ b/src/services/storage.test.ts
@@ -8,6 +8,7 @@ import {
   AUTH_VAULT_STORAGE_KEY,
   clearOfflineVaultSession,
 } from "../lib/offlineVault";
+import { db } from "../lib/db";
 
 const AUTH_STORAGE_SCHEME = "pbkdf2-aes-cbc-hmac-sha256";
 const LEGACY_AUTH_STORAGE_VERSION = 1;
@@ -317,5 +318,25 @@ describe("authStorage", () => {
 
     await expect(authStorage.getUser()).resolves.toBeNull();
     expect(localStorage.getItem("auth_user")).toBeNull();
+  });
+
+  it("clears vault IndexedDB tables when removeUser is called due to invalid persisted state", async () => {
+    const user = {
+      id: "1",
+      name: "Test User",
+      email: "test@secpal.dev",
+      emailVerified: false,
+    };
+
+    await authStorage.setUser(user);
+    expect(localStorage.getItem(AUTH_VAULT_STORAGE_KEY)).not.toBeNull();
+    expect(await db.vaultProfile.count()).toBe(1);
+
+    authStorage.removeUser();
+
+    expect(localStorage.getItem(AUTH_VAULT_STORAGE_KEY)).toBeNull();
+    // clearOfflineVaultTables is fire-and-forget; give it a microtask cycle
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(await db.vaultProfile.count()).toBe(0);
   });
 });

--- a/src/services/storage.test.ts
+++ b/src/services/storage.test.ts
@@ -144,10 +144,9 @@ describe("authStorage", () => {
 
     expect(localStorage.getItem("auth_user")).toBeNull();
     expect(storedVaultState).not.toBeNull();
-    const parsedStoredVaultState = JSON.parse(storedVaultState as string) as Record<
-      string,
-      unknown
-    >;
+    const parsedStoredVaultState = JSON.parse(
+      storedVaultState as string
+    ) as Record<string, unknown>;
 
     expect(parsedStoredVaultState).toEqual(
       expect.objectContaining({

--- a/src/services/storage.test.ts
+++ b/src/services/storage.test.ts
@@ -4,10 +4,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildEnvelopeMacPayload } from "./authStorageEnvelope";
 import { authStorage } from "./storage";
+import {
+  AUTH_VAULT_STORAGE_KEY,
+  clearOfflineVaultSession,
+} from "../lib/offlineVault";
 
-const LEGACY_AUTH_STORAGE_SCHEME = "pbkdf2-aes-cbc-hmac-sha256";
+const AUTH_STORAGE_SCHEME = "pbkdf2-aes-cbc-hmac-sha256";
 const LEGACY_AUTH_STORAGE_VERSION = 1;
+const CURRENT_AUTH_STORAGE_VERSION = 2;
 const LEGACY_AUTH_STORAGE_PBKDF2_ITERATIONS = 5_000;
+const CURRENT_AUTH_STORAGE_PBKDF2_ITERATIONS = 600_000;
 const AUTH_STORAGE_HALF_KEY_BYTES = 32;
 const AUTH_STORAGE_DERIVED_KEY_BYTES = AUTH_STORAGE_HALF_KEY_BYTES * 2;
 const textEncoder = new TextEncoder();
@@ -30,9 +36,13 @@ function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
   ) as ArrayBuffer;
 }
 
-async function createLegacyEncryptedEnvelope(
+async function createEncryptedEnvelope(
   user: Record<string, unknown>,
-  csrfToken: string
+  csrfToken: string,
+  options: {
+    version: number;
+    iterations: number;
+  }
 ): Promise<string> {
   const keyMaterial = `secpal-auth-storage:${csrfToken}`;
   const salt = crypto.getRandomValues(new Uint8Array(16));
@@ -49,7 +59,7 @@ async function createLegacyEncryptedEnvelope(
       name: "PBKDF2",
       hash: "SHA-256",
       salt: toArrayBuffer(salt),
-      iterations: LEGACY_AUTH_STORAGE_PBKDF2_ITERATIONS,
+      iterations: options.iterations,
     },
     baseKey,
     AUTH_STORAGE_DERIVED_KEY_BYTES * 8
@@ -83,8 +93,8 @@ async function createLegacyEncryptedEnvelope(
     )
   );
   const envelopeWithoutMac = {
-    scheme: LEGACY_AUTH_STORAGE_SCHEME,
-    version: LEGACY_AUTH_STORAGE_VERSION,
+    scheme: AUTH_STORAGE_SCHEME,
+    version: options.version,
     salt: encodeBase64(salt),
     iv: encodeBase64(iv),
     ciphertext: encodeBase64(ciphertext),
@@ -109,14 +119,16 @@ function setCsrfTokenCookie(value: string): void {
 describe("authStorage", () => {
   beforeEach(() => {
     localStorage.clear();
+    clearOfflineVaultSession();
     setCsrfTokenCookie("test-csrf-token");
   });
 
   afterEach(() => {
+    clearOfflineVaultSession();
     vi.restoreAllMocks();
   });
 
-  it("encrypts persisted auth state before writing to localStorage", async () => {
+  it("stores only wrapped vault state in localStorage and restores the encrypted profile from IndexedDB", async () => {
     const user = {
       id: "1",
       name: "Test User",
@@ -128,15 +140,16 @@ describe("authStorage", () => {
 
     await authStorage.setUser(user);
 
-    const storedUser = localStorage.getItem("auth_user");
+    const storedVaultState = localStorage.getItem(AUTH_VAULT_STORAGE_KEY);
 
-    expect(storedUser).not.toBeNull();
-    const parsedStoredUser = JSON.parse(storedUser as string) as Record<
+    expect(localStorage.getItem("auth_user")).toBeNull();
+    expect(storedVaultState).not.toBeNull();
+    const parsedStoredVaultState = JSON.parse(storedVaultState as string) as Record<
       string,
       unknown
     >;
 
-    expect(parsedStoredUser).toEqual(
+    expect(parsedStoredVaultState).toEqual(
       expect.objectContaining({
         scheme: expect.any(String),
         version: expect.anything(),
@@ -146,10 +159,10 @@ describe("authStorage", () => {
         mac: expect.any(String),
       })
     );
-    expect(parsedStoredUser.salt).not.toBe("");
-    expect(parsedStoredUser.iv).not.toBe("");
-    expect(parsedStoredUser.ciphertext).not.toBe("");
-    expect(parsedStoredUser.mac).not.toBe("");
+    expect(parsedStoredVaultState.salt).not.toBe("");
+    expect(parsedStoredVaultState.iv).not.toBe("");
+    expect(parsedStoredVaultState.ciphertext).not.toBe("");
+    expect(parsedStoredVaultState.mac).not.toBe("");
     await expect(authStorage.getUser()).resolves.toEqual(user);
   });
 
@@ -165,7 +178,28 @@ describe("authStorage", () => {
     setCsrfTokenCookie("rotated-csrf-token");
 
     await expect(authStorage.getUser()).resolves.toBeNull();
+    expect(localStorage.getItem(AUTH_VAULT_STORAGE_KEY)).toBeNull();
+  });
+
+  it("migrates the legacy auth_user envelope into the encrypted vault and removes auth_user from localStorage", async () => {
+    const legacyUser = {
+      id: "1",
+      name: "Legacy User",
+      email: "legacy@secpal.dev",
+      emailVerified: false,
+    };
+
+    localStorage.setItem(
+      "auth_user",
+      await createEncryptedEnvelope(legacyUser, "test-csrf-token", {
+        version: CURRENT_AUTH_STORAGE_VERSION,
+        iterations: CURRENT_AUTH_STORAGE_PBKDF2_ITERATIONS,
+      })
+    );
+
+    await expect(authStorage.getUser()).resolves.toEqual(legacyUser);
     expect(localStorage.getItem("auth_user")).toBeNull();
+    expect(localStorage.getItem(AUTH_VAULT_STORAGE_KEY)).not.toBeNull();
   });
 
   it("clears invalid JSON snapshots and logs the parse failure", () => {
@@ -276,7 +310,10 @@ describe("authStorage", () => {
 
     localStorage.setItem(
       "auth_user",
-      await createLegacyEncryptedEnvelope(legacyUser, "test-csrf-token")
+      await createEncryptedEnvelope(legacyUser, "test-csrf-token", {
+        version: LEGACY_AUTH_STORAGE_VERSION,
+        iterations: LEGACY_AUTH_STORAGE_PBKDF2_ITERATIONS,
+      })
     );
 
     await expect(authStorage.getUser()).resolves.toBeNull();

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -2,6 +2,12 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import type { User } from "../contexts/auth-context";
+import {
+  AUTH_VAULT_STORAGE_KEY,
+  clearOfflineVaultSession,
+  initializeOfflineVault,
+  readPersistedAuthUserFromVault,
+} from "../lib/offlineVault";
 import { buildEnvelopeMacPayload } from "./authStorageEnvelope";
 import { sanitizePersistedAuthUser, type PersistedAuthUser } from "./authState";
 import { getCsrfTokenFromCookie } from "./csrf";
@@ -9,8 +15,6 @@ import { getCsrfTokenFromCookie } from "./csrf";
 const AUTH_STORAGE_SCHEME = "pbkdf2-aes-cbc-hmac-sha256";
 const AUTH_STORAGE_VERSION = 2;
 const AUTH_STORAGE_PBKDF2_ITERATIONS = 600_000;
-const AUTH_STORAGE_SALT_BYTES = 16;
-const AUTH_STORAGE_IV_BYTES = 16;
 const AUTH_STORAGE_HALF_KEY_BYTES = 32;
 const AUTH_STORAGE_DERIVED_KEY_BYTES = AUTH_STORAGE_HALF_KEY_BYTES * 2;
 
@@ -44,17 +48,6 @@ function getAuthStorageKeyMaterial(): string | null {
   }
 
   return `secpal-auth-storage:${csrfToken}`;
-}
-
-function encodeBase64(bytes: Uint8Array): string {
-  let binary = "";
-
-  for (let index = 0; index < bytes.length; index += 0x8000) {
-    const chunk = bytes.subarray(index, index + 0x8000);
-    binary += String.fromCharCode(...chunk);
-  }
-
-  return btoa(binary);
 }
 
 function decodeBase64(value: string): Uint8Array {
@@ -137,19 +130,6 @@ function hasStoredUserRecord(storageKey: string): boolean {
   return localStorage.getItem(storageKey) !== null;
 }
 
-async function signEnvelopeMac(
-  envelope: Omit<AuthStorageEnvelope, "mac">,
-  macKey: CryptoKey
-): Promise<string> {
-  const mac = await crypto.subtle.sign(
-    "HMAC",
-    macKey,
-    textEncoder.encode(buildEnvelopeMacPayload(envelope))
-  );
-
-  return encodeBase64(new Uint8Array(mac));
-}
-
 async function verifyEnvelopeMac(
   envelope: Omit<AuthStorageEnvelope, "mac">,
   mac: string,
@@ -161,23 +141,6 @@ async function verifyEnvelopeMac(
     toArrayBuffer(decodeBase64(mac)),
     textEncoder.encode(buildEnvelopeMacPayload(envelope))
   );
-}
-
-async function encryptAuthPayload(
-  plaintext: string,
-  encryptionKey: CryptoKey,
-  iv: Uint8Array
-): Promise<Uint8Array> {
-  const ciphertext = await crypto.subtle.encrypt(
-    {
-      name: "AES-CBC",
-      iv: toArrayBuffer(iv),
-    },
-    encryptionKey,
-    textEncoder.encode(plaintext)
-  );
-
-  return new Uint8Array(ciphertext);
 }
 
 async function decryptAuthPayload(
@@ -199,46 +162,6 @@ async function decryptAuthPayload(
   } catch {
     return null;
   }
-}
-
-function createRandomBytes(length: number): Uint8Array {
-  return crypto.getRandomValues(new Uint8Array(length));
-}
-
-async function encryptPersistedAuthUser(
-  user: PersistedAuthUser
-): Promise<string | null> {
-  const keyMaterial = getAuthStorageKeyMaterial();
-
-  if (!keyMaterial) {
-    return null;
-  }
-
-  const salt = createRandomBytes(AUTH_STORAGE_SALT_BYTES);
-  const iv = createRandomBytes(AUTH_STORAGE_IV_BYTES);
-  const { encryptionKey, macKey } = await deriveAuthStorageKeys(
-    keyMaterial,
-    salt,
-    getAuthStorageIterations()
-  );
-  const ciphertext = await encryptAuthPayload(
-    JSON.stringify(user),
-    encryptionKey,
-    iv
-  );
-
-  const envelopeWithoutMac = {
-    scheme: AUTH_STORAGE_SCHEME,
-    version: AUTH_STORAGE_VERSION,
-    salt: encodeBase64(salt),
-    iv: encodeBase64(iv),
-    ciphertext: encodeBase64(ciphertext),
-  } satisfies Omit<AuthStorageEnvelope, "mac">;
-
-  return JSON.stringify({
-    ...envelopeWithoutMac,
-    mac: await signEnvelopeMac(envelopeWithoutMac, macKey),
-  });
 }
 
 function isAuthStorageEnvelope(value: unknown): value is AuthStorageEnvelope {
@@ -337,6 +260,7 @@ export interface AuthStorage {
  */
 class LocalStorageAuthStorage implements AuthStorage {
   private readonly USER_KEY = "auth_user";
+  private readonly VAULT_KEY = AUTH_VAULT_STORAGE_KEY;
   private readonly LOGOUT_BARRIER_KEY = "auth_logout_barrier";
 
   /**
@@ -365,7 +289,11 @@ class LocalStorageAuthStorage implements AuthStorage {
   }
 
   hasStoredUser(): boolean {
-    return !this.hasLogoutBarrier() && hasStoredUserRecord(this.USER_KEY);
+    return (
+      !this.hasLogoutBarrier() &&
+      (localStorage.getItem(this.VAULT_KEY) !== null ||
+        hasStoredUserRecord(this.USER_KEY))
+    );
   }
 
   private clearInvalidStoredUser(): null {
@@ -381,6 +309,10 @@ class LocalStorageAuthStorage implements AuthStorage {
   getUserSnapshot(): User | null {
     if (this.hasLogoutBarrier()) {
       this.removeUser();
+      return null;
+    }
+
+    if (localStorage.getItem(this.VAULT_KEY) !== null) {
       return null;
     }
 
@@ -412,6 +344,16 @@ class LocalStorageAuthStorage implements AuthStorage {
       return null;
     }
 
+    if (localStorage.getItem(this.VAULT_KEY) !== null) {
+      const storedVaultUser = await readPersistedAuthUserFromVault();
+
+      if (!storedVaultUser) {
+        return this.clearInvalidStoredUser();
+      }
+
+      return storedVaultUser;
+    }
+
     const storedUser = localStorage.getItem(this.USER_KEY);
     if (!storedUser) return null;
 
@@ -421,6 +363,8 @@ class LocalStorageAuthStorage implements AuthStorage {
       if (!sanitizedUser) {
         return this.clearInvalidStoredUser();
       }
+
+      await initializeOfflineVault(sanitizedUser);
 
       return sanitizedUser;
     } catch (error) {
@@ -439,30 +383,22 @@ class LocalStorageAuthStorage implements AuthStorage {
       return;
     }
 
-    let encryptedUser: string | null;
-
     try {
-      encryptedUser = await encryptPersistedAuthUser(sanitizedUser);
+      await initializeOfflineVault(sanitizedUser);
     } catch (error) {
       console.error("Failed to persist stored user data:", error);
       this.removeUser();
       return;
     }
 
-    if (!encryptedUser) {
-      console.warn(
-        "Failed to derive auth storage key due to missing CSRF token/session context; clearing persisted auth state."
-      );
-      this.removeUser();
-      return;
-    }
-
     this.clearLogoutBarrier();
-    localStorage.setItem(this.USER_KEY, encryptedUser);
+    localStorage.removeItem(this.USER_KEY);
   }
 
   removeUser(): void {
+    clearOfflineVaultSession();
     localStorage.removeItem(this.USER_KEY);
+    localStorage.removeItem(this.VAULT_KEY);
   }
 
   clear(): void {

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -5,6 +5,7 @@ import type { User } from "../contexts/auth-context";
 import {
   AUTH_VAULT_STORAGE_KEY,
   clearOfflineVaultSession,
+  clearOfflineVaultTables,
   initializeOfflineVault,
   readPersistedAuthUserFromVault,
 } from "../lib/offlineVault";
@@ -397,6 +398,7 @@ class LocalStorageAuthStorage implements AuthStorage {
 
   removeUser(): void {
     clearOfflineVaultSession();
+    void clearOfflineVaultTables();
     localStorage.removeItem(this.USER_KEY);
     localStorage.removeItem(this.VAULT_KEY);
   }

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -398,7 +398,9 @@ class LocalStorageAuthStorage implements AuthStorage {
 
   removeUser(): void {
     clearOfflineVaultSession();
-    void clearOfflineVaultTables();
+    void clearOfflineVaultTables().catch((error: unknown) => {
+      console.warn("Failed to clear offline vault tables on logout:", error);
+    });
     localStorage.removeItem(this.USER_KEY);
     localStorage.removeItem(this.VAULT_KEY);
   }


### PR DESCRIPTION
## Summary
- add the encrypted offline-vault baseline for persisted profile data and long-term offline IndexedDB PII
- migrate current encrypted auth storage into wrapped vault state and remove PII-bearing auth_user persistence from localStorage
- route analytics and organizational-unit offline stores through the vault-backed path and extend regression coverage for storage, auth bootstrap, and cleanup behavior

## Validation
- npm run test:run -- src/lib/offlineVault.test.ts src/services/storage.test.ts src/lib/db.test.ts src/lib/analytics.test.ts src/lib/organizationalUnitStore.test.ts src/lib/clientStateCleanup.test.ts src/contexts/AuthContext.test.tsx
- npm run typecheck
- npm run lint
- npm run build

## Issue Context
- closes #1005
- #495 remains the accepted design epic and does not need to be reopened for this implementation slice
- #1006 and #1007 remain intentionally separate follow-up slices for optional device-bound wrapping and lock/unlock UX
