### PR TITLE
fix(frontend): add start script alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Added a conventional `npm run start` alias for the existing Vite dev server so Polyscope and other generic start-script callers can boot the frontend workspace without failing on a missing `start` script.
+- Fixed the missing `npm run start` script in the frontend workspace by aliasing it directly to `vite`, so Polyscope and other generic start-script callers can boot the dev server without failing on a missing `start` script.
 - Updated audit overrides for `brace-expansion` and `ws` so the frontend dependency tree resolves to patched dev-only versions and `npm audit --audit-level=moderate` reports zero vulnerabilities.
 - Silenced the spurious Node.js stderr warning "The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set." that appeared on every Playwright worker when the parent shell exported `NO_COLOR` (e.g. on Polyscope/CI sandboxes): `playwright.config.ts` now removes `NO_COLOR` and `NODE_DISABLE_COLORS` from `process.env` before workers fork, including when those variables are set to an empty string. See issue #1121.
 - Fixed `resolvePlaywrightApiBaseUrl` in `tests/e2e/target-urls.ts`: when `PLAYWRIGHT_BASE_URL` points to a workspace preview and `PLAYWRIGHT_API_BASE_URL` is set to a non-preview live value, the API origin is now derived from the preview frontend URL so E2E runs stay bound to the same workspace preview instead of drifting to the live API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Added a conventional `npm run start` alias for the existing Vite dev server so Polyscope and other generic start-script callers can boot the frontend workspace without failing on a missing `start` script.
 - Updated audit overrides for `brace-expansion` and `ws` so the frontend dependency tree resolves to patched dev-only versions and `npm audit --audit-level=moderate` reports zero vulnerabilities.
 - Silenced the spurious Node.js stderr warning "The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set." that appeared on every Playwright worker when the parent shell exported `NO_COLOR` (e.g. on Polyscope/CI sandboxes): `playwright.config.ts` now removes `NO_COLOR` and `NODE_DISABLE_COLORS` from `process.env` before workers fork, including when those variables are set to an empty string. See issue #1121.
 - Fixed `resolvePlaywrightApiBaseUrl` in `tests/e2e/target-urls.ts`: when `PLAYWRIGHT_BASE_URL` points to a workspace preview and `PLAYWRIGHT_API_BASE_URL` is set to a non-preview live value, the API origin is now derived from the preview frontend URL so E2E runs stay bound to the same workspace preview instead of drifting to the live API.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "scripts": {
     "dev": "vite",
-    "start": "vite",
+    "start": "npm run dev",
     "build": "tsc && vite build",
     "build:analyze": "tsc && vite build --mode analyze",
     "preview": "vite preview",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "scripts": {
     "dev": "vite",
-    "start": "npm run dev",
+    "start": "vite",
     "build": "tsc && vite build",
     "build:analyze": "tsc && vite build --mode analyze",
     "preview": "vite preview",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   ],
   "scripts": {
     "dev": "vite",
+    "start": "vite",
     "build": "tsc && vite build",
     "build:analyze": "tsc && vite build --mode analyze",
     "preview": "vite preview",


### PR DESCRIPTION
## Summary
- add a conventional `npm run start` alias that points at the existing Vite dev server so generic workspace runners can boot the frontend
- document the start-script fix in `CHANGELOG.md`

## TDD / Validate-First Evidence
- Failing proof before implementation: `pushd /home/secpal/.polyscope/clones/9d1c7856/rosy-cheetah >/dev/null && npm run start -- --host 127.0.0.1 && popd >/dev/null` failed with `npm error Missing script: "start"`.
- Passing proof after implementation: `pushd /home/secpal/code/SecPal/frontend >/dev/null && npm run start -- --host 127.0.0.1 --port 4175 --strictPort && popd >/dev/null`; `pushd /home/secpal/.polyscope/clones/9d1c7856/rosy-cheetah >/dev/null && npm run start -- --host 127.0.0.1 --port 4174 --strictPort && popd >/dev/null`.
- Validate-first exception reference: `N/A`
- No executable change reason: `N/A`

## Self-review
- Findings: none. The final diff is limited to `package.json` and `CHANGELOG.md`, and the affected start path was re-run successfully before publication.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an `npm run start` alias to the existing Vite dev server and updates documentation only; no runtime application logic changes.
> 
> **Overview**
> Adds a conventional `npm run start` entry that aliases directly to `vite`, so generic tooling that expects a `start` script can launch the frontend dev server.
> 
> Updates `CHANGELOG.md` to document the new `start` script fix under *Fixed*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca754ddf669c61e91a9ae3483f00915f718adf34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->