### PR TITLE
fix(preflight): make changed-file gating branch-aware in clean pre-push runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Repaired `scripts/preflight.sh` changed-file detection for pre-push runs with a clean index/worktree by falling back to branch-vs-base (`merge-base..HEAD`) diffs for markdown and REUSE gating, and added regression tests that cover both unstaged markdown edits and committed markdown-only branch deltas.
 - Seeded Playwright's live mock-session cookies for both the browser host and the configured API host, so split-host remote runs against `app.secpal.dev` plus `api.secpal.dev` no longer fall back to `/login` when employee, Android provisioning, and onboarding-review specs install mocked auth routes.
 - Replaced the brittle live organization proof that hard-coded `WSiS Nordwest` with a stable `Headquarters` root-unit assertion, so default remote Playwright runs no longer fail when the live seed data changes while the shipped organization UI still behaves correctly.
 - Blocked onboarding review submission when the current schema-rendered step still has empty required fields, surfaced inline field errors plus a clear review-blocked status message, and kept those field errors clearing as users complete the missing inputs, resolving frontend issue #1030.

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-FileCopyrightText: 2025 SecPal Contributors
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: MIT
 
 set -euo pipefail
@@ -36,7 +36,8 @@ done
 
 # Auto-detect default branch (fallback to main)
 # Use symbolic-ref instead of remote show to avoid network hang
-BASE="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')"
+BASE_REF="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null || true)"
+BASE="${BASE_REF#refs/remotes/origin/}"
 [ -z "${BASE:-}" ] && BASE="main"
 
 echo "Using base branch: $BASE"
@@ -45,7 +46,16 @@ echo "Using base branch: $BASE"
 git fetch origin "$BASE" 2>/dev/null || true
 
 # Get list of changed files for conditional checks
-CHANGED_FILES=$(git diff --name-only --cached 2>/dev/null || git diff --name-only HEAD 2>/dev/null || echo "")
+CHANGED_FILES="$(git diff --name-only --cached 2>/dev/null || true)"
+if [ -z "$CHANGED_FILES" ]; then
+  CHANGED_FILES="$(git diff --name-only HEAD 2>/dev/null || true)"
+fi
+if [ -z "$CHANGED_FILES" ] && git rev-parse -q --verify "origin/$BASE" >/dev/null 2>&1; then
+  MERGE_BASE_FOR_CHANGED_FILES="$(git merge-base "origin/$BASE" HEAD 2>/dev/null || true)"
+  if [ -n "$MERGE_BASE_FOR_CHANGED_FILES" ]; then
+    CHANGED_FILES="$(git diff --name-only "$MERGE_BASE_FOR_CHANGED_FILES"..HEAD 2>/dev/null || true)"
+  fi
+fi
 
 # 0) Formatting & Compliance
 FORMAT_EXIT=0
@@ -75,8 +85,18 @@ fi
 # Only run REUSE lint if new files were added or license-related files changed
 if command -v reuse >/dev/null 2>&1; then
   if [ -n "$CHANGED_FILES" ]; then
-    # Check if any new files were added (A) or license files changed
-    NEW_OR_LICENSE=$(git diff --name-status --cached 2>/dev/null | grep -E '^(A|M.*LICENSE)' || echo "")
+    # Check if any new files were added (A) or license files changed.
+    NAME_STATUS_CHANGED="$(git diff --name-status --cached 2>/dev/null || true)"
+    if [ -z "$NAME_STATUS_CHANGED" ]; then
+      NAME_STATUS_CHANGED="$(git diff --name-status HEAD 2>/dev/null || true)"
+    fi
+    if [ -z "$NAME_STATUS_CHANGED" ] && git rev-parse -q --verify "origin/$BASE" >/dev/null 2>&1; then
+      MERGE_BASE_FOR_NAME_STATUS="$(git merge-base "origin/$BASE" HEAD 2>/dev/null || true)"
+      if [ -n "$MERGE_BASE_FOR_NAME_STATUS" ]; then
+        NAME_STATUS_CHANGED="$(git diff --name-status "$MERGE_BASE_FOR_NAME_STATUS"..HEAD 2>/dev/null || true)"
+      fi
+    fi
+    NEW_OR_LICENSE=$(echo "$NAME_STATUS_CHANGED" | grep -E '^(A|M[[:space:]].*LICENSE)' || true)
     if [ -n "$NEW_OR_LICENSE" ]; then
       reuse lint || FORMAT_EXIT=1
     else

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -45,17 +45,22 @@ echo "Using base branch: $BASE"
 # Fetch base branch for PR size check (failure is handled later)
 git fetch origin "$BASE" 2>/dev/null || true
 
