### PR TITLE
chore(deps): align react runtime dependabot fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: CC0-1.0
 
+---
 # Dependabot configuration for SecPal Frontend (React/TypeScript/Vite)
 # Automatically creates PRs for ALL dependency updates (including Major versions)
 # Security updates are prioritized and checked daily in early morning hours
@@ -26,6 +27,16 @@ updates:
     target-branch: "main"
     pull-request-branch-name:
       separator: "-"
+    groups:
+      react-runtime:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions - Workflow dependencies
   - package-ecosystem: "github-actions"
@@ -46,3 +57,8 @@ updates:
     target-branch: "main"
     pull-request-branch-name:
       separator: "-"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Grouped coupled React, React DOM, and React type-package minor/patch Dependabot updates into one frontend pull request, aligned the shared React runtime bump on `react` plus `react-dom` `^19.2.6`, grouped non-breaking GitHub Actions updates, and relaxed the live Lighthouse workflow regression check to require commit pinning instead of one historical `setup-chrome` SHA so Dependabot workflow bumps no longer open red CI from stale version-skew or hard-coded action pins.
 - Repaired employee-detail tab switching so hash deep links like `#contacts` no longer lock users on one tab, localized all new employee contact editing placeholders/labels, added explicit non-submit button types for emergency-contact add/remove actions, and centralized shared emergency-contact draft normalization helpers to avoid duplicate logic drift.
 - Blocked the dedicated employee contacts edit page from submitting partial overwrite payloads after an initial employee-load failure, and aligned dialog emergency-contact email handling to trim whitespace before validation so optional values behave consistently.
 - Routed onboarding pattern-validation guidance strings through Lingui catalogs (including the country-code helper text) so German onboarding flows no longer show hardcoded English validation copy.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,8 @@
         "dexie-react-hooks": "^4.4.0",
         "motion": "^12.38.0",
         "qrcode": "^1.5.4",
-        "react": "^19.2.5",
-        "react-dom": "^19.2.5",
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6",
         "react-router-dom": "^7.15.0",
         "web-vitals": "^5.2.0"
       },
@@ -11164,24 +11164,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.5"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -75,8 +75,8 @@
     "dexie-react-hooks": "^4.4.0",
     "motion": "^12.38.0",
     "qrcode": "^1.5.4",
