### PR TITLE
fix: stabilize organization UI flows and scope errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Kept `/organization` hierarchy state consistent after child creation and moves by regression-covering the create/edit/reload and move/edit/reload flows, updating optimistic tree reparenting to refresh the moved unit's parent metadata, and surfacing backend scope-self-lockout `403` messages in the scope-assignment dialog instead of collapsing them into a generic save failure.
 - Stopped browser-session offline-vault state from being cleared when Laravel rotates the `XSRF-TOKEN` cookie on authenticated `GET` requests such as `/v1/me` and `/v1/organizational-units`; the frontend now rewraps the live in-memory vault session to the new CSRF token instead of treating the vault as corrupted, so `/organization` no longer falls into `Offline vault is not available.` on `app.secpal.dev` after a successful login.
 - Restored indexed offline-vault organizational-unit lookups for `type` and parent filters by persisting plaintext vault index metadata and lazily backfilling older encrypted org-unit cache records, so filtered queries no longer decrypt the full vault cache on every lookup, resolving frontend issue #1013.
 - Hardened the Vite Lingui plugin wiring to resolve `lingui()` from either named exports or a CommonJS `default` export, and paired it with a filtered local Rolldown preset for Lingui macros, so frontend builds stay compatible with the current Node/Vite CJS-interop behavior and issue #1003 is regression-covered.

--- a/src/components/OrganizationalUnitTree.test.tsx
+++ b/src/components/OrganizationalUnitTree.test.tsx
@@ -99,12 +99,21 @@ vi.mock("./MoveOrganizationalUnitDialog", () => ({
         <div>Move "{unit.name}"</div>
         <button
           onClick={() => {
-            // Simulate successful move
+            // Simulate successful move to a non-existent parent (default)
             onSuccess("new-parent-id");
             onClose();
           }}
         >
           Confirm Move
+        </button>
+        <button
+          onClick={() => {
+            // Simulate move to a nested existing unit (unit-2 = IT Department)
+            onSuccess("unit-2");
+            onClose();
+          }}
+        >
+          Confirm Move To Nested
         </button>
         <button onClick={onClose}>Cancel</button>
       </div>
@@ -554,6 +563,40 @@ describe("OrganizationalUnitTree", () => {
         expect(onMove).toHaveBeenCalledWith(
           expect.objectContaining({ id: "unit-3", name: "North Region" })
         );
+      });
+    });
+
+    it("refreshes moved unit parent metadata after move to an existing nested unit", async () => {
+      // Use "Confirm Move To Nested" which calls onSuccess("unit-2").
+      // unit-2 (IT Department) is nested under unit-1, so findUnitInTree must
+      // recurse to find it, exercising the recursive-return path and the parent
+      // metadata refresh inside moveUnitInTree.
+      const onMove = vi.fn();
+      renderWithI18n(<OrganizationalUnitTree onMove={onMove} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("North Region")).toBeInTheDocument();
+        expect(screen.getByText("IT Department")).toBeInTheDocument();
+      });
+
+      await clickActionForUnit("North Region", "Move");
+
+      await waitFor(() => {
+        expect(screen.getByTestId("mock-move-dialog")).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText("Confirm Move To Nested"));
+
+      await waitFor(() => {
+        expect(onMove).toHaveBeenCalledWith(
+          expect.objectContaining({ id: "unit-3", name: "North Region" })
+        );
+      });
+
+      // North Region (unit-3) is now a child of IT Department (unit-2, level 1).
+      // IT Department is auto-expanded (level 1 < 2), so North Region is visible.
+      await waitFor(() => {
+        expect(screen.getByText("North Region")).toBeInTheDocument();
       });
     });
   });

--- a/src/components/OrganizationalUnitTree.test.tsx
+++ b/src/components/OrganizationalUnitTree.test.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, vi, beforeEach } from "vitest";

