### PR TITLE
fix: suppress Playwright color env warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Silenced the spurious Node.js stderr warning "The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set." that appeared on every Playwright worker when the parent shell exported `NO_COLOR` (e.g. on Polyscope/CI sandboxes): `playwright.config.ts` now removes `NO_COLOR` and `NODE_DISABLE_COLORS` from `process.env` before workers fork, including when those variables are set to an empty string. See issue #1121.
 - Fixed `resolvePlaywrightApiBaseUrl` in `tests/e2e/target-urls.ts`: when `PLAYWRIGHT_BASE_URL` points to a workspace preview and `PLAYWRIGHT_API_BASE_URL` is set to a non-preview live value, the API origin is now derived from the preview frontend URL so E2E runs stay bound to the same workspace preview instead of drifting to the live API.
 - Extended `mockNonPolyscopeCwd()` to the two Lighthouse playwright config tests that were missing it, preventing cwd-based Polyscope workspace detection from disrupting those assertions when tests run from a `.polyscope/clones/...` worktree.
 - Fixed `getAuthStateCachePath` in `tests/e2e/auth-helpers.ts` to derive the cache scope from `new URL(resolved).host` for all parseable URLs, so local-HTTPS targets such as `*.ddev.site` and different localhost ports each produce distinct auth state files instead of sharing a single `local-*.json` path.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,6 +16,30 @@ import {
 } from "./tests/e2e/target-urls";
 
 /**
+ * Suppress the Node.js stderr warning:
+ *   "The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set."
+ *
+ * Playwright unconditionally injects `FORCE_COLOR=1` (and `DEBUG_COLORS=1`)
+ * into every worker and web-server child it spawns so its terminal output
+ * stays colorized; see `WorkerHost` and `DEFAULT_ENVIRONMENT_VARIABLES`
+ * in `node_modules/playwright/lib/runner/index.js`. When the parent shell
+ * also exports `NO_COLOR` (common on Polyscope/CI sandboxes that disable
+ * color globally), every spawned process inherits both variables and
+ * Node's `tty.warnOnDeactivatedColors()` emits the warning on each one.
+ *
+ * `NO_COLOR` has no effect on Playwright runs in the first place because
+ * Playwright always overrides it. Removing it (and the legacy
+ * `NODE_DISABLE_COLORS`) from `process.env` before workers fork keeps the
+ * runtime behaviour identical and silences the noise. See issue #1121.
+ */
+for (const name of ["NO_COLOR", "NODE_DISABLE_COLORS"] as const) {
+  const value = process.env[name];
+  if (value !== undefined) {
+    delete process.env[name];
+  }
+}
+
+/**
  * Playwright E2E Test Configuration
  *
  * Three modes of operation:

--- a/tests/playwright-config.test.ts
+++ b/tests/playwright-config.test.ts
@@ -95,4 +95,60 @@ describe("playwright config", () => {
     expect(chromiumProject?.use).toBeDefined();
     expect(chromiumProject?.use?.launchOptions).toBeUndefined();
   });
+
+  /**
+   * Regression guard for issue #1121: Playwright forks every worker and the
+   * webServer with a hardcoded `FORCE_COLOR=1`. If the parent shell also
+   * exports `NO_COLOR` (or the legacy `NODE_DISABLE_COLORS`), Node's
+   * `tty.warnOnDeactivatedColors()` spams the warning
+   *   "The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set."
+   * on each child. `playwright.config.ts` strips those vars from
+   * `process.env` at import time so the fork inherits a clean env.
+   */
+  describe("color env conflict scrub (issue #1121)", () => {
+    it.each([["NO_COLOR"], ["NODE_DISABLE_COLORS"]] as const)(
+      "removes %s from process.env when set to a non-empty value",
+      async (name) => {
+        vi.stubEnv("CI", "");
+        vi.stubEnv("PLAYWRIGHT_BASE_URL", "");
+        vi.stubEnv(name, "1");
+        mockNonPolyscopeCwd();
+        vi.resetModules();
+
+        expect(process.env[name]).toBe("1");
+        await import("../playwright.config");
+
+        expect(process.env[name]).toBeUndefined();
+      }
+    );
+
+    it.each([["NO_COLOR"], ["NODE_DISABLE_COLORS"]] as const)(
+      "also removes an empty %s value to keep child env strictly clean",
+      async (name) => {
+        vi.stubEnv("CI", "");
+        vi.stubEnv("PLAYWRIGHT_BASE_URL", "");
+        vi.stubEnv(name, "");
+        mockNonPolyscopeCwd();
+        vi.resetModules();
+
+        await import("../playwright.config");
+
+        expect(process.env[name]).toBeUndefined();
+      }
+    );
+
+    it("leaves process.env untouched when neither color-disabling var is set", async () => {
+      vi.stubEnv("CI", "");
+      vi.stubEnv("PLAYWRIGHT_BASE_URL", "");
+      delete process.env.NO_COLOR;
+      delete process.env.NODE_DISABLE_COLORS;
+      mockNonPolyscopeCwd();
+      vi.resetModules();
+
+      await import("../playwright.config");
+
+      expect(process.env.NO_COLOR).toBeUndefined();
+      expect(process.env.NODE_DISABLE_COLORS).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Reproduced Defect

Issue #1121 reproduced repeated Playwright worker stderr warnings during the focused passkey E2E run:

```sh
npm run test:e2e -- tests/e2e/passkeys.spec.ts --project=chromium
```

The observed warning was:

```text
Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
```

## Change

- Remove `NO_COLOR` and `NODE_DISABLE_COLORS` from `process.env` in `playwright.config.ts` before Playwright forks workers and web-server children.
- Document why this preserves Playwright behavior: Playwright already forces color output for spawned processes.
- Add the fix to `CHANGELOG.md`.

Closes #1121.

## Validation

- `git diff --check`
- `npm run typecheck`
- `npm run lint`
- `NO_COLOR=1 NODE_DISABLE_COLORS=1 npx playwright test --list`

The targeted Playwright validation completed without the `NO_COLOR` / `FORCE_COLOR` warning.

## PR Readiness Notes

- First PR state is draft, per repository policy.
- No linked workspaces were used for this frontend-only fix.
- No out-of-scope findings were identified during this PR prep.
- Before marking ready: wait for GitHub CI and perform the final PR-view self-review; only mark ready if that review still finds zero issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-runner configuration only, with a small, well-covered env-var scrub that should not affect production runtime behavior.
> 
> **Overview**
> Silences the repeated Node stderr warning about `NO_COLOR` vs `FORCE_COLOR` during Playwright runs by deleting `NO_COLOR` and legacy `NODE_DISABLE_COLORS` from `process.env` at `playwright.config.ts` import time (before workers/webServer fork).
> 
> Adds Vitest regression coverage in `tests/playwright-config.test.ts` to assert the env scrub occurs for both non-empty and empty values, and records the fix in `CHANGELOG.md` (issue #1121).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd18589c871c22c42bcfcba96c03a80c663feb0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->