### PR TITLE
fix: restore remote CSRF login bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Treated an empty production `VITE_API_URL` on `app.secpal.dev` the same as other leaked SPA-side API origins by collapsing it to the canonical `https://api.secpal.dev` host, so browser-session login can fetch `/sanctum/csrf-cookie` and bootstrap remote Playwright auth without failing immediately on the live app, resolving frontend issue #1046.
 - Preserved `/organization` tree state across back-to-back optimistic creates by keeping newly created parent units in the local tree overlay until the offline-sync hook has fetched them for real, so creating a company and then an immediate child branch no longer collapses the tree back to only the holding until a manual reload.
 - Replaced the placeholder pre-contract onboarding wizard with a schema-driven Catalyst form that renders localized template fields, restores saved draft answers, uses inline feedback instead of browser alerts, and updates existing onboarding submissions via `PATCH` before navigation or review submission.
 - Corrected the `/organization` Playwright XSRF-rotation regression to rotate the browser-visible app cookie instead of asserting a brittle cross-origin cookie detail, added end-to-end coverage that keeps restricted child-unit delete actions hidden across reloads, guarded the repaired live parent relationship on `app.secpal.dev`, and added an opt-in live CRUD proof for creating and deleting a child unit under `Headquarters` against the real live stack.

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -133,15 +133,19 @@ describe("config", () => {
     );
   });
 
-  it("resolveApiBaseUrl throws ApiBaseUrlConfigurationError on app.secpal.dev when VITE_API_URL is empty", async () => {
+  it("resolveApiBaseUrl returns the canonical live origin on app.secpal.dev when VITE_API_URL is empty", async () => {
     vi.stubEnv("MODE", "production");
     vi.stubEnv("VITE_API_URL", "");
 
-    const { resolveApiBaseUrl, ApiBaseUrlConfigurationError } =
-      await import("./config");
+    const { resolveApiBaseUrl, buildApiUrl } = await import("./config");
 
-    expect(() =>
-      resolveApiBaseUrl({ runtimeHostname: "app.secpal.dev" })
-    ).toThrow(ApiBaseUrlConfigurationError);
+    expect(resolveApiBaseUrl({ runtimeHostname: "app.secpal.dev" })).toBe(
+      "https://api.secpal.dev"
+    );
+    expect(
+      buildApiUrl("/sanctum/csrf-cookie", {
+        runtimeHostname: "app.secpal.dev",
+      })
+    ).toBe("https://api.secpal.dev/sanctum/csrf-cookie");
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -67,7 +67,7 @@ function shouldUseCanonicalLiveApiOrigin(
   }
 
   if (!normalizedConfiguredBaseUrl) {
-    return false;
+    return true;
   }
 
   if (!isAbsoluteHttpUrl(normalizedConfiguredBaseUrl)) {


### PR DESCRIPTION
## Summary
- treat an empty production `VITE_API_URL` on `app.secpal.dev` as another leaked SPA-side API origin and fall back to `https://api.secpal.dev`
- cover the live-host fallback in `src/config.test.ts` so `/sanctum/csrf-cookie` resolves to the canonical API host instead of failing during browser-session login bootstrap
- document the live login bootstrap fix in `CHANGELOG.md`

## Validation
- npx vitest run src/config.test.ts
- npm run typecheck
- npx eslint src/config.ts src/config.test.ts
- npm exec -- prettier --check src/config.ts src/config.test.ts CHANGELOG.md

Closes #1046
