### PR TITLE
fix: stabilize live e2e coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Seeded Playwright's live mock-session cookies for both the browser host and the configured API host, so split-host remote runs against `app.secpal.dev` plus `api.secpal.dev` no longer fall back to `/login` when employee, Android provisioning, and onboarding-review specs install mocked auth routes.
+- Replaced the brittle live organization proof that hard-coded `WSiS Nordwest` with a stable `Headquarters` root-unit assertion, so default remote Playwright runs no longer fail when the live seed data changes while the shipped organization UI still behaves correctly.
 - Blocked onboarding review submission when the current schema-rendered step still has empty required fields, surfaced inline field errors plus a clear review-blocked status message, and kept those field errors clearing as users complete the missing inputs, resolving frontend issue #1030.
 - Treated an empty production `VITE_API_URL` on `app.secpal.dev` the same as other leaked SPA-side API origins by collapsing it to the canonical `https://api.secpal.dev` host, so browser-session login can fetch `/sanctum/csrf-cookie` and bootstrap remote Playwright auth without failing immediately on the live app, resolving frontend issue #1046.
 - Stopped the generic employee edit form from sending `status` through `PATCH /v1/employees/:id` and made the status control read-only there, so non-status edits such as management-level or position updates no longer trip the backend's dedicated status-transition guard, resolving frontend issue #1045.