-    "react": "^19.2.5",
-    "react-dom": "^19.2.5",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6",
     "react-router-dom": "^7.15.0",
     "web-vitals": "^5.2.0"
   },

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -129,7 +129,7 @@ describe("Build Configuration and Source Verification", () => {
       "name: Playwright Live Lighthouse"
     );
     expect(liveLighthouseWorkflow).toMatch(
-      /browser-actions\/setup-chrome@[0-9a-f]{40}/
+      /^\s*uses:\s*browser-actions\/setup-chrome@[0-9a-f]{40}$/m
     );
     expect(liveLighthouseWorkflow).toContain("id: setup-chrome");
     expect(liveLighthouseWorkflow).toContain("chrome-version: stable");

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -128,8 +128,8 @@ describe("Build Configuration and Source Verification", () => {
     expect(liveLighthouseWorkflow).toContain(
       "name: Playwright Live Lighthouse"
     );
-    expect(liveLighthouseWorkflow).toContain(
-      "browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded"
+    expect(liveLighthouseWorkflow).toMatch(
+      /browser-actions\/setup-chrome@[0-9a-f]{40}/
     );
     expect(liveLighthouseWorkflow).toContain("id: setup-chrome");
     expect(liveLighthouseWorkflow).toContain("chrome-version: stable");

--- a/tests/dependabot.config.test.ts
+++ b/tests/dependabot.config.test.ts
@@ -6,35 +6,35 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 describe("Dependabot configuration", () => {
-    const configPath = join(process.cwd(), ".github", "dependabot.yml");
-    const configText = readFileSync(configPath, "utf8");
-    const packageJsonPath = join(process.cwd(), "package.json");
-    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
-        dependencies?: Record<string, string>;
-    };
+  const configPath = join(process.cwd(), ".github", "dependabot.yml");
+  const configText = readFileSync(configPath, "utf8");
+  const packageJsonPath = join(process.cwd(), "package.json");
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+    dependencies?: Record<string, string>;
+  };
 
-    it("keeps the Dependabot config in the repository", () => {
-        expect(existsSync(configPath)).toBe(true);
-    });
+  it("keeps the Dependabot config in the repository", () => {
+    expect(existsSync(configPath)).toBe(true);
+  });
 
-    it("groups coupled React minor and patch updates into one pull request", () => {
-        expect(configText).toContain("react-runtime:");
-        expect(configText).toContain('- "react"');
-        expect(configText).toContain('- "react-dom"');
-        expect(configText).toContain('- "@types/react"');
-        expect(configText).toContain('- "@types/react-dom"');
-        expect(configText).toContain('- "minor"');
-        expect(configText).toContain('- "patch"');
-    });
+  it("groups coupled React minor and patch updates into one pull request", () => {
+    expect(configText).toContain("react-runtime:");
+    expect(configText).toContain('- "react"');
+    expect(configText).toContain('- "react-dom"');
+    expect(configText).toContain('- "@types/react"');
+    expect(configText).toContain('- "@types/react-dom"');
+    expect(configText).toContain('- "minor"');
+    expect(configText).toContain('- "patch"');
+  });
 
-    it("groups non-breaking GitHub Actions updates to reduce Dependabot PR noise", () => {
-        expect(configText).toContain('package-ecosystem: "github-actions"');
-        expect(configText).toContain("minor-and-patch:");
-    });
+  it("groups non-breaking GitHub Actions updates to reduce Dependabot PR noise", () => {
+    expect(configText).toContain('package-ecosystem: "github-actions"');
+    expect(configText).toContain("minor-and-patch:");
+  });
 
-    it("keeps top-level react runtime versions aligned", () => {
-        expect(packageJson.dependencies?.react).toBe(
-            packageJson.dependencies?.["react-dom"]
-        );
-    });
+  it("keeps top-level react runtime versions aligned", () => {
+    expect(packageJson.dependencies?.react).toBe(
+      packageJson.dependencies?.["react-dom"]
+    );
+  });
 });

--- a/tests/dependabot.config.test.ts
+++ b/tests/dependabot.config.test.ts
@@ -6,35 +6,35 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 describe("Dependabot configuration", () => {
-  const configPath = join(process.cwd(), ".github", "dependabot.yml");
-  const configText = readFileSync(configPath, "utf8");
-  const packageJsonPath = join(process.cwd(), "package.json");
-  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
-    dependencies?: Record<string, string>;
-  };
+    const configPath = join(process.cwd(), ".github", "dependabot.yml");
+    const configText = readFileSync(configPath, "utf8");
+    const packageJsonPath = join(process.cwd(), "package.json");
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+        dependencies?: Record<string, string>;
+    };
 
-  it("keeps the Dependabot config in the repository", () => {
-    expect(existsSync(configPath)).toBe(true);
-  });
+    it("keeps the Dependabot config in the repository", () => {
+        expect(existsSync(configPath)).toBe(true);
+    });
 
-  it("groups coupled React minor and patch updates into one pull request", () => {
-    expect(configText).toContain("react-runtime:");
-    expect(configText).toContain('- "react"');
-    expect(configText).toContain('- "react-dom"');
-    expect(configText).toContain('- "@types/react"');
-    expect(configText).toContain('- "@types/react-dom"');
-    expect(configText).toContain('- "minor"');
-    expect(configText).toContain('- "patch"');
-  });
+    it("groups coupled React minor and patch updates into one pull request", () => {
+        expect(configText).toContain("react-runtime:");
+        expect(configText).toContain('- "react"');
+        expect(configText).toContain('- "react-dom"');
+        expect(configText).toContain('- "@types/react"');
+        expect(configText).toContain('- "@types/react-dom"');
+        expect(configText).toContain('- "minor"');
+        expect(configText).toContain('- "patch"');
+    });
 
-  it("groups non-breaking GitHub Actions updates to reduce Dependabot PR noise", () => {
-    expect(configText).toContain('package-ecosystem: "github-actions"');
-    expect(configText).toContain("minor-and-patch:");
-  });
+    it("groups non-breaking GitHub Actions updates to reduce Dependabot PR noise", () => {
+        expect(configText).toContain('package-ecosystem: "github-actions"');
+        expect(configText).toContain("minor-and-patch:");
+    });
 
-  it("keeps top-level react runtime versions aligned", () => {
-    expect(packageJson.dependencies?.react).toBe(
-      packageJson.dependencies?.["react-dom"]
-    );
-  });
+    it("keeps top-level react runtime versions aligned", () => {
+        expect(packageJson.dependencies?.react).toBe(
+            packageJson.dependencies?.["react-dom"]
+        );
+    });
 });

