### PR TITLE
fix: sanitize contact href targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Blocked unsafe server-provided customer and site contact email/phone values from becoming `mailto:` or `tel:` links unless they match the expected address/dial-string shape, preventing mail client query/header injection and dialer parameter abuse.
 - Blocked unsafe server-provided BWR export download URLs in the employee panel by allowing only HTTPS URLs, plus HTTP loopback URLs only for local development or loopback app origins, before rendering a download link.
 - Added the Phase-2 offline-vault baseline for persisted frontend PII: the authenticated profile now moves out of `auth_user` localStorage into wrapped vault-backed IndexedDB storage, legacy encrypted `auth_user` records are migrated one-way into the vault, and long-term offline analytics plus organizational-unit cache records now persist encrypted at rest with focused regression coverage for frontend issue #1005.
 - Added an optional native device-bound wrapper boundary for the offline vault so native-capable runtimes can prefer bridge-backed root-key wrapping while browser and unsupported runtimes keep the browser-session wrapper fallback; the missing Android bridge implementation is now tracked separately in `SecPal/android#191`, resolving the frontend-side scope of issue #1006.

--- a/src/pages/Customers/CustomerDetail.test.tsx
+++ b/src/pages/Customers/CustomerDetail.test.tsx
@@ -41,6 +41,20 @@ function renderWithRouter() {
   );
 }
 