-# Get list of changed files for conditional checks
-CHANGED_FILES="$(git diff --name-only --cached 2>/dev/null || true)"
-if [ -z "$CHANGED_FILES" ]; then
-  CHANGED_FILES="$(git diff --name-only HEAD 2>/dev/null || true)"
+# Compute merge-base once for reuse across all branch-aware gates.
+MERGE_BASE=""
+if git rev-parse -q --verify "origin/$BASE" >/dev/null 2>&1; then
+  MERGE_BASE="$(git merge-base "origin/$BASE" HEAD 2>/dev/null || true)"
 fi
-if [ -z "$CHANGED_FILES" ] && git rev-parse -q --verify "origin/$BASE" >/dev/null 2>&1; then
-  MERGE_BASE_FOR_CHANGED_FILES="$(git merge-base "origin/$BASE" HEAD 2>/dev/null || true)"
-  if [ -n "$MERGE_BASE_FOR_CHANGED_FILES" ]; then
-    CHANGED_FILES="$(git diff --name-only "$MERGE_BASE_FOR_CHANGED_FILES"..HEAD 2>/dev/null || true)"
-  fi
+
+# Collect changed files: staged, unstaged, and always the committed branch delta
+# so gates fire for pushed commits even when local edits are also present.
+_cf_staged="$(git diff --name-only --cached 2>/dev/null || true)"
+_cf_head="$(git diff --name-only HEAD 2>/dev/null || true)"
+_cf_branch=""
+if [ -n "$MERGE_BASE" ]; then
+  _cf_branch="$(git diff --name-only "$MERGE_BASE"..HEAD 2>/dev/null || true)"
 fi
+CHANGED_FILES="$(printf '%s\n%s\n%s\n' "$_cf_staged" "$_cf_head" "$_cf_branch" | grep -v '^[[:space:]]*$' | sort -u || true)"
+unset _cf_staged _cf_head _cf_branch
 
 # 0) Formatting & Compliance
 FORMAT_EXIT=0
@@ -85,18 +90,20 @@ fi
 # Only run REUSE lint if new files were added or license-related files changed
 if command -v reuse >/dev/null 2>&1; then
   if [ -n "$CHANGED_FILES" ]; then
-    # Check if any new files were added (A) or license files changed.
-    NAME_STATUS_CHANGED="$(git diff --name-status --cached 2>/dev/null || true)"
-    if [ -z "$NAME_STATUS_CHANGED" ]; then
-      NAME_STATUS_CHANGED="$(git diff --name-status HEAD 2>/dev/null || true)"
+    # Collect name-status from staged, unstaged, and always the committed branch
+    # delta so .license sidecars and REUSE.toml changes are caught even when
+    # local edits are present.
+    _ns_staged="$(git diff --name-status --cached 2>/dev/null || true)"
+    _ns_head="$(git diff --name-status HEAD 2>/dev/null || true)"
+    _ns_branch=""
+    if [ -n "$MERGE_BASE" ]; then
+      _ns_branch="$(git diff --name-status "$MERGE_BASE"..HEAD 2>/dev/null || true)"
     fi
-    if [ -z "$NAME_STATUS_CHANGED" ] && git rev-parse -q --verify "origin/$BASE" >/dev/null 2>&1; then
-      MERGE_BASE_FOR_NAME_STATUS="$(git merge-base "origin/$BASE" HEAD 2>/dev/null || true)"
-      if [ -n "$MERGE_BASE_FOR_NAME_STATUS" ]; then
-        NAME_STATUS_CHANGED="$(git diff --name-status "$MERGE_BASE_FOR_NAME_STATUS"..HEAD 2>/dev/null || true)"
-      fi
-    fi
-    NEW_OR_LICENSE=$(echo "$NAME_STATUS_CHANGED" | grep -E '^(A|M[[:space:]].*LICENSE)' || true)
+    NAME_STATUS_CHANGED="$(printf '%s\n%s\n%s\n' "$_ns_staged" "$_ns_head" "$_ns_branch" | grep -v '^[[:space:]]*$' || true)"
+    unset _ns_staged _ns_head _ns_branch
+    # Trigger REUSE lint for any new file or changes to .license sidecars,
+    # REUSE.toml, or LICENSE files.
+    NEW_OR_LICENSE=$(echo "$NAME_STATUS_CHANGED" | grep -E '^A|^[MD][[:space:]]+.*(LICENSE|\.license$|REUSE\.toml$)' || true)
     if [ -n "$NEW_OR_LICENSE" ]; then
       reuse lint || FORMAT_EXIT=1
     else

