### PR TITLE
fix: preserve sequential organization optimistic creates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Preserved `/organization` tree state across back-to-back optimistic creates by keeping newly created parent units in the local tree overlay until the offline-sync hook has fetched them for real, so creating a company and then an immediate child branch no longer collapses the tree back to only the holding until a manual reload.
 - Replaced the placeholder pre-contract onboarding wizard with a schema-driven Catalyst form that renders localized template fields, restores saved draft answers, uses inline feedback instead of browser alerts, and updates existing onboarding submissions via `PATCH` before navigation or review submission.
 - Corrected the `/organization` Playwright XSRF-rotation regression to rotate the browser-visible app cookie instead of asserting a brittle cross-origin cookie detail, added end-to-end coverage that keeps restricted child-unit delete actions hidden across reloads, guarded the repaired live parent relationship on `app.secpal.dev`, and added an opt-in live CRUD proof for creating and deleting a child unit under `Headquarters` against the real live stack.
 - Hid `/organization` tree actions when the current unit permissions deny them and extended the child-create reload regression to assert the selected unit still shows its parent after refresh, so users no longer get offered unauthorized delete/edit/move actions and the child-create cache regression stays covered end-to-end

--- a/src/components/OrganizationalUnitTree.test.tsx
+++ b/src/components/OrganizationalUnitTree.test.tsx
@@ -584,6 +584,76 @@ describe("OrganizationalUnitTree", () => {
         expect(screen.getByText("New Branch")).toBeInTheDocument();
       });
     });
