### PR TITLE
fix(tests): align API preview URL when PLAYWRIGHT_API_BASE_URL is non-preview

### DIFF
--- a/tests/e2e/target-urls.ts
+++ b/tests/e2e/target-urls.ts
@@ -138,6 +138,21 @@ export function resolvePlaywrightApiBaseUrl(
       );
     }
 
+    const configuredBaseUrl = readTrimmedEnvValue(env.PLAYWRIGHT_BASE_URL);
+    const configuredBasePreviewHostname = configuredBaseUrl
+      ? getPreviewHostnameFromBaseUrl(configuredBaseUrl)
+      : undefined;
+
+    if (
+      configuredBasePreviewHostname &&
+      (configuredBasePreviewHostname.repo === null ||
+        configuredBasePreviewHostname.repo === "frontend")
+    ) {
+      return buildWorkspacePreviewApiBaseUrl(
+        configuredBasePreviewHostname.workspace
+      );
+    }
+
     return configuredApiBaseUrl;
   }
 

--- a/tests/playwright-config.test.ts
+++ b/tests/playwright-config.test.ts
@@ -63,6 +63,7 @@ describe("playwright config", () => {
     vi.stubEnv("CI", "true");
     vi.stubEnv("PLAYWRIGHT_BASE_URL", "");
     vi.stubEnv("PLAYWRIGHT_LIGHTHOUSE", "1");
+    mockNonPolyscopeCwd();
     vi.resetModules();
     const { default: config } = await import("../playwright.config");
 
@@ -82,6 +83,7 @@ describe("playwright config", () => {
     vi.stubEnv("CI", "true");
     vi.stubEnv("PLAYWRIGHT_BASE_URL", "");
     vi.stubEnv("PLAYWRIGHT_LIGHTHOUSE", "");
+    mockNonPolyscopeCwd();
     vi.resetModules();
     const { default: config } = await import("../playwright.config");
 

--- a/tests/playwright-target-resolution.test.ts
+++ b/tests/playwright-target-resolution.test.ts
@@ -148,4 +148,22 @@ describe("playwright target resolution", () => {
     );
     expect(config.webServer).toBeUndefined();
   });
+
+  it("derives the API preview URL from the frontend preview when PLAYWRIGHT_API_BASE_URL is a non-preview value", async () => {
+    vi.stubEnv(
+      "PLAYWRIGHT_BASE_URL",
+      "https://frontend-grumpy-lynx.preview.secpal.dev"
+    );
+    vi.stubEnv("PLAYWRIGHT_API_BASE_URL", "https://api.secpal.dev");
+    vi.stubEnv("POLYSCOPE_WORKSPACE", "");
+    vi.stubEnv("CI", "");
+    vi.spyOn(process, "cwd").mockReturnValue("/home/user/my-app");
+
+    const { resolvePlaywrightApiBaseUrl } =
+      await import("./e2e/target-urls.ts");
+
+    expect(resolvePlaywrightApiBaseUrl()).toBe(
+      "https://api-grumpy-lynx.preview.secpal.dev"
+    );
+  });
 });


### PR DESCRIPTION
## Description

Addresses two findings from the Copilot review of #1095:

1. **API preview URL drift** (from `copilot-pull-request-reviewer`): When
   `PLAYWRIGHT_BASE_URL` points to a workspace preview and
   `PLAYWRIGHT_API_BASE_URL` is set to a non-preview live URL (e.g.
   `https://api.secpal.dev`), `resolvePlaywrightApiBaseUrl()` was returning
   the stale live API URL, splitting E2E runs across a preview frontend and the
   live API. Fixed by checking whether `PLAYWRIGHT_BASE_URL` resolves to a
   workspace preview before returning the configured API URL.

2. **Polyscope cwd isolation** (from `copilot-pull-request-reviewer`): The two
   Lighthouse playwright config tests (`enables a fixed chromium CDP port` and
   `does not pin chromium CDP port`) were missing `mockNonPolyscopeCwd()`,
   leaving them fragile when the test suite runs from inside a
   `.polyscope/clones/...` worktree. Extended the existing helper to cover
   those tests.

## Related Issues

Follows up #1095 Copilot review findings.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] TDD: new failing test added first, fix implemented, then green
- [x] Passing proof: `npx vitest run tests/playwright-target-resolution.test.ts tests/playwright-config.test.ts tests/auth-e2e-helpers.test.ts` (36 tests pass)

## TDD / Validate-First Evidence

- Failing proof before implementation: `derives the API preview URL from the frontend preview when PLAYWRIGHT_API_BASE_URL is a non-preview value` fails with `expected https://api.secpal.dev to be https://api-grumpy-lynx.preview.secpal.dev`
- Passing proof after implementation: all 36 tests pass
- No executable change reason: N/A

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] CHANGELOG.md updated
- [x] No new warnings introduced
- [x] Tests pass locally
- [x] Related issues linked above

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Playwright E2E target resolution so the API base URL can be implicitly rewritten to a workspace preview based on `PLAYWRIGHT_BASE_URL`, which could redirect CI/E2E runs to different backends if env vars are mis-set. Impact is limited to test configuration and URL selection logic.
> 
> **Overview**
> Prevents E2E runs from accidentally splitting traffic between a workspace preview frontend and the live API by teaching `resolvePlaywrightApiBaseUrl()` to derive the API preview origin from `PLAYWRIGHT_BASE_URL` when `PLAYWRIGHT_API_BASE_URL` is set to a non-preview value.
> 
> Hardens Playwright config tests by mocking a non-Polyscope `cwd` in the Lighthouse/CI cases, and adds a regression test covering the “preview frontend + live API URL” scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0049fd879b35cec0908ea8efb591aee73715bf11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->