### PR TITLE
perf(frontend): restore indexed vault org-unit lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Restored indexed offline-vault organizational-unit lookups for `type` and parent filters by persisting plaintext vault index metadata and lazily backfilling older encrypted org-unit cache records, so filtered queries no longer decrypt the full vault cache on every lookup, resolving frontend issue #1013.
 - Hardened the Vite Lingui plugin wiring to resolve `lingui()` from either named exports or a CommonJS `default` export, and paired it with a filtered local Rolldown preset for Lingui macros, so frontend builds stay compatible with the current Node/Vite CJS-interop behavior and issue #1003 is regression-covered.
 - Changed both `viteStaticCopy` `rename` options for `assetlinks.json` from the unsupported object form (`{ stripBase: true, name: "assetlinks.json" }`) to the correct string form (`"assetlinks.json"`); the object form was silently producing wrong output paths for Android Digital Asset Links at build time, resolving frontend issue #997.
 - Mirrored backend `429` login lockouts into the frontend login rate limiter via `Retry-After` and added Playwright regression coverage, so the login UI now stays in the authoritative cooldown state instead of falling back to local failed-attempt tracking, resolving frontend issue #803.

--- a/src/lib/db-constants.ts
+++ b/src/lib/db-constants.ts
@@ -22,6 +22,6 @@ export const DB_NAME = "SecPalDB";
  *
  * When incrementing:
  * 1. Update this constant
- * 2. Update the single version() block in db.ts
+ * 2. Update the latest version() block in db.ts
  */
-export const DB_VERSION = 11;
+export const DB_VERSION = 12;

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -36,5 +36,15 @@ describe("IndexedDB Database", () => {
       expect(tableNames).not.toContain("syncQueue");
       expect(tableNames).not.toContain("apiCache");
     });
