### PR TITLE
Require discoverable passkey login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `getCountrySelectOptions` in `src/lib/iso3166CountryOptions.ts` to generate a locale-sorted ISO 3166-1 alpha-2 country dropdown with per-code `Intl.DisplayNames` fallback for unsupported region identifiers.
 - Added shared `EmployeeAddressFields` component with OpenPLZ street/locality autocomplete, keyboard navigation, and a country combobox; adopted in the employee create, edit, contacts-edit, and inline postal-address dialog flows.
 
-### Changed
-
-- Passkey sign-in now always starts a discoverable (resident-credential) challenge without sending an email hint to the server. The previous two-attempt fallback — try discoverable, then retry with an email-scoped `allow_credentials` list — has been removed. Browsers that do not support empty `allowCredentials` lists will now receive an error instead of a silent retry. The native-bridge `loginWithPasskey` call no longer forwards the typed email either.
-
 ### Fixed
 
 - Fixed `resolvePlaywrightApiBaseUrl` in `tests/e2e/target-urls.ts`: when `PLAYWRIGHT_BASE_URL` points to a workspace preview and `PLAYWRIGHT_API_BASE_URL` is set to a non-preview live value, the API origin is now derived from the preview frontend URL so E2E runs stay bound to the same workspace preview instead of drifting to the live API.
@@ -40,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Passkey sign-in now always starts a discoverable (resident-credential) challenge without sending an email hint to the server. The previous two-attempt fallback — try discoverable, then retry with an email-scoped `allow_credentials` list — has been removed. Browsers that do not support empty `allowCredentials` lists will now receive an error instead of a silent retry. The native-bridge `loginWithPasskey` call no longer forwards the typed email either.
 - Migrated employee contact and detail flows from flat `address_*` fields to the `addresses` relation: responses now use `addresses`, optional `current_address`, and `structured_address`; contact edit and inline postal edits send full replacement `addresses` payloads that keep historical rows and refresh the open-ended current row, with shared helpers in `src/lib/employeeAddresses.ts`.
 - Added an inline onboarding-wizard attachment upload section for editable steps, automatically creating a draft submission before the first upload when needed, surfacing upload success/failure inline, and wiring the flow to the current `/v1/onboarding/submissions/{submission}/files` API contract (closes #1029)
 - Renamed the onboarding review and Android provisioning frontend API clients to the neutral `/v1/onboarding-review/...` and `/v1/android-enrollment-sessions...` endpoints, and aligned supporting fixtures/examples with the removed Admin model.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `getCountrySelectOptions` in `src/lib/iso3166CountryOptions.ts` to generate a locale-sorted ISO 3166-1 alpha-2 country dropdown with per-code `Intl.DisplayNames` fallback for unsupported region identifiers.
 - Added shared `EmployeeAddressFields` component with OpenPLZ street/locality autocomplete, keyboard navigation, and a country combobox; adopted in the employee create, edit, contacts-edit, and inline postal-address dialog flows.
 
+### Changed
+
+- Passkey sign-in now always starts a discoverable (resident-credential) challenge without sending an email hint to the server. The previous two-attempt fallback — try discoverable, then retry with an email-scoped `allow_credentials` list — has been removed. Browsers that do not support empty `allowCredentials` lists will now receive an error instead of a silent retry. The native-bridge `loginWithPasskey` call no longer forwards the typed email either.
+
 ### Fixed
 
 - Fixed `resolvePlaywrightApiBaseUrl` in `tests/e2e/target-urls.ts`: when `PLAYWRIGHT_BASE_URL` points to a workspace preview and `PLAYWRIGHT_API_BASE_URL` is set to a non-preview live value, the API origin is now derived from the preview frontend URL so E2E runs stay bound to the same workspace preview instead of drifting to the live API.

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -258,7 +258,7 @@ describe("Login", () => {
     ).toBeInTheDocument();
   });
 