--- a/tests/e2e/offline-live-helpers.ts
+++ b/tests/e2e/offline-live-helpers.ts
@@ -9,7 +9,7 @@ const MOCK_XSRF_TOKEN = "test-xsrf-token";
 const MOCK_SESSION_COOKIE_NAME = "secpal-playwright-session";
 
 function getMockCookieHostname(url: string | undefined): string | null {
-  if (!isRemoteE2ETarget(url)) {
+  if (!url || !isRemoteE2ETarget(url)) {
     return null;
   }
 

--- a/tests/e2e/offline-live-helpers.ts
+++ b/tests/e2e/offline-live-helpers.ts
@@ -8,27 +8,55 @@ import { isRemoteE2ETarget, waitForLoginFormReady } from "./auth-helpers";
 const MOCK_XSRF_TOKEN = "test-xsrf-token";
 const MOCK_SESSION_COOKIE_NAME = "secpal-playwright-session";
 
-function getMockCookieDomain(): string {
-  const baseUrl = process.env.PLAYWRIGHT_BASE_URL ?? "";
-  if (isRemoteE2ETarget(baseUrl)) {
-    return new URL(baseUrl).hostname;
+function getMockCookieHostname(url: string | undefined): string | null {
+  if (!isRemoteE2ETarget(url)) {
+    return null;
   }
-  return "localhost";
+
+  return new URL(url).hostname;
+}
+
+export function getMockCookieDomains(
+  baseUrl = process.env.PLAYWRIGHT_BASE_URL,
+  apiBaseUrl = process.env.PLAYWRIGHT_API_BASE_URL
+): string[] {
+  const domains = new Set<string>();
+  const baseHostname = getMockCookieHostname(baseUrl);
+  const apiHostname = getMockCookieHostname(apiBaseUrl);
+
+  if (baseHostname) {
+    domains.add(baseHostname);
+  }
+
+  if (apiHostname) {
+    domains.add(apiHostname);
+  }
+
+  if (domains.size === 0) {
+    domains.add("localhost");
+  }
+
+  return [...domains];
+}
+
+function shouldUseSecureMockCookies(): boolean {
+  return getMockCookieDomains().every((domain) => domain !== "localhost");
 }
 
 async function ensureMockXsrfCookie(context: BrowserContext): Promise<void> {
-  const isHttps = isRemoteE2ETarget(process.env.PLAYWRIGHT_BASE_URL);
-  await context.addCookies([
-    {
+  const secure = shouldUseSecureMockCookies();
+
+  await context.addCookies(
+    getMockCookieDomains().map((domain) => ({
       name: "XSRF-TOKEN",
       value: MOCK_XSRF_TOKEN,
-      domain: getMockCookieDomain(),
+      domain,
       path: "/",
-      sameSite: "Lax",
-      secure: isHttps,
+      sameSite: "Lax" as const,
+      secure,
       httpOnly: false,
-    },
-  ]);
+    }))
+  );
 }
 
 export const offlineLiveMockUser = {
@@ -56,19 +84,19 @@ async function ensureMockSessionCookie(
   context: BrowserContext,
   value = "authenticated"
 ): Promise<void> {
-  const isHttps = isRemoteE2ETarget(process.env.PLAYWRIGHT_BASE_URL);
+  const secure = shouldUseSecureMockCookies();
 
-  await context.addCookies([
-    {
+  await context.addCookies(
+    getMockCookieDomains().map((domain) => ({
       name: MOCK_SESSION_COOKIE_NAME,
       value,
-      domain: getMockCookieDomain(),
+      domain,
       path: "/",
-      sameSite: "Lax",
-      secure: isHttps,
+      sameSite: "Lax" as const,
+      secure,
       httpOnly: true,
-    },
-  ]);
+    }))
+  );
 }
 
 function requestHasMockSessionCookie(cookieHeader: string | null): boolean {

--- a/tests/e2e/organization.spec.ts
+++ b/tests/e2e/organization.spec.ts
@@ -846,7 +846,7 @@ test.describe("Organization Management", () => {
   });
 
   test.describe("Live organization proof", () => {
-    test("should show WSiS Nordwest under Headquarters on live targets", async ({
+    test("should show the Headquarters root unit on live targets", async ({
       authenticatedPage: page,
     }) => {
       test.skip(
@@ -857,19 +857,22 @@ test.describe("Organization Management", () => {
       await page.goto("/organization");
       await page.waitForLoadState("networkidle");
 
-      const wsisTreeItem = page
-        .getByRole("treeitem", { name: /WSiS Nordwest/i })
+      const headquartersTreeItem = page
+        .getByRole("treeitem", { name: /Headquarters/i })
         .first();
 
-      await expect(wsisTreeItem).toBeVisible();
-      await wsisTreeItem.click();
+      await expect(headquartersTreeItem).toBeVisible();
+      await headquartersTreeItem.click();
 
-      await expect(page.getByText(/^Parent$/i)).toBeVisible();
+      await expect(
+        page.getByRole("heading", { level: 3, name: /Headquarters/i })
+      ).toBeVisible();
       await expect(
         page
-          .locator("dt", { hasText: /^Parent$/i })
+          .locator("dt", { hasText: /^Type$/i })
           .locator("xpath=following-sibling::dd[1]")
-      ).toHaveText("Headquarters");
+      ).toHaveText(/Holding/i);
+      await expect(page.locator("dt", { hasText: /^Parent$/i })).toHaveCount(0);
     });
 
     test("should create and remove a live child unit under Headquarters", async ({

--- a/tests/unit/offlineLiveHelpers.test.ts
+++ b/tests/unit/offlineLiveHelpers.test.ts
@@ -9,6 +9,13 @@ describe("offlineLiveHelpers", () => {
     vi.unstubAllEnvs();
   });
 
+  it("ignores a missing API base URL for remote targets", () => {
+    vi.stubEnv("PLAYWRIGHT_BASE_URL", "https://app.secpal.dev");
+    delete process.env.PLAYWRIGHT_API_BASE_URL;
+
+    expect(getMockCookieDomains()).toEqual(["app.secpal.dev"]);
+  });
+
   it("returns both app and API domains for split-host remote targets", () => {
     vi.stubEnv("PLAYWRIGHT_BASE_URL", "https://app.secpal.dev");
     vi.stubEnv("PLAYWRIGHT_API_BASE_URL", "https://api.secpal.dev");

--- a/tests/unit/offlineLiveHelpers.test.ts
+++ b/tests/unit/offlineLiveHelpers.test.ts
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getMockCookieDomains } from "../e2e/offline-live-helpers";
+
+describe("offlineLiveHelpers", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns both app and API domains for split-host remote targets", () => {
+    vi.stubEnv("PLAYWRIGHT_BASE_URL", "https://app.secpal.dev");
+    vi.stubEnv("PLAYWRIGHT_API_BASE_URL", "https://api.secpal.dev");
+
+    expect(getMockCookieDomains()).toEqual([
+      "app.secpal.dev",
+      "api.secpal.dev",
+    ]);
+  });
+
+  it("deduplicates the cookie domains when app and API share a host", () => {
+    vi.stubEnv("PLAYWRIGHT_BASE_URL", "https://app.secpal.dev");
+    vi.stubEnv("PLAYWRIGHT_API_BASE_URL", "https://app.secpal.dev");
+
+    expect(getMockCookieDomains()).toEqual(["app.secpal.dev"]);
+  });
+
+  it("falls back to localhost for non-remote targets", () => {
+    vi.stubEnv("PLAYWRIGHT_BASE_URL", "http://localhost:4173");
+    vi.stubEnv("PLAYWRIGHT_API_BASE_URL", "http://localhost:8000");
+
+    expect(getMockCookieDomains()).toEqual(["localhost"]);
+  });
+});


### PR DESCRIPTION
## Summary
- seed Playwright mock auth cookies for both the browser host and the configured API host so split-host live runs against app.secpal.dev and api.secpal.dev keep mocked E2E requests authenticated
- add a focused unit regression for the split-host cookie-domain helper behavior
- replace the brittle live organization proof that depended on WSiS Nordwest seed data with a stable Headquarters root-unit assertion

## Testing
- npm run test -- tests/unit/offlineLiveHelpers.test.ts
- npm run typecheck
- npm exec -- prettier --check CHANGELOG.md tests/e2e/offline-live-helpers.ts tests/e2e/organization.spec.ts tests/unit/offlineLiveHelpers.test.ts
- npm exec -- eslint tests/e2e/offline-live-helpers.ts tests/unit/offlineLiveHelpers.test.ts tests/e2e/organization.spec.ts
- TEST_USER_EMAIL=test@example.com TEST_USER_PASSWORD=password PLAYWRIGHT_BASE_URL=https://app.secpal.dev PLAYWRIGHT_API_BASE_URL=https://api.secpal.dev npx playwright test tests/e2e/leadership-levels.spec.ts tests/e2e/onboarding-review-and-android-provisioning.spec.ts --project=chromium --project=mobile-chrome --reporter=line
- TEST_USER_EMAIL=test@example.com TEST_USER_PASSWORD=password PLAYWRIGHT_BASE_URL=https://app.secpal.dev PLAYWRIGHT_API_BASE_URL=https://api.secpal.dev npx playwright test tests/e2e/organization.spec.ts --project=chromium --project=mobile-chrome --grep 'Headquarters root unit' --reporter=line
- TEST_USER_EMAIL=test@example.com TEST_USER_PASSWORD=password PLAYWRIGHT_BASE_URL=https://app.secpal.dev PLAYWRIGHT_API_BASE_URL=https://api.secpal.dev npx playwright test --reporter=line

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Playwright test helpers/spec assertions and a small new unit test; risk is mainly potential E2E flakiness or mis-seeded cookies on remote runs.
> 
> **Overview**
> Stabilizes remote Playwright runs against split-host deployments by **seeding mocked `XSRF-TOKEN` and session cookies for both the app and API hosts** (with deduping and correct `Secure` handling) via a new `getMockCookieDomains()` helper.
> 
> Updates the live `/organization` proof to assert a stable `Headquarters` root-unit presence instead of relying on mutable seed data, and adds focused unit coverage for the cookie-domain helper behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c72f47e7bdde351633104ccb3e7cfc5751910103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->