+
+    it("indexes vault organizational units by type and parent_id", () => {
+      const indexNames = db.vaultOrganizationalUnitCache.schema.indexes.map(
+        (index) => index.name
+      );
+
+      expect(indexNames).toEqual(
+        expect.arrayContaining(["type", "parentLookupKey", "parent_id"])
+      );
+    });
   });
 });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -80,6 +80,9 @@ export interface VaultAnalyticsRecord extends EncryptedVaultRecord {
 
 export interface VaultOrganizationalUnitCacheRecord extends EncryptedVaultRecord {
   id: string;
+  type?: OrganizationalUnitCacheEntry["type"];
+  parent_id?: string | null;
+  parentLookupKey?: string;
   cachedAt: Date;
   lastSynced: Date;
 }
@@ -103,11 +106,20 @@ export const db = new Dexie(DB_NAME) as Dexie & {
 };
 
 // Schema version 11 - Adds encrypted vault-backed offline stores for long-term PII.
+db.version(11).stores({
+  analytics: "++id, synced, timestamp, sessionId, type",
+  organizationalUnitCache: "id, type, parent_id, updated_at, cachedAt",
+  vaultProfile: "id",
+  vaultAnalytics: "++id, synced, timestamp",
+  vaultOrganizationalUnitCache: "id, cachedAt, lastSynced",
+});
+
+// Schema version 12 - Restores indexed vault organizational-unit lookups.
 // 0.x keeps the IndexedDB schema focused on the currently supported offline data.
 db.version(DB_VERSION).stores({
   analytics: "++id, synced, timestamp, sessionId, type",
   organizationalUnitCache: "id, type, parent_id, updated_at, cachedAt",
   vaultProfile: "id",
   vaultAnalytics: "++id, synced, timestamp",
-  vaultOrganizationalUnitCache: "id, cachedAt, lastSynced",
+  vaultOrganizationalUnitCache: "id, type, parentLookupKey, parent_id, cachedAt, lastSynced",
 });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -121,5 +121,6 @@ db.version(DB_VERSION).stores({
   organizationalUnitCache: "id, type, parent_id, updated_at, cachedAt",
   vaultProfile: "id",
   vaultAnalytics: "++id, synced, timestamp",
-  vaultOrganizationalUnitCache: "id, type, parentLookupKey, parent_id, cachedAt, lastSynced",
+  vaultOrganizationalUnitCache:
+    "id, type, parentLookupKey, parent_id, cachedAt, lastSynced",
 });

--- a/src/lib/offlineVault.ts
+++ b/src/lib/offlineVault.ts
@@ -917,11 +917,12 @@ async function decryptVaultOrganizationalUnitRecord(
   record: VaultOrganizationalUnitCacheRecord,
   session: VaultSession
 ): Promise<OrganizationalUnitCacheEntry | null> {
-  const decryptedRecord = await decryptVaultRecord<OrganizationalUnitCacheEntry>(
-    record,
-    "organizationalUnitCache",
-    session
-  );
+  const decryptedRecord =
+    await decryptVaultRecord<OrganizationalUnitCacheEntry>(
+      record,
+      "organizationalUnitCache",
+      session
+    );
 
   if (!decryptedRecord) {
     return null;

--- a/src/lib/offlineVault.ts
+++ b/src/lib/offlineVault.ts
@@ -28,6 +28,7 @@ const AUTH_VAULT_DERIVED_KEY_BYTES = AUTH_VAULT_HALF_KEY_BYTES * 2;
 const VAULT_RECORD_IV_BYTES = 12;
 const VAULT_RECORD_TAG_BYTES = 16;
 const PROFILE_RECORD_ID = "profile";
+const ROOT_ORGANIZATIONAL_UNIT_PARENT_LOOKUP_KEY = "__root__";
 
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
@@ -94,6 +95,11 @@ interface VaultSession {
 type VaultAnalyticsPayload = Omit<
   AnalyticsEvent,
   "id" | "synced" | "timestamp"
+>;
+
+type VaultOrganizationalUnitIndexFields = Pick<
+  VaultOrganizationalUnitCacheRecord,
+  "type" | "parent_id" | "parentLookupKey"
 >;
 
 let activeVaultSession: VaultSession | null = null;
@@ -881,6 +887,128 @@ async function decryptVaultRecord<T>(
   }
 }
 
+function getVaultOrganizationalUnitParentLookupKey(
+  parentId: string | null | undefined
+): string {
+  return parentId ?? ROOT_ORGANIZATIONAL_UNIT_PARENT_LOOKUP_KEY;
+}
+
+function buildVaultOrganizationalUnitIndexFields(
+  unit: Pick<OrganizationalUnitCacheEntry, "type" | "parent_id">
+): VaultOrganizationalUnitIndexFields {
+  return {
+    type: unit.type,
+    parent_id: unit.parent_id ?? null,
+    parentLookupKey: getVaultOrganizationalUnitParentLookupKey(unit.parent_id),
+  };
+}
+
+function needsVaultOrganizationalUnitIndexBackfill(
+  record: VaultOrganizationalUnitCacheRecord
+): boolean {
+  return (
+    typeof record.type !== "string" ||
+    record.parent_id === undefined ||
+    typeof record.parentLookupKey !== "string"
+  );
+}
+
+async function decryptVaultOrganizationalUnitRecord(
+  record: VaultOrganizationalUnitCacheRecord,
+  session: VaultSession
+): Promise<OrganizationalUnitCacheEntry | null> {
+  const decryptedRecord = await decryptVaultRecord<OrganizationalUnitCacheEntry>(
+    record,
+    "organizationalUnitCache",
+    session
+  );
+
+  if (!decryptedRecord) {
+    return null;
+  }
+
+  return {
+    ...decryptedRecord,
+    cachedAt: record.cachedAt,
+    lastSynced: record.lastSynced,
+  };
+}
+
+async function decryptVaultOrganizationalUnitRecords(
+  records: VaultOrganizationalUnitCacheRecord[],
+  session: VaultSession
+): Promise<OrganizationalUnitCacheEntry[]> {
+  const invalidIds: string[] = [];
+  const decryptedRecords = await Promise.all(
+    records.map(async (record) => {
+      const decryptedRecord = await decryptVaultOrganizationalUnitRecord(
+        record,
+        session
+      );
+
+      if (!decryptedRecord) {
+        invalidIds.push(record.id);
+        return null;
+      }
+
+      return decryptedRecord;
+    })
+  );
+
+  if (invalidIds.length > 0) {
+    await db.vaultOrganizationalUnitCache.bulkDelete(invalidIds);
+  }
+
+  return decryptedRecords.filter(
+    (record): record is OrganizationalUnitCacheEntry => record !== null
+  );
+}
+
+async function ensureVaultOrganizationalUnitIndexes(
+  session: VaultSession
+): Promise<void> {
+  const legacyRecords = await db.vaultOrganizationalUnitCache
+    .filter(needsVaultOrganizationalUnitIndexBackfill)
+    .toArray();
+
+  if (legacyRecords.length === 0) {
+    return;
+  }
+
+  const updates: Array<{
+    key: string;
+    changes: VaultOrganizationalUnitIndexFields;
+  }> = [];
+  const invalidIds: string[] = [];
+
+  await Promise.all(
+    legacyRecords.map(async (record) => {
+      const decryptedRecord = await decryptVaultOrganizationalUnitRecord(
+        record,
+        session
+      );
+
+      if (!decryptedRecord) {
+        invalidIds.push(record.id);
+        return;
+      }
+
+      updates.push({
+        key: record.id,
+        changes: buildVaultOrganizationalUnitIndexFields(decryptedRecord),
+      });
+    })
+  );
+
+  if (updates.length > 0) {
+    await db.vaultOrganizationalUnitCache.bulkUpdate(updates);
+  }
+
+  if (invalidIds.length > 0) {
+    await db.vaultOrganizationalUnitCache.bulkDelete(invalidIds);
+  }
+}
+
 async function ensureOfflineVaultSession(): Promise<VaultSession | null> {
   const currentKeyMaterial = getAuthVaultKeyMaterial();
   const storedState = getStoredVaultState();
@@ -1092,6 +1220,7 @@ async function migrateLegacyOrganizationalUnitRecords(
 
       return {
         id: record.id,
+        ...buildVaultOrganizationalUnitIndexFields(record),
         cachedAt: record.cachedAt,
         lastSynced: record.lastSynced,
         ...encryptedPayload,
@@ -1301,6 +1430,7 @@ export async function saveVaultOrganizationalUnit(
 
   await db.vaultOrganizationalUnitCache.put({
     id: unit.id,
+    ...buildVaultOrganizationalUnitIndexFields(unit),
     cachedAt: unit.cachedAt,
     lastSynced: unit.lastSynced,
     ...encryptedPayload,
@@ -1326,23 +1456,17 @@ export async function getVaultOrganizationalUnit(
     return undefined;
   }
 
-  const decryptedRecord =
-    await decryptVaultRecord<OrganizationalUnitCacheEntry>(
-      record,
-      "organizationalUnitCache",
-      session
-    );
+  const decryptedRecord = await decryptVaultOrganizationalUnitRecord(
+    record,
+    session
+  );
 
   if (!decryptedRecord) {
     await db.vaultOrganizationalUnitCache.delete(id);
     return undefined;
   }
 
-  return {
-    ...decryptedRecord,
-    cachedAt: record.cachedAt,
-    lastSynced: record.lastSynced,
-  };
+  return decryptedRecord;
 }
 
 export async function listVaultOrganizationalUnits(): Promise<
@@ -1358,36 +1482,52 @@ export async function listVaultOrganizationalUnits(): Promise<
 
   await migrateLegacyOrganizationalUnitRecords(session);
 
-  const records = await db.vaultOrganizationalUnitCache.toArray();
-  const invalidIds: string[] = [];
-  const decryptedRecords = await Promise.all(
-    records.map(async (record) => {
-      const decryptedRecord =
-        await decryptVaultRecord<OrganizationalUnitCacheEntry>(
-          record,
-          "organizationalUnitCache",
-          session
-        );
-
-      if (!decryptedRecord) {
-        invalidIds.push(record.id);
-        return null;
-      }
-
-      return {
-        ...decryptedRecord,
-        cachedAt: record.cachedAt,
-        lastSynced: record.lastSynced,
-      };
-    })
+  return decryptVaultOrganizationalUnitRecords(
+    await db.vaultOrganizationalUnitCache.toArray(),
+    session
   );
+}
 
-  if (invalidIds.length > 0) {
-    await db.vaultOrganizationalUnitCache.bulkDelete(invalidIds);
+export async function listVaultOrganizationalUnitsByType(
+  type: OrganizationalUnitCacheEntry["type"]
+): Promise<OrganizationalUnitCacheEntry[]> {
+  const session = await ensureOfflineVaultSession();
+
+  if (!session) {
+    return [];
   }
 
-  return decryptedRecords.filter(
-    (record): record is OrganizationalUnitCacheEntry => record !== null
+  await ensureVaultDatabaseOpen();
+
+  await migrateLegacyOrganizationalUnitRecords(session);
+  await ensureVaultOrganizationalUnitIndexes(session);
+
+  return decryptVaultOrganizationalUnitRecords(
+    await db.vaultOrganizationalUnitCache.where("type").equals(type).toArray(),
+    session
+  );
+}
+
+export async function listVaultOrganizationalUnitsByParent(
+  parentId: string | null
+): Promise<OrganizationalUnitCacheEntry[]> {
+  const session = await ensureOfflineVaultSession();
+
+  if (!session) {
+    return [];
+  }
+
+  await ensureVaultDatabaseOpen();
+
+  await migrateLegacyOrganizationalUnitRecords(session);
+  await ensureVaultOrganizationalUnitIndexes(session);
+
+  return decryptVaultOrganizationalUnitRecords(
+    await db.vaultOrganizationalUnitCache
+      .where("parentLookupKey")
+      .equals(getVaultOrganizationalUnitParentLookupKey(parentId))
+      .toArray(),
+    session
   );
 }
 

--- a/src/lib/offlineVault.ts
+++ b/src/lib/offlineVault.ts
@@ -103,6 +103,7 @@ type VaultOrganizationalUnitIndexFields = Pick<
 >;
 
 let activeVaultSession: VaultSession | null = null;
+let vaultOrgUnitIndexEnsured = false;
 
 function isAuthVaultStateEnvelopeV1(
   value: unknown
@@ -314,6 +315,7 @@ export function clearOfflineVaultSession(): void {
   }
 
   activeVaultSession = null;
+  vaultOrgUnitIndexEnsured = false;
 }
 
 export function clearStoredOfflineVaultState(): void {
@@ -968,11 +970,16 @@ async function decryptVaultOrganizationalUnitRecords(
 async function ensureVaultOrganizationalUnitIndexes(
   session: VaultSession
 ): Promise<void> {
+  if (vaultOrgUnitIndexEnsured) {
+    return;
+  }
+
   const legacyRecords = await db.vaultOrganizationalUnitCache
     .filter(needsVaultOrganizationalUnitIndexBackfill)
     .toArray();
 
   if (legacyRecords.length === 0) {
+    vaultOrgUnitIndexEnsured = true;
     return;
   }
 
@@ -1008,6 +1015,8 @@ async function ensureVaultOrganizationalUnitIndexes(
   if (invalidIds.length > 0) {
     await db.vaultOrganizationalUnitCache.bulkDelete(invalidIds);
   }
+
+  vaultOrgUnitIndexEnsured = true;
 }
 
 async function ensureOfflineVaultSession(): Promise<VaultSession | null> {

--- a/src/lib/organizationalUnitStore.test.ts
+++ b/src/lib/organizationalUnitStore.test.ts
@@ -576,6 +576,48 @@ describe("OrganizationalUnitStore", () => {
         })
       );
     });
+
+    it("runs the vault org-unit index backfill scan at most once per vault session", async () => {
+      await saveOrganizationalUnit({
+        id: "branch-1",
+        type: "branch",
+        name: "Berlin Branch",
+        parent_id: null,
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+        cachedAt: new Date("2025-01-10T00:00:00Z"),
+        lastSynced: new Date("2025-01-10T00:00:00Z"),
+      });
+
+      // Strip index fields to force a backfill on the first query
+      const record = await db.vaultOrganizationalUnitCache.get("branch-1");
+      if (record) {
+        const legacyRecord = {
+          ...record,
+        } as Partial<VaultOrganizationalUnitCacheRecord>;
+        delete legacyRecord.type;
+        delete legacyRecord.parent_id;
+        delete legacyRecord.parentLookupKey;
+        await db.vaultOrganizationalUnitCache.put(
+          legacyRecord as VaultOrganizationalUnitCacheRecord
+        );
+      }
+
+      const decryptSpy = vi.spyOn(crypto.subtle, "decrypt");
+
+      // First query: backfill scan runs (decrypt for backfill + decrypt for query result)
+      await getOrganizationalUnitsByType("branch");
+      const decryptsAfterFirstCall = decryptSpy.mock.calls.length;
+
+      decryptSpy.mockClear();
+
+      // Second query in the same session: backfill flag is already set, only the indexed query decrypt happens
+      await getOrganizationalUnitsByType("branch");
+      const decryptsAfterSecondCall = decryptSpy.mock.calls.length;
+
+      expect(decryptsAfterSecondCall).toBeLessThan(decryptsAfterFirstCall);
+      expect(decryptsAfterSecondCall).toBe(1);
+    });
   });
 
   describe("searchOrganizationalUnits", () => {

--- a/src/lib/organizationalUnitStore.test.ts
+++ b/src/lib/organizationalUnitStore.test.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { describe, it, expect, beforeEach } from "vitest";
-import { db } from "./db";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { db, type VaultOrganizationalUnitCacheRecord } from "./db";
 import type { OrganizationalUnitCacheEntry } from "./db";
 import type { OrganizationalUnit } from "../types/organizational";
 import {
@@ -358,6 +358,43 @@ describe("OrganizationalUnitStore", () => {
       const units = await getOrganizationalUnitsByType("holding");
       expect(units).toEqual([]);
     });
+
+    it("decrypts only matching vault records for indexed type lookups", async () => {
+      await saveOrganizationalUnit({
+        id: "branch-1",
+        type: "branch",
+        name: "Berlin Branch",
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+        cachedAt: new Date("2025-01-10T00:00:00Z"),
+        lastSynced: new Date("2025-01-10T00:00:00Z"),
+      });
+      await saveOrganizationalUnit({
+        id: "branch-2",
+        type: "branch",
+        name: "Hamburg Branch",
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+        cachedAt: new Date("2025-01-10T00:00:00Z"),
+        lastSynced: new Date("2025-01-10T00:00:00Z"),
+      });
+      await saveOrganizationalUnit({
+        id: "company-1",
+        type: "company",
+        name: "SecPal GmbH",
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+        cachedAt: new Date("2025-01-10T00:00:00Z"),
+        lastSynced: new Date("2025-01-10T00:00:00Z"),
+      });
+
+      const decryptSpy = vi.spyOn(crypto.subtle, "decrypt");
+
+      const branches = await getOrganizationalUnitsByType("branch");
+
+      expect(branches.map((unit) => unit.id)).toEqual(["branch-1", "branch-2"]);
+      expect(decryptSpy).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe("getOrganizationalUnitsByParent", () => {
@@ -436,6 +473,101 @@ describe("OrganizationalUnitStore", () => {
       const rootUnits = await getOrganizationalUnitsByParent(null);
       expect(rootUnits).toHaveLength(1);
       expect(rootUnits[0]!.name).toBe("Root Holding");
+    });
+
+    it("decrypts only matching vault records for indexed parent lookups", async () => {
+      await saveOrganizationalUnit({
+        id: "company-1",
+        type: "company",
+        name: "SecPal GmbH",
+        parent_id: null,
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+        cachedAt: new Date("2025-01-10T00:00:00Z"),
+        lastSynced: new Date("2025-01-10T00:00:00Z"),
+      });
+      await saveOrganizationalUnit({
+        id: "branch-1",
+        type: "branch",
+        name: "Berlin Branch",
+        parent_id: "company-1",
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+        cachedAt: new Date("2025-01-10T00:00:00Z"),
+        lastSynced: new Date("2025-01-10T00:00:00Z"),
+      });
+      await saveOrganizationalUnit({
+        id: "branch-2",
+        type: "branch",
+        name: "Hamburg Branch",
+        parent_id: "company-2",
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+        cachedAt: new Date("2025-01-10T00:00:00Z"),
+        lastSynced: new Date("2025-01-10T00:00:00Z"),
+      });
+
+      const decryptSpy = vi.spyOn(crypto.subtle, "decrypt");
+
+      const children = await getOrganizationalUnitsByParent("company-1");
+
+      expect(children.map((unit) => unit.id)).toEqual(["branch-1"]);
+      expect(decryptSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("backfills missing vault org-unit index fields during filtered lookups", async () => {
+      await saveOrganizationalUnit({
+        id: "company-1",
+        type: "company",
+        name: "SecPal GmbH",
+        parent_id: null,
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+        cachedAt: new Date("2025-01-10T00:00:00Z"),
+        lastSynced: new Date("2025-01-10T00:00:00Z"),
+      });
+      await saveOrganizationalUnit({
+        id: "branch-1",
+        type: "branch",
+        name: "Berlin Branch",
+        parent_id: "company-1",
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+        cachedAt: new Date("2025-01-10T00:00:00Z"),
+        lastSynced: new Date("2025-01-10T00:00:00Z"),
+      });
+
+      const branchRecord = await db.vaultOrganizationalUnitCache.get("branch-1");
+      const companyRecord = await db.vaultOrganizationalUnitCache.get("company-1");
+
+      const toLegacyRecord = (record: VaultOrganizationalUnitCacheRecord) => {
+        const legacyRecord = {
+          ...record,
+        } as Partial<VaultOrganizationalUnitCacheRecord>;
+
+        delete legacyRecord.type;
+        delete legacyRecord.parent_id;
+        delete legacyRecord.parentLookupKey;
+
+        return legacyRecord as VaultOrganizationalUnitCacheRecord;
+      };
+
+      await db.vaultOrganizationalUnitCache.bulkPut(
+        [branchRecord, companyRecord]
+          .filter((record): record is NonNullable<typeof record> => record !== undefined)
+          .map(toLegacyRecord)
+      );
+
+      await expect(getOrganizationalUnitsByType("branch")).resolves.toEqual([
+        expect.objectContaining({ id: "branch-1" }),
+      ]);
+      await expect(db.vaultOrganizationalUnitCache.get("branch-1")).resolves.toEqual(
+        expect.objectContaining({
+          type: "branch",
+          parent_id: "company-1",
+          parentLookupKey: "company-1",
+        })
+      );
     });
   });
 

--- a/src/lib/organizationalUnitStore.test.ts
+++ b/src/lib/organizationalUnitStore.test.ts
@@ -537,8 +537,10 @@ describe("OrganizationalUnitStore", () => {
         lastSynced: new Date("2025-01-10T00:00:00Z"),
       });
 
-      const branchRecord = await db.vaultOrganizationalUnitCache.get("branch-1");
-      const companyRecord = await db.vaultOrganizationalUnitCache.get("company-1");
+      const branchRecord =
+        await db.vaultOrganizationalUnitCache.get("branch-1");
+      const companyRecord =
+        await db.vaultOrganizationalUnitCache.get("company-1");
 
       const toLegacyRecord = (record: VaultOrganizationalUnitCacheRecord) => {
         const legacyRecord = {
@@ -554,14 +556,19 @@ describe("OrganizationalUnitStore", () => {
 
       await db.vaultOrganizationalUnitCache.bulkPut(
         [branchRecord, companyRecord]
-          .filter((record): record is NonNullable<typeof record> => record !== undefined)
+          .filter(
+            (record): record is NonNullable<typeof record> =>
+              record !== undefined
+          )
           .map(toLegacyRecord)
       );
 
       await expect(getOrganizationalUnitsByType("branch")).resolves.toEqual([
         expect.objectContaining({ id: "branch-1" }),
       ]);
-      await expect(db.vaultOrganizationalUnitCache.get("branch-1")).resolves.toEqual(
+      await expect(
+        db.vaultOrganizationalUnitCache.get("branch-1")
+      ).resolves.toEqual(
         expect.objectContaining({
           type: "branch",
           parent_id: "company-1",

--- a/src/lib/organizationalUnitStore.ts
+++ b/src/lib/organizationalUnitStore.ts
@@ -7,6 +7,8 @@ import {
   clearVaultOrganizationalUnits,
   deleteVaultOrganizationalUnit,
   getVaultOrganizationalUnit,
+  listVaultOrganizationalUnitsByParent,
+  listVaultOrganizationalUnitsByType,
   listVaultOrganizationalUnits,
   saveVaultOrganizationalUnit,
 } from "./offlineVault";
@@ -127,9 +129,7 @@ export async function deleteOrganizationalUnit(id: string): Promise<void> {
 export async function getOrganizationalUnitsByType(
   type: OrganizationalUnitCacheEntry["type"]
 ): Promise<OrganizationalUnitCacheEntry[]> {
-  const units = (await listVaultOrganizationalUnits()).filter(
-    (unit) => unit.type === type
-  );
+  const units = await listVaultOrganizationalUnitsByType(type);
 
   return units.sort((a, b) => a.name.localeCompare(b.name));
 }
@@ -149,13 +149,7 @@ export async function getOrganizationalUnitsByType(
 export async function getOrganizationalUnitsByParent(
   parentId: string | null
 ): Promise<OrganizationalUnitCacheEntry[]> {
-  const allUnits = await listVaultOrganizationalUnits();
-  const units =
-    parentId === null
-      ? allUnits.filter(
-          (unit) => unit.parent_id === null || unit.parent_id === undefined
-        )
-      : allUnits.filter((unit) => unit.parent_id === parentId);
+  const units = await listVaultOrganizationalUnitsByParent(parentId);
 
   return units.sort((a, b) => a.name.localeCompare(b.name));
 }


### PR DESCRIPTION
## Summary
- restore indexed vault organizational-unit lookups for type and parent filters
- persist plaintext vault index metadata for org-unit records and lazily backfill older encrypted records
- add regression coverage that proves filtered lookups decrypt only matching vault records

## Testing
- npm run test:run -- src/lib/organizationalUnitStore.test.ts src/lib/db.test.ts src/lib/offlineVault.test.ts
- npm run typecheck
- npm run lint
- npm run build

Closes #1013
