### PR TITLE
fix: remove admin-prefixed review clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Renamed the onboarding review and Android provisioning frontend API clients to the neutral `/v1/onboarding-review/...` and `/v1/android-enrollment-sessions...` endpoints, and aligned supporting fixtures/examples with the removed Admin model.
 - Removed the frontend's role-list based elevated UI gating and obsolete `hasRole` auth-context helper: organization access now follows the authoritative `hasOrganizationalScopes` flag, customer/site/employee/android capability checks now depend on explicit permissions plus scope/access flags, and the obsolete `admin` organizational-scope access level was dropped from frontend types and tests to match the API's removed Admin model (breaking change, closes #1031)
 - Reframed the frontend `README.md` around the currently shipped workforce-operations routes and runtime guidance, removing stale Secrets-era password-vault, attachment-encryption, and migration-status sections that no longer matched the live app surface, resolving frontend issue #531.
 - Switched the Vite Lingui macro transform from an unfiltered Babel plugin run to a filtered Rolldown Babel preset around `@lingui/babel-plugin-lingui-macro`, reducing unnecessary production-build plugin work and hardening the frontend against renewed Rolldown `PLUGIN_TIMINGS` warnings during `npm run build` (frontend issue #901).

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -55,9 +55,9 @@ function getStoredAuthState(): string | null {
 // Mock ResizeObserver for HeadlessUI Menu component
 beforeAll(() => {
   global.ResizeObserver = class ResizeObserver {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
+    observe() { }
+    unobserve() { }
+    disconnect() { }
   };
 });
 
@@ -438,7 +438,7 @@ describe("ApplicationLayout", () => {
 
       const consoleSpy = vi
         .spyOn(console, "error")
-        .mockImplementation(() => {});
+        .mockImplementation(() => { });
 
       renderWithProviders(
         <ApplicationLayout>
@@ -472,7 +472,7 @@ describe("ApplicationLayout", () => {
 
       const consoleSpy = vi
         .spyOn(console, "error")
-        .mockImplementation(() => {});
+        .mockImplementation(() => { });
 
       renderWithProviders(
         <ApplicationLayout>
@@ -540,8 +540,8 @@ describe("ApplicationLayout", () => {
     it("generates correct initials for single-word name", async () => {
       await seedAuthenticatedUser({
         id: 1,
-        name: "Admin",
-        email: "admin@secpal.dev",
+        name: "Operations",
+        email: "operations@secpal.dev",
       });
 
       renderWithProviders(
@@ -551,7 +551,7 @@ describe("ApplicationLayout", () => {
       );
 
       // Avatar in navbar (stacked layout has avatar only in navbar)
-      const avatars = await screen.findAllByText("A");
+      const avatars = await screen.findAllByText("O");
       expect(avatars.length).toBeGreaterThanOrEqual(1);
     });
 
@@ -799,8 +799,8 @@ describe("ApplicationLayout", () => {
     it("shows Activity Logs menu item when user has permission", async () => {
       await seedAuthenticatedUser({
         id: 1,
-        name: "Admin User",
-        email: "admin@secpal.dev",
+        name: "Operations User",
+        email: "operations@secpal.dev",
         permissions: ["activity_log.read"],
       });
 
@@ -833,8 +833,8 @@ describe("ApplicationLayout", () => {
     it("highlights Activity Logs when on that page", async () => {
       await seedAuthenticatedUser({
         id: 1,
-        name: "Admin User",
-        email: "admin@secpal.dev",
+        name: "Operations User",
+        email: "operations@secpal.dev",
         permissions: ["activity_log.read"],
       });
 
@@ -854,8 +854,8 @@ describe("ApplicationLayout", () => {
     it("links to /activity-logs route", async () => {
       await seedAuthenticatedUser({
         id: 1,
-        name: "Admin User",
-        email: "admin@secpal.dev",
+        name: "Operations User",
+        email: "operations@secpal.dev",
         permissions: ["activity_log.read"],
       });
 
@@ -887,8 +887,8 @@ describe("ApplicationLayout", () => {
 
       await seedAuthenticatedUser({
         id: 1,
-        name: "Admin User",
-        email: "admin@secpal.dev",
+        name: "Operations User",
+        email: "operations@secpal.dev",
         hasOrganizationalScopes: true,
         roles: [],
         permissions: ["android_enrollment.read"],
@@ -909,8 +909,8 @@ describe("ApplicationLayout", () => {
     it("hides the Android provisioning navigation entry without read access", async () => {
       await seedAuthenticatedUser({
         id: 1,
-        name: "Admin User",
-        email: "admin@secpal.dev",
+        name: "Operations User",
+        email: "operations@secpal.dev",
         hasOrganizationalScopes: true,
         roles: [],
         permissions: ["activity_log.read"],

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -55,9 +55,9 @@ function getStoredAuthState(): string | null {
 // Mock ResizeObserver for HeadlessUI Menu component
 beforeAll(() => {
   global.ResizeObserver = class ResizeObserver {
-    observe() { }
-    unobserve() { }
-    disconnect() { }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
   };
 });
 
@@ -438,7 +438,7 @@ describe("ApplicationLayout", () => {
 
       const consoleSpy = vi
         .spyOn(console, "error")
-        .mockImplementation(() => { });
+        .mockImplementation(() => {});
 
       renderWithProviders(
         <ApplicationLayout>
@@ -472,7 +472,7 @@ describe("ApplicationLayout", () => {
 
       const consoleSpy = vi
         .spyOn(console, "error")
-        .mockImplementation(() => { });
+        .mockImplementation(() => {});
 
       renderWithProviders(
         <ApplicationLayout>

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -175,12 +175,12 @@ describe("AuthContext", () => {
         id: 1,
         name: "Test User",
         email: "test@secpal.dev",
-        permissions: ["reports.generate"],
+        permissions: ["manage"],
       });
 
       render(
         <AuthProvider>
-          <PermissionTestComponent permission="reports.generate" />
+          <PermissionTestComponent permission="manage" />
         </AuthProvider>
       );
 

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -175,12 +175,12 @@ describe("AuthContext", () => {
         id: 1,
         name: "Test User",
         email: "test@secpal.dev",
-        permissions: ["admin"],
+        permissions: ["reports.generate"],
       });
 
       render(
         <AuthProvider>
-          <PermissionTestComponent permission="admin" />
+          <PermissionTestComponent permission="reports.generate" />
         </AuthProvider>
       );
 

--- a/src/pages/AndroidProvisioning/AndroidProvisioningPage.test.tsx
+++ b/src/pages/AndroidProvisioning/AndroidProvisioningPage.test.tsx
@@ -82,7 +82,7 @@ describe("AndroidProvisioningPage", () => {
       screen.getByRole("button", { name: /create enrollment session/i })
     ).toBeInTheDocument();
     expect(apiFetch).toHaveBeenCalledWith(
-      `${apiConfig.baseUrl}/v1/admin/android-enrollment-sessions?per_page=15`,
+      `${apiConfig.baseUrl}/v1/android-enrollment-sessions?per_page=15`,
       expect.objectContaining({ headers: expect.any(Headers) })
     );
     const [, init] = vi.mocked(apiFetch).mock.calls[0]!;
@@ -247,7 +247,7 @@ describe("AndroidProvisioningPage", () => {
     ).toBeInTheDocument();
     expect(screen.getAllByText("Reception kiosk")).toHaveLength(2);
     expect(apiFetch).toHaveBeenLastCalledWith(
-      `${apiConfig.baseUrl}/v1/admin/android-enrollment-sessions`,
+      `${apiConfig.baseUrl}/v1/android-enrollment-sessions`,
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({

--- a/src/pages/AndroidProvisioning/AndroidProvisioningPage.tsx
+++ b/src/pages/AndroidProvisioning/AndroidProvisioningPage.tsx
@@ -152,14 +152,14 @@ async function requestJson<T>(path: string, init?: RequestInit): Promise<T> {
     const payload = (await response
       .json()
       .catch(() => ({ message: response.statusText }))) as {
-      errors?: Record<string, string[]>;
-      message?: string;
-    };
+        errors?: Record<string, string[]>;
+        message?: string;
+      };
 
     throw new ApiError(
       payload.message ||
-        response.statusText ||
-        "Android provisioning request failed",
+      response.statusText ||
+      "Android provisioning request failed",
       response.status,
       payload.errors,
       response
@@ -189,7 +189,7 @@ export default function AndroidProvisioningPage() {
     let active = true;
 
     void requestJson<AndroidSessionListResponse>(
-      "/v1/admin/android-enrollment-sessions?per_page=15"
+      "/v1/android-enrollment-sessions?per_page=15"
     )
       .then((response) => {
         if (!active) {
@@ -226,7 +226,7 @@ export default function AndroidProvisioningPage() {
 
     try {
       const response = await requestJson<AndroidCreateSessionResponse>(
-        "/v1/admin/android-enrollment-sessions",
+        "/v1/android-enrollment-sessions",
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -263,7 +263,7 @@ export default function AndroidProvisioningPage() {
 
     try {
       const response = await requestJson<ApiEnvelope<AndroidEnrollmentSession>>(
-        `/v1/admin/android-enrollment-sessions/${session.id}/revoke`,
+        `/v1/android-enrollment-sessions/${session.id}/revoke`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },

--- a/src/pages/AndroidProvisioning/AndroidProvisioningPage.tsx
+++ b/src/pages/AndroidProvisioning/AndroidProvisioningPage.tsx
@@ -152,14 +152,14 @@ async function requestJson<T>(path: string, init?: RequestInit): Promise<T> {
     const payload = (await response
       .json()
       .catch(() => ({ message: response.statusText }))) as {
-        errors?: Record<string, string[]>;
-        message?: string;
-      };
+      errors?: Record<string, string[]>;
+      message?: string;
+    };
 
     throw new ApiError(
       payload.message ||
-      response.statusText ||
-      "Android provisioning request failed",
+        response.statusText ||
+        "Android provisioning request failed",
       response.status,
       payload.errors,
       response

--- a/src/services/employeeApi.test.ts
+++ b/src/services/employeeApi.test.ts
@@ -264,7 +264,9 @@ describe("employeeApi - JSON Parsing Error Handling", () => {
 
       expect(result.onboarding_workflow?.status).toBe("ready_for_activation");
       expect(mockFetch).toHaveBeenLastCalledWith(
-        expect.stringContaining("/v1/admin/onboarding/employees/emp-1/confirm"),
+        expect.stringContaining(
+          "/v1/onboarding-review/employees/emp-1/confirm"
+        ),
         expect.objectContaining({
           method: "POST",
           body: JSON.stringify({ notes: "Contract signed and reviewed." }),

--- a/src/services/employeeApi.ts
+++ b/src/services/employeeApi.ts
@@ -272,7 +272,7 @@ export async function confirmEmployeeOnboarding(
   id: string,
   payload?: ConfirmEmployeeOnboardingPayload
 ): Promise<Employee> {
-  const url = `${apiConfig.baseUrl}/v1/admin/onboarding/employees/${id}/confirm`;
+  const url = `${apiConfig.baseUrl}/v1/onboarding-review/employees/${id}/confirm`;
   const response = await apiFetch(url, {
     method: "POST",
     headers: {

--- a/src/services/onboardingApi.ts
+++ b/src/services/onboardingApi.ts
@@ -447,7 +447,7 @@ export async function uploadOnboardingFile(
 export async function approveOnboardingSubmission(
   submissionId: string
 ): Promise<OnboardingSubmission> {
-  const url = `${apiConfig.baseUrl}/v1/admin/onboarding/submissions/${submissionId}/approve`;
+  const url = `${apiConfig.baseUrl}/v1/onboarding-review/submissions/${submissionId}/approve`;
   const response = await apiFetch(url, {
     method: "POST",
   });
@@ -473,7 +473,7 @@ export async function rejectOnboardingSubmission(
   submissionId: string,
   reason: string
 ): Promise<OnboardingSubmission> {
-  const url = `${apiConfig.baseUrl}/v1/admin/onboarding/submissions/${submissionId}/reject`;
+  const url = `${apiConfig.baseUrl}/v1/onboarding-review/submissions/${submissionId}/reject`;
   const response = await apiFetch(url, {
     method: "POST",
     headers: {

--- a/tests/e2e/onboarding-review-and-android-provisioning.spec.ts
+++ b/tests/e2e/onboarding-review-and-android-provisioning.spec.ts
@@ -1,0 +1,319 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { BrowserContext, Page } from "@playwright/test";
+import { expect, test } from "./auth.setup";
+import {
+  buildOfflineLiveMockUser,
+  installMockAuthRoutes,
+  installStoredMockBrowserSession,
+} from "./offline-live-helpers";
+
+const androidProvisioningMockUser = buildOfflineLiveMockUser({
+  permissions: ["android_enrollment.read", "android_enrollment.write"],
+});
+
+const onboardingReviewMockUser = buildOfflineLiveMockUser({
+  permissions: ["employees.read", "employees.activate", "onboarding.confirm"],
+});
+
+const baseAndroidSession = {
+  id: "session-1",
+  device_label: "Front desk tablet",
+  status: "pending",
+  update_channel: "managed_device",
+  bootstrap_token_expires_at: "2026-05-02T12:00:00Z",
+  revoked_at: null,
+  revocation_reason: null,
+};
+
+function buildEmployeeDetailResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "emp-onboarding",
+    employee_number: "E404",
+    first_name: "Jordan",
+    last_name: "Reviewer",
+    full_name: "Jordan Reviewer",
+    email: "jordan.reviewer@secpal.dev",
+    phone: "+49 151 00000042",
+    date_of_birth: "1990-01-01",
+    position: "Operations Lead",
+    contract_start_date: "2026-05-10",
+    bwr_id: null,
+    bwr_status: "not_registered",
+    bwr_registered_at: null,
+    bwr_submission_date: null,
+    bwr_notes: null,
+    status: "pre_contract",
+    contract_type: "full_time",
+    management_level: 2,
+    onboarding_completed: true,
+    onboarding_workflow: {
+      status: "submitted_for_review",
+    },
+    onboarding_invitation: {
+      status: "sent",
+      requested_at: "2026-05-01T09:00:00Z",
+      token_created_at: "2026-05-01T09:00:00Z",
+      mail_sent_at: "2026-05-01T09:01:00Z",
+      mail_failed_at: null,
+      failure_reason: null,
+    },
+    organizational_unit: {
+      id: "org-root-1",
+      name: "Operations",
+    },
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+async function installAndroidProvisioningMockSession(page: Page) {
+  await installMockAuthRoutes(page.context(), androidProvisioningMockUser);
+  await installStoredMockBrowserSession(page, androidProvisioningMockUser);
+}
+
+async function installOnboardingReviewMockSession(page: Page) {
+  await installMockAuthRoutes(page.context(), onboardingReviewMockUser);
+  await installStoredMockBrowserSession(page, onboardingReviewMockUser);
+}
+
+async function installAndroidProvisioningRoutes(
+  context: BrowserContext,
+  requestLog: string[]
+) {
+  const sessions = [{ ...baseAndroidSession }];
+
+  await context.route(
+    "**/v1/android-enrollment-sessions?per_page=15",
+    async (route) => {
+      const url = new URL(route.request().url());
+      requestLog.push(
+        `${route.request().method()} ${url.pathname}${url.search}`
+      );
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: sessions }),
+      });
+    }
+  );
+
+  await context.route("**/v1/android-enrollment-sessions", async (route) => {
+    const url = new URL(route.request().url());
+    requestLog.push(`${route.request().method()} ${url.pathname}${url.search}`);
+
+    if (route.request().method() !== "POST") {
+      await route.fallback();
+      return;
+    }
+
+    const payload = route.request().postDataJSON() as
+      | { device_label?: string; update_channel?: string }
+      | undefined;
+    const createdSession = {
+      id: "session-2",
+      device_label: payload?.device_label ?? "Reception kiosk",
+      status: "pending",
+      update_channel: payload?.update_channel ?? "managed_device",
+      bootstrap_token_expires_at: "2026-05-02T13:00:00Z",
+      revoked_at: null,
+      revocation_reason: null,
+    };
+
+    sessions.unshift(createdSession);
+
+    await route.fulfill({
+      status: 201,
+      contentType: "application/json",
+      body: JSON.stringify({
+        data: {
+          session: createdSession,
+          provisioning_qr_payload: {
+            "android.app.extra.PROVISIONING_DEVICE_ADMIN_COMPONENT_NAME":
+              "app.secpal/.SecPalDeviceAdminReceiver",
+            "android.app.extra.PROVISIONING_ADMIN_EXTRAS_BUNDLE": {
+              bootstrap_token: "tok-android-session-2",
+              enrollment_session_id: createdSession.id,
+            },
+          },
+        },
+      }),
+    });
+  });
+
+  await context.route(
+    "**/v1/android-enrollment-sessions/*/revoke",
+    async (route) => {
+      const url = new URL(route.request().url());
+      requestLog.push(
+        `${route.request().method()} ${url.pathname}${url.search}`
+      );
+
+      const revokedSessionId = url.pathname.split("/").at(-2);
+      const payload = route.request().postDataJSON() as { reason?: string };
+      const targetSession = sessions.find(
+        (session) => session.id === revokedSessionId
+      );
+
+      if (!targetSession) {
+        await route.fulfill({
+          status: 404,
+          contentType: "application/json",
+          body: JSON.stringify({ message: "Not found" }),
+        });
+        return;
+      }
+
+      targetSession.status = "revoked";
+      targetSession.revoked_at = "2026-05-01T10:00:00Z";
+      targetSession.revocation_reason = payload.reason ?? null;
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: targetSession }),
+      });
+    }
+  );
+}
+
+async function installOnboardingReviewRoutes(
+  context: BrowserContext,
+  requestLog: string[]
+) {
+  let employee = buildEmployeeDetailResponse();
+
+  await context.route("**/v1/employees/emp-onboarding", async (route) => {
+    const url = new URL(route.request().url());
+    requestLog.push(`${route.request().method()} ${url.pathname}${url.search}`);
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ data: employee }),
+    });
+  });
+
+  await context.route(
+    "**/v1/onboarding-review/employees/emp-onboarding/confirm",
+    async (route) => {
+      const url = new URL(route.request().url());
+      requestLog.push(
+        `${route.request().method()} ${url.pathname}${url.search}`
+      );
+
+      employee = buildEmployeeDetailResponse({
+        onboarding_workflow: {
+          status: "ready_for_activation",
+        },
+      });
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: employee }),
+      });
+    }
+  );
+}
+
+test.describe("Neutral review and provisioning flows", () => {
+  test("uses the neutral Android enrollment endpoints for load and create", async ({
+    authenticatedPage: page,
+  }) => {
+    const requestLog: string[] = [];
+
+    await installAndroidProvisioningMockSession(page);
+    await installAndroidProvisioningRoutes(page.context(), requestLog);
+
+    await page.goto("/android-provisioning");
+    await page.waitForLoadState("networkidle");
+
+    await expect(
+      page.getByRole("heading", { name: /Android Provisioning/i })
+    ).toBeVisible();
+    await expect(page.getByText("Front desk tablet")).toBeVisible();
+    expect(requestLog).toContain(
+      "GET /v1/android-enrollment-sessions?per_page=15"
+    );
+
+    await page.getByLabel(/Device label/i).fill("Reception kiosk");
+    await page.getByLabel(/Update channel/i).selectOption("direct_apk");
+    await page
+      .getByRole("button", { name: /Create enrollment session/i })
+      .click();
+
+    await expect(
+      page.getByRole("heading", { name: /Provisioning QR code/i })
+    ).toBeVisible();
+    await expect(
+      page.getByAltText(/Android provisioning QR code/i)
+    ).toBeVisible();
+    expect(requestLog).toContain("POST /v1/android-enrollment-sessions");
+  });
+
+  test("uses the neutral Android revoke endpoint", async ({
+    authenticatedPage: page,
+  }) => {
+    const requestLog: string[] = [];
+
+    await installAndroidProvisioningMockSession(page);
+    await installAndroidProvisioningRoutes(page.context(), requestLog);
+
+    await page.goto("/android-provisioning");
+    await page.waitForLoadState("networkidle");
+
+    page.once("dialog", async (dialog) => {
+      expect(dialog.type()).toBe("prompt");
+      await dialog.accept("Token exposed");
+    });
+
+    await page
+      .getByRole("button", { name: /Revoke/i })
+      .first()
+      .click();
+
+    await expect(
+      page
+        .locator("span")
+        .filter({ hasText: /^Revoked$/ })
+        .first()
+    ).toBeVisible();
+    await expect(page.getByText(/Token exposed/i)).toBeVisible();
+    expect(requestLog).toContain(
+      "POST /v1/android-enrollment-sessions/session-1/revoke"
+    );
+  });
+
+  test("uses the neutral onboarding review confirm endpoint from employee detail", async ({
+    authenticatedPage: page,
+  }) => {
+    const requestLog: string[] = [];
+
+    await installOnboardingReviewMockSession(page);
+    await installOnboardingReviewRoutes(page.context(), requestLog);
+
+    await page.goto("/employees/emp-onboarding");
+    await page.waitForLoadState("networkidle");
+
+    await expect(
+      page.getByRole("button", { name: /Confirm Onboarding/i })
+    ).toBeVisible();
+    expect(requestLog).toContain("GET /v1/employees/emp-onboarding");
+
+    page.once("dialog", async (dialog) => {
+      expect(dialog.type()).toBe("confirm");
+      await dialog.accept();
+    });
+
+    await page.getByRole("button", { name: /Confirm Onboarding/i }).click();
+
+    await expect(page.getByRole("button", { name: /Activate/i })).toBeVisible();
+    expect(requestLog).toContain(
+      "POST /v1/onboarding-review/employees/emp-onboarding/confirm"
+    );
+  });
+});

--- a/tests/unit/services/onboardingApi.test.ts
+++ b/tests/unit/services/onboardingApi.test.ts
@@ -3,12 +3,14 @@
 
 import { beforeEach, describe, it, expect, vi } from "vitest";
 import {
+  approveOnboardingSubmission,
   completeOnboarding,
   createOnboardingSubmission,
   fetchOnboardingSteps,
   fetchOnboardingTemplate,
   fetchOnboardingSubmissions,
   fetchOnboardingTemplates,
+  rejectOnboardingSubmission,
   validateOnboardingToken,
 } from "../../../src/services/onboardingApi";
 import { apiFetch } from "../../../src/services/csrf";
@@ -499,5 +501,80 @@ describe("createOnboardingSubmission", () => {
         status: "draft",
       })
     ).rejects.toThrow("Missing onboarding form template identifier");
+  });
+});
+
+describe("approveOnboardingSubmission", () => {
+  it("posts the onboarding review approval action to the neutral runtime path", async () => {
+    vi.mocked(apiFetch).mockResolvedValueOnce(
+      makeFetchResponse(200, {
+        data: {
+          id: "submission-9",
+          employee_id: "employee-1",
+          form_template_id: "template-9",
+          form_data: { legal_name: "Casey Example" },
+          status: "approved",
+          reviewed_by: "reviewer-1",
+          reviewed_at: "2026-05-01T12:00:00Z",
+          created_at: "2026-05-01T11:00:00Z",
+          updated_at: "2026-05-01T12:00:00Z",
+        },
+      })
+    );
+
+    await expect(approveOnboardingSubmission("submission-9")).resolves.toEqual(
+      expect.objectContaining({
+        id: "submission-9",
+        status: "approved",
+      })
+    );
+
+    expect(apiFetch).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "/v1/onboarding-review/submissions/submission-9/approve"
+      ),
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+});
+
+describe("rejectOnboardingSubmission", () => {
+  it("posts the onboarding review rejection action to the neutral runtime path", async () => {
+    vi.mocked(apiFetch).mockResolvedValueOnce(
+      makeFetchResponse(200, {
+        data: {
+          id: "submission-9",
+          employee_id: "employee-1",
+          form_template_id: "template-9",
+          form_data: { legal_name: "Casey Example" },
+          status: "rejected",
+          review_notes: "Missing signature",
+          reviewed_by: "reviewer-1",
+          reviewed_at: "2026-05-01T12:00:00Z",
+          created_at: "2026-05-01T11:00:00Z",
+          updated_at: "2026-05-01T12:00:00Z",
+        },
+      })
+    );
+
+    await expect(
+      rejectOnboardingSubmission("submission-9", "Missing signature")
+    ).resolves.toEqual(
+      expect.objectContaining({
+        id: "submission-9",
+        status: "rejected",
+        review_notes: "Missing signature",
+      })
+    );
+
+    expect(apiFetch).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "/v1/onboarding-review/submissions/submission-9/reject"
+      ),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ reason: "Missing signature" }),
+      })
+    );
   });
 });


### PR DESCRIPTION
Summary: retarget onboarding review and Android provisioning clients to the neutral /v1/onboarding-review/... and /v1/android-enrollment-sessions... endpoints; remove admin-labeled test fixtures that still implied the deleted runtime model; add focused Playwright coverage proving the routed employee-detail and Android provisioning pages now call the neutral endpoints. Validation: eslint on touched services/pages/tests; vitest on touched onboarding, employee, Android provisioning, auth-context, and application-layout suites; PLAYWRIGHT_SKIP_GLOBAL_LOGIN=1 playwright test tests/e2e/onboarding-review-and-android-provisioning.spec.ts --project=chromium. Refs SecPal/.github#404.