--- a/src/components/OrganizationalUnitTree.tsx
+++ b/src/components/OrganizationalUnitTree.tsx
@@ -235,10 +235,11 @@ const TreeNode = memo(
     return (
       <div className="select-none">
         <div
-          className={`group flex items-center gap-1.5 py-2 px-2 rounded-lg cursor-pointer transition-colors ${isSelected
+          className={`group flex items-center gap-1.5 py-2 px-2 rounded-lg cursor-pointer transition-colors ${
+            isSelected
               ? "bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-800"
               : "hover:bg-gray-50 dark:hover:bg-gray-800/50"
-            }`}
+          }`}
           style={{ paddingLeft: `${Math.min(level * 16, 64) + 8}px` }}
           onClick={handleSelect}
           role="treeitem"
@@ -255,10 +256,11 @@ const TreeNode = memo(
           {/* Expand/Collapse Button */}
           <button
             type="button"
-            className={`shrink-0 p-0.5 rounded transition-colors ${hasChildren
+            className={`shrink-0 p-0.5 rounded transition-colors ${
+              hasChildren
                 ? "hover:bg-gray-200 dark:hover:bg-gray-700"
                 : "invisible"
-              }`}
+            }`}
             onClick={handleToggle}
             aria-label={isExpanded ? t`Collapse` : t`Expand`}
           >
@@ -534,12 +536,12 @@ function moveUnitInTree(
     ...unitToMove,
     parent: nextParent
       ? {
-        id: nextParent.id,
-        type: nextParent.type,
-        name: nextParent.name,
-        created_at: nextParent.created_at,
-        updated_at: nextParent.updated_at,
-      }
+          id: nextParent.id,
+          type: nextParent.type,
+          name: nextParent.name,
+          created_at: nextParent.created_at,
+          updated_at: nextParent.updated_at,
+        }
       : undefined,
   };
 

--- a/src/components/OrganizationalUnitTree.tsx
+++ b/src/components/OrganizationalUnitTree.tsx
@@ -235,11 +235,10 @@ const TreeNode = memo(
     return (
       <div className="select-none">
         <div
-          className={`group flex items-center gap-1.5 py-2 px-2 rounded-lg cursor-pointer transition-colors ${
-            isSelected
+          className={`group flex items-center gap-1.5 py-2 px-2 rounded-lg cursor-pointer transition-colors ${isSelected
               ? "bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-800"
               : "hover:bg-gray-50 dark:hover:bg-gray-800/50"
-          }`}
+            }`}
           style={{ paddingLeft: `${Math.min(level * 16, 64) + 8}px` }}
           onClick={handleSelect}
           role="treeitem"
@@ -256,11 +255,10 @@ const TreeNode = memo(
           {/* Expand/Collapse Button */}
           <button
             type="button"
-            className={`shrink-0 p-0.5 rounded transition-colors ${
-              hasChildren
+            className={`shrink-0 p-0.5 rounded transition-colors ${hasChildren
                 ? "hover:bg-gray-200 dark:hover:bg-gray-700"
                 : "invisible"
-            }`}
+              }`}
             onClick={handleToggle}
             aria-label={isExpanded ? t`Collapse` : t`Expand`}
           >
@@ -468,6 +466,26 @@ function addUnitToTree(
   });
 }
 
+function findUnitInTree(
+  units: OrganizationalUnit[],
+  unitId: string
+): OrganizationalUnit | null {
+  for (const unit of units) {
+    if (unit.id === unitId) {
+      return unit;
+    }
+
+    if (unit.children && unit.children.length > 0) {
+      const nestedMatch = findUnitInTree(unit.children, unitId);
+      if (nestedMatch) {
+        return nestedMatch;
+      }
+    }
+  }
+
+  return null;
+}
+
 /**
  * Optimistic UI helper: Move a unit to a new parent in the tree
  * @param units - Current tree structure
@@ -508,8 +526,25 @@ function moveUnitInTree(
     return units; // Unit not found, return unchanged
   }
 
+  const nextParent = newParentId
+    ? findUnitInTree(treeWithoutUnit, newParentId)
+    : null;
+
+  const movedUnit: OrganizationalUnit = {
+    ...unitToMove,
+    parent: nextParent
+      ? {
+        id: nextParent.id,
+        type: nextParent.type,
+        name: nextParent.name,
+        created_at: nextParent.created_at,
+        updated_at: nextParent.updated_at,
+      }
+      : undefined,
+  };
+
   // Step 2: Insert the unit (with its children) at the new location
-  return addUnitToTree(treeWithoutUnit, unitToMove, newParentId);
+  return addUnitToTree(treeWithoutUnit, movedUnit, newParentId);
 }
 
 /**

--- a/src/components/OrganizationalUnitTree.tsx
+++ b/src/components/OrganizationalUnitTree.tsx
@@ -524,16 +524,18 @@ function moveUnitInTree(
 
   const treeWithoutUnit = extractUnit(units);
 
-  if (!unitToMove) {
+  if (unitToMove === null) {
     return units; // Unit not found, return unchanged
   }
+
+  const extractedUnit = unitToMove as OrganizationalUnit;
 
   const nextParent = newParentId
     ? findUnitInTree(treeWithoutUnit, newParentId)
     : null;
 
   const movedUnit: OrganizationalUnit = {
-    ...unitToMove,
+    ...extractedUnit,
     parent: nextParent
       ? {
           id: nextParent.id,

--- a/src/components/OrganizationalUnitTree.tsx
+++ b/src/components/OrganizationalUnitTree.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { useState, useCallback, useMemo, lazy, Suspense, memo } from "react";

--- a/src/services/organizationalScopeApi.test.ts
+++ b/src/services/organizationalScopeApi.test.ts
@@ -124,4 +124,20 @@ describe("organizationalScopeApi", () => {
       statusCode: 500,
     } satisfies Partial<ApiError>);
   });
+
+  it("falls back to built-in message when response body is null JSON", async () => {
+    mockApiFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => null,
+    } as unknown as Response);
+
+    await expect(
+      updateOrganizationalScope("unit-1", "scope-1", { access_level: "read" })
+    ).rejects.toMatchObject({
+      name: "ApiError",
+      message: "Failed to update organizational scope",
+      statusCode: 500,
+    } satisfies Partial<ApiError>);
+  });
 });

--- a/src/services/organizationalScopeApi.test.ts
+++ b/src/services/organizationalScopeApi.test.ts
@@ -6,7 +6,7 @@ import { ApiError } from "./ApiError";
 import { updateOrganizationalScope } from "./organizationalScopeApi";
 
 vi.mock("./csrf", () => ({
-    apiFetch: vi.fn(),
+  apiFetch: vi.fn(),
 }));
 
 import { apiFetch } from "./csrf";
@@ -14,29 +14,29 @@ import { apiFetch } from "./csrf";
 const mockApiFetch = vi.mocked(apiFetch);
 
 describe("organizationalScopeApi", () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-    });
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
-    it("forwards authorization messages from organizational scope updates", async () => {
-        mockApiFetch.mockResolvedValue({
-            ok: false,
-            status: 403,
-            json: async () => ({
-                message:
-                    "You cannot remove your own last scope-management access for this organizational unit.",
-            }),
-        } as Response);
+  it("forwards authorization messages from organizational scope updates", async () => {
+    mockApiFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({
+        message:
+          "You cannot remove your own last scope-management access for this organizational unit.",
+      }),
+    } as Response);
 
-        await expect(
-            updateOrganizationalScope("unit-1", "scope-1", {
-                access_level: "manage",
-            })
-        ).rejects.toMatchObject({
-            name: "ApiError",
-            message:
-                "You cannot remove your own last scope-management access for this organizational unit.",
-            statusCode: 403,
-        } satisfies Partial<ApiError>);
-    });
+    await expect(
+      updateOrganizationalScope("unit-1", "scope-1", {
+        access_level: "manage",
+      })
+    ).rejects.toMatchObject({
+      name: "ApiError",
+      message:
+        "You cannot remove your own last scope-management access for this organizational unit.",
+      statusCode: 403,
+    } satisfies Partial<ApiError>);
+  });
 });

--- a/src/services/organizationalScopeApi.test.ts
+++ b/src/services/organizationalScopeApi.test.ts
@@ -3,10 +3,16 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "./ApiError";
-import { updateOrganizationalScope } from "./organizationalScopeApi";
+import {
+    createOrganizationalScope,
+    deleteOrganizationalScope,
+    getMyOrganizationalScopes,
+    listOrganizationalScopes,
+    updateOrganizationalScope,
+} from "./organizationalScopeApi";
 
 vi.mock("./csrf", () => ({
-  apiFetch: vi.fn(),
+    apiFetch: vi.fn(),
 }));
 
 import { apiFetch } from "./csrf";
@@ -14,29 +20,108 @@ import { apiFetch } from "./csrf";
 const mockApiFetch = vi.mocked(apiFetch);
 
 describe("organizationalScopeApi", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
 
-  it("forwards authorization messages from organizational scope updates", async () => {
-    mockApiFetch.mockResolvedValue({
-      ok: false,
-      status: 403,
-      json: async () => ({
-        message:
-          "You cannot remove your own last scope-management access for this organizational unit.",
-      }),
-    } as Response);
+    it("forwards authorization messages from organizational scope updates", async () => {
+        mockApiFetch.mockResolvedValue({
+            ok: false,
+            status: 403,
+            json: async () => ({
+                message:
+                    "You cannot remove your own last scope-management access for this organizational unit.",
+            }),
+        } as Response);
 
-    await expect(
-      updateOrganizationalScope("unit-1", "scope-1", {
-        access_level: "manage",
-      })
-    ).rejects.toMatchObject({
-      name: "ApiError",
-      message:
-        "You cannot remove your own last scope-management access for this organizational unit.",
-      statusCode: 403,
-    } satisfies Partial<ApiError>);
-  });
+        await expect(
+            updateOrganizationalScope("unit-1", "scope-1", {
+                access_level: "manage",
+            })
+        ).rejects.toMatchObject({
+            name: "ApiError",
+            message:
+                "You cannot remove your own last scope-management access for this organizational unit.",
+            statusCode: 403,
+        } satisfies Partial<ApiError>);
+    });
+
+    it("throws ApiError with status code on scope list failure", async () => {
+        mockApiFetch.mockResolvedValue({
+            ok: false,
+            status: 403,
+            json: async () => ({ message: "Forbidden" }),
+        } as Response);
+
+        await expect(listOrganizationalScopes("unit-1")).rejects.toMatchObject({
+            name: "ApiError",
+            message: "Forbidden",
+            statusCode: 403,
+        } satisfies Partial<ApiError>);
+    });
+
+    it("throws ApiError with status code on scope create failure", async () => {
+        mockApiFetch.mockResolvedValue({
+            ok: false,
+            status: 422,
+            json: async () => ({ message: "Unprocessable Entity" }),
+        } as Response);
+
+        await expect(
+            createOrganizationalScope("unit-1", {
+                user_id: "user-1",
+                organizational_unit_id: "unit-1",
+                access_level: "read",
+            })
+        ).rejects.toMatchObject({
+            name: "ApiError",
+            statusCode: 422,
+        } satisfies Partial<ApiError>);
+    });
+
+    it("throws ApiError with status code on scope delete failure", async () => {
+        mockApiFetch.mockResolvedValue({
+            ok: false,
+            status: 404,
+            json: async () => ({ message: "Not Found" }),
+        } as Response);
+
+        await expect(
+            deleteOrganizationalScope("unit-1", "scope-1")
+        ).rejects.toMatchObject({
+            name: "ApiError",
+            statusCode: 404,
+        } satisfies Partial<ApiError>);
+    });
+
+    it("throws ApiError with status code on my-scopes fetch failure", async () => {
+        mockApiFetch.mockResolvedValue({
+            ok: false,
+            status: 401,
+            json: async () => ({ message: "Unauthenticated" }),
+        } as Response);
+
+        await expect(getMyOrganizationalScopes()).rejects.toMatchObject({
+            name: "ApiError",
+            statusCode: 401,
+        } satisfies Partial<ApiError>);
+    });
+
+    it("falls back to built-in message when response body cannot be parsed", async () => {
+        mockApiFetch.mockResolvedValue({
+            ok: false,
+            status: 500,
+            json: async () => {
+                throw new Error("invalid json");
+            },
+        } as unknown as Response);
+
+        await expect(
+            updateOrganizationalScope("unit-1", "scope-1", { access_level: "read" })
+        ).rejects.toMatchObject({
+            name: "ApiError",
+            message: "Failed to update organizational scope",
+            statusCode: 500,
+        } satisfies Partial<ApiError>);
+    });
 });

--- a/src/services/organizationalScopeApi.test.ts
+++ b/src/services/organizationalScopeApi.test.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "./ApiError";
+import { updateOrganizationalScope } from "./organizationalScopeApi";
+
+vi.mock("./csrf", () => ({
+    apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from "./csrf";
+
+const mockApiFetch = vi.mocked(apiFetch);
+
+describe("organizationalScopeApi", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("forwards authorization messages from organizational scope updates", async () => {
+        mockApiFetch.mockResolvedValue({
+            ok: false,
+            status: 403,
+            json: async () => ({
+                message:
+                    "You cannot remove your own last scope-management access for this organizational unit.",
+            }),
+        } as Response);
+
+        await expect(
+            updateOrganizationalScope("unit-1", "scope-1", {
+                access_level: "manage",
+            })
+        ).rejects.toMatchObject({
+            name: "ApiError",
+            message:
+                "You cannot remove your own last scope-management access for this organizational unit.",
+            statusCode: 403,
+        } satisfies Partial<ApiError>);
+    });
+});

--- a/src/services/organizationalScopeApi.test.ts
+++ b/src/services/organizationalScopeApi.test.ts
@@ -4,15 +4,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "./ApiError";
 import {
-    createOrganizationalScope,
-    deleteOrganizationalScope,
-    getMyOrganizationalScopes,
-    listOrganizationalScopes,
-    updateOrganizationalScope,
+  createOrganizationalScope,
+  deleteOrganizationalScope,
+  getMyOrganizationalScopes,
+  listOrganizationalScopes,
+  updateOrganizationalScope,
 } from "./organizationalScopeApi";
 
 vi.mock("./csrf", () => ({
-    apiFetch: vi.fn(),
+  apiFetch: vi.fn(),
 }));
 
 import { apiFetch } from "./csrf";
@@ -20,108 +20,108 @@ import { apiFetch } from "./csrf";
 const mockApiFetch = vi.mocked(apiFetch);
 
 describe("organizationalScopeApi", () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-    });
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
-    it("forwards authorization messages from organizational scope updates", async () => {
-        mockApiFetch.mockResolvedValue({
-            ok: false,
-            status: 403,
-            json: async () => ({
-                message:
-                    "You cannot remove your own last scope-management access for this organizational unit.",
-            }),
-        } as Response);
+  it("forwards authorization messages from organizational scope updates", async () => {
+    mockApiFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({
+        message:
+          "You cannot remove your own last scope-management access for this organizational unit.",
+      }),
+    } as Response);
 
-        await expect(
-            updateOrganizationalScope("unit-1", "scope-1", {
-                access_level: "manage",
-            })
-        ).rejects.toMatchObject({
-            name: "ApiError",
-            message:
-                "You cannot remove your own last scope-management access for this organizational unit.",
-            statusCode: 403,
-        } satisfies Partial<ApiError>);
-    });
+    await expect(
+      updateOrganizationalScope("unit-1", "scope-1", {
+        access_level: "manage",
+      })
+    ).rejects.toMatchObject({
+      name: "ApiError",
+      message:
+        "You cannot remove your own last scope-management access for this organizational unit.",
+      statusCode: 403,
+    } satisfies Partial<ApiError>);
+  });
 
-    it("throws ApiError with status code on scope list failure", async () => {
-        mockApiFetch.mockResolvedValue({
-            ok: false,
-            status: 403,
-            json: async () => ({ message: "Forbidden" }),
-        } as Response);
+  it("throws ApiError with status code on scope list failure", async () => {
+    mockApiFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ message: "Forbidden" }),
+    } as Response);
 
-        await expect(listOrganizationalScopes("unit-1")).rejects.toMatchObject({
-            name: "ApiError",
-            message: "Forbidden",
-            statusCode: 403,
-        } satisfies Partial<ApiError>);
-    });
+    await expect(listOrganizationalScopes("unit-1")).rejects.toMatchObject({
+      name: "ApiError",
+      message: "Forbidden",
+      statusCode: 403,
+    } satisfies Partial<ApiError>);
+  });
 
-    it("throws ApiError with status code on scope create failure", async () => {
-        mockApiFetch.mockResolvedValue({
-            ok: false,
-            status: 422,
-            json: async () => ({ message: "Unprocessable Entity" }),
-        } as Response);
+  it("throws ApiError with status code on scope create failure", async () => {
+    mockApiFetch.mockResolvedValue({
+      ok: false,
+      status: 422,
+      json: async () => ({ message: "Unprocessable Entity" }),
+    } as Response);
 
-        await expect(
-            createOrganizationalScope("unit-1", {
-                user_id: "user-1",
-                organizational_unit_id: "unit-1",
-                access_level: "read",
-            })
-        ).rejects.toMatchObject({
-            name: "ApiError",
-            statusCode: 422,
-        } satisfies Partial<ApiError>);
-    });
+    await expect(
+      createOrganizationalScope("unit-1", {
+        user_id: "user-1",
+        organizational_unit_id: "unit-1",
+        access_level: "read",
+      })
+    ).rejects.toMatchObject({
+      name: "ApiError",
+      statusCode: 422,
+    } satisfies Partial<ApiError>);
+  });
 
-    it("throws ApiError with status code on scope delete failure", async () => {
-        mockApiFetch.mockResolvedValue({
-            ok: false,
-            status: 404,
-            json: async () => ({ message: "Not Found" }),
-        } as Response);
+  it("throws ApiError with status code on scope delete failure", async () => {
+    mockApiFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ message: "Not Found" }),
+    } as Response);
 
-        await expect(
-            deleteOrganizationalScope("unit-1", "scope-1")
-        ).rejects.toMatchObject({
-            name: "ApiError",
-            statusCode: 404,
-        } satisfies Partial<ApiError>);
-    });
+    await expect(
+      deleteOrganizationalScope("unit-1", "scope-1")
+    ).rejects.toMatchObject({
+      name: "ApiError",
+      statusCode: 404,
+    } satisfies Partial<ApiError>);
+  });
 
-    it("throws ApiError with status code on my-scopes fetch failure", async () => {
-        mockApiFetch.mockResolvedValue({
-            ok: false,
-            status: 401,
-            json: async () => ({ message: "Unauthenticated" }),
-        } as Response);
+  it("throws ApiError with status code on my-scopes fetch failure", async () => {
+    mockApiFetch.mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ message: "Unauthenticated" }),
+    } as Response);
 
-        await expect(getMyOrganizationalScopes()).rejects.toMatchObject({
-            name: "ApiError",
-            statusCode: 401,
-        } satisfies Partial<ApiError>);
-    });
+    await expect(getMyOrganizationalScopes()).rejects.toMatchObject({
+      name: "ApiError",
+      statusCode: 401,
+    } satisfies Partial<ApiError>);
+  });
 
-    it("falls back to built-in message when response body cannot be parsed", async () => {
-        mockApiFetch.mockResolvedValue({
-            ok: false,
-            status: 500,
-            json: async () => {
-                throw new Error("invalid json");
-            },
-        } as unknown as Response);
+  it("falls back to built-in message when response body cannot be parsed", async () => {
+    mockApiFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => {
+        throw new Error("invalid json");
+      },
+    } as unknown as Response);
 
-        await expect(
-            updateOrganizationalScope("unit-1", "scope-1", { access_level: "read" })
-        ).rejects.toMatchObject({
-            name: "ApiError",
-            message: "Failed to update organizational scope",
-            statusCode: 500,
-        } satisfies Partial<ApiError>);
-    });
+    await expect(
+      updateOrganizationalScope("unit-1", "scope-1", { access_level: "read" })
+    ).rejects.toMatchObject({
+      name: "ApiError",
+      message: "Failed to update organizational scope",
+      statusCode: 500,
+    } satisfies Partial<ApiError>);
+  });
 });

--- a/src/services/organizationalScopeApi.ts
+++ b/src/services/organizationalScopeApi.ts
@@ -3,6 +3,7 @@
 
 import { apiConfig } from "../config";
 import { apiFetch } from "./csrf";
+import { ApiError } from "./ApiError";
 import type { OrganizationalScope } from "../types/organizationalScope";
 
 export interface OrganizationalScopeFormData {
@@ -18,6 +19,22 @@ export interface OrganizationalScopeFormData {
   allow_self_access?: boolean;
 }
 
+async function buildScopeApiError(
+  response: Response,
+  fallbackMessage: string
+): Promise<ApiError> {
+  const error = await response
+    .json()
+    .catch(() => ({ message: fallbackMessage }));
+
+  return new ApiError(
+    error.message || fallbackMessage,
+    response.status,
+    error.errors,
+    response
+  );
+}
+
 /**
  * Fetch all scope assignments for an organizational unit
  */
@@ -29,7 +46,10 @@ export async function listOrganizationalScopes(
   );
 
   if (!response.ok) {
-    throw new Error("Failed to fetch organizational scopes");
+    throw await buildScopeApiError(
+      response,
+      "Failed to fetch organizational scopes"
+    );
   }
 
   return await response.json();
@@ -54,7 +74,10 @@ export async function createOrganizationalScope(
   );
 
   if (!response.ok) {
-    throw new Error("Failed to create organizational scope");
+    throw await buildScopeApiError(
+      response,
+      "Failed to create organizational scope"
+    );
   }
 
   return await response.json();
@@ -80,7 +103,10 @@ export async function updateOrganizationalScope(
   );
 
   if (!response.ok) {
-    throw new Error("Failed to update organizational scope");
+    throw await buildScopeApiError(
+      response,
+      "Failed to update organizational scope"
+    );
   }
 
   return await response.json();
@@ -101,7 +127,10 @@ export async function deleteOrganizationalScope(
   );
 
   if (!response.ok) {
-    throw new Error("Failed to delete organizational scope");
+    throw await buildScopeApiError(
+      response,
+      "Failed to delete organizational scope"
+    );
   }
 }
 
@@ -116,7 +145,10 @@ export async function getMyOrganizationalScopes(): Promise<{
   );
 
   if (!response.ok) {
-    throw new Error("Failed to fetch my organizational scopes");
+    throw await buildScopeApiError(
+      response,
+      "Failed to fetch my organizational scopes"
+    );
   }
 
   return await response.json();

--- a/src/services/organizationalScopeApi.ts
+++ b/src/services/organizationalScopeApi.ts
@@ -1,9 +1,9 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { apiConfig } from "../config";
 import { apiFetch } from "./csrf";
-import { ApiError } from "./ApiError";
+import { ApiError, type ApiValidationErrors } from "./ApiError";
 import type { OrganizationalScope } from "../types/organizationalScope";
 
 export interface OrganizationalScopeFormData {
@@ -23,14 +23,20 @@ async function buildScopeApiError(
   response: Response,
   fallbackMessage: string
 ): Promise<ApiError> {
-  const error = await response
-    .json()
-    .catch(() => ({ message: fallbackMessage }));
+  const body: unknown = await response.json().catch(() => null);
+  const error =
+    typeof body === "object" && body !== null
+      ? (body as Record<string, unknown>)
+      : null;
 
   return new ApiError(
-    error.message || fallbackMessage,
+    typeof error?.message === "string" && error.message.length > 0
+      ? error.message
+      : fallbackMessage,
     response.status,
-    error.errors,
+    typeof error?.errors === "object" && error.errors !== null
+      ? (error.errors as ApiValidationErrors)
+      : undefined,
     response
   );
 }

--- a/tests/e2e/organization.spec.ts
+++ b/tests/e2e/organization.spec.ts
@@ -149,7 +149,10 @@ test.describe("Organization Management", () => {
           return;
         }
 
-        if (method === "GET") {
+        if (
+          method === "GET" &&
+          /\/v1\/organizational-units(\?.*)?$/.test(url)
+        ) {
           const units: Array<Record<string, unknown>> = [
             offlineLiveMockOrganizationUnit,
           ];
@@ -157,7 +160,7 @@ test.describe("Organization Management", () => {
           if (childUnitCreated) {
             postCreateListRequestCount += 1;
 
-            if (postCreateListRequestCount > 1) {
+            if (postCreateListRequestCount >= 1) {
               units.push({
                 id: CREATED_CHILD_UNIT_ID,
                 type: "company",
@@ -313,17 +316,19 @@ test.describe("Organization Management", () => {
         name: MOVED_UNIT_NAME,
         custom_type_name: null,
         description: movedUnitDescription,
-        parent: moveCompleted
-          ? {
-              id: TARGET_PARENT_ID,
-              type: "company",
-              name: TARGET_PARENT_NAME,
-            }
-          : {
-              id: offlineLiveMockOrganizationUnit.id,
-              type: offlineLiveMockOrganizationUnit.type,
-              name: offlineLiveMockOrganizationUnit.name,
-            },
+        get parent() {
+          return moveCompleted
+            ? {
+                id: TARGET_PARENT_ID,
+                type: "company",
+                name: TARGET_PARENT_NAME,
+              }
+            : {
+                id: offlineLiveMockOrganizationUnit.id,
+                type: offlineLiveMockOrganizationUnit.type,
+                name: offlineLiveMockOrganizationUnit.name,
+              };
+        },
         created_at: "2026-04-29T10:00:00Z",
         updated_at: "2026-04-29T10:00:00Z",
       };
@@ -340,6 +345,11 @@ test.describe("Organization Management", () => {
       };
 
       await context.route("**/v1/organizational-units**", async (route) => {
+        if (!/\/v1\/organizational-units(\?.*)?$/.test(route.request().url())) {
+          await route.fallback();
+          return;
+        }
+
         await route.fulfill({
           status: 200,
           contentType: "application/json",

--- a/tests/e2e/organization.spec.ts
+++ b/tests/e2e/organization.spec.ts
@@ -340,8 +340,6 @@ test.describe("Organization Management", () => {
       };
 
       await context.route("**/v1/organizational-units**", async (route) => {
-        const request = route.request();
-
         await route.fulfill({
           status: 200,
           contentType: "application/json",
@@ -455,7 +453,7 @@ test.describe("Organization Management", () => {
       await page.getByRole("menuitem", { name: /move/i }).click();
 
       await expect(
-        page.getByText(new RegExp(`Move \"${MOVED_UNIT_NAME}\"`, "i"))
+        page.getByText(new RegExp(`Move "${MOVED_UNIT_NAME}"`, "i"))
       ).toBeVisible();
       await page.getByRole("button", { name: /select new parent/i }).click();
       await page

--- a/tests/e2e/organization.spec.ts
+++ b/tests/e2e/organization.spec.ts
@@ -51,8 +51,8 @@ test.describe("Organization Management", () => {
           headers:
             organizationRequestCount === 1
               ? {
-                "set-cookie": `XSRF-TOKEN=${ROTATED_XSRF_TOKEN}; Path=/; SameSite=Lax`,
-              }
+                  "set-cookie": `XSRF-TOKEN=${ROTATED_XSRF_TOKEN}; Path=/; SameSite=Lax`,
+                }
               : {},
           body: JSON.stringify({
             data: [offlineLiveMockOrganizationUnit],
@@ -255,18 +255,21 @@ test.describe("Organization Management", () => {
       await page.goto("/organization");
       await page.waitForLoadState("networkidle");
 
-      await page.getByText(offlineLiveMockOrganizationUnit.name).first().click();
+      await page
+        .getByText(offlineLiveMockOrganizationUnit.name)
+        .first()
+        .click();
       await page.getByRole("button", { name: /add child unit/i }).click();
 
-      await expect(
-        page.getByText(/create organizational unit/i)
-      ).toBeVisible();
+      await expect(page.getByText(/create organizational unit/i)).toBeVisible();
 
       await page.getByLabel(/name/i).fill(CREATED_CHILD_UNIT_NAME);
       await page.getByRole("button", { name: /^create$/i }).click();
 
       const childTreeItem = page
-        .getByRole("treeitem", { name: new RegExp(CREATED_CHILD_UNIT_NAME, "i") })
+        .getByRole("treeitem", {
+          name: new RegExp(CREATED_CHILD_UNIT_NAME, "i"),
+        })
         .first();
 
       await expect(childTreeItem).toBeVisible();
@@ -274,9 +277,7 @@ test.describe("Organization Management", () => {
       await childTreeItem.click();
       await expect(page.getByRole("button", { name: /^edit$/i })).toBeVisible();
       await page.getByRole("button", { name: /^edit$/i }).click();
-      await expect(
-        page.getByText(/edit organizational unit/i)
-      ).toBeVisible();
+      await expect(page.getByText(/edit organizational unit/i)).toBeVisible();
 
       await page.getByLabel(/description/i).fill(UPDATED_CHILD_DESCRIPTION);
       await page.getByRole("button", { name: /save changes/i }).click();
@@ -287,16 +288,16 @@ test.describe("Organization Management", () => {
       await page.waitForLoadState("networkidle");
 
       const reloadedChildTreeItem = page
-        .getByRole("treeitem", { name: new RegExp(CREATED_CHILD_UNIT_NAME, "i") })
+        .getByRole("treeitem", {
+          name: new RegExp(CREATED_CHILD_UNIT_NAME, "i"),
+        })
         .first();
 
       await expect(reloadedChildTreeItem).toBeVisible();
 
       await reloadedChildTreeItem.click();
       await expect(page.getByText(UPDATED_CHILD_DESCRIPTION)).toBeVisible();
-      await expect(
-        page.getByRole("button", { name: /^edit$/i })
-      ).toBeVisible();
+      await expect(page.getByRole("button", { name: /^edit$/i })).toBeVisible();
     });
 
     test("should keep a moved unit visible and editable after reload", async ({
@@ -314,15 +315,15 @@ test.describe("Organization Management", () => {
         description: movedUnitDescription,
         parent: moveCompleted
           ? {
-            id: TARGET_PARENT_ID,
-            type: "company",
-            name: TARGET_PARENT_NAME,
-          }
+              id: TARGET_PARENT_ID,
+              type: "company",
+              name: TARGET_PARENT_NAME,
+            }
           : {
-            id: offlineLiveMockOrganizationUnit.id,
-            type: offlineLiveMockOrganizationUnit.type,
-            name: offlineLiveMockOrganizationUnit.name,
-          },
+              id: offlineLiveMockOrganizationUnit.id,
+              type: offlineLiveMockOrganizationUnit.type,
+              name: offlineLiveMockOrganizationUnit.name,
+            },
         created_at: "2026-04-29T10:00:00Z",
         updated_at: "2026-04-29T10:00:00Z",
       };
@@ -353,15 +354,15 @@ test.describe("Organization Management", () => {
                 description: movedUnitDescription,
                 parent: moveCompleted
                   ? {
-                    id: TARGET_PARENT_ID,
-                    type: "company",
-                    name: TARGET_PARENT_NAME,
-                  }
+                      id: TARGET_PARENT_ID,
+                      type: "company",
+                      name: TARGET_PARENT_NAME,
+                    }
                   : {
-                    id: offlineLiveMockOrganizationUnit.id,
-                    type: offlineLiveMockOrganizationUnit.type,
-                    name: offlineLiveMockOrganizationUnit.name,
-                  },
+                      id: offlineLiveMockOrganizationUnit.id,
+                      type: offlineLiveMockOrganizationUnit.type,
+                      name: offlineLiveMockOrganizationUnit.name,
+                    },
               },
             ],
             meta: {
@@ -369,7 +370,10 @@ test.describe("Organization Management", () => {
               last_page: 1,
               per_page: 100,
               total: 3,
-              root_unit_ids: [offlineLiveMockOrganizationUnit.id, TARGET_PARENT_ID],
+              root_unit_ids: [
+                offlineLiveMockOrganizationUnit.id,
+                TARGET_PARENT_ID,
+              ],
             },
           }),
         });
@@ -418,15 +422,15 @@ test.describe("Organization Management", () => {
                 description: movedUnitDescription,
                 parent: moveCompleted
                   ? {
-                    id: TARGET_PARENT_ID,
-                    type: "company",
-                    name: TARGET_PARENT_NAME,
-                  }
+                      id: TARGET_PARENT_ID,
+                      type: "company",
+                      name: TARGET_PARENT_NAME,
+                    }
                   : {
-                    id: offlineLiveMockOrganizationUnit.id,
-                    type: offlineLiveMockOrganizationUnit.type,
-                    name: offlineLiveMockOrganizationUnit.name,
-                  },
+                      id: offlineLiveMockOrganizationUnit.id,
+                      type: offlineLiveMockOrganizationUnit.type,
+                      name: offlineLiveMockOrganizationUnit.name,
+                    },
                 updated_at: "2026-04-29T10:06:00Z",
               },
             }),
@@ -450,9 +454,13 @@ test.describe("Organization Management", () => {
       await moveActionsButton.click();
       await page.getByRole("menuitem", { name: /move/i }).click();
 
-      await expect(page.getByText(new RegExp(`Move \"${MOVED_UNIT_NAME}\"`, "i"))).toBeVisible();
+      await expect(
+        page.getByText(new RegExp(`Move \"${MOVED_UNIT_NAME}\"`, "i"))
+      ).toBeVisible();
       await page.getByRole("button", { name: /select new parent/i }).click();
-      await page.getByRole("option", { name: new RegExp(TARGET_PARENT_NAME, "i") }).click();
+      await page
+        .getByRole("option", { name: new RegExp(TARGET_PARENT_NAME, "i") })
+        .click();
       await page.getByRole("button", { name: /^move$/i }).click();
 
       const reparentedTreeItem = page

--- a/tests/e2e/organization.spec.ts
+++ b/tests/e2e/organization.spec.ts
@@ -6,6 +6,13 @@ import { offlineLiveMockOrganizationUnit } from "./offline-live-helpers";
 import { getCachedOrgUnitsCount } from "../utils/offline-helpers";
 
 const ROTATED_XSRF_TOKEN = "rotated-xsrf-token";
+const CREATED_CHILD_UNIT_ID = "org-child-1";
+const CREATED_CHILD_UNIT_NAME = "Operations Branch";
+const UPDATED_CHILD_DESCRIPTION = "Updated after create";
+const MOVED_UNIT_ID = "org-move-1";
+const MOVED_UNIT_NAME = "Field Office";
+const TARGET_PARENT_ID = "org-target-parent";
+const TARGET_PARENT_NAME = "Northern Region";
 
 /**
  * Organization Management E2E Tests
@@ -44,8 +51,8 @@ test.describe("Organization Management", () => {
           headers:
             organizationRequestCount === 1
               ? {
-                  "set-cookie": `XSRF-TOKEN=${ROTATED_XSRF_TOKEN}; Path=/; SameSite=Lax`,
-                }
+                "set-cookie": `XSRF-TOKEN=${ROTATED_XSRF_TOKEN}; Path=/; SameSite=Lax`,
+              }
               : {},
           body: JSON.stringify({
             data: [offlineLiveMockOrganizationUnit],
@@ -100,6 +107,386 @@ test.describe("Organization Management", () => {
         page.getByText("Offline vault is not available.")
       ).toHaveCount(0);
       expect(organizationRequestCount).toBeGreaterThanOrEqual(2);
+    });
+
+    test("should keep a newly created child unit visible and editable after reload", async ({
+      authenticatedPage: page,
+    }) => {
+      const context = page.context();
+      let childUnitDescription: string | null = null;
+      let childUnitCreated = false;
+      let postCreateListRequestCount = 0;
+
+      await context.route("**/v1/organizational-units**", async (route) => {
+        const request = route.request();
+        const method = request.method();
+        const url = request.url();
+
+        if (method === "POST" && /\/v1\/organizational-units$/.test(url)) {
+          childUnitCreated = true;
+
+          await route.fulfill({
+            status: 201,
+            contentType: "application/json",
+            body: JSON.stringify({
+              data: {
+                id: CREATED_CHILD_UNIT_ID,
+                type: "company",
+                name: CREATED_CHILD_UNIT_NAME,
+                custom_type_name: null,
+                description: childUnitDescription,
+                parent: {
+                  id: offlineLiveMockOrganizationUnit.id,
+                  type: offlineLiveMockOrganizationUnit.type,
+                  name: offlineLiveMockOrganizationUnit.name,
+                },
+                created_at: "2026-04-29T10:00:00Z",
+                updated_at: "2026-04-29T10:00:00Z",
+              },
+            }),
+          });
+
+          return;
+        }
+
+        if (method === "GET") {
+          const units: Array<Record<string, unknown>> = [
+            offlineLiveMockOrganizationUnit,
+          ];
+
+          if (childUnitCreated) {
+            postCreateListRequestCount += 1;
+
+            if (postCreateListRequestCount > 1) {
+              units.push({
+                id: CREATED_CHILD_UNIT_ID,
+                type: "company",
+                name: CREATED_CHILD_UNIT_NAME,
+                custom_type_name: null,
+                description: childUnitDescription,
+                parent: {
+                  id: offlineLiveMockOrganizationUnit.id,
+                  type: offlineLiveMockOrganizationUnit.type,
+                  name: offlineLiveMockOrganizationUnit.name,
+                },
+                created_at: "2026-04-29T10:00:00Z",
+                updated_at: "2026-04-29T10:00:00Z",
+              });
+            }
+          }
+
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+              data: units,
+              meta: {
+                current_page: 1,
+                last_page: 1,
+                per_page: 100,
+                total: units.length,
+                root_unit_ids: [offlineLiveMockOrganizationUnit.id],
+              },
+            }),
+          });
+
+          return;
+        }
+
+        await route.fallback();
+      });
+
+      await context.route(
+        `**/v1/organizational-units/${CREATED_CHILD_UNIT_ID}`,
+        async (route) => {
+          const request = route.request();
+
+          if (request.method() === "PATCH") {
+            const payload = request.postDataJSON() as { description?: string };
+            childUnitDescription = payload.description ?? null;
+
+            await route.fulfill({
+              status: 200,
+              contentType: "application/json",
+              body: JSON.stringify({
+                data: {
+                  id: CREATED_CHILD_UNIT_ID,
+                  type: "company",
+                  name: CREATED_CHILD_UNIT_NAME,
+                  custom_type_name: null,
+                  description: childUnitDescription,
+                  parent: {
+                    id: offlineLiveMockOrganizationUnit.id,
+                    type: offlineLiveMockOrganizationUnit.type,
+                    name: offlineLiveMockOrganizationUnit.name,
+                  },
+                  created_at: "2026-04-29T10:00:00Z",
+                  updated_at: "2026-04-29T10:05:00Z",
+                },
+              }),
+            });
+
+            return;
+          }
+
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+              data: {
+                id: CREATED_CHILD_UNIT_ID,
+                type: "company",
+                name: CREATED_CHILD_UNIT_NAME,
+                custom_type_name: null,
+                description: childUnitDescription,
+                parent: {
+                  id: offlineLiveMockOrganizationUnit.id,
+                  type: offlineLiveMockOrganizationUnit.type,
+                  name: offlineLiveMockOrganizationUnit.name,
+                },
+                created_at: "2026-04-29T10:00:00Z",
+                updated_at: "2026-04-29T10:05:00Z",
+              },
+            }),
+          });
+        }
+      );
+
+      await page.goto("/organization");
+      await page.waitForLoadState("networkidle");
+
+      await page.getByText(offlineLiveMockOrganizationUnit.name).first().click();
+      await page.getByRole("button", { name: /add child unit/i }).click();
+
+      await expect(
+        page.getByText(/create organizational unit/i)
+      ).toBeVisible();
+
+      await page.getByLabel(/name/i).fill(CREATED_CHILD_UNIT_NAME);
+      await page.getByRole("button", { name: /^create$/i }).click();
+
+      const childTreeItem = page
+        .getByRole("treeitem", { name: new RegExp(CREATED_CHILD_UNIT_NAME, "i") })
+        .first();
+
+      await expect(childTreeItem).toBeVisible();
+
+      await childTreeItem.click();
+      await expect(page.getByRole("button", { name: /^edit$/i })).toBeVisible();
+      await page.getByRole("button", { name: /^edit$/i }).click();
+      await expect(
+        page.getByText(/edit organizational unit/i)
+      ).toBeVisible();
+
+      await page.getByLabel(/description/i).fill(UPDATED_CHILD_DESCRIPTION);
+      await page.getByRole("button", { name: /save changes/i }).click();
+
+      await expect(page.getByText(UPDATED_CHILD_DESCRIPTION)).toBeVisible();
+
+      await page.reload();
+      await page.waitForLoadState("networkidle");
+
+      const reloadedChildTreeItem = page
+        .getByRole("treeitem", { name: new RegExp(CREATED_CHILD_UNIT_NAME, "i") })
+        .first();
+
+      await expect(reloadedChildTreeItem).toBeVisible();
+
+      await reloadedChildTreeItem.click();
+      await expect(page.getByText(UPDATED_CHILD_DESCRIPTION)).toBeVisible();
+      await expect(
+        page.getByRole("button", { name: /^edit$/i })
+      ).toBeVisible();
+    });
+
+    test("should keep a moved unit visible and editable after reload", async ({
+      authenticatedPage: page,
+    }) => {
+      const context = page.context();
+      let moveCompleted = false;
+      let movedUnitDescription: string | null = null;
+
+      const movedUnit = {
+        id: MOVED_UNIT_ID,
+        type: "department",
+        name: MOVED_UNIT_NAME,
+        custom_type_name: null,
+        description: movedUnitDescription,
+        parent: moveCompleted
+          ? {
+            id: TARGET_PARENT_ID,
+            type: "company",
+            name: TARGET_PARENT_NAME,
+          }
+          : {
+            id: offlineLiveMockOrganizationUnit.id,
+            type: offlineLiveMockOrganizationUnit.type,
+            name: offlineLiveMockOrganizationUnit.name,
+          },
+        created_at: "2026-04-29T10:00:00Z",
+        updated_at: "2026-04-29T10:00:00Z",
+      };
+
+      const targetParent = {
+        id: TARGET_PARENT_ID,
+        type: "company",
+        name: TARGET_PARENT_NAME,
+        custom_type_name: null,
+        description: null,
+        parent: null,
+        created_at: "2026-04-29T09:00:00Z",
+        updated_at: "2026-04-29T09:00:00Z",
+      };
+
+      await context.route("**/v1/organizational-units**", async (route) => {
+        const request = route.request();
+
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            data: [
+              offlineLiveMockOrganizationUnit,
+              targetParent,
+              {
+                ...movedUnit,
+                description: movedUnitDescription,
+                parent: moveCompleted
+                  ? {
+                    id: TARGET_PARENT_ID,
+                    type: "company",
+                    name: TARGET_PARENT_NAME,
+                  }
+                  : {
+                    id: offlineLiveMockOrganizationUnit.id,
+                    type: offlineLiveMockOrganizationUnit.type,
+                    name: offlineLiveMockOrganizationUnit.name,
+                  },
+              },
+            ],
+            meta: {
+              current_page: 1,
+              last_page: 1,
+              per_page: 100,
+              total: 3,
+              root_unit_ids: [offlineLiveMockOrganizationUnit.id, TARGET_PARENT_ID],
+            },
+          }),
+        });
+      });
+
+      await context.route(
+        `**/v1/organizational-units/${MOVED_UNIT_ID}/parent`,
+        async (route) => {
+          moveCompleted = true;
+
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+              data: {
+                ...movedUnit,
+                description: movedUnitDescription,
+                parent: {
+                  id: TARGET_PARENT_ID,
+                  type: "company",
+                  name: TARGET_PARENT_NAME,
+                },
+                updated_at: "2026-04-29T10:05:00Z",
+              },
+            }),
+          });
+        }
+      );
+
+      await context.route(
+        `**/v1/organizational-units/${MOVED_UNIT_ID}`,
+        async (route) => {
+          const request = route.request();
+
+          if (request.method() === "PATCH") {
+            const payload = request.postDataJSON() as { description?: string };
+            movedUnitDescription = payload.description ?? null;
+          }
+
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+              data: {
+                ...movedUnit,
+                description: movedUnitDescription,
+                parent: moveCompleted
+                  ? {
+                    id: TARGET_PARENT_ID,
+                    type: "company",
+                    name: TARGET_PARENT_NAME,
+                  }
+                  : {
+                    id: offlineLiveMockOrganizationUnit.id,
+                    type: offlineLiveMockOrganizationUnit.type,
+                    name: offlineLiveMockOrganizationUnit.name,
+                  },
+                updated_at: "2026-04-29T10:06:00Z",
+              },
+            }),
+          });
+        }
+      );
+
+      await page.goto("/organization");
+      await page.waitForLoadState("networkidle");
+
+      const movedUnitTreeItem = page
+        .getByRole("treeitem", { name: new RegExp(MOVED_UNIT_NAME, "i") })
+        .first();
+
+      await movedUnitTreeItem.click();
+      await expect(page.getByRole("button", { name: /^edit$/i })).toBeVisible();
+
+      const moveActionsButton = page.getByRole("button", {
+        name: new RegExp(`Actions for ${MOVED_UNIT_NAME}`, "i"),
+      });
+      await moveActionsButton.click();
+      await page.getByRole("menuitem", { name: /move/i }).click();
+
+      await expect(page.getByText(new RegExp(`Move \"${MOVED_UNIT_NAME}\"`, "i"))).toBeVisible();
+      await page.getByRole("button", { name: /select new parent/i }).click();
+      await page.getByRole("option", { name: new RegExp(TARGET_PARENT_NAME, "i") }).click();
+      await page.getByRole("button", { name: /^move$/i }).click();
+
+      const reparentedTreeItem = page
+        .getByRole("treeitem", { name: new RegExp(MOVED_UNIT_NAME, "i") })
+        .first();
+      await expect(reparentedTreeItem).toBeVisible();
+
+      await reparentedTreeItem.click();
+      await expect(
+        page.getByRole("definition").filter({ hasText: TARGET_PARENT_NAME })
+      ).toBeVisible();
+
+      await page.getByRole("button", { name: /^edit$/i }).click();
+      await expect(page.getByText(/edit organizational unit/i)).toBeVisible();
+
+      await page.getByLabel(/description/i).fill("Updated after move");
+      await page.getByRole("button", { name: /save changes/i }).click();
+
+      await expect(page.getByText("Updated after move")).toBeVisible();
+
+      await page.reload();
+      await page.waitForLoadState("networkidle");
+
+      const reloadedMovedTreeItem = page
+        .getByRole("treeitem", { name: new RegExp(MOVED_UNIT_NAME, "i") })
+        .first();
+      await expect(reloadedMovedTreeItem).toBeVisible();
+
+      await reloadedMovedTreeItem.click();
+      await expect(
+        page.getByRole("definition").filter({ hasText: TARGET_PARENT_NAME })
+      ).toBeVisible();
+      await expect(page.getByText("Updated after move")).toBeVisible();
+      await expect(page.getByRole("button", { name: /^edit$/i })).toBeVisible();
     });
   });
 


### PR DESCRIPTION
## Summary
- keep /organization child-create and move flows visible, editable, and reload-stable with focused Playwright regression coverage
- update optimistic tree reparenting so moved units refresh their parent metadata consistently in the detail panel
- forward organizational scope API failures as ApiError so dialogs show actionable backend authorization messages

## Validation
- npx vitest run src/components/OrganizationalUnitTree.test.tsx src/services/organizationalScopeApi.test.ts
- npx playwright test tests/e2e/organization.spec.ts
- npm run typecheck

## Issue Links
- Closes SecPal/.github#398
- Part of SecPal/.github#400