--- a/tests/dependabot.config.test.ts
+++ b/tests/dependabot.config.test.ts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("Dependabot configuration", () => {
+  const configPath = join(process.cwd(), ".github", "dependabot.yml");
+  const configText = readFileSync(configPath, "utf8");
+  const packageJsonPath = join(process.cwd(), "package.json");
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+    dependencies?: Record<string, string>;
+  };
+
+  it("keeps the Dependabot config in the repository", () => {
+    expect(existsSync(configPath)).toBe(true);
+  });
+
+  it("groups coupled React minor and patch updates into one pull request", () => {
+    expect(configText).toContain("react-runtime:");
+    expect(configText).toContain('- "react"');
+    expect(configText).toContain('- "react-dom"');
+    expect(configText).toContain('- "@types/react"');
+    expect(configText).toContain('- "@types/react-dom"');
+    expect(configText).toContain('- "minor"');
+    expect(configText).toContain('- "patch"');
+  });
+
+  it("groups non-breaking GitHub Actions updates to reduce Dependabot PR noise", () => {
+    expect(configText).toContain('package-ecosystem: "github-actions"');
+    expect(configText).toContain("minor-and-patch:");
+  });
+
+  it("keeps top-level react runtime versions aligned", () => {
+    expect(packageJson.dependencies?.react).toBe(
+      packageJson.dependencies?.["react-dom"]
+    );
+  });
+});