--- a/tests/unit/scripts/preflight.changed-files.test.ts
+++ b/tests/unit/scripts/preflight.changed-files.test.ts
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { spawnSync } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../.."
+);
+
+function run(
+  command: string,
+  args: string[],
+  cwd: string,
+  env?: NodeJS.ProcessEnv
+) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    env: env ?? process.env,
+  });
+  expect(result.error).toBeUndefined();
+  expect(result.status, result.stderr).toBe(0);
+  return result;
+}
+
+function installMockBinaries(tempDir: string) {
+  const binDir = path.join(tempDir, "bin");
+  mkdirSync(binDir, { recursive: true });
+
+  writeFileSync(
+    path.join(binDir, "npx"),
+    `#!/usr/bin/env bash
+echo "$@" >> "$NPX_LOG_PATH"
+exit 0
+`,
+    "utf8"
+  );
+  writeFileSync(
+    path.join(binDir, "reuse"),
+    `#!/usr/bin/env bash
+echo "reuse $@" >> "$REUSE_LOG_PATH"
+exit 0
+`,
+    "utf8"
+  );
+  run("chmod", ["+x", path.join(binDir, "npx")], tempDir);
+  run("chmod", ["+x", path.join(binDir, "reuse")], tempDir);
+
+  return binDir;
+}
+
+function prepareScript(tempDir: string) {
+  const scriptsDir = path.join(tempDir, "scripts");
+  mkdirSync(scriptsDir, { recursive: true });
+  const preflightScriptPath = path.join(scriptsDir, "preflight.sh");
+  writeFileSync(
+    preflightScriptPath,
+    readFileSync(path.join(repoRoot, "scripts", "preflight.sh"), "utf8")
+  );
+  run("chmod", ["+x", preflightScriptPath], tempDir);
+  return preflightScriptPath;
+}
+
+describe("preflight changed-file detection", () => {
+  it("runs markdownlint when markdown is changed but unstaged", () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "secpal-preflight-"));
+
+    try {
+      const preflightScriptPath = prepareScript(tempDir);
+      const binDir = installMockBinaries(tempDir);
+
+      const npxLogPath = path.join(tempDir, "npx.log");
+      const reuseLogPath = path.join(tempDir, "reuse.log");
+
+      run("git", ["init", "-b", "main"], tempDir);
+      run("git", ["config", "user.name", "SecPal Test"], tempDir);
+      run("git", ["config", "user.email", "test@secpal.dev"], tempDir);
+
+      writeFileSync(path.join(tempDir, "README.md"), "# SecPal\n", "utf8");
+      run("git", ["add", "README.md"], tempDir);
+      run("git", ["commit", "-m", "init"], tempDir);
+      run("git", ["checkout", "-b", "topic/preflight-test"], tempDir);
+
+      writeFileSync(
+        path.join(tempDir, "README.md"),
+        "# SecPal\n\nUpdated content.\n",
+        "utf8"
+      );
+
+      const preflight = spawnSync("bash", [preflightScriptPath], {
+        cwd: tempDir,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          NPX_LOG_PATH: npxLogPath,
+          REUSE_LOG_PATH: reuseLogPath,
+        },
+      });
+
+      expect(preflight.error).toBeUndefined();
+      expect(preflight.status, preflight.stderr).toBe(0);
+
+      const npxLog = readFileSync(npxLogPath, "utf8");
+      expect(npxLog).toContain("prettier");
+      expect(npxLog).toContain("markdownlint-cli2");
+      expect(preflight.stdout + preflight.stderr).not.toContain(
+        "No markdown files changed, skipping markdownlint"
+      );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("runs markdownlint for committed markdown changes when index and workspace are clean", () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "secpal-preflight-"));
+
+    try {
+      const preflightScriptPath = prepareScript(tempDir);
+      const binDir = installMockBinaries(tempDir);
+      const npxLogPath = path.join(tempDir, "npx.log");
+      const reuseLogPath = path.join(tempDir, "reuse.log");
+      const remoteDir = path.join(tempDir, "remote.git");
+
+      run("git", ["init", "--bare", remoteDir], tempDir);
+      run("git", ["init", "-b", "main"], tempDir);
+      run("git", ["config", "user.name", "SecPal Test"], tempDir);
+      run("git", ["config", "user.email", "test@secpal.dev"], tempDir);
+
+      writeFileSync(path.join(tempDir, "README.md"), "# SecPal\n", "utf8");
+      run("git", ["add", "README.md"], tempDir);
+      run("git", ["commit", "-m", "init"], tempDir);
+      run("git", ["remote", "add", "origin", remoteDir], tempDir);
+      run("git", ["push", "-u", "origin", "main"], tempDir);
+      run(
+        "git",
+        [
+          "symbolic-ref",
+          "refs/remotes/origin/HEAD",
+          "refs/remotes/origin/main",
+        ],
+        tempDir
+      );
+
+      run("git", ["checkout", "-b", "topic/preflight-committed-md"], tempDir);
+      writeFileSync(
+        path.join(tempDir, "README.md"),
+        "# SecPal\n\nCommitted update.\n",
+        "utf8"
+      );
+      run("git", ["commit", "-am", "update markdown"], tempDir);
+
+      const preflight = spawnSync("bash", [preflightScriptPath], {
+        cwd: tempDir,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          NPX_LOG_PATH: npxLogPath,
+          REUSE_LOG_PATH: reuseLogPath,
+        },
+      });
+
+      expect(preflight.error).toBeUndefined();
+      expect(preflight.status, preflight.stderr).toBe(0);
+
+      const npxLog = readFileSync(npxLogPath, "utf8");
+      expect(npxLog).toContain("prettier");
+      expect(npxLog).toContain("markdownlint-cli2");
+      expect(preflight.stdout + preflight.stderr).not.toContain(
+        "No markdown files changed, skipping markdownlint"
+      );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/scripts/preflight.changed-files.test.ts
+++ b/tests/unit/scripts/preflight.changed-files.test.ts
@@ -186,4 +186,163 @@ describe("preflight changed-file detection", () => {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("runs markdownlint for committed markdown changes even when local staged edits exist", () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "secpal-preflight-"));
+
+    try {
+      const preflightScriptPath = prepareScript(tempDir);
+      const binDir = installMockBinaries(tempDir);
+      const npxLogPath = path.join(tempDir, "npx.log");
+      const reuseLogPath = path.join(tempDir, "reuse.log");
+      const remoteDir = path.join(tempDir, "remote.git");
+
+      run("git", ["init", "--bare", remoteDir], tempDir);
+      run("git", ["init", "-b", "main"], tempDir);
+      run("git", ["config", "user.name", "SecPal Test"], tempDir);
+      run("git", ["config", "user.email", "test@secpal.dev"], tempDir);
+
+      writeFileSync(path.join(tempDir, "README.md"), "# SecPal\n", "utf8");
+      writeFileSync(
+        path.join(tempDir, "other.ts"),
+        "export const x = 1;\n",
+        "utf8"
+      );
+      run("git", ["add", "."], tempDir);
+      run("git", ["commit", "-m", "init"], tempDir);
+      run("git", ["remote", "add", "origin", remoteDir], tempDir);
+      run("git", ["push", "-u", "origin", "main"], tempDir);
+      run(
+        "git",
+        [
+          "symbolic-ref",
+          "refs/remotes/origin/HEAD",
+          "refs/remotes/origin/main",
+        ],
+        tempDir
+      );
+
+      run("git", ["checkout", "-b", "topic/md-plus-staged"], tempDir);
+      writeFileSync(
+        path.join(tempDir, "README.md"),
+        "# SecPal\n\nCommitted update.\n",
+        "utf8"
+      );
+      run("git", ["commit", "-am", "update markdown"], tempDir);
+
+      // Simulate local staged edit unrelated to markdown – this must not mask the committed md change.
+      writeFileSync(
+        path.join(tempDir, "other.ts"),
+        "export const x = 2;\n",
+        "utf8"
+      );
+      run("git", ["add", "other.ts"], tempDir);
+
+      const preflight = spawnSync("bash", [preflightScriptPath], {
+        cwd: tempDir,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          NPX_LOG_PATH: npxLogPath,
+          REUSE_LOG_PATH: reuseLogPath,
+        },
+      });
+
+      expect(preflight.error).toBeUndefined();
+      expect(preflight.status, preflight.stderr).toBe(0);
+
+      const npxLog = readFileSync(npxLogPath, "utf8");
+      expect(npxLog).toContain("markdownlint-cli2");
+      expect(preflight.stdout + preflight.stderr).not.toContain(
+        "No markdown files changed, skipping markdownlint"
+      );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("runs reuse lint for committed .license sidecar changes even when local staged edits exist", () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "secpal-preflight-"));
+
+    try {
+      const preflightScriptPath = prepareScript(tempDir);
+      const binDir = installMockBinaries(tempDir);
+      const npxLogPath = path.join(tempDir, "npx.log");
+      const reuseLogPath = path.join(tempDir, "reuse.log");
+      const remoteDir = path.join(tempDir, "remote.git");
+
+      run("git", ["init", "--bare", remoteDir], tempDir);
+      run("git", ["init", "-b", "main"], tempDir);
+      run("git", ["config", "user.name", "SecPal Test"], tempDir);
+      run("git", ["config", "user.email", "test@secpal.dev"], tempDir);
+
+      writeFileSync(
+        path.join(tempDir, "src.ts"),
+        "export const v = 1;\n",
+        "utf8"
+      );
+      writeFileSync(
+        path.join(tempDir, "src.ts.license"),
+        "SPDX-FileCopyrightText: 2026 SecPal\nSPDX-License-Identifier: AGPL-3.0-or-later\n",
+        "utf8"
+      );
+      writeFileSync(
+        path.join(tempDir, "other.ts"),
+        "export const x = 1;\n",
+        "utf8"
+      );
+      run("git", ["add", "."], tempDir);
+      run("git", ["commit", "-m", "init"], tempDir);
+      run("git", ["remote", "add", "origin", remoteDir], tempDir);
+      run("git", ["push", "-u", "origin", "main"], tempDir);
+      run(
+        "git",
+        [
+          "symbolic-ref",
+          "refs/remotes/origin/HEAD",
+          "refs/remotes/origin/main",
+        ],
+        tempDir
+      );
+
+      run("git", ["checkout", "-b", "topic/license-plus-staged"], tempDir);
+      writeFileSync(
+        path.join(tempDir, "src.ts.license"),
+        "SPDX-FileCopyrightText: 2026 SecPal Contributors\nSPDX-License-Identifier: AGPL-3.0-or-later\n",
+        "utf8"
+      );
+      run("git", ["commit", "-am", "update license sidecar"], tempDir);
+
+      // Simulate local staged edit that would otherwise mask the committed license change.
+      writeFileSync(
+        path.join(tempDir, "other.ts"),
+        "export const x = 2;\n",
+        "utf8"
+      );
+      run("git", ["add", "other.ts"], tempDir);
+
+      const preflight = spawnSync("bash", [preflightScriptPath], {
+        cwd: tempDir,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          NPX_LOG_PATH: npxLogPath,
+          REUSE_LOG_PATH: reuseLogPath,
+        },
+      });
+
+      expect(preflight.error).toBeUndefined();
+      expect(preflight.status, preflight.stderr).toBe(0);
+
+      const reuseLog = readFileSync(reuseLogPath, "utf8");
+      expect(reuseLog).toContain("reuse lint");
+      expect(preflight.stdout + preflight.stderr).not.toContain(
+        "No new files or license changes, skipping REUSE lint"
+      );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Defect Reproduction First
A failing-first regression test showed that `scripts/preflight.sh` could miss markdown/license-related deltas in pre-push contexts when the index/worktree were clean and changes existed only in branch commits.