-  it("routes passkey sign-in through the native auth bridge when available", async () => {
+  it("routes passkey sign-in through the native auth bridge without forwarding the typed email", async () => {
     const authGlobal = globalThis as {
       SecPalNativeAuthBridge?: {
         login: ReturnType<typeof vi.fn>;
@@ -293,11 +293,10 @@ describe("Login", () => {
       );
 
       await waitFor(() => {
-        expect(nativeBridge.loginWithPasskey).toHaveBeenCalledWith({
-          email: "test@secpal.dev",
-        });
+        expect(nativeBridge.loginWithPasskey).toHaveBeenCalledTimes(1);
       });
 
+      expect(nativeBridge.loginWithPasskey).toHaveBeenCalledWith(undefined);
       expect(
         authApi.startPasskeyAuthenticationChallenge
       ).not.toHaveBeenCalled();
@@ -792,7 +791,7 @@ describe("Login", () => {
     });
   });
 
-  it("starts passkey sign-in with an email-scoped challenge when the email is already entered", async () => {
+  it("starts passkey sign-in with a discoverable challenge even when the email field is filled", async () => {
     vi.mocked(passkeyBrowser.isPasskeySupported).mockReturnValue(true);
     vi.mocked(
       authApi.startPasskeyAuthenticationChallenge
@@ -804,12 +803,6 @@ describe("Login", () => {
           rp_id: "app.secpal.dev",
           timeout: 60000,
           user_verification: "preferred",
-          allow_credentials: [
-            {
-              id: "credential-id",
-              type: "public-key",
-            },
-          ],
         },
         mediation: "optional",
         expires_at: "2026-04-06T12:00:00Z",
@@ -847,14 +840,16 @@ describe("Login", () => {
     );
 
     await waitFor(() => {
-      expect(
-        authApi.startPasskeyAuthenticationChallenge
-      ).toHaveBeenNthCalledWith(1, { email: "test@secpal.dev" });
-      expect(authApi.verifyPasskeyAuthenticationChallenge).toHaveBeenCalledWith(
-        "550e8400-e29b-41d4-a716-446655440100",
-        expect.anything()
+      expect(authApi.startPasskeyAuthenticationChallenge).toHaveBeenCalledTimes(
+        1
       );
     });
+
+    expect(authApi.startPasskeyAuthenticationChallenge).toHaveBeenCalledWith();
+    expect(authApi.verifyPasskeyAuthenticationChallenge).toHaveBeenCalledWith(
+      "550e8400-e29b-41d4-a716-446655440100",
+      expect.anything()
+    );
   });
 
   it("shows passkey sign-in errors inline when the passkey flow fails", async () => {
@@ -984,7 +979,7 @@ describe("Login", () => {
     ).toBeInTheDocument();
   });
 
-  it("asks for an email address when passkey sign-in needs a credential allow-list", async () => {
+  it("surfaces resident-credential errors instead of retrying with an email-scoped challenge", async () => {
     vi.mocked(passkeyBrowser.isPasskeySupported).mockReturnValue(true);
     vi.mocked(
       authApi.startPasskeyAuthenticationChallenge
@@ -1009,15 +1004,21 @@ describe("Login", () => {
 
     renderLogin();
 
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "test@secpal.dev" },
+    });
     fireEvent.click(
       await screen.findByRole("button", { name: /sign in with passkey/i })
     );
 
     expect(
-      await screen.findByText(
-        /this browser requires your email address for passkey sign-in/i
-      )
+      await screen.findByText(/resident credentials/i)
     ).toBeInTheDocument();
+
+    expect(authApi.startPasskeyAuthenticationChallenge).toHaveBeenCalledTimes(
+      1
+    );
+    expect(authApi.startPasskeyAuthenticationChallenge).toHaveBeenCalledWith();
   });
 
   it("shows a browser-check prompt while waiting for the WebAuthn credential", async () => {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -56,14 +56,6 @@ const NATIVE_PASSKEY_PROVIDER_UNAVAILABLE_PATTERN =
 
 type Translate = ReturnType<typeof useLingui>["_"];
 
-function isResidentCredentialError(error: unknown): error is Error {
-  return (
-    error instanceof Error &&
-    (error.message.includes("resident credentials") ||
-      error.message.includes("allowCredentials"))
-  );
-}
-
 function getPasskeySignInErrorMessage(
   error: unknown,
   translate: Translate
@@ -335,17 +327,11 @@ export function Login() {
     setIsSubmittingPasskey(true);
     setPasskeyStep("challenge");
 
-    const normalizedEmail = email.trim().toLowerCase();
-    const initialChallengeEmail =
-      normalizedEmail !== "" ? normalizedEmail : undefined;
-
     if (authTransport.kind === "native-bridge") {
       try {
         setPasskeyStep("native");
 
-        const response = await authTransport.loginWithPasskey(
-          initialChallengeEmail ? { email: initialChallengeEmail } : undefined
-        );
+        const response = await authTransport.loginWithPasskey();
 
         resetAttempts();
         await login(response.user);
@@ -361,10 +347,8 @@ export function Login() {
       return;
     }
 
-    const completePasskeySignIn = async (challengeEmail?: string) => {
-      const challengeResponse = await startPasskeyAuthenticationChallenge(
-        challengeEmail ? { email: challengeEmail } : undefined
-      );
+    try {
+      const challengeResponse = await startPasskeyAuthenticationChallenge();
       console.info(
         "[SecPal] Passkey login: challenge created id=%s credentials=%d",
         challengeResponse.data.challenge_id,
@@ -382,33 +366,12 @@ export function Login() {
       console.info("[SecPal] Passkey login: browser assertion complete");
 
       setPasskeyStep("verifying");
-      return verifyPasskeyAuthenticationChallenge(
+      const response = await verifyPasskeyAuthenticationChallenge(
         challengeResponse.data.challenge_id,
         {
           credential,
         }
       );
-    };
-
-    try {
-      let response;
-
-      try {
-        response = await completePasskeySignIn(initialChallengeEmail);
-      } catch (firstError) {
-        if (!isResidentCredentialError(firstError) || initialChallengeEmail) {
-          throw firstError;
-        }
-
-        if (normalizedEmail === "") {
-          throw new Error(
-            "This browser requires your email address for passkey sign-in. Enter your email address and try again.",
-            { cause: firstError }
-          );
-        }
-
-        response = await completePasskeySignIn(normalizedEmail);
-      }
 
       console.info(
         "[SecPal] Passkey login: verify succeeded mode=%s",

--- a/src/services/authApi.test.ts
+++ b/src/services/authApi.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, assert } from "vitest";
 import {
   startPasskeyAuthenticationChallenge,
   verifyPasskeyAuthenticationChallenge,
@@ -679,7 +679,7 @@ describe("authApi", () => {
   });
 
   describe("passkey authentication", () => {
-    it("starts a browser passkey authentication challenge", async () => {
+    it("starts a discoverable browser passkey authentication challenge without sending email", async () => {
       const mockResponse = {
         data: {
           challenge_id: "550e8400-e29b-41d4-a716-446655440099",
@@ -714,49 +714,16 @@ describe("authApi", () => {
           cache: "no-store",
         })
       );
-    });
 
-    it("starts an email-scoped browser passkey authentication challenge", async () => {
-      const mockResponse = {
-        data: {
-          challenge_id: "550e8400-e29b-41d4-a716-446655440099",
-          public_key: {
-            challenge: "Zm9vYmFy",
-            rp_id: "app.secpal.dev",
-            timeout: 60000,
-            user_verification: "preferred",
-            allow_credentials: [
-              {
-                id: "credential-id",
-                type: "public-key",
-              },
-            ],
-          },
-          mediation: "optional",
-          expires_at: "2026-04-06T12:00:00Z",
-        },
-      };
-
-      mockFetch.mockResolvedValueOnce({ ok: true } as Response);
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: 201,
-        json: async () => mockResponse,
-      } as Response);
-
-      await expect(
-        startPasskeyAuthenticationChallenge({ email: "test@secpal.dev" })
-      ).resolves.toEqual(mockResponse);
-
-      expect(mockFetch).toHaveBeenNthCalledWith(
-        2,
-        expect.stringContaining("/v1/auth/passkeys/challenges"),
-        expect.objectContaining({
-          method: "POST",
-          credentials: "include",
-          body: JSON.stringify({ email: "test@secpal.dev" }),
-        })
+      const challengeCall = mockFetch.mock.calls[1];
+      assert(
+        challengeCall !== undefined,
+        "expected challenge fetch call to exist"
       );
+      const requestInit = challengeCall[1] as RequestInit;
+      const headers = requestInit.headers as Headers;
+      expect(headers.get("Content-Type")).toBeNull();
+      expect(requestInit.body).toBeUndefined();
     });
 
     it("verifies a browser passkey authentication challenge", async () => {

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -7,7 +7,6 @@ import type {
   MfaRecoveryCodeRevealResponse,
   MfaStatusResponse,
   MfaTotpEnrollmentResponse,
-  PasskeyAuthenticationChallengeRequest,
   MfaVerificationCodeRequest,
   PasskeyDeletionResponse,
   PasskeyAuthenticationChallengeResponse,
@@ -201,21 +200,15 @@ export async function verifyMfaChallenge(
   );
 }
 
-export async function startPasskeyAuthenticationChallenge(
-  payload?: PasskeyAuthenticationChallengeRequest
-): Promise<PasskeyAuthenticationChallengeResponse> {
+export async function startPasskeyAuthenticationChallenge(): Promise<PasskeyAuthenticationChallengeResponse> {
   await fetchCsrfToken();
-
-  const hasPayload = typeof payload?.email === "string" && payload.email !== "";
 
   const response = await apiFetch(buildApiUrl("/v1/auth/passkeys/challenges"), {
     method: "POST",
     cache: "no-store",
     headers: {
       Accept: "application/json",
-      ...(hasPayload ? { "Content-Type": "application/json" } : {}),
     },
-    ...(hasPayload ? { body: JSON.stringify(payload) } : {}),
   });
 
   if (!response.ok) {

--- a/src/types/api/auth.ts
+++ b/src/types/api/auth.ts
@@ -210,10 +210,6 @@ export interface PasskeyAuthenticationChallengeResponse {
   };
 }
 
-export interface PasskeyAuthenticationChallengeRequest {
-  email?: string;
-}
-
 export interface PasskeyAssertionResponsePayload {
   client_data_json: string;
   authenticator_data: string;

--- a/tests/e2e/passkeys.spec.ts
+++ b/tests/e2e/passkeys.spec.ts
@@ -71,21 +71,6 @@ const authenticationChallenge = {
   },
 };
 
-const fallbackAuthenticationChallenge = {
-  data: {
-    challenge_id: "550e8400-e29b-41d4-a716-446655440002",
-    public_key: {
-      challenge: "YmFyZm9v",
-      rp_id: "app.secpal.dev",
-      timeout: 60000,
-      user_verification: "preferred",
-      allow_credentials: [{ id: "Y3JlZGVudGlhbC1pZA", type: "public-key" }],
-    },
-    mediation: "optional",
-    expires_at: "2026-04-09T17:00:00Z",
-  },
-};
-
 async function fulfillJson(route: Route, body: unknown, status = 200) {
   await route.fulfill({
     status,
@@ -94,81 +79,57 @@ async function fulfillJson(route: Route, body: unknown, status = 200) {
   });
 }
 
-async function installPasskeyBrowserMocks(
-  page: Page,
-  options?: { failDiscoverableOnce?: boolean }
-) {
-  await page.addInitScript(
-    ({ failDiscoverableOnce }) => {
-      let assertionCalls = 0;
+async function installPasskeyBrowserMocks(page: Page) {
+  await page.addInitScript(() => {
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: true,
+    });
 
-      Object.defineProperty(window, "isSecureContext", {
-        configurable: true,
-        value: true,
-      });
+    class PublicKeyCredentialMock {}
 
-      class PublicKeyCredentialMock {}
+    Object.defineProperty(window, "PublicKeyCredential", {
+      configurable: true,
+      value: PublicKeyCredentialMock,
+    });
 
-      Object.defineProperty(window, "PublicKeyCredential", {
-        configurable: true,
-        value: PublicKeyCredentialMock,
-      });
-
-      Object.defineProperty(navigator, "credentials", {
-        configurable: true,
-        value: {
-          create: async () => ({
-            id: "new-credential-id",
-            rawId: Uint8Array.from([114, 97, 119, 45, 105, 100]).buffer,
-            type: "public-key",
-            response: {
-              clientDataJSON: Uint8Array.from([99, 108, 105, 101, 110, 116])
-                .buffer,
-              attestationObject: Uint8Array.from([
-                97, 116, 116, 101, 115, 116, 97, 116, 105, 111, 110,
-              ]).buffer,
-              getTransports: () => ["internal"],
-            },
-            getClientExtensionResults: () => ({}),
-          }),
-          get: async (options?: CredentialRequestOptions) => {
-            const allowCredentials = options?.publicKey?.allowCredentials ?? [];
-
-            assertionCalls += 1;
-
-            if (
-              failDiscoverableOnce &&
-              assertionCalls === 1 &&
-              allowCredentials.length === 0
-            ) {
-              throw new Error(
-                "Resident credentials or empty allowCredentials lists are not supported"
-              );
-            }
-
-            return {
-              id: "credential-id",
-              rawId: Uint8Array.from([114, 97, 119, 45, 105, 100]).buffer,
-              type: "public-key",
-              response: {
-                clientDataJSON: Uint8Array.from([99, 108, 105, 101, 110, 116])
-                  .buffer,
-                authenticatorData: Uint8Array.from([
-                  97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 111, 114,
-                ]).buffer,
-                signature: Uint8Array.from([
-                  115, 105, 103, 110, 97, 116, 117, 114, 101,
-                ]).buffer,
-                userHandle: null,
-              },
-              getClientExtensionResults: () => ({}),
-            };
+    Object.defineProperty(navigator, "credentials", {
+      configurable: true,
+      value: {
+        create: async () => ({
+          id: "new-credential-id",
+          rawId: Uint8Array.from([114, 97, 119, 45, 105, 100]).buffer,
+          type: "public-key",
+          response: {
+            clientDataJSON: Uint8Array.from([99, 108, 105, 101, 110, 116])
+              .buffer,
+            attestationObject: Uint8Array.from([
+              97, 116, 116, 101, 115, 116, 97, 116, 105, 111, 110,
+            ]).buffer,
+            getTransports: () => ["internal"],
           },
-        },
-      });
-    },
-    { failDiscoverableOnce: options?.failDiscoverableOnce ?? false }
-  );
+          getClientExtensionResults: () => ({}),
+        }),
+        get: async () => ({
+          id: "credential-id",
+          rawId: Uint8Array.from([114, 97, 119, 45, 105, 100]).buffer,
+          type: "public-key",
+          response: {
+            clientDataJSON: Uint8Array.from([99, 108, 105, 101, 110, 116])
+              .buffer,
+            authenticatorData: Uint8Array.from([
+              97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 111, 114,
+            ]).buffer,
+            signature: Uint8Array.from([
+              115, 105, 103, 110, 97, 116, 117, 114, 101,
+            ]).buffer,
+            userHandle: null,
+          },
+          getClientExtensionResults: () => ({}),
+        }),
+      },
+    });
+  });
 }
 
 test.describe("Passkeys", () => {
@@ -288,10 +249,12 @@ test.describe("Passkeys", () => {
     await expect(page).not.toHaveURL(/\/login$/);
   });
 
-  test("retries passkey sign-in with an email-scoped challenge when discoverable mode is unsupported", async ({
+  test("ignores a typed email and always starts the public passkey challenge without a body", async ({
     page,
   }) => {
-    await installPasskeyBrowserMocks(page, { failDiscoverableOnce: true });
+    await installPasskeyBrowserMocks(page);
+
+    const publicChallengeBodies: Array<string | null> = [];
 
     await page.route("**/health/ready", async (route) => {
       await fulfillJson(route, {
@@ -308,18 +271,11 @@ test.describe("Passkeys", () => {
       await route.fulfill({ status: 204, body: "" });
     });
     await page.route("**/v1/auth/passkeys/challenges", async (route) => {
-      const rawBody = route.request().postData();
-      const body = rawBody ? (JSON.parse(rawBody) as { email?: string }) : null;
-
-      if (body?.email === "test@example.com") {
-        await fulfillJson(route, fallbackAuthenticationChallenge, 201);
-        return;
-      }
-
+      publicChallengeBodies.push(route.request().postData());
       await fulfillJson(route, authenticationChallenge, 201);
     });
     await page.route(
-      "**/v1/auth/passkeys/challenges/550e8400-e29b-41d4-a716-446655440002/verify",
+      "**/v1/auth/passkeys/challenges/550e8400-e29b-41d4-a716-446655440001/verify",
       async (route) => {
         await fulfillJson(route, {
           user: authUser,
@@ -338,9 +294,10 @@ test.describe("Passkeys", () => {
     await page.getByRole("button", { name: /sign in with passkey/i }).click();
 
     await expect(page).not.toHaveURL(/\/login$/);
+    expect(publicChallengeBodies).toEqual([null]);
   });
 
-  test("keeps registration persistence and email-first login lookup in sync", async ({
+  test("keeps registration persistence and discoverable login lookup in sync", async ({
     page,
   }) => {
     await installPasskeyBrowserMocks(page);
@@ -395,48 +352,28 @@ test.describe("Passkeys", () => {
     );
     await page.route("**/v1/auth/passkeys/challenges", async (route) => {
       const rawBody = route.request().postData();
-      const body = rawBody ? (JSON.parse(rawBody) as { email?: string }) : null;
 
-      if (body?.email === "test@example.com" && storedPasskeys.length > 0) {
+      if (rawBody !== null) {
         await fulfillJson(
           route,
           {
-            data: {
-              challenge_id: fallbackAuthenticationChallenge.data.challenge_id,
-              public_key: {
-                ...fallbackAuthenticationChallenge.data.public_key,
-                allow_credentials: [
-                  {
-                    id: storedPasskeys[0]!.id,
-                    type: "public-key",
-                  },
-                ],
-              },
-              mediation: fallbackAuthenticationChallenge.data.mediation,
-              expires_at: fallbackAuthenticationChallenge.data.expires_at,
+            message:
+              "Email-scoped public passkey challenges are no longer supported.",
+            errors: {
+              email: [
+                "Email-scoped public passkey challenges are no longer supported.",
+              ],
             },
           },
-          201
+          422
         );
         return;
       }
 
-      await fulfillJson(
-        route,
-        {
-          message:
-            "Passkey sign-in is not available for the provided email address.",
-          errors: {
-            email: [
-              "Passkey sign-in is not available for the provided email address.",
-            ],
-          },
-        },
-        422
-      );
+      await fulfillJson(route, authenticationChallenge, 201);
     });
     await page.route(
-      "**/v1/auth/passkeys/challenges/550e8400-e29b-41d4-a716-446655440002/verify",
+      "**/v1/auth/passkeys/challenges/550e8400-e29b-41d4-a716-446655440001/verify",
       async (route) => {
         await fulfillJson(route, {
           user: authUser,


### PR DESCRIPTION
## Failing test / reproduced defect

The regression is covered by tests that now fail against the previous implementation:

- `src/pages/Login.test.tsx` expects passkey sign-in to call `startPasskeyAuthenticationChallenge()` without forwarding a typed email, and expects resident-credential errors to surface instead of retrying with an email-scoped challenge.
- `src/services/authApi.test.ts` expects the browser passkey challenge request to omit both `Content-Type` and a JSON body.
- `tests/e2e/passkeys.spec.ts` expects typed email input to be ignored for public passkey sign-in and verifies the challenge request body is `null`.

## Change summary

- Removed the browser fallback that retried passkey login with an email-scoped `allow_credentials` challenge.
- Updated native bridge passkey login so it no longer forwards the typed email hint.
- Removed the frontend API request type and client payload support for email-scoped public passkey authentication challenges.
- Updated unit and Playwright coverage to require discoverable passkey authentication.
- Added a changelog entry for the observable passkey sign-in behavior change.

## Validation

- `npm run test:run -- src/services/authApi.test.ts src/pages/Login.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run test:e2e -- tests/e2e/passkeys.spec.ts --project=chromium`
- `npx prettier --check CHANGELOG.md src/pages/Login.test.tsx src/pages/Login.tsx src/services/authApi.test.ts src/services/authApi.ts src/types/api/auth.ts tests/e2e/passkeys.spec.ts`
- `git diff --check`
- Verified the commit is GPG/SSH signed with `git log -1 --show-signature --format=fuller`.

## Follow-up before ready

- First PR state is draft, as required.
- No linked workspaces were used for this change.
- Playwright validation passed, but it emitted an out-of-scope environment warning about `NO_COLOR` being ignored because `FORCE_COLOR` is set. Tracked separately in #1121.
- Before marking ready, perform the final PR-view self-review and only mark ready if it still finds zero issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the passkey login contract to always use discoverable credentials and removes the email-scoped fallback, which may break sign-in on browsers/devices that require an `allowCredentials` list. Touches authentication flow and API request shaping, so regressions would directly impact login reliability.
> 
> **Overview**
> **Passkey sign-in now always uses discoverable WebAuthn challenges.** The login flow no longer sends the typed email to the server (or the native bridge) and removes the retry path that previously fell back to an email-scoped `allow_credentials` challenge.
> 
> The auth API client drops support for `PasskeyAuthenticationChallengeRequest` bodies and always POSTs `/v1/auth/passkeys/challenges` without `Content-Type`/JSON payload. Unit and Playwright coverage is updated to assert the new behavior and to surface resident-credential/empty-`allowCredentials` failures instead of silently retrying, and the changelog documents the user-visible behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbb562967cb57e48d50e981e23b0877f92957715. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->