--- a/tests/dependabot.config.test.ts
+++ b/tests/dependabot.config.test.ts
@@ -5,6 +5,32 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
+function getIndentedSection(text: string, sectionName: string): string {
+  const lines = text.split("\n");
+  const startIndex = lines.findIndex(
+    (line) => line.trim() === `${sectionName}:`
+  );
+
+  if (startIndex === -1) {
+    return "";
+  }
+
+  const sectionIndent = lines[startIndex].match(/^ */)?.[0].length ?? 0;
+  const sectionLines = [lines[startIndex]];
+
+  for (const line of lines.slice(startIndex + 1)) {
+    const lineIndent = line.match(/^ */)?.[0].length ?? 0;
+
+    if (line.trim() !== "" && lineIndent <= sectionIndent) {
+      break;
+    }
+
+    sectionLines.push(line);
+  }
+
+  return sectionLines.join("\n");
+}
+
 describe("Dependabot configuration", () => {
   const configPath = join(process.cwd(), ".github", "dependabot.yml");
   const configText = readFileSync(configPath, "utf8");
@@ -12,19 +38,20 @@ describe("Dependabot configuration", () => {
   const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
     dependencies?: Record<string, string>;
   };
+  const reactRuntimeGroup = getIndentedSection(configText, "react-runtime");
 
   it("keeps the Dependabot config in the repository", () => {
     expect(existsSync(configPath)).toBe(true);
   });
 
   it("groups coupled React minor and patch updates into one pull request", () => {
-    expect(configText).toContain("react-runtime:");
-    expect(configText).toContain('- "react"');
-    expect(configText).toContain('- "react-dom"');
-    expect(configText).toContain('- "@types/react"');
-    expect(configText).toContain('- "@types/react-dom"');
-    expect(configText).toContain('- "minor"');
-    expect(configText).toContain('- "patch"');
+    expect(reactRuntimeGroup).toContain("react-runtime:");
+    expect(reactRuntimeGroup).toContain('- "react"');
+    expect(reactRuntimeGroup).toContain('- "react-dom"');
+    expect(reactRuntimeGroup).toContain('- "@types/react"');
+    expect(reactRuntimeGroup).toContain('- "@types/react-dom"');
+    expect(reactRuntimeGroup).toContain('- "minor"');
+    expect(reactRuntimeGroup).toContain('- "patch"');
   });
 
   it("groups non-breaking GitHub Actions updates to reduce Dependabot PR noise", () => {

--- a/tests/dependabot.config.test.ts
+++ b/tests/dependabot.config.test.ts
@@ -33,18 +33,36 @@ function getIndentedSection(text: string, sectionName: string): string {
 
 describe("Dependabot configuration", () => {
   const configPath = join(process.cwd(), ".github", "dependabot.yml");
-  const configText = readFileSync(configPath, "utf8");
   const packageJsonPath = join(process.cwd(), "package.json");
-  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
-    dependencies?: Record<string, string>;
-  };
-  const reactRuntimeGroup = getIndentedSection(configText, "react-runtime");
+
+  function readConfigText(): string {
+    expect(existsSync(configPath)).toBe(true);
+
+    return readFileSync(configPath, "utf8");
+  }
+
+  function readDependencies(): Record<string, string> {
+    expect(existsSync(packageJsonPath)).toBe(true);
+
+    return (
+      (
+        JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+          dependencies?: Record<string, string>;
+        }
+      ).dependencies ?? {}
+    );
+  }
 
   it("keeps the Dependabot config in the repository", () => {
     expect(existsSync(configPath)).toBe(true);
   });
 
   it("groups coupled React minor and patch updates into one pull request", () => {
+    const reactRuntimeGroup = getIndentedSection(
+      readConfigText(),
+      "react-runtime"
+    );
+
     expect(reactRuntimeGroup).toContain("react-runtime:");
     expect(reactRuntimeGroup).toContain('- "react"');
     expect(reactRuntimeGroup).toContain('- "react-dom"');
@@ -55,13 +73,17 @@ describe("Dependabot configuration", () => {
   });
 
   it("groups non-breaking GitHub Actions updates to reduce Dependabot PR noise", () => {
+    const configText = readConfigText();
+
     expect(configText).toContain('package-ecosystem: "github-actions"');
     expect(configText).toContain("minor-and-patch:");
   });
 
   it("keeps top-level react runtime versions aligned", () => {
-    expect(packageJson.dependencies?.react).toBe(
-      packageJson.dependencies?.["react-dom"]
-    );
+    const dependencies = readDependencies();
+
+    expect(dependencies.react).toBeDefined();
+    expect(dependencies["react-dom"]).toBeDefined();
+    expect(dependencies.react).toBe(dependencies["react-dom"]);
   });
 });


### PR DESCRIPTION
## Summary
- group coupled React runtime and non-breaking GitHub Actions Dependabot updates to prevent split CI failures
- bump react and react-dom together to ^19.2.6 in one shared change set
- relax the live Lighthouse workflow regression check to require commit pinning rather than one historical setup-chrome SHA

## Notes
- GitHub cannot reopen #1075 and #1076 directly because their Dependabot branches were deleted; @dependabot recreate has been requested on both PRs so Dependabot can recreate them untouched
- this PR intentionally leaves the Dependabot PRs themselves unmodified and provides the shared green path for the paired React bump

## Validation
- npm exec -- vitest run tests/dependabot.config.test.ts tests/build.test.ts
- npm run lint
- npm run typecheck
- npm run build
- npm exec -- prettier --check .github/dependabot.yml tests/dependabot.config.test.ts tests/build.test.ts CHANGELOG.md package.json package-lock.json

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: configuration/test updates plus a small React/ReactDOM patch bump; no runtime logic changes beyond dependency versions.
> 
> **Overview**
> **Dependabot update noise/CI skew is reduced** by grouping coupled `react`/`react-dom` and React type-package *minor/patch* updates into a single PR, and by grouping non-breaking GitHub Actions updates.
> 
> Bumps `react` and `react-dom` from `^19.2.5` to `^19.2.6` (lockfile included) and adds Vitest coverage (`tests/dependabot.config.test.ts`) to keep the Dependabot grouping and React version alignment enforced.
> 
> Relaxes the build regression check for the live Lighthouse workflow from a hard-coded `browser-actions/setup-chrome` SHA to a “pinned-to-40-hex-SHA” regex, and documents the change in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72cc6f06ed645f108a60d88ff524842574a18702. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->