### PR TITLE
Restrict loopback export URLs in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Blocked unsafe server-provided BWR export download URLs in the employee panel by allowing only HTTPS URLs, plus HTTP loopback URLs for local development, before rendering a download link.
+- Blocked unsafe server-provided BWR export download URLs in the employee panel by allowing only HTTPS URLs, plus HTTP loopback URLs only for local development or loopback app origins, before rendering a download link.
 - Added the Phase-2 offline-vault baseline for persisted frontend PII: the authenticated profile now moves out of `auth_user` localStorage into wrapped vault-backed IndexedDB storage, legacy encrypted `auth_user` records are migrated one-way into the vault, and long-term offline analytics plus organizational-unit cache records now persist encrypted at rest with focused regression coverage for frontend issue #1005.
 - Added an optional native device-bound wrapper boundary for the offline vault so native-capable runtimes can prefer bridge-backed root-key wrapping while browser and unsupported runtimes keep the browser-session wrapper fallback; the missing Android bridge implementation is now tracked separately in `SecPal/android#191`, resolving the frontend-side scope of issue #1006.
 - Added a local offline-vault lock flow that clears in-memory access without deleting encrypted at-rest data, exposes a non-PII unlock screen across protected routes, propagates lock state across tabs, and keeps explicit sign-out destructive for device cleanup, resolving frontend issue #1007.

