### PR TITLE
test: add XSRF rotation organization E2E regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a Playwright regression that rotates the `XSRF-TOKEN` cookie on mocked authenticated organization GET traffic and proves protected-route reloads stay authenticated without falling into `Offline vault is not available.`, resolving frontend issue #1020.
 - Added `docs/OFFLINE_ENCRYPTED_VAULT_DESIGN.md` as the accepted Phase 2 design record for frontend issue #495, documenting the target vault key hierarchy, device-bound key comparison, lock/unlock/logout semantics, and follow-up implementation slices for offline PII protection.
 - Added native Android passkey registration fallback in Settings so the shared passkey enrollment flow can delegate attestation creation to the injected Android bridge when the embedded WebView does not support browser WebAuthn registration, while keeping browser behavior unchanged.
 - Added native-bridge passkey sign-in to the shared login flow so Android can complete token-based passkey authentication through the injected native auth bridge while browsers keep the existing WebAuthn ceremony and progress states.

--- a/tests/e2e/organization.spec.ts
+++ b/tests/e2e/organization.spec.ts
@@ -3,6 +3,7 @@
 
 import { test, expect } from "./auth.setup";
 import { offlineLiveMockOrganizationUnit } from "./offline-live-helpers";
+import { getCachedOrgUnitsCount } from "../utils/offline-helpers";
 
 const ROTATED_XSRF_TOKEN = "rotated-xsrf-token";
 

--- a/tests/e2e/organization.spec.ts
+++ b/tests/e2e/organization.spec.ts
@@ -43,8 +43,8 @@ test.describe("Organization Management", () => {
           headers:
             organizationRequestCount === 1
               ? {
-                "set-cookie": `XSRF-TOKEN=${ROTATED_XSRF_TOKEN}; Path=/; SameSite=Lax`,
-              }
+                  "set-cookie": `XSRF-TOKEN=${ROTATED_XSRF_TOKEN}; Path=/; SameSite=Lax`,
+                }
               : {},
           body: JSON.stringify({
             data: [offlineLiveMockOrganizationUnit],

--- a/tests/e2e/organization.spec.ts
+++ b/tests/e2e/organization.spec.ts
@@ -1,8 +1,10 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { test, expect } from "./auth.setup";
-import { getCachedOrgUnitsCount } from "../utils/offline-helpers";
+import { offlineLiveMockOrganizationUnit } from "./offline-live-helpers";
+
+const ROTATED_XSRF_TOKEN = "rotated-xsrf-token";
 
 /**
  * Organization Management E2E Tests
@@ -24,6 +26,79 @@ test.describe("Organization Management", () => {
       await expect(
         page.getByRole("heading", { level: 1 }).first()
       ).toBeVisible();
+    });
+
+    test("should keep browser-session organization access after XSRF token rotation on authenticated GET refreshes", async ({
+      authenticatedPage: page,
+    }) => {
+      const context = page.context();
+      let organizationRequestCount = 0;
+
+      await context.route("**/v1/organizational-units**", async (route) => {
+        organizationRequestCount += 1;
+
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          headers:
+            organizationRequestCount === 1
+              ? {
+                "set-cookie": `XSRF-TOKEN=${ROTATED_XSRF_TOKEN}; Path=/; SameSite=Lax`,
+              }
+              : {},
+          body: JSON.stringify({
+            data: [offlineLiveMockOrganizationUnit],
+            meta: {
+              current_page: 1,
+              last_page: 1,
+              per_page: 100,
+              total: 1,
+              root_unit_ids: [offlineLiveMockOrganizationUnit.id],
+            },
+          }),
+        });
+      });
+
+      await page.goto("/organization");
+      await page.waitForLoadState("networkidle");
+
+      await expect(
+        page.getByRole("heading", { name: /organization structure/i })
+      ).toBeVisible();
+      await expect(
+        page.getByText(offlineLiveMockOrganizationUnit.name).first()
+      ).toBeVisible();
+      await expect(
+        page.getByRole("button", { name: /user menu/i })
+      ).toBeVisible();
+      await expect(
+        page.getByText("Offline vault is not available.")
+      ).toHaveCount(0);
+
+      await expect
+        .poll(async () => {
+          const cookies = await context.cookies();
+
+          return cookies.find((cookie) => cookie.name === "XSRF-TOKEN")?.value;
+        })
+        .toBe(ROTATED_XSRF_TOKEN);
+
+      await page.reload();
+      await page.waitForLoadState("networkidle");
+
+      await expect(
+        page.getByRole("heading", { name: /organization structure/i })
+      ).toBeVisible();
+      await expect(
+        page.getByText(offlineLiveMockOrganizationUnit.name).first()
+      ).toBeVisible();
+      await expect(
+        page.getByRole("button", { name: /user menu/i })
+      ).toBeVisible();
+      await expect(
+        page.getByText("Offline vault is not available.")
+      ).toHaveCount(0);
+      expect(organizationRequestCount).toBeGreaterThanOrEqual(2);
     });
   });
 

--- a/tests/e2e/organization.spec.ts
+++ b/tests/e2e/organization.spec.ts
@@ -78,7 +78,7 @@ test.describe("Organization Management", () => {
 
       await expect
         .poll(async () => {
-          const cookies = await context.cookies();
+          const cookies = await context.cookies([page.url()]);
 
           return cookies.find((cookie) => cookie.name === "XSRF-TOKEN")?.value;
         })


### PR DESCRIPTION
## Summary

- add a Playwright regression for the organization route that rotates `XSRF-TOKEN` on mocked authenticated GET traffic
- verify a protected-route reload stays authenticated, keeps rendering `/organization`, and does not surface `Offline vault is not available.`
- document the added regression coverage in `CHANGELOG.md`

## Issue 1020 status

- current `main` already contains the product fix for the original XSRF rotation bug
- the remaining valid scope on issue #1020 is the missing explicit Playwright E2E regression for that path
- this PR addresses that remaining gap without re-scoping into a second product fix

## Validation

- `npm run typecheck`
- `npm exec -- eslint tests/e2e/organization.spec.ts`
- `npm exec -- playwright test tests/e2e/organization.spec.ts --project=chromium --project=mobile-chrome --grep "XSRF token rotation"`

Closes #1020
