### PR TITLE
chore(deps): fix npm audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Updated audit overrides for `brace-expansion` and `ws` so the frontend dependency tree resolves to patched dev-only versions and `npm audit --audit-level=moderate` reports zero vulnerabilities.
 - Silenced the spurious Node.js stderr warning "The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set." that appeared on every Playwright worker when the parent shell exported `NO_COLOR` (e.g. on Polyscope/CI sandboxes): `playwright.config.ts` now removes `NO_COLOR` and `NODE_DISABLE_COLORS` from `process.env` before workers fork, including when those variables are set to an empty string. See issue #1121.
 - Fixed `resolvePlaywrightApiBaseUrl` in `tests/e2e/target-urls.ts`: when `PLAYWRIGHT_BASE_URL` points to a workspace preview and `PLAYWRIGHT_API_BASE_URL` is set to a non-preview live value, the API origin is now derived from the preview frontend URL so E2E runs stay bound to the same workspace preview instead of drifting to the live API.
 - Extended `mockNonPolyscopeCwd()` to the two Lighthouse playwright config tests that were missing it, preventing cwd-based Polyscope workspace detection from disrupting those assertions when tests run from a `.polyscope/clones/...` worktree.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6405,9 +6405,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13786,9 +13786,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -135,11 +135,12 @@
     "flatted": "3.4.2",
     "picomatch@^2": "2.3.2",
     "picomatch@^4": "4.0.4",
-    "brace-expansion": ">=5.0.5",
+    "brace-expansion": ">=5.0.6",
     "@isaacs/brace-expansion": ">=5.0.1",
     "minimatch": ">=10.2.4",
     "yauzl": "3.2.1",
-    "glob": "^13.0.6"
+    "glob": "^13.0.6",
+    "ws@^8.0.0": "^8.20.1"
   },
   "engines": {
     "node": ">=20.0.0",


### PR DESCRIPTION
## Reproduced / failing check

- `npm audit --audit-level=moderate` was the relevant dependency-audit check for this branch. After updating the audit overrides, it reports `found 0 vulnerabilities`.

## Change summary

- Raised the `brace-expansion` override to `>=5.0.6`.
- Added a scoped `ws@^8.0.0` override to resolve `ws` to `^8.20.1`.
- Updated `package-lock.json` so the resolved dev-only dependency tree uses the patched versions.
- Added the dependency-audit fix to `CHANGELOG.md`.

## Validation already run

- `npm audit --audit-level=moderate`
- `npm run build`
- `npm run format:check`
- `git diff --check`

## Scope and follow-up

- Scope is limited to one dependency-audit topic.
- No linked workspaces were used for this frontend PR.
- No out-of-scope findings were identified, so no follow-up GitHub issues were created.
- GitHub CI and Cursor Bugbot checks were still pending immediately after PR creation; review those results before marking the draft ready.
- This PR is intentionally opened as a draft. It should only be marked ready after the final self-review in the PR view still finds zero issues.