--- a/src/pages/Employees/EmployeeBwrPanel.tsx
+++ b/src/pages/Employees/EmployeeBwrPanel.tsx
@@ -179,8 +179,15 @@ export function EmployeeBwrPanel({
       setExportLoading(true);
       const response = await exportEmployeeBwr(employee.id, exportFormat);
       const safeDownloadUrl = response.download_url.trim();
-      const hasSafeDownloadUrl = isSafeHttpUrl(safeDownloadUrl);
-      setLatestExportUrl(hasSafeDownloadUrl ? safeDownloadUrl : null);
+      if (!isSafeHttpUrl(safeDownloadUrl)) {
+        setPanelError(
+          _(
+            msg`The export download link returned by the server is not safe to open.`
+          )
+        );
+        return;
+      }
+      setLatestExportUrl(safeDownloadUrl);
       const refreshedEmployee = await onRefresh();
       if (refreshedEmployee) {
         const refreshedStatus =
@@ -190,14 +197,6 @@ export function EmployeeBwrPanel({
         );
         setBwrId(refreshedEmployee.bwr_id ?? "");
         setNotes(refreshedEmployee.bwr_notes ?? "");
-      }
-      if (!hasSafeDownloadUrl) {
-        setPanelError(
-          _(
-            msg`The export download link returned by the server is not safe to open.`
-          )
-        );
-        return;
       }
       setSuccessMessage(_(msg`BWR export generated. Download the file below.`));
     } catch (error) {

--- a/src/utils/safeUrl.test.ts
+++ b/src/utils/safeUrl.test.ts
@@ -8,12 +8,43 @@ describe("isSafeHttpUrl", () => {
   it.each([
     "https://api.secpal.dev/v1/employees/emp-1/export.csv",
     "https://api.secpal.dev/path?token=abc#download",
+  ])("allows HTTPS URLs: %s", (value) => {
+    expect(isSafeHttpUrl(value)).toBe(true);
+  });
+
+  it.each([
     "http://localhost:5173/export.csv",
     "http://127.0.0.1:4173/export.csv",
     "http://127.42.0.1:4173/export.csv",
     "http://[::1]:4173/export.csv",
-  ])("allows safe HTTP URLs: %s", (value) => {
-    expect(isSafeHttpUrl(value)).toBe(true);
+  ])("allows loopback HTTP URLs in development: %s", (value) => {
+    expect(isSafeHttpUrl(value, { allowDevLoopback: true })).toBe(true);
+  });
+
+  it.each([
+    "http://localhost:5173/export.csv",
+    "http://127.0.0.1:4173/export.csv",
+    "http://[::1]:4173/export.csv",
+  ])("allows loopback HTTP URLs from loopback app origins: %s", (value) => {
+    expect(
+      isSafeHttpUrl(value, {
+        allowDevLoopback: false,
+        currentHostname: "localhost",
+      })
+    ).toBe(true);
+  });
+
+  it.each([
+    "http://localhost:5173/export.csv",
+    "http://127.0.0.1:4173/export.csv",
+    "http://[::1]:4173/export.csv",
+  ])("rejects loopback HTTP URLs from production app origins: %s", (value) => {
+    expect(
+      isSafeHttpUrl(value, {
+        allowDevLoopback: false,
+        currentHostname: "app.secpal.dev",
+      })
+    ).toBe(false);
   });
 
   it.each([

--- a/src/utils/safeUrl.ts
+++ b/src/utils/safeUrl.ts
@@ -1,19 +1,53 @@
 // SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
-const LOOPBACK_IPV4_PATTERN = /^127(?:\.\d{1,3}){3}$/;
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "::1", "[::1]"]);
+
+interface SafeHttpUrlOptions {
+  currentHostname?: string;
+  allowDevLoopback?: boolean;
+}
+
+function isIpv4LoopbackHostname(hostname: string): boolean {
+  const parts = hostname.split(".");
+  if (parts.length !== 4) {
+    return false;
+  }
+
+  const octets = parts.map((part) => Number(part));
+  return (
+    parts.every((part) => /^\d+$/.test(part)) &&
+    octets.every(
+      (octet) => Number.isInteger(octet) && octet >= 0 && octet <= 255
+    ) &&
+    octets[0] === 127
+  );
+}
 
 function isLoopbackHostname(hostname: string): boolean {
   const normalizedHostname = hostname.toLowerCase();
 
   return (
     LOOPBACK_HOSTNAMES.has(normalizedHostname) ||
-    LOOPBACK_IPV4_PATTERN.test(normalizedHostname)
+    isIpv4LoopbackHostname(normalizedHostname)
   );
 }
 
-export function isSafeHttpUrl(value: string): boolean {
+function isLoopbackHttpAllowed(options: SafeHttpUrlOptions): boolean {
+  if (options.allowDevLoopback ?? import.meta.env.DEV) {
+    return true;
+  }
+
+  const currentHostname =
+    options.currentHostname ?? globalThis.location?.hostname ?? "";
+
+  return isLoopbackHostname(currentHostname);
+}
+
+export function isSafeHttpUrl(
+  value: string,
+  options: SafeHttpUrlOptions = {}
+): boolean {
   const trimmedValue = value.trim();
   if (trimmedValue === "") {
     return false;
@@ -31,6 +65,8 @@ export function isSafeHttpUrl(value: string): boolean {
   }
 
   return (
-    parsedUrl.protocol === "http:" && isLoopbackHostname(parsedUrl.hostname)
+    parsedUrl.protocol === "http:" &&
+    isLoopbackHostname(parsedUrl.hostname) &&
+    isLoopbackHttpAllowed(options)
   );
 }


### PR DESCRIPTION
## Summary
- Restrict `http:` loopback export download URLs to local development or loopback app origins only.
- Keep HTTPS export URLs allowed while preventing production app origins from rendering `http://localhost`, `127.0.0.0/8`, or `::1` links.
- Extend safe URL tests for production-origin loopback rejection.

## Test plan
- [x] `npm run test -- src/utils/safeUrl.test.ts src/pages/Employees/EmployeeBwrPanel.test.tsx src/pages/Employees/EmployeeDetail.test.tsx`
- [x] `npm run typecheck`
- [x] `npm run lint`

Follow-up to #1109 after the Copilot review fix landed after merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens URL validation for server-provided download links, which is security-relevant and could block legitimate exports if origin/hostname detection is misconfigured.
> 
> **Overview**
> Prevents the employee BWR export panel from rendering server-provided `http://` loopback download links unless the app is running in *development* or the current app origin is itself loopback; `https://` links remain allowed.
> 
> Updates `isSafeHttpUrl` to accept options (`allowDevLoopback`, `currentHostname`) and adds test coverage for rejecting loopback URLs from production origins, plus a small flow tweak in `EmployeeBwrPanel` to fail fast and surface an error when an unsafe link is returned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d0ca1def81c07ca0f370e62f714aa930a87f53c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->