## What Changed (Single Topic)
This PR fixes preflight changed-file detection logic and keeps it branch-aware:
- hardens base-branch resolution (`origin/HEAD` fallback handling under `set -e`),
- resolves staged-only detection gaps by falling back to `merge-base..HEAD` file lists when needed,
- applies the same fallback strategy to REUSE gating (`name-status`) so license/new-file checks are not silently skipped,
- adds regression coverage in `tests/unit/scripts/preflight.changed-files.test.ts` for:
  - unstaged markdown changes,
  - committed markdown changes with clean index/worktree.

## User/API/Contract/Governance Impact
- User-visible: local preflight now correctly runs markdown gating in clean pre-push scenarios.
- API/contract: no runtime API contract changes.
- Governance: pre-push quality gates are now enforced against actual branch deltas instead of only staged state.

## Validation Run
- `npm test -- tests/unit/scripts/preflight.changed-files.test.ts`
- `npm run -s typecheck`
- `npm run -s lint`
- `./scripts/preflight.sh`

## CHANGELOG
- Updated `CHANGELOG.md` under `Unreleased > Fixed`.

## Linked-Repo Impact
- None.

## Out-of-Scope Findings Filed
- None identified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-push gating logic in `scripts/preflight.sh`, which could accidentally over/under-trigger markdown/REUSE checks and block developer pushes if the git diff detection is wrong. Risk is mitigated by new unit regression coverage for the affected scenarios.
> 
> **Overview**
> Fixes `scripts/preflight.sh` changed-file detection so markdownlint and REUSE gating run based on the *branch delta* (via `merge-base..HEAD`) even when the index/worktree are clean or when unrelated staged changes exist.
> 
> Adds Vitest regression tests that spin up temporary git repos/remotes and assert markdownlint runs for unstaged + committed markdown-only changes, and that `reuse lint` triggers for committed `.license` sidecar updates. Updates `CHANGELOG.md` to document the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dda316956bd6eeaac51f7faf8b7ef47be619689. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->