### PR TITLE
Support short German contract start dates

### DIFF
--- a/src/pages/Employees/EmployeeCreate.test.tsx
+++ b/src/pages/Employees/EmployeeCreate.test.tsx
@@ -895,6 +895,28 @@ describe("EmployeeCreate", () => {
       i18n.activate("en");
     });
 
+    it("should normalize short German contract start date without year to current year", async () => {
+      i18n.activate("de");
+      renderWithProviders(<EmployeeCreate />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Main Office")).toBeInTheDocument();
+      });
+
+      const currentYear = new Date().getFullYear();
+      const contractStartDateInput = screen.getByLabelText(/datum des vertragsbeginns/i);
+
+      fireEvent.change(contractStartDateInput, { target: { value: "1.6." } });
+      fireEvent.blur(contractStartDateInput);
+
+      await waitFor(() => {
+        expect(contractStartDateInput).toHaveValue(`01.06.${currentYear}`);
+        expect(screen.queryByText(/ungültiges datum/i)).not.toBeInTheDocument();
+      });
+
+      i18n.activate("en");
+    });
+
     it("should validate contract start date format", async () => {
       renderWithProviders(<EmployeeCreate />);
 

--- a/src/pages/Employees/EmployeeCreate.test.tsx
+++ b/src/pages/Employees/EmployeeCreate.test.tsx
@@ -41,7 +41,9 @@ const renderWithProviders = (component: React.ReactNode) => {
 };
 
 function submitEmployeeCreateForm() {
-  fireEvent.click(screen.getByRole("button", { name: /create employee/i }));
+  fireEvent.click(
+    screen.getByRole("button", { name: /create employee|mitarbeiter anlegen/i })
+  );
 }
 
 const mockOrganizationalUnits = [
@@ -914,6 +916,73 @@ describe("EmployeeCreate", () => {
       await waitFor(() => {
         expect(contractStartDateInput).toHaveValue(`01.06.${currentYear}`);
         expect(screen.queryByText(/ungültiges datum/i)).not.toBeInTheDocument();
+      });
+
+      i18n.activate("en");
+    });
+
+    it("should submit short German contract start date without blur using current year", async () => {
+      i18n.activate("de");
+      const mockCreateEmployee = vi.mocked(employeeApi.createEmployee);
+      mockCreateEmployee.mockResolvedValue({
+        id: "emp-de-1",
+        employee_number: "EMP-DE-1",
+        first_name: "Max",
+        last_name: "Mustermann",
+        full_name: "Max Mustermann",
+        email: "max.mustermann@secpal.dev",
+        phone: "",
+        date_of_birth: "1990-01-01",
+        contract_start_date: `${new Date().getFullYear()}-06-01`,
+        position: "Sicherheitsmitarbeiter",
+        status: "pre_contract",
+        contract_type: "full_time",
+        management_level: 0,
+        organizational_unit: {
+          id: "unit-1",
+          name: "Main Office",
+        },
+        user: undefined,
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+      });
+
+      renderWithProviders(<EmployeeCreate />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Main Office")).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByLabelText(/vorname/i), {
+        target: { value: "Max" },
+      });
+      fireEvent.change(screen.getByLabelText(/nachname/i), {
+        target: { value: "Mustermann" },
+      });
+      fireEvent.change(screen.getByLabelText(/e-mail-adresse/i), {
+        target: { value: "max.mustermann@secpal.dev" },
+      });
+      fireEvent.change(screen.getByLabelText(/geburtsdatum/i), {
+        target: { value: "01.01.1990" },
+      });
+      fireEvent.change(screen.getByLabelText("Position *"), {
+        target: { value: "Sicherheitsmitarbeiter" },
+      });
+      fireEvent.change(screen.getByLabelText(/datum des vertragsbeginns/i), {
+        target: { value: "1.6." },
+      });
+      fireEvent.change(screen.getByLabelText(/organisatorische einheit/i), {
+        target: { value: "unit-1" },
+      });
+
+      submitEmployeeCreateForm();
+
+      await waitFor(() => {
+        expect(mockCreateEmployee).toHaveBeenCalledWith(
+          expect.objectContaining({
+            contract_start_date: `${new Date().getFullYear()}-06-01`,
+          })
+        );
       });
 
       i18n.activate("en");

--- a/src/pages/Employees/EmployeeCreate.test.tsx
+++ b/src/pages/Employees/EmployeeCreate.test.tsx
@@ -904,7 +904,9 @@ describe("EmployeeCreate", () => {
       });
 
       const currentYear = new Date().getFullYear();
-      const contractStartDateInput = screen.getByLabelText(/datum des vertragsbeginns/i);
+      const contractStartDateInput = screen.getByLabelText(
+        /datum des vertragsbeginns/i
+      );
 
       fireEvent.change(contractStartDateInput, { target: { value: "1.6." } });
       fireEvent.blur(contractStartDateInput);

--- a/src/pages/Employees/EmployeeCreate.tsx
+++ b/src/pages/Employees/EmployeeCreate.tsx
@@ -599,7 +599,8 @@ export function EmployeeCreate() {
                         i18n.locale,
                         {
                           allowIsoInput: true,
-                          defaultCurrentYearForMissingYear: i18n.locale === "de",
+                          defaultCurrentYearForMissingYear:
+                            i18n.locale === "de",
                         }
                       );
                       if (result.valid) {

--- a/src/pages/Employees/EmployeeCreate.tsx
+++ b/src/pages/Employees/EmployeeCreate.tsx
@@ -26,7 +26,11 @@ import { Input } from "../../components/input";
 import { Select } from "../../components/select";
 import { Switch } from "../../components/switch";
 import { EmployeeStatusOptions } from "./EmployeeStatusOptions";
-import { parseEmployeeDateToISO } from "./employeeDateUtils";
+import {
+  GERMAN_CONTRACT_START_DATE_ERROR,
+  GERMAN_CONTRACT_START_DATE_HINT,
+  parseEmployeeDateToISO,
+} from "./employeeDateUtils";
 
 type EmployeeFormField = keyof EmployeeFormData;
 type EmployeeFormErrors = Partial<Record<EmployeeFormField, string>>;
@@ -46,11 +50,6 @@ const fieldOrder: EmployeeFormField[] = [
 ];
 
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const germanContractStartDateHint =
-  "Erwartetes Format: TT.MM.JJJJ. Optional ist TT.MM.; das aktuelle Jahr wird automatisch ergänzt.";
-const germanContractStartDateError =
-  "Ungültiges Datum. Bitte verwenden Sie das Format TT.MM.JJJJ (optional TT.MM. für das aktuelle Jahr).";
-
 /**
  * Employee Create Form
  */
@@ -230,7 +229,7 @@ export function EmployeeCreate() {
       if (!contractDate.valid) {
         errors.contract_start_date =
           i18n.locale === "de"
-            ? germanContractStartDateError
+            ? GERMAN_CONTRACT_START_DATE_ERROR
             : "Invalid date. Please use format MM/DD/YYYY";
       } else {
         normalizedData.contract_start_date = contractDate.iso;
@@ -615,7 +614,7 @@ export function EmployeeCreate() {
                           ...prev,
                           contract_start_date:
                             i18n.locale === "de"
-                              ? germanContractStartDateError
+                              ? GERMAN_CONTRACT_START_DATE_ERROR
                               : "Invalid date. Please use format MM/DD/YYYY",
                         }));
                       }
@@ -623,7 +622,7 @@ export function EmployeeCreate() {
                   />
                   {i18n.locale === "de" && (
                     <Text className="text-zinc-600 dark:text-zinc-400 text-sm mt-1">
-                      {germanContractStartDateHint}
+                      {GERMAN_CONTRACT_START_DATE_HINT}
                     </Text>
                   )}
                   {fieldErrors.contract_start_date && (

--- a/src/pages/Employees/EmployeeCreate.tsx
+++ b/src/pages/Employees/EmployeeCreate.tsx
@@ -46,6 +46,10 @@ const fieldOrder: EmployeeFormField[] = [
 ];
 
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const germanContractStartDateHint =
+  "Erwartetes Format: TT.MM.JJJJ. Optional ist TT.MM.; das aktuelle Jahr wird automatisch ergänzt.";
+const germanContractStartDateError =
+  "Ungültiges Datum. Bitte verwenden Sie das Format TT.MM.JJJJ (optional TT.MM. für das aktuelle Jahr).";
 
 /**
  * Employee Create Form
@@ -226,7 +230,7 @@ export function EmployeeCreate() {
       if (!contractDate.valid) {
         errors.contract_start_date =
           i18n.locale === "de"
-            ? "Ungültiges Datum. Bitte verwenden Sie das Format TT.MM.JJJJ"
+            ? germanContractStartDateError
             : "Invalid date. Please use format MM/DD/YYYY";
       } else {
         normalizedData.contract_start_date = contractDate.iso;
@@ -611,12 +615,17 @@ export function EmployeeCreate() {
                           ...prev,
                           contract_start_date:
                             i18n.locale === "de"
-                              ? "Ungültiges Datum. Bitte verwenden Sie das Format TT.MM.JJJJ"
+                              ? germanContractStartDateError
                               : "Invalid date. Please use format MM/DD/YYYY",
                         }));
                       }
                     }}
                   />
+                  {i18n.locale === "de" && (
+                    <Text className="text-zinc-600 dark:text-zinc-400 text-sm mt-1">
+                      {germanContractStartDateHint}
+                    </Text>
+                  )}
                   {fieldErrors.contract_start_date && (
                     <ErrorMessage id={getFieldErrorId("contract_start_date")}>
                       {fieldErrors.contract_start_date}

--- a/src/pages/Employees/EmployeeCreate.tsx
+++ b/src/pages/Employees/EmployeeCreate.tsx
@@ -218,7 +218,10 @@ export function EmployeeCreate() {
       const contractDate = parseEmployeeDateToISO(
         normalizedContractDateDisplay,
         i18n.locale,
-        { allowIsoInput: true }
+        {
+          allowIsoInput: true,
+          defaultCurrentYearForMissingYear: i18n.locale === "de",
+        }
       );
       if (!contractDate.valid) {
         errors.contract_start_date =
@@ -594,7 +597,10 @@ export function EmployeeCreate() {
                       const result = parseEmployeeDateToISO(
                         e.target.value,
                         i18n.locale,
-                        { allowIsoInput: true }
+                        {
+                          allowIsoInput: true,
+                          defaultCurrentYearForMissingYear: i18n.locale === "de",
+                        }
                       );
                       if (result.valid) {
                         setContractDateDisplay(result.formatted);

--- a/src/pages/Employees/EmployeeEdit.test.tsx
+++ b/src/pages/Employees/EmployeeEdit.test.tsx
@@ -629,6 +629,37 @@ describe("EmployeeEdit", () => {
       });
     });
 
+    it("should normalize short German contract start date without year to current year", async () => {
+      await act(async () => {
+        i18n.activate("de");
+      });
+
+      renderWithProviders("emp-1");
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/datum des vertragsbeginns/i)).toHaveValue(
+          "01.01.2025"
+        );
+      });
+
+      const currentYear = new Date().getFullYear();
+      const contractStartDateInput = screen.getByLabelText(
+        /datum des vertragsbeginns/i
+      );
+
+      fireEvent.change(contractStartDateInput, { target: { value: "1.6." } });
+      fireEvent.blur(contractStartDateInput);
+
+      await waitFor(() => {
+        expect(contractStartDateInput).toHaveValue(`01.06.${currentYear}`);
+        expect(screen.queryByText(/ungültiges datum/i)).not.toBeInTheDocument();
+      });
+
+      await act(async () => {
+        i18n.activate("en");
+      });
+    });
+
     it("should validate contract start date", async () => {
       renderWithProviders("emp-1");
 

--- a/src/pages/Employees/EmployeeEdit.test.tsx
+++ b/src/pages/Employees/EmployeeEdit.test.tsx
@@ -630,6 +630,9 @@ describe("EmployeeEdit", () => {
     });
 
     it("should normalize short German contract start date without year to current year", async () => {
+      const mockUpdateEmployee = vi.mocked(employeeApi.updateEmployee);
+      mockUpdateEmployee.mockResolvedValue(mockEmployee);
+
       await act(async () => {
         i18n.activate("de");
       });
@@ -653,6 +656,63 @@ describe("EmployeeEdit", () => {
       await waitFor(() => {
         expect(contractStartDateInput).toHaveValue(`01.06.${currentYear}`);
         expect(screen.queryByText(/ungültiges datum/i)).not.toBeInTheDocument();
+      });
+
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: /save changes|änderungen speichern/i,
+        })
+      );
+
+      await waitFor(() => {
+        expect(mockUpdateEmployee).toHaveBeenCalledWith(
+          "emp-1",
+          expect.objectContaining({
+            contract_start_date: `${currentYear}-06-01`,
+          })
+        );
+      });
+
+      await act(async () => {
+        i18n.activate("en");
+      });
+    });
+
+    it("should submit short German contract start date without blur", async () => {
+      const mockUpdateEmployee = vi.mocked(employeeApi.updateEmployee);
+      mockUpdateEmployee.mockResolvedValue(mockEmployee);
+
+      await act(async () => {
+        i18n.activate("de");
+      });
+
+      renderWithProviders("emp-1");
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/datum des vertragsbeginns/i)).toHaveValue(
+          "01.01.2025"
+        );
+      });
+
+      const currentYear = new Date().getFullYear();
+      const contractStartDateInput = screen.getByLabelText(
+        /datum des vertragsbeginns/i
+      );
+
+      fireEvent.change(contractStartDateInput, { target: { value: "1.6." } });
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: /save changes|änderungen speichern/i,
+        })
+      );
+
+      await waitFor(() => {
+        expect(mockUpdateEmployee).toHaveBeenCalledWith(
+          "emp-1",
+          expect.objectContaining({
+            contract_start_date: `${currentYear}-06-01`,
+          })
+        );
       });
 
       await act(async () => {

--- a/src/pages/Employees/EmployeeEdit.test.tsx
+++ b/src/pages/Employees/EmployeeEdit.test.tsx
@@ -601,6 +601,52 @@ describe("EmployeeEdit", () => {
       });
     });
 
+    it("should submit changed birth date without blur", async () => {
+      const mockUpdateEmployee = vi.mocked(employeeApi.updateEmployee);
+      mockUpdateEmployee.mockResolvedValue(mockEmployee);
+
+      renderWithProviders("emp-1");
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/first name/i)).toHaveValue("John");
+      });
+
+      const birthDateInput = screen.getByLabelText(/date of birth/i);
+      fireEvent.change(birthDateInput, { target: { value: "06/15/1985" } });
+      fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(mockUpdateEmployee).toHaveBeenCalledWith(
+          "emp-1",
+          expect.objectContaining({
+            date_of_birth: "1985-06-15",
+          })
+        );
+      });
+    });
+
+    it("should block submit when changed birth date is invalid without blur", async () => {
+      const mockUpdateEmployee = vi.mocked(employeeApi.updateEmployee);
+      mockUpdateEmployee.mockResolvedValue(mockEmployee);
+
+      renderWithProviders("emp-1");
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/first name/i)).toHaveValue("John");
+      });
+
+      const birthDateInput = screen.getByLabelText(/date of birth/i);
+      fireEvent.change(birthDateInput, { target: { value: "invalid" } });
+      fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/invalid date.*mm\/dd\/yyyy/i)
+        ).toBeInTheDocument();
+      });
+      expect(mockUpdateEmployee).not.toHaveBeenCalled();
+    });
+
     it("should accept and normalize short German date format", async () => {
       await act(async () => {
         i18n.activate("de");
@@ -714,6 +760,45 @@ describe("EmployeeEdit", () => {
           })
         );
       });
+
+      await act(async () => {
+        i18n.activate("en");
+      });
+    });
+
+    it("should block submit when changed german contract start date is invalid without blur", async () => {
+      const mockUpdateEmployee = vi.mocked(employeeApi.updateEmployee);
+      mockUpdateEmployee.mockResolvedValue(mockEmployee);
+
+      await act(async () => {
+        i18n.activate("de");
+      });
+
+      renderWithProviders("emp-1");
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/datum des vertragsbeginns/i)).toHaveValue(
+          "01.01.2025"
+        );
+      });
+
+      fireEvent.change(screen.getByLabelText(/datum des vertragsbeginns/i), {
+        target: { value: "invalid" },
+      });
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: /save changes|änderungen speichern/i,
+        })
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            /ungültiges datum\. bitte verwenden sie das format tt\.mm\.jjjj/i
+          )
+        ).toBeInTheDocument();
+      });
+      expect(mockUpdateEmployee).not.toHaveBeenCalled();
 
       await act(async () => {
         i18n.activate("en");

--- a/src/pages/Employees/EmployeeEdit.tsx
+++ b/src/pages/Employees/EmployeeEdit.tsx
@@ -387,7 +387,10 @@ export function EmployeeEdit() {
                     onBlur={(e) => {
                       const result = parseEmployeeDateToISO(
                         e.target.value,
-                        i18n.locale
+                        i18n.locale,
+                        {
+                          defaultCurrentYearForMissingYear: i18n.locale === "de",
+                        }
                       );
                       if (result.valid) {
                         setContractDateDisplay(result.formatted);

--- a/src/pages/Employees/EmployeeEdit.tsx
+++ b/src/pages/Employees/EmployeeEdit.tsx
@@ -26,13 +26,10 @@ import { Switch } from "../../components/switch";
 import { EmployeeStatusOptions } from "./EmployeeStatusOptions";
 import {
   formatEmployeeDateForDisplay,
+  GERMAN_CONTRACT_START_DATE_FORMAT,
+  GERMAN_CONTRACT_START_DATE_HINT,
   parseEmployeeDateToISO,
 } from "./employeeDateUtils";
-
-const germanContractStartDateHint =
-  "Erwartetes Format: TT.MM.JJJJ. Optional ist TT.MM.; das aktuelle Jahr wird automatisch ergänzt.";
-const germanContractStartDateFormat =
-  "TT.MM.JJJJ (optional TT.MM. für das aktuelle Jahr)";
 
 /**
  * Employee Edit Form
@@ -45,6 +42,8 @@ export function EmployeeEdit() {
   // Display values for date inputs
   const [birthDateDisplay, setBirthDateDisplay] = useState("");
   const [contractDateDisplay, setContractDateDisplay] = useState("");
+  const [birthDateDirty, setBirthDateDirty] = useState(false);
+  const [contractDateDirty, setContractDateDirty] = useState(false);
   // Date validation errors
   const [birthDateError, setBirthDateError] = useState<string | null>(null);
   const [contractDateError, setContractDateError] = useState<string | null>(
@@ -138,6 +137,8 @@ export function EmployeeEdit() {
             )
           );
         }
+        setBirthDateDirty(false);
+        setContractDateDirty(false);
       })
       .catch((err) => {
         if (!active) {
@@ -178,44 +179,64 @@ export function EmployeeEdit() {
       return;
     }
 
-    const birthDateResult = parseEmployeeDateToISO(
-      birthDateDisplay,
-      i18n.locale
-    );
-    if (!birthDateResult.valid) {
-      const format = i18n.locale === "de" ? "TT.MM.JJJJ" : "MM/DD/YYYY";
-      setBirthDateError(i18n._(msg`Invalid date. Please use format ${format}`));
-      return;
+    let normalizedBirthDateIso = formData.date_of_birth;
+    let normalizedBirthDateDisplay = birthDateDisplay;
+    if (birthDateDirty) {
+      const birthDateResult = parseEmployeeDateToISO(
+        birthDateDisplay,
+        i18n.locale
+      );
+      if (!birthDateResult.valid) {
+        const format = i18n.locale === "de" ? "TT.MM.JJJJ" : "MM/DD/YYYY";
+        setBirthDateError(
+          i18n._(msg`Invalid date. Please use format ${format}`)
+        );
+        return;
+      }
+
+      normalizedBirthDateIso = birthDateResult.iso;
+      normalizedBirthDateDisplay = birthDateResult.formatted;
     }
 
-    const contractDateResult = parseEmployeeDateToISO(
-      contractDateDisplay,
-      i18n.locale,
-      {
-        defaultCurrentYearForMissingYear: i18n.locale === "de",
-      }
-    );
-    if (!contractDateResult.valid) {
-      const format =
-        i18n.locale === "de" ? germanContractStartDateFormat : "MM/DD/YYYY";
-      setContractDateError(
-        i18n._(msg`Invalid date. Please use format ${format}`)
+    let normalizedContractDateIso = formData.contract_start_date;
+    let normalizedContractDateDisplay = contractDateDisplay;
+    if (contractDateDirty) {
+      const contractDateResult = parseEmployeeDateToISO(
+        contractDateDisplay,
+        i18n.locale,
+        {
+          defaultCurrentYearForMissingYear: i18n.locale === "de",
+        }
       );
-      return;
+      if (!contractDateResult.valid) {
+        const format =
+          i18n.locale === "de"
+            ? GERMAN_CONTRACT_START_DATE_FORMAT
+            : "MM/DD/YYYY";
+        setContractDateError(
+          i18n._(msg`Invalid date. Please use format ${format}`)
+        );
+        return;
+      }
+
+      normalizedContractDateIso = contractDateResult.iso;
+      normalizedContractDateDisplay = contractDateResult.formatted;
     }
 
     try {
       setLoading(true);
       setError(null);
-      setBirthDateDisplay(birthDateResult.formatted);
-      setContractDateDisplay(contractDateResult.formatted);
+      setBirthDateDisplay(normalizedBirthDateDisplay);
+      setContractDateDisplay(normalizedContractDateDisplay);
       setBirthDateError(null);
       setContractDateError(null);
+      setBirthDateDirty(false);
+      setContractDateDirty(false);
 
       const updatePayload: Partial<EmployeeFormData> = {
         ...formData,
-        date_of_birth: birthDateResult.iso,
-        contract_start_date: contractDateResult.iso,
+        date_of_birth: normalizedBirthDateIso,
+        contract_start_date: normalizedContractDateIso,
       };
       delete updatePayload.status;
       await updateEmployee(id, updatePayload);
@@ -333,6 +354,7 @@ export function EmployeeEdit() {
                     value={birthDateDisplay}
                     onChange={(e) => {
                       setBirthDateDisplay(e.target.value);
+                      setBirthDateDirty(true);
                       setBirthDateError(null); // Clear error on change
                     }}
                     onBlur={(e) => {
@@ -343,6 +365,7 @@ export function EmployeeEdit() {
                       if (result.valid) {
                         setBirthDateDisplay(result.formatted);
                         handleChange("date_of_birth", result.iso);
+                        setBirthDateDirty(false);
                         setBirthDateError(null);
                       } else if (e.target.value) {
                         const format =
@@ -422,6 +445,7 @@ export function EmployeeEdit() {
                     value={contractDateDisplay}
                     onChange={(e) => {
                       setContractDateDisplay(e.target.value);
+                      setContractDateDirty(true);
                       setContractDateError(null); // Clear error on change
                     }}
                     onBlur={(e) => {
@@ -436,11 +460,12 @@ export function EmployeeEdit() {
                       if (result.valid) {
                         setContractDateDisplay(result.formatted);
                         handleChange("contract_start_date", result.iso);
+                        setContractDateDirty(false);
                         setContractDateError(null);
                       } else if (e.target.value) {
                         const format =
                           i18n.locale === "de"
-                            ? germanContractStartDateFormat
+                            ? GERMAN_CONTRACT_START_DATE_FORMAT
                             : "MM/DD/YYYY";
                         setContractDateError(
                           i18n._(msg`Invalid date. Please use format ${format}`)
@@ -450,7 +475,7 @@ export function EmployeeEdit() {
                   />
                   {i18n.locale === "de" && (
                     <Text className="text-zinc-600 dark:text-zinc-400 text-sm mt-1">
-                      {germanContractStartDateHint}
+                      {GERMAN_CONTRACT_START_DATE_HINT}
                     </Text>
                   )}
                   {contractDateError && (

--- a/src/pages/Employees/EmployeeEdit.tsx
+++ b/src/pages/Employees/EmployeeEdit.tsx
@@ -29,6 +29,11 @@ import {
   parseEmployeeDateToISO,
 } from "./employeeDateUtils";
 
+const germanContractStartDateHint =
+  "Erwartetes Format: TT.MM.JJJJ. Optional ist TT.MM.; das aktuelle Jahr wird automatisch ergänzt.";
+const germanContractStartDateFormat =
+  "TT.MM.JJJJ (optional TT.MM. für das aktuelle Jahr)";
+
 /**
  * Employee Edit Form
  */
@@ -173,10 +178,45 @@ export function EmployeeEdit() {
       return;
     }
 
+    const birthDateResult = parseEmployeeDateToISO(
+      birthDateDisplay,
+      i18n.locale
+    );
+    if (!birthDateResult.valid) {
+      const format = i18n.locale === "de" ? "TT.MM.JJJJ" : "MM/DD/YYYY";
+      setBirthDateError(i18n._(msg`Invalid date. Please use format ${format}`));
+      return;
+    }
+
+    const contractDateResult = parseEmployeeDateToISO(
+      contractDateDisplay,
+      i18n.locale,
+      {
+        defaultCurrentYearForMissingYear: i18n.locale === "de",
+      }
+    );
+    if (!contractDateResult.valid) {
+      const format =
+        i18n.locale === "de" ? germanContractStartDateFormat : "MM/DD/YYYY";
+      setContractDateError(
+        i18n._(msg`Invalid date. Please use format ${format}`)
+      );
+      return;
+    }
+
     try {
       setLoading(true);
       setError(null);
-      const updatePayload: Partial<EmployeeFormData> = { ...formData };
+      setBirthDateDisplay(birthDateResult.formatted);
+      setContractDateDisplay(contractDateResult.formatted);
+      setBirthDateError(null);
+      setContractDateError(null);
+
+      const updatePayload: Partial<EmployeeFormData> = {
+        ...formData,
+        date_of_birth: birthDateResult.iso,
+        contract_start_date: contractDateResult.iso,
+      };
       delete updatePayload.status;
       await updateEmployee(id, updatePayload);
       navigate(`/employees/${id}`);
@@ -399,13 +439,20 @@ export function EmployeeEdit() {
                         setContractDateError(null);
                       } else if (e.target.value) {
                         const format =
-                          i18n.locale === "de" ? "TT.MM.JJJJ" : "MM/DD/YYYY";
+                          i18n.locale === "de"
+                            ? germanContractStartDateFormat
+                            : "MM/DD/YYYY";
                         setContractDateError(
                           i18n._(msg`Invalid date. Please use format ${format}`)
                         );
                       }
                     }}
                   />
+                  {i18n.locale === "de" && (
+                    <Text className="text-zinc-600 dark:text-zinc-400 text-sm mt-1">
+                      {germanContractStartDateHint}
+                    </Text>
+                  )}
                   {contractDateError && (
                     <Text className="text-red-600 dark:text-red-400 text-sm mt-1">
                       {contractDateError}

--- a/src/pages/Employees/EmployeeEdit.tsx
+++ b/src/pages/Employees/EmployeeEdit.tsx
@@ -389,7 +389,8 @@ export function EmployeeEdit() {
                         e.target.value,
                         i18n.locale,
                         {
-                          defaultCurrentYearForMissingYear: i18n.locale === "de",
+                          defaultCurrentYearForMissingYear:
+                            i18n.locale === "de",
                         }
                       );
                       if (result.valid) {

--- a/src/pages/Employees/employeeDateUtils.ts
+++ b/src/pages/Employees/employeeDateUtils.ts
@@ -7,6 +7,13 @@ export interface ParsedEmployeeDate {
   valid: boolean;
 }
 
+export const GERMAN_CONTRACT_START_DATE_HINT =
+  "Erwartetes Format: TT.MM.JJJJ. Optional ist TT.MM.; das aktuelle Jahr wird automatisch ergänzt.";
+export const GERMAN_CONTRACT_START_DATE_FORMAT =
+  "TT.MM.JJJJ (optional TT.MM. für das aktuelle Jahr)";
+export const GERMAN_CONTRACT_START_DATE_ERROR =
+  "Ungültiges Datum. Bitte verwenden Sie das Format TT.MM.JJJJ (optional TT.MM. für das aktuelle Jahr).";
+
 interface ParseEmployeeDateToIsoOptions {
   allowIsoInput?: boolean;
   defaultCurrentYearForMissingYear?: boolean;

--- a/src/pages/Employees/employeeDateUtils.ts
+++ b/src/pages/Employees/employeeDateUtils.ts
@@ -9,19 +9,22 @@ export interface ParsedEmployeeDate {
 
 interface ParseEmployeeDateToIsoOptions {
   allowIsoInput?: boolean;
+  defaultCurrentYearForMissingYear?: boolean;
 }
 
 function parseDateParts(
   displayDate: string,
   locale: string,
-  allowIsoInput: boolean
+  allowIsoInput: boolean,
+  defaultCurrentYearForMissingYear: boolean
 ): { day: number; month: number; year: number } | null {
   let day: number;
   let month: number;
   let year: number;
+  const normalizedDisplayDate = displayDate.trim();
 
-  if (allowIsoInput && /^\d{4}-\d{2}-\d{2}$/.test(displayDate)) {
-    const parts = displayDate.split("-");
+  if (allowIsoInput && /^\d{4}-\d{2}-\d{2}$/.test(normalizedDisplayDate)) {
+    const parts = normalizedDisplayDate.split("-");
     if (parts.length !== 3 || !parts[0] || !parts[1] || !parts[2]) {
       return null;
     }
@@ -29,7 +32,23 @@ function parseDateParts(
     month = parseInt(parts[1], 10);
     day = parseInt(parts[2], 10);
   } else if (locale === "de") {
-    const parts = displayDate.split(".");
+    const shortDateMatch = normalizedDisplayDate.match(
+      /^(\d{1,2})\.(\d{1,2})\.?$/
+    );
+    if (defaultCurrentYearForMissingYear && shortDateMatch) {
+      const shortDay = shortDateMatch[1];
+      const shortMonth = shortDateMatch[2];
+      if (!shortDay || !shortMonth) {
+        return null;
+      }
+
+      day = parseInt(shortDay, 10);
+      month = parseInt(shortMonth, 10);
+      year = new Date().getFullYear();
+      return { day, month, year };
+    }
+
+    const parts = normalizedDisplayDate.split(".");
     if (parts.length !== 3 || !parts[0] || !parts[1] || !parts[2]) {
       return null;
     }
@@ -37,7 +56,7 @@ function parseDateParts(
     month = parseInt(parts[1], 10);
     year = parseInt(parts[2], 10);
   } else {
-    const parts = displayDate.split("/");
+    const parts = normalizedDisplayDate.split("/");
     if (parts.length !== 3 || !parts[0] || !parts[1] || !parts[2]) {
       return null;
     }
@@ -89,7 +108,8 @@ export function parseEmployeeDateToISO(
     const parsedDate = parseDateParts(
       displayDate,
       locale,
-      options.allowIsoInput === true
+      options.allowIsoInput === true,
+      options.defaultCurrentYearForMissingYear === true
     );
     if (!parsedDate) {
       return { iso: "", formatted: displayDate, valid: false };


### PR DESCRIPTION
## Summary
- allow German short contract-start input without year (for example: `1.6.`)
- normalize to the current year and keep existing strict parsing for other formats
- cover create/edit employee flows with regression tests

## Testing
- npm run test -- src/pages/Employees/EmployeeCreate.test.tsx src/pages/Employees/EmployeeEdit.test.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes employee date parsing/validation and edit-submit behavior, which can affect what data is sent to the API and potentially block/allow submissions in create/edit flows.
> 
> **Overview**
> Adds support for *German short contract start dates without a year* (e.g. `1.6.`), defaulting the missing year to the current year and updating the error/hint copy for German users.
> 
> Updates `EmployeeCreate` and `EmployeeEdit` to use the new parsing option, show a German-only hint under the contract start date field, and in `EmployeeEdit` validates/normalizes dirty date fields on submit so changes are handled correctly even when the user doesn’t blur the input.
> 
> Expands create/edit test coverage to include the new German contract-date behavior and regression tests for submitting (or blocking) date changes without blur.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56315e6ece35ee5dd28ea607a3e5b0de3adbdada. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->