### PR TITLE
fix(config): route preview workspaces to sibling API

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -344,6 +344,19 @@ describe("config", () => {
     ).toBe("https://api-velvet-zebra.preview.secpal.dev");
   });
 
+  it("normalizes preview workspace casing before matching the configured API host", async () => {
+    vi.stubEnv("MODE", "production");
+    vi.stubEnv("VITE_API_URL", "https://velvet-zebra.preview.secpal.dev");
+
+    const { resolveApiBaseUrl } = await import("./config");
+
+    expect(
+      resolveApiBaseUrl({
+        runtimeHostname: "Velvet-Zebra.preview.secpal.dev",
+      })
+    ).toBe("https://api-velvet-zebra.preview.secpal.dev");
+  });
+
   it("uses the Polyscope workspace sibling API when the bundle leaked a loopback base on a prefixed frontend preview host", async () => {
     vi.stubEnv("MODE", "preview");
     vi.stubEnv("VITE_API_URL", "http://localhost:4173");

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -185,7 +185,7 @@ describe("config", () => {
     ).toBe("https://api-grumpy-lynx.preview.secpal.dev/v1/auth/login");
   });
 
-  it("falls back to the current workspace preview API origin on frontend preview hosts when VITE_API_URL points at another absolute preview origin", async () => {
+  it("preserves an explicitly configured different preview API host on frontend preview hosts", async () => {
     vi.stubEnv("MODE", "production");
     vi.stubEnv("VITE_API_URL", "https://api-otter.preview.secpal.dev");
 
@@ -195,12 +195,12 @@ describe("config", () => {
       resolveApiBaseUrl({
         runtimeHostname: "frontend-grumpy-lynx.preview.secpal.dev",
       })
-    ).toBe("https://api-grumpy-lynx.preview.secpal.dev");
+    ).toBe("https://api-otter.preview.secpal.dev");
     expect(
       buildApiUrl("/v1/auth/login", {
         runtimeHostname: "frontend-grumpy-lynx.preview.secpal.dev",
       })
-    ).toBe("https://api-grumpy-lynx.preview.secpal.dev/v1/auth/login");
+    ).toBe("https://api-otter.preview.secpal.dev/v1/auth/login");
   });
 
   it("falls back to the workspace preview API origin on generic workspace preview hosts when the bundle kept a loopback API base", async () => {
@@ -239,7 +239,7 @@ describe("config", () => {
     ).toBe("https://api-grumpy-lynx.preview.secpal.dev/v1/auth/login");
   });
 
-  it("falls back to the current workspace preview API origin on generic workspace preview hosts when VITE_API_URL points at an unrelated absolute API origin", async () => {
+  it("preserves an explicitly configured unrelated API origin on generic workspace preview hosts", async () => {
     vi.stubEnv("MODE", "production");
     vi.stubEnv("VITE_API_URL", "https://api.secpal.dev");
 
@@ -249,11 +249,130 @@ describe("config", () => {
       resolveApiBaseUrl({
         runtimeHostname: "grumpy-lynx.preview.secpal.dev",
       })
-    ).toBe("https://api-grumpy-lynx.preview.secpal.dev");
+    ).toBe("https://api.secpal.dev");
     expect(
       buildApiUrl("/sanctum/csrf-cookie", {
         runtimeHostname: "grumpy-lynx.preview.secpal.dev",
       })
-    ).toBe("https://api-grumpy-lynx.preview.secpal.dev/sanctum/csrf-cookie");
+    ).toBe("https://api.secpal.dev/sanctum/csrf-cookie");
+  });
+
+  it("uses the Polyscope workspace sibling API when the bundle leaked a loopback base on a preview workspace host", async () => {
+    vi.stubEnv("MODE", "preview");
+    vi.stubEnv("VITE_API_URL", "http://localhost:4173");
+
+    const { resolveApiBaseUrl, buildApiUrl } = await import("./config");
+
+    expect(
+      resolveApiBaseUrl({
+        runtimeHostname: "velvet-zebra.preview.secpal.dev",
+      })
+    ).toBe("https://api-velvet-zebra.preview.secpal.dev");
+
+    expect(
+      buildApiUrl("/sanctum/csrf-cookie", {
+        runtimeHostname: "velvet-zebra.preview.secpal.dev",
+      })
+    ).toBe("https://api-velvet-zebra.preview.secpal.dev/sanctum/csrf-cookie");
+  });
+
+  it("uses the Polyscope workspace API in production mode when the runtime host is a preview workspace and VITE_API_URL is loopback", async () => {
+    vi.stubEnv("MODE", "production");
+    vi.stubEnv("VITE_API_URL", "http://localhost:4173");
+
+    const { resolveApiBaseUrl } = await import("./config");
+
+    expect(
+      resolveApiBaseUrl({
+        runtimeHostname: "velvet-zebra.preview.secpal.dev",
+      })
+    ).toBe("https://api-velvet-zebra.preview.secpal.dev");
+  });
+
+  it("uses the Polyscope workspace API when production VITE_API_URL is empty on a preview workspace host", async () => {
+    vi.stubEnv("MODE", "production");
+    vi.stubEnv("VITE_API_URL", "");
+
+    const { resolveApiBaseUrl } = await import("./config");
+
+    expect(
+      resolveApiBaseUrl({
+        runtimeHostname: "velvet-zebra.preview.secpal.dev",
+      })
+    ).toBe("https://api-velvet-zebra.preview.secpal.dev");
+  });
+
+  it("keeps an explicit non-loopback API base on Polyscope preview workspaces", async () => {
+    vi.stubEnv("MODE", "production");
+    vi.stubEnv(
+      "VITE_API_URL",
+      "https://api-velvet-zebra.preview.secpal.dev/custom/path"
+    );
+
+    const { resolveApiBaseUrl } = await import("./config");
+
+    expect(
+      resolveApiBaseUrl({
+        runtimeHostname: "velvet-zebra.preview.secpal.dev",
+      })
+    ).toBe("https://api-velvet-zebra.preview.secpal.dev");
+  });
+
+  it("does not override a different explicit preview API host on a Polyscope workspace app", async () => {
+    vi.stubEnv("MODE", "production");
+    vi.stubEnv("VITE_API_URL", "https://api-other.preview.secpal.dev");
+
+    const { resolveApiBaseUrl } = await import("./config");
+
+    expect(
+      resolveApiBaseUrl({
+        runtimeHostname: "velvet-zebra.preview.secpal.dev",
+      })
+    ).toBe("https://api-other.preview.secpal.dev");
+  });
+
+  it("replaces an API base that mistakenly points at the SPA preview host with the workspace API", async () => {
+    vi.stubEnv("MODE", "production");
+    vi.stubEnv("VITE_API_URL", "https://velvet-zebra.preview.secpal.dev");
+
+    const { resolveApiBaseUrl } = await import("./config");
+
+    expect(
+      resolveApiBaseUrl({
+        runtimeHostname: "velvet-zebra.preview.secpal.dev",
+      })
+    ).toBe("https://api-velvet-zebra.preview.secpal.dev");
+  });
+
+  it("uses the Polyscope workspace sibling API when the bundle leaked a loopback base on a prefixed frontend preview host", async () => {
+    vi.stubEnv("MODE", "preview");
+    vi.stubEnv("VITE_API_URL", "http://localhost:4173");
+
+    const { resolveApiBaseUrl, buildApiUrl } = await import("./config");
+
+    expect(
+      resolveApiBaseUrl({
+        runtimeHostname: "frontend-velvet-zebra.preview.secpal.dev",
+      })
+    ).toBe("https://api-velvet-zebra.preview.secpal.dev");
+
+    expect(
+      buildApiUrl("/sanctum/csrf-cookie", {
+        runtimeHostname: "frontend-velvet-zebra.preview.secpal.dev",
+      })
+    ).toBe("https://api-velvet-zebra.preview.secpal.dev/sanctum/csrf-cookie");
+  });
+
+  it("uses the Polyscope workspace API when production VITE_API_URL is empty on a prefixed frontend preview host", async () => {
+    vi.stubEnv("MODE", "production");
+    vi.stubEnv("VITE_API_URL", "");
+
+    const { resolveApiBaseUrl } = await import("./config");
+
+    expect(
+      resolveApiBaseUrl({
+        runtimeHostname: "frontend-velvet-zebra.preview.secpal.dev",
+      })
+    ).toBe("https://api-velvet-zebra.preview.secpal.dev");
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,6 +60,12 @@ function getRuntimeHostname(): string | null {
   return window.location.hostname || null;
 }
 
+/**
+ * Polyscope preview apps are served at `{workspace}.preview.secpal.dev` with a
+ * sibling API host `api-{workspace}.preview.secpal.dev`. CI or mis-built bundles
+ * sometimes bake in `http://localhost:4173` as `VITE_API_URL`; in the browser we
+ * must still talk to the workspace API, not the developer machine.
+ */
 function getCanonicalPreviewApiOrigin(
   runtimeHostname: string | null
 ): string | null {
@@ -73,6 +79,54 @@ function getCanonicalPreviewApiOrigin(
   }
 
   return `https://api-${previewHostname.workspace}.preview.secpal.dev`;
+}
+
+/**
+ * Returns true only when the configured API base should be replaced by the
+ * workspace-sibling preview API: empty, relative, loopback, or pointing at the
+ * SPA preview host itself. Explicitly configured hosts for a different workspace
+ * or a production API are preserved as-is.
+ */
+function shouldReplaceConfiguredApiBaseWithPreviewWorkspaceOrigin(
+  normalizedConfiguredBaseUrl: string,
+  runtimeHostname: string | null
+): boolean {
+  const runtimePreviewHostname = parsePreviewHostname(runtimeHostname);
+
+  if (
+    !runtimePreviewHostname ||
+    (runtimePreviewHostname.repo !== null &&
+      runtimePreviewHostname.repo !== "frontend")
+  ) {
+    return false;
+  }
+
+  if (!normalizedConfiguredBaseUrl) {
+    return true;
+  }
+
+  if (!isAbsoluteHttpUrl(normalizedConfiguredBaseUrl)) {
+    return true;
+  }
+
+  let configuredHostname: string;
+  try {
+    configuredHostname = new URL(normalizedConfiguredBaseUrl).hostname;
+  } catch {
+    return true;
+  }
+
+  if (isLoopbackApiHost(configuredHostname)) {
+    return true;
+  }
+
+  const configuredPreviewHostname = parsePreviewHostname(configuredHostname);
+
+  return Boolean(
+    configuredPreviewHostname?.workspace === runtimePreviewHostname.workspace &&
+      (configuredPreviewHostname.repo === null ||
+        configuredPreviewHostname.repo === "frontend")
+  );
 }
 
 function shouldUseCanonicalLiveApiOrigin(
@@ -124,7 +178,13 @@ export function resolveApiBaseUrl(options?: {
   const canonicalPreviewApiOrigin =
     getCanonicalPreviewApiOrigin(runtimeHostname);
 
-  if (canonicalPreviewApiOrigin !== null) {
+  if (
+    canonicalPreviewApiOrigin &&
+    shouldReplaceConfiguredApiBaseWithPreviewWorkspaceOrigin(
+      normalizedConfiguredBaseUrl,
+      runtimeHostname
+    )
+  ) {
     return canonicalPreviewApiOrigin;
   }
 
@@ -174,6 +234,10 @@ export const apiConfig = {
    * - Demo/Testing: https://api.secpal.dev
    * - Production: deployment-specific absolute API origin provided during deployment
    * - Customer On-Premise: customer-specific absolute API origin provided during deployment
+   * - Polyscope preview: `{workspace}.preview.secpal.dev` resolves to
+   *   `https://api-{workspace}.preview.secpal.dev` when the bundle’s base URL is
+   *   empty, relative, loopback, or the SPA host (so leaked CI `localhost:4173`
+   *   never overrides the workspace API).
    *
    * Note: The backend uses apiPrefix: '' in Laravel's bootstrap/app.php,
    * so routes are accessible at /v1/* NOT /api/v1/*

--- a/src/config.ts
+++ b/src/config.ts
@@ -124,8 +124,8 @@ function shouldReplaceConfiguredApiBaseWithPreviewWorkspaceOrigin(
 
   return Boolean(
     configuredPreviewHostname?.workspace === runtimePreviewHostname.workspace &&
-      (configuredPreviewHostname.repo === null ||
-        configuredPreviewHostname.repo === "frontend")
+    (configuredPreviewHostname.repo === null ||
+      configuredPreviewHostname.repo === "frontend")
   );
 }
 


### PR DESCRIPTION
## Summary
- route Polyscope preview frontends to the matching `api-{workspace}.preview.secpal.dev` host when the bundle leaks a loopback, relative, or SPA-host API base
- keep explicitly configured non-loopback preview API hosts intact instead of rewriting valid deploy-time configuration
- add focused config coverage for bare and prefixed preview hostnames across preview and production runtime modes

## Test plan
- [x] `npx vitest run src/config.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime API routing decisions for preview workspace hosts, which could affect auth/API traffic if the hostname matching is wrong, but the behavior is narrowly scoped and covered by new tests.
> 
> **Overview**
> Ensures Polyscope preview workspace frontends (e.g. `*.preview.secpal.dev` and `frontend-*.preview.secpal.dev`) automatically use the sibling API origin `https://api-{workspace}.preview.secpal.dev` when `VITE_API_URL` is missing/relative, loopback, invalid, or mistakenly points at the SPA preview host.
> 
> Adds preview-host parsing and replacement rules that *preserve explicitly configured non-loopback API hosts* (including different preview API hosts), and expands `config.test.ts` coverage across preview/production modes and hostname casing/prefix variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c654b5b8b3f6d241071f64e85732e0c3714f02cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->