### PR TITLE
test(onboarding): add German regressions for pattern-validation copy

### DIFF
--- a/tests/unit/pages/Onboarding/OnboardingWizard.test.tsx
+++ b/tests/unit/pages/Onboarding/OnboardingWizard.test.tsx
@@ -992,6 +992,82 @@ describe("OnboardingWizard", () => {
     expect(onboardingApi.updateOnboardingSubmission).not.toHaveBeenCalled();
   });
 
+  it("localizes generic non-country regex guidance in German", async () => {
+    i18n.load("de", deMessages);
+    i18n.activate("de");
+    vi.mocked(onboardingApi.fetchOnboardingSteps).mockResolvedValue([
+      {
+        step_number: 1,
+        title: "Address Details",
+        description: "Address Details description",
+        template_id: "template-address",
+        is_required: true,
+        is_completed: false,
+        submission: makeSubmission("template-address", {
+          postal_code: "12A45",
+        }),
+      },
+      {
+        step_number: 2,
+        title: "Final Review",
+        description: "Final Review description",
+        template_id: "template-final",
+        is_required: true,
+        is_completed: false,
+        submission: makeSubmission("template-final", {
+          legal_name: "Jane Doe",
+        }),
+      },
+    ]);
+
+    vi.mocked(onboardingApi.fetchOnboardingTemplate)
+      .mockReset()
+      .mockResolvedValueOnce(
+        makeTemplate(
+          "template-address",
+          "Address Details",
+          "Address Details description",
+          {
+            type: "object",
+            required: ["postal_code"],
+            properties: {
+              postal_code: {
+                type: "string",
+                title: "Postal Code",
+                pattern: "^\\d{5}$",
+              },
+            },
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        makeTemplate(
+          "template-final",
+          "Final Review",
+          "Final Review description"
+        )
+      );
+
+    renderWizard();
+
+    await waitFor(() => {
+      expect(screen.getByText("Address Details")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /weiter/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Postal Code: Bitte verwenden Sie das erforderliche Format (^\\d{5}$)."
+        )
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Final Review")).not.toBeInTheDocument();
+    expect(onboardingApi.updateOnboardingSubmission).not.toHaveBeenCalled();
+  });
+
   it("replaces pattern fallback errors without a concrete regex with generic guidance", async () => {
     vi.mocked(onboardingApi.fetchOnboardingSteps).mockResolvedValue([
       {
@@ -1045,6 +1121,69 @@ describe("OnboardingWizard", () => {
     await waitFor(() => {
       expect(
         screen.getByText("This field: Please use the required format.")
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("localizes pattern fallback errors without a concrete regex in German", async () => {
+    i18n.load("de", deMessages);
+    i18n.activate("de");
+    vi.mocked(onboardingApi.fetchOnboardingSteps).mockResolvedValue([
+      {
+        step_number: 1,
+        title: "Country Details",
+        description: "Country Details description",
+        template_id: "template-country",
+        is_required: true,
+        is_completed: false,
+        submission: makeSubmission("template-country", {
+          country_code: "DE",
+        }),
+      },
+    ]);
+
+    vi.mocked(onboardingApi.fetchOnboardingTemplate)
+      .mockReset()
+      .mockResolvedValue(
+        makeTemplate(
+          "template-country",
+          "Country Details",
+          "Country Details description",
+          {
+            type: "object",
+            required: ["country_code"],
+            properties: {
+              country_code: {
+                type: "string",
+                title: "Country Code",
+                pattern: "^[A-Z]{2}$",
+              },
+            },
+          }
+        )
+      );
+
+    vi.mocked(onboardingApi.updateOnboardingSubmission).mockRejectedValueOnce(
+      new ApiError("The value does not match the required pattern.", 422, {
+        status: ["Validation failed"],
+      })
+    );
+
+    renderWizard();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Country Code")).toBeInTheDocument();
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /zur überprüfung einreichen/i })
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Dieses Feld: Bitte verwenden Sie das erforderliche Format."
+        )
       ).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## Summary
- add a German regression for the generic explicit-regex guidance path (`Please use the required format ({actualPattern}).`)
- add a German regression for the `form_data` fallback-label path (`This field: Please use the required format.`)
- keep existing English regressions and validate both localized branches that Copilot flagged in #1063

## Validation
- npm run -s test -- tests/unit/pages/Onboarding/OnboardingWizard.test.tsx
- npm run -s test:coverage -- tests/unit/pages/Onboarding/OnboardingWizard.test.tsx
- npm run -s lint
- npm run -s typecheck

## Context
Follow-up to merged PR #1063 and Copilot review comments:
- https://github.com/SecPal/frontend/pull/1063#discussion_r3182077976
- https://github.com/SecPal/frontend/pull/1063#discussion_r3182078009