+function expectNoUnsafeContactHrefs(container: HTMLElement) {
+  const contactHrefs = Array.from(
+    container.querySelectorAll<HTMLAnchorElement>(
+      'a[href^="mailto:"], a[href^="tel:"]'
+    )
+  ).map((anchor) => anchor.getAttribute("href") ?? "");
+
+  expect(contactHrefs).not.toEqual(
+    expect.arrayContaining([
+      expect.stringMatching(/^(?:mailto|tel):.*[?&#\n\r]/),
+    ])
+  );
+}
+
 describe("CustomerDetail", () => {
   const mockCustomer = {
     id: "customer-123",
@@ -102,6 +116,41 @@ describe("CustomerDetail", () => {
 
     expect(screen.getByText("max@test-customer.de")).toBeInTheDocument();
     expect(screen.getByText("+49 89 12345678")).toBeInTheDocument();
+    expect(
+      screen.getByText("max@test-customer.de").closest("a")
+    ).toHaveAttribute("href", "mailto:max@test-customer.de");
+    expect(screen.getByText("+49 89 12345678").closest("a")).toHaveAttribute(
+      "href",
+      "tel:+49 89 12345678"
+    );
+  });
+
+  it("renders unsafe contact email and phone as plain text", async () => {
+    const unsafeCustomer = {
+      ...mockCustomer,
+      contact: {
+        ...mockCustomer.contact,
+        email: "target@example.com?bcc=attacker@evil.com&subject=PWN",
+        phone: "+49?suffix=evil",
+      },
+    };
+    vi.mocked(customersApi.getCustomer).mockResolvedValue(unsafeCustomer);
+
+    const { container } = renderWithRouter();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(unsafeCustomer.contact.email)
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(unsafeCustomer.contact.email).closest("a")
+    ).toBeNull();
+    expect(
+      screen.getByText(unsafeCustomer.contact.phone).closest("a")
+    ).toBeNull();
+    expectNoUnsafeContactHrefs(container);
   });
 
   it("displays notes", async () => {

--- a/src/pages/Customers/CustomerDetail.tsx
+++ b/src/pages/Customers/CustomerDetail.tsx
@@ -28,6 +28,7 @@ import {
   DialogActions,
 } from "../../components/dialog";
 import { useUserCapabilities } from "../../hooks/useUserCapabilities";
+import { isSafeMailtoTarget, isSafeTelTarget } from "../../utils/safeUrl";
 
 export default function CustomerDetail() {
   const capabilities = useUserCapabilities();
@@ -174,12 +175,16 @@ export default function CustomerDetail() {
                     <Trans>Email</Trans>
                   </DescriptionTerm>
                   <DescriptionDetails>
-                    <a
-                      href={`mailto:${customer.contact.email}`}
-                      className="text-blue-600 hover:underline"
-                    >
-                      {customer.contact.email}
-                    </a>
+                    {isSafeMailtoTarget(customer.contact.email) ? (
+                      <a
+                        href={`mailto:${customer.contact.email}`}
+                        className="text-blue-600 hover:underline"
+                      >
+                        {customer.contact.email}
+                      </a>
+                    ) : (
+                      customer.contact.email
+                    )}
                   </DescriptionDetails>
                 </>
               )}
@@ -190,12 +195,16 @@ export default function CustomerDetail() {
                     <Trans>Phone</Trans>
                   </DescriptionTerm>
                   <DescriptionDetails>
-                    <a
-                      href={`tel:${customer.contact.phone}`}
-                      className="text-blue-600 hover:underline"
-                    >
-                      {customer.contact.phone}
-                    </a>
+                    {isSafeTelTarget(customer.contact.phone) ? (
+                      <a
+                        href={`tel:${customer.contact.phone}`}
+                        className="text-blue-600 hover:underline"
+                      >
+                        {customer.contact.phone}
+                      </a>
+                    ) : (
+                      customer.contact.phone
+                    )}
                   </DescriptionDetails>
                 </>
               )}

--- a/src/pages/Employees/EmployeeBwrPanel.tsx
+++ b/src/pages/Employees/EmployeeBwrPanel.tsx
@@ -178,8 +178,7 @@ export function EmployeeBwrPanel({
     try {
       setExportLoading(true);
       const response = await exportEmployeeBwr(employee.id, exportFormat);
-      const safeDownloadUrl = response.download_url.trim();
-      if (!isSafeHttpUrl(safeDownloadUrl)) {
+      if (!isSafeHttpUrl(response.download_url)) {
         setPanelError(
           _(
             msg`The export download link returned by the server is not safe to open.`
@@ -187,7 +186,7 @@ export function EmployeeBwrPanel({
         );
         return;
       }
-      setLatestExportUrl(safeDownloadUrl);
+      setLatestExportUrl(response.download_url);
       const refreshedEmployee = await onRefresh();
       if (refreshedEmployee) {
         const refreshedStatus =

--- a/src/pages/Sites/SiteDetail.test.tsx
+++ b/src/pages/Sites/SiteDetail.test.tsx
@@ -42,6 +42,20 @@ function renderWithRouter() {
   );
 }
 
+function expectNoUnsafeContactHrefs(container: HTMLElement) {
+  const contactHrefs = Array.from(
+    container.querySelectorAll<HTMLAnchorElement>(
+      'a[href^="mailto:"], a[href^="tel:"]'
+    )
+  ).map((anchor) => anchor.getAttribute("href") ?? "");
+
+  expect(contactHrefs).not.toEqual(
+    expect.arrayContaining([
+      expect.stringMatching(/^(?:mailto|tel):.*[?&#\n\r]/),
+    ])
+  );
+}
+
 describe("SiteDetail", () => {
   const mockSite = {
     id: "site-123",
@@ -178,6 +192,40 @@ describe("SiteDetail", () => {
 
     expect(screen.getByText("max@test.de")).toBeInTheDocument();
     expect(screen.getByText("+49 89 123456")).toBeInTheDocument();
+    expect(screen.getByText("max@test.de").closest("a")).toHaveAttribute(
+      "href",
+      "mailto:max@test.de"
+    );
+    expect(screen.getByText("+49 89 123456").closest("a")).toHaveAttribute(
+      "href",
+      "tel:+49 89 123456"
+    );
+  });
+
+  it("renders unsafe contact email and phone as plain text", async () => {
+    const unsafeSite = {
+      ...mockSite,
+      contact: {
+        ...mockSite.contact,
+        email: "target@example.com?bcc=attacker@evil.com&subject=PWN",
+        phone: "+49?suffix=evil",
+      },
+    };
+    vi.mocked(customersApi.getSite).mockResolvedValue(unsafeSite);
+    vi.mocked(customersApi.getCustomer).mockResolvedValue(mockCustomer);
+    vi.mocked(organizationalUnitApi.getOrganizationalUnit).mockResolvedValue(
+      mockOrgUnit
+    );
+
+    const { container } = renderWithRouter();
+
+    await waitFor(() => {
+      expect(screen.getByText(unsafeSite.contact.email)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(unsafeSite.contact.email).closest("a")).toBeNull();
+    expect(screen.getByText(unsafeSite.contact.phone).closest("a")).toBeNull();
+    expectNoUnsafeContactHrefs(container);
   });
 
   it("shows edit and delete buttons", async () => {

--- a/src/pages/Sites/SiteDetail.tsx
+++ b/src/pages/Sites/SiteDetail.tsx
@@ -24,6 +24,7 @@ import {
   DescriptionDetails,
 } from "../../components/description-list";
 import { formatDate } from "../../lib/dateUtils";
+import { isSafeMailtoTarget, isSafeTelTarget } from "../../utils/safeUrl";
 import {
   Dialog,
   DialogTitle,
@@ -196,12 +197,16 @@ export default function SiteDetail() {
                     <Trans>Email</Trans>
                   </DescriptionTerm>
                   <DescriptionDetails>
-                    <a
-                      href={`mailto:${site.contact.email}`}
-                      className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
-                    >
-                      {site.contact.email}
-                    </a>
+                    {isSafeMailtoTarget(site.contact.email) ? (
+                      <a
+                        href={`mailto:${site.contact.email}`}
+                        className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                      >
+                        {site.contact.email}
+                      </a>
+                    ) : (
+                      site.contact.email
+                    )}
                   </DescriptionDetails>
                 </>
               )}
@@ -212,12 +217,16 @@ export default function SiteDetail() {
                     <Trans>Phone</Trans>
                   </DescriptionTerm>
                   <DescriptionDetails>
-                    <a
-                      href={`tel:${site.contact.phone}`}
-                      className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
-                    >
-                      {site.contact.phone}
-                    </a>
+                    {isSafeTelTarget(site.contact.phone) ? (
+                      <a
+                        href={`tel:${site.contact.phone}`}
+                        className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                      >
+                        {site.contact.phone}
+                      </a>
+                    ) : (
+                      site.contact.phone
+                    )}
                   </DescriptionDetails>
                 </>
               )}

--- a/src/utils/safeUrl.test.ts
+++ b/src/utils/safeUrl.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, expect, it } from "vitest";
-import { isSafeHttpUrl } from "./safeUrl";
+import { isSafeHttpUrl, isSafeMailtoTarget, isSafeTelTarget } from "./safeUrl";
 
 describe("isSafeHttpUrl", () => {
   it.each([
@@ -65,5 +65,69 @@ describe("isSafeHttpUrl", () => {
     "http://127.0.0.1.evil.com/export.csv",
   ])("rejects unsafe or non-absolute URLs: %s", (value) => {
     expect(isSafeHttpUrl(value)).toBe(false);
+  });
+});
+
+describe("isSafeMailtoTarget", () => {
+  it.each([
+    "user@example.com",
+    "first.last@example.co.uk",
+    "service+alerts@sub.example.com",
+  ])("allows email addresses without mailto parameters: %s", (value) => {
+    expect(isSafeMailtoTarget(value)).toBe(true);
+  });
+
+  it.each([
+    "",
+    "   ",
+    "foo@bar.com?bcc=attacker@example.com",
+    "foo@bar.com&subject=Injected",
+    "foo@bar.com#fragment",
+    "foo@bar.com\nBcc: attacker@example.com",
+    "foo@bar.com\r\nBcc: attacker@example.com",
+    "foo@bar.com%0ABcc:attacker@example.com",
+    // local-part injection: ? & # in local part produce header-injection mailto URIs
+    "foo?bcc=attacker@bar.com",
+    "foo&subject=Injected@bar.com",
+    "foo#fragment@bar.com",
+    // percent-encoding bypass: %40 decodes to @ producing double-@ addresses
+    "foo%40bar@example.com",
+    // % in local part
+    "foo%2Fbar@example.com",
+    "javascript:alert(1)",
+    "mailto:foo@bar.com",
+    "foo bar@example.com",
+    "foo@bar",
+  ])("rejects unsafe mailto targets: %s", (value) => {
+    expect(isSafeMailtoTarget(value)).toBe(false);
+  });
+});
+
+describe("isSafeTelTarget", () => {
+  it.each([
+    "+49 30 1234567",
+    "+1-202-555-0100",
+    "030.1234567",
+    "+49 30 1234567;ext=42",
+  ])("allows dial strings with visual separators: %s", (value) => {
+    expect(isSafeTelTarget(value)).toBe(true);
+  });
+
+  it.each([
+    "",
+    "   ",
+    "+49?suffix=evil",
+    "+49&suffix=evil",
+    "+49#evil",
+    "+49\n1234567",
+    "+49\r1234567",
+    "+49%0A1234567",
+    "javascript:alert(1)",
+    "tel:+49301234567",
+    "+49,301234567",
+    "+49;phone-context=example.com",
+    "+49;ext=abc",
+  ])("rejects unsafe tel targets: %s", (value) => {
+    expect(isSafeTelTarget(value)).toBe(false);
   });
 });

--- a/src/utils/safeUrl.test.ts
+++ b/src/utils/safeUrl.test.ts
@@ -73,6 +73,10 @@ describe("isSafeMailtoTarget", () => {
     "user@example.com",
     "first.last@example.co.uk",
     "service+alerts@sub.example.com",
+    "user@intranet",
+    "me@example",
+    "user@example.xn--p1ai",
+    "user@xn--bcher-kva.de",
   ])("allows email addresses without mailto parameters: %s", (value) => {
     expect(isSafeMailtoTarget(value)).toBe(true);
   });
@@ -97,7 +101,6 @@ describe("isSafeMailtoTarget", () => {
     "javascript:alert(1)",
     "mailto:foo@bar.com",
     "foo bar@example.com",
-    "foo@bar",
   ])("rejects unsafe mailto targets: %s", (value) => {
     expect(isSafeMailtoTarget(value)).toBe(false);
   });
@@ -109,6 +112,8 @@ describe("isSafeTelTarget", () => {
     "+1-202-555-0100",
     "030.1234567",
     "+49 30 1234567;ext=42",
+    "(202) 555-0100",
+    "+1 202 555 0100 x42",
   ])("allows dial strings with visual separators: %s", (value) => {
     expect(isSafeTelTarget(value)).toBe(true);
   });
@@ -127,6 +132,8 @@ describe("isSafeTelTarget", () => {
     "+49,301234567",
     "+49;phone-context=example.com",
     "+49;ext=abc",
+    // space immediately before ;ext= produces a malformed RFC 3966 dial string
+    "+49 30 1234567 ;ext=42",
   ])("rejects unsafe tel targets: %s", (value) => {
     expect(isSafeTelTarget(value)).toBe(false);
   });

--- a/src/utils/safeUrl.ts
+++ b/src/utils/safeUrl.ts
@@ -7,8 +7,9 @@ const PERCENT_ENCODED_RE = /%[0-9a-f]{2}/i;
 // meaning in mailto URIs (?  & # %) to prevent header injection or
 // percent-encoding bypass.
 const MAILTO_TARGET_RE =
-  /^[A-Za-z0-9!$'*+/=^_`{|}~-]+(?:\.[A-Za-z0-9!$'*+/=^_`{|}~-]+)*@(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}$/;
-const TEL_TARGET_RE = /^\+?[0-9][0-9 .-]*(?:;ext=[0-9]+)?$/;
+  /^[A-Za-z0-9!$'*+/=^_`{|}~-]+(?:\.[A-Za-z0-9!$'*+/=^_`{|}~-]+)*@(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*)$/;
+const TEL_TARGET_RE = /^[+0-9(][+0-9(). -]*(?<! )(?:;ext=[0-9]+| x[0-9]+)?$/i;
+const MIN_TEL_DIGITS = 3;
 
 interface SafeHttpUrlOptions {
   currentHostname?: string;
@@ -99,5 +100,9 @@ export function isSafeTelTarget(value: string): boolean {
     return false;
   }
 
-  return TEL_TARGET_RE.test(value);
+  if (!TEL_TARGET_RE.test(value)) {
+    return false;
+  }
+
+  return (value.match(/\d/g) ?? []).length >= MIN_TEL_DIGITS;
 }

--- a/src/utils/safeUrl.ts
+++ b/src/utils/safeUrl.ts
@@ -2,6 +2,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 const LOOPBACK_HOSTNAMES = new Set(["localhost", "::1", "[::1]"]);
+const PERCENT_ENCODED_RE = /%[0-9a-f]{2}/i;
+// Local-part uses RFC 5321 atext: excludes specials and characters that carry
+// meaning in mailto URIs (?  & # %) to prevent header injection or
+// percent-encoding bypass.
+const MAILTO_TARGET_RE =
+  /^[A-Za-z0-9!$'*+/=^_`{|}~-]+(?:\.[A-Za-z0-9!$'*+/=^_`{|}~-]+)*@(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}$/;
+const TEL_TARGET_RE = /^\+?[0-9][0-9 .-]*(?:;ext=[0-9]+)?$/;
 
 interface SafeHttpUrlOptions {
   currentHostname?: string;
@@ -69,4 +76,28 @@ export function isSafeHttpUrl(
     isLoopbackHostname(parsedUrl.hostname) &&
     isLoopbackHttpAllowed(options)
   );
+}
+
+export function isSafeMailtoTarget(value: string): boolean {
+  if (
+    value === "" ||
+    value !== value.trim() ||
+    PERCENT_ENCODED_RE.test(value)
+  ) {
+    return false;
+  }
+
+  return MAILTO_TARGET_RE.test(value);
+}
+
+export function isSafeTelTarget(value: string): boolean {
+  if (
+    value === "" ||
+    value !== value.trim() ||
+    PERCENT_ENCODED_RE.test(value)
+  ) {
+    return false;
+  }
+
+  return TEL_TARGET_RE.test(value);
 }


### PR DESCRIPTION
## Failing test / reproduced defect

- Added regression coverage for unsafe contact values that previously rendered directly as `mailto:` and `tel:` hrefs in customer and site detail views. The new cases cover mail client query/header injection payloads such as `target@example.com?bcc=attacker@evil.com&subject=PWN` and dialer parameter abuse such as `+49?suffix=evil`; those payloads now remain visible as plain text and do not create unsafe anchors.

## Change summary

- Added `isSafeMailtoTarget` and `isSafeTelTarget` helpers beside the existing safe URL utility.
- Updated customer and site contact details to render links only when server-provided email and phone values match the expected address or dial-string shape.
- Preserved valid `mailto:` and `tel:` rendering for ordinary contact values.
- Updated `CHANGELOG.md` under Security.

## Validation already run

- `npm run test:run -- src/utils/safeUrl.test.ts src/pages/Customers/CustomerDetail.test.tsx src/pages/Sites/SiteDetail.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`
- `reuse lint`
- Verified the commit is GPG/SSH signed.
- Pushed with `PREFLIGHT_RUN_TESTS=1 git push -u origin fix-contact-hrefs`.

## Linked workspaces / follow-up before ready

- Related Polyscope workspaces were available for contracts, API, and Android, but this PR only changes `SecPal/frontend`; no linked workspace changes were required.
- No out-of-scope findings were identified during local review, so no new GitHub issues were opened.
- Keep this PR in draft until the PR-view self-review reports zero issues and any GitHub checks have completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens URL/link rendering in customer/site detail views, which is security-relevant and could inadvertently block some legitimate email/phone formats if the new validators are too strict. Also changes how BWR export URLs are validated, which could affect download-link behavior if server responses include leading/trailing whitespace.
> 
> **Overview**
> **Blocks unsafe contact links** by rendering customer/site email and phone as clickable `mailto:`/`tel:` anchors *only* when the server-provided values pass new `isSafeMailtoTarget` / `isSafeTelTarget` validators; otherwise they stay as plain text.
> 
> Adds comprehensive unit tests for the new validators plus page-level regressions ensuring injected query/header/newline payloads never become `mailto:`/`tel:` hrefs, and updates `EmployeeBwrPanel` to validate the raw `download_url` directly with `isSafeHttpUrl` (no extra trimming). Also records the change in `CHANGELOG.md` under Security.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ab8f00222db757b4d171cfcc1bf5d9290f522dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->