+
+    it("applies multiple pending optimistic creations in order", async () => {
+      vi.mocked(useOrganizationalUnitsWithOffline).mockReturnValue({
+        ...mockHookResponse,
+        units: [
+          {
+            id: "holding-1",
+            type: "holding",
+            name: "SecPal Holding",
+            permissions: mockPermissions,
+            created_at: "2025-01-01T00:00:00Z",
+            updated_at: "2025-01-01T00:00:00Z",
+          },
+        ],
+        rootUnitIds: ["holding-1"],
+      });
+
+      const createdCompany: OrganizationalUnit = {
+        id: "company-1",
+        type: "company",
+        name: "SecPal GmbH",
+        parent: {
+          id: "holding-1",
+          type: "holding",
+          name: "SecPal Holding",
+          created_at: "2025-01-01T00:00:00Z",
+          updated_at: "2025-01-01T00:00:00Z",
+        },
+        created_at: "2025-01-15T00:00:00Z",
+        updated_at: "2025-01-15T00:00:00Z",
+      };
+
+      const createdBranch: OrganizationalUnit = {
+        id: "branch-1",
+        type: "branch",
+        name: "Berlin Branch",
+        parent: {
+          id: "company-1",
+          type: "company",
+          name: "SecPal GmbH",
+          created_at: "2025-01-15T00:00:00Z",
+          updated_at: "2025-01-15T00:00:00Z",
+        },
+        created_at: "2025-01-16T00:00:00Z",
+        updated_at: "2025-01-16T00:00:00Z",
+      };
+
+      const { rerender } = renderWithI18n(<OrganizationalUnitTree />);
+
+      await waitFor(() => {
+        expect(screen.getByText("SecPal Holding")).toBeInTheDocument();
+      });
+
+      rerender(
+        <I18nProvider i18n={i18n}>
+          <OrganizationalUnitTree
+            createdUnits={[
+              { unit: createdCompany, parentId: "holding-1", key: 1 },
+              { unit: createdBranch, parentId: "company-1", key: 2 },
+            ]}
+          />
+        </I18nProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("SecPal Holding")).toBeInTheDocument();
+        expect(screen.getByText("SecPal GmbH")).toBeInTheDocument();
+        expect(screen.getByText("Berlin Branch")).toBeInTheDocument();
+      });
+    });
   });
 
   describe("Optimistic Move (Issue #303)", () => {

--- a/src/components/OrganizationalUnitTree.tsx
+++ b/src/components/OrganizationalUnitTree.tsx
@@ -480,7 +480,7 @@ function upsertCreatedUnitInTree(
   createdUnit: { unit: OrganizationalUnit; parentId: string | null }
 ): OrganizationalUnit[] {
   if (findUnitInTree(units, createdUnit.unit.id)) {
-    return updateUnitInTree(units, createdUnit.unit);
+    return units;
   }
 
   return addUnitToTree(units, createdUnit.unit, createdUnit.parentId);

--- a/src/components/OrganizationalUnitTree.tsx
+++ b/src/components/OrganizationalUnitTree.tsx
@@ -766,7 +766,8 @@ export function OrganizationalUnitTree({
 
   const units = useMemo(() => {
     let nextUnits = baseUnits;
-    const pendingCreatedUnits = createdUnits ?? (createdUnit ? [createdUnit] : []);
+    const pendingCreatedUnits =
+      createdUnits ?? (createdUnit ? [createdUnit] : []);
 
     for (const pendingCreatedUnit of pendingCreatedUnits) {
       nextUnits = upsertCreatedUnitInTree(nextUnits, pendingCreatedUnit);

--- a/src/components/OrganizationalUnitTree.tsx
+++ b/src/components/OrganizationalUnitTree.tsx
@@ -475,6 +475,17 @@ function addUnitToTree(
   });
 }
 
+function upsertCreatedUnitInTree(
+  units: OrganizationalUnit[],
+  createdUnit: { unit: OrganizationalUnit; parentId: string | null }
+): OrganizationalUnit[] {
+  if (findUnitInTree(units, createdUnit.unit.id)) {
+    return updateUnitInTree(units, createdUnit.unit);
+  }
+
+  return addUnitToTree(units, createdUnit.unit, createdUnit.parentId);
+}
+
 function findUnitInTree(
   units: OrganizationalUnit[],
   unitId: string
@@ -667,6 +678,16 @@ export interface OrganizationalUnitTreeProps {
     key: number;
   } | null;
   /**
+   * Optimistic UI: When provided, applies multiple pending creations in order.
+   * Used when the parent component needs to preserve back-to-back creations until
+   * the offline hook refresh catches up.
+   */
+  createdUnits?: Array<{
+    unit: OrganizationalUnit;
+    parentId: string | null;
+    key: number;
+  }>;
+  /**
    * Optimistic UI: When provided, updates the unit in the tree after editing
    * without reloading. Should contain the updated unit and a unique key.
    */
@@ -706,6 +727,7 @@ export function OrganizationalUnitTree({
   onCreateChild,
   onCreate,
   createdUnit,
+  createdUnits,
   updatedUnit,
   selectedId,
   typeFilter,
@@ -744,13 +766,10 @@ export function OrganizationalUnitTree({
 
   const units = useMemo(() => {
     let nextUnits = baseUnits;
+    const pendingCreatedUnits = createdUnits ?? (createdUnit ? [createdUnit] : []);
 
-    if (createdUnit) {
-      nextUnits = addUnitToTree(
-        nextUnits,
-        createdUnit.unit,
-        createdUnit.parentId
-      );
+    for (const pendingCreatedUnit of pendingCreatedUnits) {
+      nextUnits = upsertCreatedUnitInTree(nextUnits, pendingCreatedUnit);
     }
 
     if (updatedUnit) {
@@ -769,6 +788,7 @@ export function OrganizationalUnitTree({
   }, [
     baseUnits,
     createdUnit,
+    createdUnits,
     updatedUnit,
     locallyDeletedUnitIds,
     locallyMovedParents,

--- a/src/pages/Organization/OrganizationPage.test.tsx
+++ b/src/pages/Organization/OrganizationPage.test.tsx
@@ -517,7 +517,9 @@ describe("OrganizationPage", () => {
       await user.click(screen.getByRole("button", { name: /^Edit$/i }));
 
       await waitFor(() => {
-        expect(screen.getByText("Edit Organizational Unit")).toBeInTheDocument();
+        expect(
+          screen.getByText("Edit Organizational Unit")
+        ).toBeInTheDocument();
       });
 
       const nameInput = screen.getByDisplayValue("SecPal Holding");

--- a/src/pages/Organization/OrganizationPage.test.tsx
+++ b/src/pages/Organization/OrganizationPage.test.tsx
@@ -333,6 +333,150 @@ describe("OrganizationPage", () => {
     SLOW_TEST_TIMEOUT
   );
 
+  it(
+    "keeps a newly created company visible when a child branch is created before hook refresh catches up",
+    async () => {
+      const user = userEvent.setup();
+
+      vi.mocked(
+        organizationalUnitsHook.useOrganizationalUnitsWithOffline
+      ).mockReturnValue({
+        units: [
+          {
+            id: "holding-1",
+            type: "holding",
+            name: "SecPal Holding",
+            description: "Root organizational unit",
+            created_at: "2025-01-01T00:00:00Z",
+            updated_at: "2025-01-01T00:00:00Z",
+            permissions: {
+              create_child: true,
+              update: true,
+              delete: true,
+              manage_scopes: true,
+            },
+          },
+        ],
+        loading: false,
+        error: null,
+        isOffline: false,
+        isStale: false,
+        rootUnitIds: ["holding-1"],
+        lastSynced: null,
+        refresh: vi.fn(),
+      });
+
+      vi.mocked(
+        organizationalUnitApi.createOrganizationalUnit
+      ).mockResolvedValueOnce({
+        id: "company-1",
+        type: "company",
+        name: "SecPal GmbH",
+        description: null,
+        parent: {
+          id: "holding-1",
+          type: "holding",
+          name: "SecPal Holding",
+          created_at: "2025-01-01T00:00:00Z",
+          updated_at: "2025-01-01T00:00:00Z",
+        },
+        permissions: {
+          create_child: true,
+          update: true,
+          delete: true,
+          manage_scopes: true,
+        },
+        created_at: "2025-01-15T00:00:00Z",
+        updated_at: "2025-01-15T00:00:00Z",
+      });
+
+      vi.mocked(
+        organizationalUnitApi.createOrganizationalUnit
+      ).mockResolvedValueOnce({
+        id: "branch-1",
+        type: "branch",
+        name: "Berlin Branch",
+        description: null,
+        parent: {
+          id: "company-1",
+          type: "company",
+          name: "SecPal GmbH",
+          created_at: "2025-01-15T00:00:00Z",
+          updated_at: "2025-01-15T00:00:00Z",
+        },
+        permissions: {
+          create_child: true,
+          update: true,
+          delete: true,
+          manage_scopes: true,
+        },
+        created_at: "2025-01-16T00:00:00Z",
+        updated_at: "2025-01-16T00:00:00Z",
+      });
+
+      renderWithProviders(<OrganizationPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("SecPal Holding")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("SecPal Holding"));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /Add Child Unit/i })
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /Add Child Unit/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Create Organizational Unit")
+        ).toBeInTheDocument();
+      });
+
+      await user.type(
+        screen.getByPlaceholderText(/e\.g\., Berlin Branch/i),
+        "SecPal GmbH"
+      );
+      await user.click(screen.getByRole("button", { name: /^Create$/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText("SecPal GmbH")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("SecPal GmbH"));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /Add Child Unit/i })
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /Add Child Unit/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Create Organizational Unit")
+        ).toBeInTheDocument();
+      });
+
+      await user.type(
+        screen.getByPlaceholderText(/e\.g\., Berlin Branch/i),
+        "Berlin Branch"
+      );
+      await user.click(screen.getByRole("button", { name: /^Create$/i }));
+
+      await waitFor(() => {
+        expect(screen.getAllByText("SecPal Holding").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("SecPal GmbH").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("Berlin Branch").length).toBeGreaterThan(0);
+      });
+    },
+    SLOW_TEST_TIMEOUT
+  );
+
   it("shows all type labels translated correctly", async () => {
     const user = userEvent.setup();
     renderWithProviders(<OrganizationPage />);

--- a/src/pages/Organization/OrganizationPage.test.tsx
+++ b/src/pages/Organization/OrganizationPage.test.tsx
@@ -477,6 +477,64 @@ describe("OrganizationPage", () => {
     SLOW_TEST_TIMEOUT
   );
 
+  it(
+    "updates the selected unit after a successful edit",
+    async () => {
+      const user = userEvent.setup();
+      const updatedUnit: OrganizationalUnit = {
+        id: "unit-1",
+        type: "holding",
+        name: "SecPal Holding Updated",
+        description: "Root organizational unit",
+        permissions: {
+          create_child: true,
+          update: true,
+          delete: true,
+          manage_scopes: true,
+        },
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-02T00:00:00Z",
+      };
+
+      vi.mocked(
+        organizationalUnitApi.updateOrganizationalUnit
+      ).mockResolvedValueOnce(updatedUnit);
+
+      renderWithProviders(<OrganizationPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("SecPal Holding")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("SecPal Holding"));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /^Edit$/i })
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /^Edit$/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Edit Organizational Unit")).toBeInTheDocument();
+      });
+
+      const nameInput = screen.getByDisplayValue("SecPal Holding");
+      await user.clear(nameInput);
+      await user.type(nameInput, updatedUnit.name);
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(`"${updatedUnit.name}" updated successfully`)
+        ).toBeInTheDocument();
+        expect(screen.getAllByText(updatedUnit.name).length).toBeGreaterThan(0);
+      });
+    },
+    SLOW_TEST_TIMEOUT
+  );
+
   it("shows all type labels translated correctly", async () => {
     const user = userEvent.setup();
     renderWithProviders(<OrganizationPage />);

--- a/src/pages/Organization/OrganizationPage.tsx
+++ b/src/pages/Organization/OrganizationPage.tsx
@@ -220,7 +220,9 @@ export function OrganizationPage() {
       if (dialogMode === "create") {
         setOptimisticUpdate((current) => ({
           createdUnits: [
-            ...current.createdUnits.filter((entry) => entry.unit.id !== unit.id),
+            ...current.createdUnits.filter(
+              (entry) => entry.unit.id !== unit.id
+            ),
             { unit, parentId: dialogParentId, key: Date.now() },
           ],
           updatedUnit: null,

--- a/src/pages/Organization/OrganizationPage.tsx
+++ b/src/pages/Organization/OrganizationPage.tsx
@@ -38,7 +38,8 @@ import { useOrganizationalUnitsWithOffline } from "../../hooks/useOrganizational
 /**
  * Optimistic UI state for tree updates without reloading
  * @see Issue #303: UX improvement - avoid full tree reload
- * Each update has a unique key to ensure React triggers the useEffect
+ * Each create entry has a unique key so that replacing an entry with the same unit id
+ * changes the array reference and triggers the memoized tree recomputation.
  */
 interface OptimisticTreeUpdate {
   createdUnits: Array<{

--- a/src/pages/Organization/OrganizationPage.tsx
+++ b/src/pages/Organization/OrganizationPage.tsx
@@ -41,11 +41,11 @@ import { useOrganizationalUnitsWithOffline } from "../../hooks/useOrganizational
  * Each update has a unique key to ensure React triggers the useEffect
  */
 interface OptimisticTreeUpdate {
-  createdUnit: {
+  createdUnits: Array<{
     unit: OrganizationalUnit;
     parentId: string | null;
     key: number;
-  } | null;
+  }>;
   updatedUnit: { unit: OrganizationalUnit; key: number } | null;
 }
 
@@ -88,7 +88,7 @@ export function OrganizationPage() {
   // Optimistic UI state for tree updates (Issue #303)
   const [optimisticUpdate, setOptimisticUpdate] =
     useState<OptimisticTreeUpdate>({
-      createdUnit: null,
+      createdUnits: [],
       updatedUnit: null,
     });
 
@@ -218,15 +218,18 @@ export function OrganizationPage() {
       // Optimistic UI update (Issue #303) - update tree without reload
       // Use Date.now() as key to ensure each update triggers useEffect
       if (dialogMode === "create") {
-        setOptimisticUpdate({
-          createdUnit: { unit, parentId: dialogParentId, key: Date.now() },
+        setOptimisticUpdate((current) => ({
+          createdUnits: [
+            ...current.createdUnits.filter((entry) => entry.unit.id !== unit.id),
+            { unit, parentId: dialogParentId, key: Date.now() },
+          ],
           updatedUnit: null,
-        });
+        }));
       } else {
-        setOptimisticUpdate({
-          createdUnit: null,
+        setOptimisticUpdate((current) => ({
+          createdUnits: current.createdUnits,
           updatedUnit: { unit, key: Date.now() },
-        });
+        }));
         // Update selected unit if editing
         setSelectedUnit(unit);
       }
@@ -292,7 +295,7 @@ export function OrganizationPage() {
             onCreateChild={handleCreateChild}
             onCreate={handleCreate}
             onMove={handleMove}
-            createdUnit={optimisticUpdate.createdUnit}
+            createdUnits={optimisticUpdate.createdUnits}
             updatedUnit={optimisticUpdate.updatedUnit}
             selectedId={selectedUnit?.id}
           />


### PR DESCRIPTION
## Summary
- preserve newly created parent units in the local organization tree overlay until the offline refresh catches up
- apply multiple optimistic creates in order so creating a company and then an immediate child branch does not collapse the tree back to only the holding
- add page-level and tree-level regression coverage for back-to-back optimistic organization creates

## Validation
- npx vitest run src/components/OrganizationalUnitTree.test.tsx src/pages/Organization/OrganizationPage.test.tsx
- npx eslint src/components/OrganizationalUnitTree.tsx src/components/OrganizationalUnitTree.test.tsx src/pages/Organization/OrganizationPage.tsx src/pages/Organization/OrganizationPage.test.tsx
