### PR TITLE
feat: wire browser web push lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Wired authenticated browser Web Push lifecycle management to deployment bootstrap metadata and the notification-installations API: the PWA now reads runtime VAPID metadata from browser bootstrap instead of `VITE_VAPID_PUBLIC_KEY`, upserts existing subscriptions on app load, refreshes stale runtime metadata by rotating the local subscription, re-runs reconciliation after service-worker replacement, revokes the remote installation before browser-session logout, and clears local browser push state during logout/reset and denied-permission cleanup. Closes #1139.
 - Fixed the missing `npm run start` script in the frontend workspace by aliasing it directly to `vite`, so Polyscope and other generic start-script callers can boot the dev server without failing on a missing `start` script.
 - Updated audit overrides for `brace-expansion` and `ws` so the frontend dependency tree resolves to patched dev-only versions and `npm audit --audit-level=moderate` reports zero vulnerabilities.
 - Silenced the spurious Node.js stderr warning "The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set." that appeared on every Playwright worker when the parent shell exported `NO_COLOR` (e.g. on Polyscope/CI sandboxes): `playwright.config.ts` now removes `NO_COLOR` and `NODE_DISABLE_COLORS` from `process.env` before workers fork, including when those variables are set to an empty string. See issue #1121.

--- a/PWA_OFFLINE_PERSISTENCE_AUDIT.md
+++ b/PWA_OFFLINE_PERSISTENCE_AUDIT.md
@@ -29,7 +29,7 @@ See issue #495 and `docs/OFFLINE_ENCRYPTED_VAULT_DESIGN.md` for the accepted Pha
 - FINDING-04: `static-assets` cache in the service worker without expiration
 - FINDING-06: `pwaRuntimeCaching.ts` expiration config is ineffective with `injectManifest` (more specific than #493)
 - FINDING-09: `XSRF-TOKEN` cookie remains after logout (backend-side)
-- FINDING-10: Push subscription potentially remains active after logout
+- FINDING-10: Push subscription persistence after logout required a cross-repo fix (resolved in #1139)
 
 **Confirmation of existing issues with additional detail:**
 
@@ -42,14 +42,15 @@ See issue #495 and `docs/OFFLINE_ENCRYPTED_VAULT_DESIGN.md` for the accepted Pha
 
 ### 1.1 localStorage
 
-| Key                               | Content                                                                                                                                                 | Sensitive?                 | Cleanup on logout?                       |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | ---------------------------------------- |
-| `auth_user`                       | User object (id, name, email, roles, permissions, hasOrganizationalScopes, hasCustomerAccess, hasSiteAccess) — **no** employee field in persisted state | Medium (PII: name, e-mail) | **Yes** – `clearSensitiveClientState()`  |
-| `auth_token`                      | Legacy field, actively removed in the `LocalStorageAuthStorage` constructor                                                                             | High (if present)          | **Yes** – both cleanup and legacy wipe   |
-| `auth_logout_barrier`             | Flag ("1") for BFCache protection                                                                                                                       | No                         | No (intentional – deleted on next login) |
-| `secpal-notification-preferences` | JSON with notification categories (alerts, updates, maintenance)                                                                                        | Low                        | **Yes**                                  |
-| `secpal-locale`                   | Language preference (e.g. "de")                                                                                                                         | No                         | **No** (intentional – user-neutral)      |
-| `login_rate_limit`                | Failsafe counter (attempts, lockoutEndTime, lastAttemptTime)                                                                                            | Low                        | **No**                                   |
+| Key                                   | Content                                                                                                                                                 | Sensitive?                 | Cleanup on logout?                       |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | ---------------------------------------- |
+| `auth_user`                           | User object (id, name, email, roles, permissions, hasOrganizationalScopes, hasCustomerAccess, hasSiteAccess) — **no** employee field in persisted state | Medium (PII: name, e-mail) | **Yes** – `clearSensitiveClientState()`  |
+| `auth_token`                          | Legacy field, actively removed in the `LocalStorageAuthStorage` constructor                                                                             | High (if present)          | **Yes** – both cleanup and legacy wipe   |
+| `auth_logout_barrier`                 | Flag ("1") for BFCache protection                                                                                                                       | No                         | No (intentional – deleted on next login) |
+| `secpal-notification-preferences`     | JSON with notification categories (alerts, updates, maintenance)                                                                                        | Low                        | **Yes**                                  |
+| `secpal-browser-push-installation-id` | Stable browser push installation ID used for authenticated `/v1/me/notification-installations/{installationId}` upserts and revokes                     | Low                        | **Yes**                                  |
+| `secpal-locale`                       | Language preference (e.g. "de")                                                                                                                         | No                         | **No** (intentional – user-neutral)      |
+| `login_rate_limit`                    | Failsafe counter (attempts, lockoutEndTime, lastAttemptTime)                                                                                            | Low                        | **No**                                   |
 
 ### 1.2 sessionStorage
 
@@ -200,11 +201,11 @@ See issue #495 and `docs/OFFLINE_ENCRYPTED_VAULT_DESIGN.md` for the accepted Pha
 
 ### FINDING-10: Push notification subscription may persist after logout
 
-- **Severity:** Low to medium
-- **Type:** Plausible risk
-- **Affected:** [src/hooks/usePushSubscription.ts](src/hooks/usePushSubscription.ts)
-- **Description:** Push subscriptions are registered with the browser via the Web Push API. On logout, `secpal-notification-preferences` are deleted from localStorage and the backend is notified (`POST /v1/auth/logout`). Whether the backend removes the push subscription (VAPID endpoint) on logout could not be verified from the frontend code. If the subscription persists server-side, push messages could be delivered to the device after logout.
-- **Fix:** In the logout flow, before calling `POST /v1/auth/logout`, explicitly call `PushManager.getSubscription()`, call `.unsubscribe()`, and deregister the endpoint server-side. Alternatively: confirm whether the backend automatically removes all push subscriptions for the session on logout.
+- **Severity:** Fixed
+- **Type:** Resolved in issue #1139
+- **Affected:** [src/hooks/useNotifications.ts](src/hooks/useNotifications.ts), [src/services/authTransport.ts](src/services/authTransport.ts), [src/lib/clientStateCleanup.ts](src/lib/clientStateCleanup.ts), [src/App.tsx](src/App.tsx)
+- **Description:** Browser web push is now wired through the selected deployment bootstrap and the authenticated notification-installations API. The frontend reads the runtime VAPID metadata from `GET /v1/bootstrap?client_platform=browser`, upserts existing subscriptions on app load, retries stale-runtime conflicts by refreshing bootstrap and rotating the local subscription, re-runs the authenticated reconciliation after `controllerchange`, revokes the stored installation before browser-session logout, and clears both the local installation ID and any existing browser subscription during logout/reset cleanup or denied-permission reconciliation.
+- **Fix:** Implemented. The browser-side `VITE_VAPID_PUBLIC_KEY` production fallback was removed so deployment bootstrap stays authoritative, and logout/reset now clear both remote and local browser push state.
 
 ---
 
@@ -251,7 +252,7 @@ See issue #495 and `docs/OFFLINE_ENCRYPTED_VAULT_DESIGN.md` for the accepted Pha
 | 07  | Multi-tab logout race (IndexedDB)          | Low        | Edge case           | No (fallback sufficient) |
 | 08  | PII (name, e-mail) in localStorage         | Medium     | Privacy             | Consider trade-off       |
 | 09  | XSRF-TOKEN after logout                    | Low        | Completeness        | Optional (backend)       |
-| 10  | Push subscription after logout             | Low–medium | Privacy             | **Verify** (backend)     |
+| 10  | Push subscription after logout             | Fixed      | Resolved            | Implemented              |
 
 ---
 
@@ -265,9 +266,7 @@ See issue #495 and `docs/OFFLINE_ENCRYPTED_VAULT_DESIGN.md` for the accepted Pha
 
 ### Medium
 
-1. **Verify push subscription on logout** (FINDING-10): Confirm that the backend removes push subscriptions on logout/session invalidation. → Separate issue recommended (cross-repo: frontend + API).
-
-2. **Delete `login_rate_limit` on logout** (FINDING-01): Add to `USER_SCOPED_LOCAL_STORAGE_KEYS`. → Separate issue recommended.
+1. **Delete `login_rate_limit` on logout** (FINDING-01): Add to `USER_SCOPED_LOCAL_STORAGE_KEYS`. → Separate issue recommended.
 
 ### Low
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -152,8 +152,8 @@ function NotificationLifecycleCoordinator() {
 function App() {
   return (
     <AuthProvider>
-      <NotificationLifecycleCoordinator />
       <BrowserRouter>
+        <NotificationLifecycleCoordinator />
         <NativeRuntimePwaGuard />
         <UpdatePrompt />
         <Suspense fallback={<RouteLoader />}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { NativeRuntimePwaGuard } from "./components/NativeRuntimePwaGuard";
 import { OfflineIndicator } from "./components/OfflineIndicator";
 import { UpdatePrompt } from "./components/UpdatePrompt";
 import { AuthProvider } from "./contexts/AuthContext";
+import { useNotifications } from "./hooks/useNotifications";
 import {
   AppAccessRoute,
   OnboardingOnlyRoute,
@@ -142,9 +143,16 @@ function AppFeatureRoute(props: React.ComponentProps<typeof FeatureRoute>) {
   );
 }
 
+function NotificationLifecycleCoordinator() {
+  useNotifications({ autoSync: true });
+
+  return null;
+}
+
 function App() {
   return (
     <AuthProvider>
+      <NotificationLifecycleCoordinator />
       <BrowserRouter>
         <NativeRuntimePwaGuard />
         <UpdatePrompt />

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -1066,6 +1066,243 @@ describe("useNotifications", () => {
       );
     });
 
+    it("retries auto sync after requestPermission hits a rotation retry and the rotated upsert fails once", async () => {
+      document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
+
+      let currentSubscription: typeof mockPushSubscription | null = null;
+      const rotatedPushSubscription = {
+        endpoint:
+          "https://updates.push.services.mozilla.com/wpush/v2/gAAAAABoUmVxdWVzdFBlcm1pc3Npb25SZXRyeTEyMzQ1Njc4OTA",
+        expirationTime: 1782568800000,
+        toJSON: vi.fn().mockReturnValue({
+          endpoint:
+            "https://updates.push.services.mozilla.com/wpush/v2/gAAAAABoUmVxdWVzdFBlcm1pc3Npb25SZXRyeTEyMzQ1Njc4OTA",
+          expirationTime: 1782568800000,
+          keys: {
+            p256dh: "BMozillaRequestRetryP256dh0123456789abcdefghijklmnopq",
+            auth: "Qm9PqRs7WxY",
+          },
+        }),
+        unsubscribe: vi.fn().mockImplementation(async () => {
+          currentSubscription = null;
+          return true;
+        }),
+      };
+
+      mockPushManager.getSubscription.mockImplementation(
+        async () => currentSubscription
+      );
+      mockPushManager.subscribe.mockImplementation(async () => {
+        currentSubscription = rotatedPushSubscription;
+        return rotatedPushSubscription;
+      });
+
+      globalThis.Notification.requestPermission = vi
+        .fn()
+        .mockImplementation(async () => {
+          Object.defineProperty(globalThis.Notification, "permission", {
+            writable: true,
+            value: "granted",
+          });
+          return "granted";
+        });
+
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: {
+                client_platform: "browser",
+                compatibility: {
+                  bootstrap_version: "v1",
+                  schema_version: 3,
+                },
+                features: {
+                  notification_channels: {
+                    android_fcm: false,
+                    web_push: true,
+                  },
+                },
+                notification_channels: {
+                  web_push: {
+                    channel: "web_push",
+                    metadata_revision: 4,
+                    public_runtime_metadata: {
+                      vapid_public_key:
+                        "BE9tfo-aCxwtPk9QYXKDlAUGBwgJCgsMDQ4PEBESExQVobLD1OX2BxgpMEFSY3SFlgcYKTBLXG1-j5ABAgMEBQA",
+                    },
+                  },
+                },
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              message:
+                "Notification runtime metadata changed; refresh bootstrap before retrying this installation update.",
+              code: "NOTIFICATION_RUNTIME_STATE_INVALID",
+              details: {
+                bootstrap_version: "v1",
+                schema_version: 3,
+                channel: "web_push",
+                provided_metadata_revision: 4,
+                expected_metadata_revision: 5,
+              },
+            }),
+            {
+              status: 409,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: {
+                client_platform: "browser",
+                compatibility: {
+                  bootstrap_version: "v1",
+                  schema_version: 3,
+                },
+                features: {
+                  notification_channels: {
+                    android_fcm: false,
+                    web_push: true,
+                  },
+                },
+                notification_channels: {
+                  web_push: {
+                    channel: "web_push",
+                    metadata_revision: 5,
+                    public_runtime_metadata: {
+                      vapid_public_key:
+                        "BE9tfo-aCxwtPk9QYXKDlAUGBwgJCgsMDQ4PEBESExQVobLD1OX2BxgpMEFSY3SFlgcYKTBLXG1-j5ABAgMEBQY",
+                    },
+                  },
+                },
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              message: "Temporary installation sync failure",
+            }),
+            {
+              status: 503,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: {
+                client_platform: "browser",
+                compatibility: {
+                  bootstrap_version: "v1",
+                  schema_version: 3,
+                },
+                features: {
+                  notification_channels: {
+                    android_fcm: false,
+                    web_push: true,
+                  },
+                },
+                notification_channels: {
+                  web_push: {
+                    channel: "web_push",
+                    metadata_revision: 5,
+                    public_runtime_metadata: {
+                      vapid_public_key:
+                        "BE9tfo-aCxwtPk9QYXKDlAUGBwgJCgsMDQ4PEBESExQVobLD1OX2BxgpMEFSY3SFlgcYKTBLXG1-j5ABAgMEBQY",
+                    },
+                  },
+                },
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: {
+                installation_id: "installation-id",
+                channel: "web_push",
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        );
+
+      vi.stubGlobal("fetch", mockFetch);
+
+      const { result } = renderHook(
+        () => useNotifications({ autoSync: true }),
+        {
+          wrapper: AuthenticatedWrapper,
+        }
+      );
+
+      await act(async () => {
+        await expect(result.current.requestPermission()).rejects.toThrow(
+          "Temporary installation sync failure"
+        );
+      });
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(6);
+      });
+
+      const recoveredUpsertCall = mockFetch.mock.calls[5];
+      const recoveredUpsertPayload = JSON.parse(
+        String(recoveredUpsertCall?.[1]?.body ?? "{}")
+      ) as {
+        lifecycle_event: string;
+        runtime: { metadata_revision: number };
+        registration: { subscription: { endpoint: string } };
+      };
+
+      expect(rotatedPushSubscription.unsubscribe).toHaveBeenCalledTimes(1);
+      expect(mockPushManager.subscribe).toHaveBeenCalledTimes(2);
+      expect(recoveredUpsertPayload.lifecycle_event).toBe("client_updated");
+      expect(recoveredUpsertPayload.runtime.metadata_revision).toBe(5);
+      expect(recoveredUpsertPayload.registration.subscription.endpoint).toBe(
+        rotatedPushSubscription.endpoint
+      );
+    });
+
     it("revokes the authenticated browser installation and clears local push state when permission is denied", async () => {
       document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
       Object.defineProperty(globalThis.Notification, "permission", {

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -831,6 +831,238 @@ describe("useNotifications", () => {
       );
     });
 
+    it("retries auto sync after a rotated subscription fails to upsert", async () => {
+      document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
+      Object.defineProperty(globalThis.Notification, "permission", {
+        writable: true,
+        value: "granted",
+      });
+
+      let currentSubscription: typeof mockPushSubscription | null =
+        mockPushSubscription;
+      const rotatedPushSubscription = {
+        endpoint:
+          "https://updates.push.services.mozilla.com/wpush/v2/gAAAAABoUmVjb3Zlcnktc3Vic2NyaXB0aW9uLTEyMzQ1Njc4OTA",
+        expirationTime: 1782565200000,
+        toJSON: vi.fn().mockReturnValue({
+          endpoint:
+            "https://updates.push.services.mozilla.com/wpush/v2/gAAAAABoUmVjb3Zlcnktc3Vic2NyaXB0aW9uLTEyMzQ1Njc4OTA",
+          expirationTime: 1782565200000,
+          keys: {
+            p256dh: "BMozillaRecoveryP256dh0123456789abcdefghijklmnopqrst",
+            auth: "Pm9QqRs7UvW",
+          },
+        }),
+        unsubscribe: vi.fn().mockImplementation(async () => {
+          currentSubscription = null;
+          return true;
+        }),
+      };
+
+      mockPushSubscription.unsubscribe.mockImplementationOnce(async () => {
+        currentSubscription = null;
+        return true;
+      });
+      mockPushManager.getSubscription.mockImplementation(
+        async () => currentSubscription
+      );
+      mockPushManager.subscribe.mockImplementation(async () => {
+        currentSubscription = rotatedPushSubscription;
+        return rotatedPushSubscription;
+      });
+
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: {
+                client_platform: "browser",
+                compatibility: {
+                  bootstrap_version: "v1",
+                  schema_version: 3,
+                },
+                features: {
+                  notification_channels: {
+                    android_fcm: false,
+                    web_push: true,
+                  },
+                },
+                notification_channels: {
+                  web_push: {
+                    channel: "web_push",
+                    metadata_revision: 4,
+                    public_runtime_metadata: {
+                      vapid_public_key:
+                        "BE9tfo-aCxwtPk9QYXKDlAUGBwgJCgsMDQ4PEBESExQVobLD1OX2BxgpMEFSY3SFlgcYKTBLXG1-j5ABAgMEBQA",
+                    },
+                  },
+                },
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              message:
+                "Notification runtime metadata changed; refresh bootstrap before retrying this installation update.",
+              code: "NOTIFICATION_RUNTIME_STATE_INVALID",
+              details: {
+                bootstrap_version: "v1",
+                schema_version: 3,
+                channel: "web_push",
+                provided_metadata_revision: 4,
+                expected_metadata_revision: 5,
+              },
+            }),
+            {
+              status: 409,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: {
+                client_platform: "browser",
+                compatibility: {
+                  bootstrap_version: "v1",
+                  schema_version: 3,
+                },
+                features: {
+                  notification_channels: {
+                    android_fcm: false,
+                    web_push: true,
+                  },
+                },
+                notification_channels: {
+                  web_push: {
+                    channel: "web_push",
+                    metadata_revision: 5,
+                    public_runtime_metadata: {
+                      vapid_public_key:
+                        "BE9tfo-aCxwtPk9QYXKDlAUGBwgJCgsMDQ4PEBESExQVobLD1OX2BxgpMEFSY3SFlgcYKTBLXG1-j5ABAgMEBQY",
+                    },
+                  },
+                },
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              message: "Temporary installation sync failure",
+            }),
+            {
+              status: 503,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: {
+                client_platform: "browser",
+                compatibility: {
+                  bootstrap_version: "v1",
+                  schema_version: 3,
+                },
+                features: {
+                  notification_channels: {
+                    android_fcm: false,
+                    web_push: true,
+                  },
+                },
+                notification_channels: {
+                  web_push: {
+                    channel: "web_push",
+                    metadata_revision: 5,
+                    public_runtime_metadata: {
+                      vapid_public_key:
+                        "BE9tfo-aCxwtPk9QYXKDlAUGBwgJCgsMDQ4PEBESExQVobLD1OX2BxgpMEFSY3SFlgcYKTBLXG1-j5ABAgMEBQY",
+                    },
+                  },
+                },
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: {
+                installation_id: "installation-id",
+                channel: "web_push",
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        );
+
+      vi.stubGlobal("fetch", mockFetch);
+
+      const { result } = renderHook(
+        () => useNotifications({ autoSync: true }),
+        {
+          wrapper: AuthenticatedWrapper,
+        }
+      );
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(6);
+        expect(result.current.error).toBeNull();
+      });
+
+      expect(mockPushSubscription.unsubscribe).toHaveBeenCalledTimes(1);
+      expect(mockPushManager.subscribe).toHaveBeenCalledTimes(1);
+
+      const recoveredUpsertCall = mockFetch.mock.calls[5];
+      const recoveredUpsertPayload = JSON.parse(
+        String(recoveredUpsertCall?.[1]?.body ?? "{}")
+      ) as {
+        lifecycle_event: string;
+        runtime: { metadata_revision: number };
+        registration: { subscription: { endpoint: string } };
+      };
+
+      expect(recoveredUpsertPayload.lifecycle_event).toBe("client_updated");
+      expect(recoveredUpsertPayload.runtime.metadata_revision).toBe(5);
+      expect(recoveredUpsertPayload.registration.subscription.endpoint).toBe(
+        rotatedPushSubscription.endpoint
+      );
+    });
+
     it("revokes the authenticated browser installation and clears local push state when permission is denied", async () => {
       document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
       Object.defineProperty(globalThis.Notification, "permission", {

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -1303,6 +1303,172 @@ describe("useNotifications", () => {
       );
     });
 
+    it("caps auto sync recovery attempts after repeated rotated upsert failures", async () => {
+      document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
+      Object.defineProperty(globalThis.Notification, "permission", {
+        writable: true,
+        value: "granted",
+      });
+
+      let currentSubscription: typeof mockPushSubscription | null =
+        mockPushSubscription;
+      const rotatedPushSubscription = {
+        endpoint:
+          "https://updates.push.services.mozilla.com/wpush/v2/gAAAAABoQ2FwcGVkLXJvdGF0aW9uLXN1YnNjcmlwdGlvbi0xMjM0NTY",
+        expirationTime: 1782568800000,
+        toJSON: vi.fn().mockReturnValue({
+          endpoint:
+            "https://updates.push.services.mozilla.com/wpush/v2/gAAAAABoQ2FwcGVkLXJvdGF0aW9uLXN1YnNjcmlwdGlvbi0xMjM0NTY",
+          expirationTime: 1782568800000,
+          keys: {
+            p256dh: "BMozillaCappedP256dh0123456789abcdefghijklmnopqrstu",
+            auth: "Qm9RqSt8VwX",
+          },
+        }),
+        unsubscribe: vi.fn().mockImplementation(async () => {
+          currentSubscription = null;
+          return true;
+        }),
+      };
+
+      mockPushSubscription.unsubscribe.mockImplementationOnce(async () => {
+        currentSubscription = null;
+        return true;
+      });
+      mockPushManager.getSubscription.mockImplementation(
+        async () => currentSubscription
+      );
+      mockPushManager.subscribe.mockImplementation(async () => {
+        currentSubscription = rotatedPushSubscription;
+        return rotatedPushSubscription;
+      });
+
+      const createBootstrapResponse = (
+        metadataRevision: number,
+        vapidPublicKey: string
+      ) =>
+        new Response(
+          JSON.stringify({
+            data: {
+              client_platform: "browser",
+              compatibility: {
+                bootstrap_version: "v1",
+                schema_version: 3,
+              },
+              features: {
+                notification_channels: {
+                  android_fcm: false,
+                  web_push: true,
+                },
+              },
+              notification_channels: {
+                web_push: {
+                  channel: "web_push",
+                  metadata_revision: metadataRevision,
+                  public_runtime_metadata: {
+                    vapid_public_key: vapidPublicKey,
+                  },
+                },
+              },
+            },
+          }),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+            },
+          }
+        );
+      const createRuntimeStateInvalidResponse = () =>
+        new Response(
+          JSON.stringify({
+            message:
+              "Notification runtime metadata changed; refresh bootstrap before retrying this installation update.",
+            code: "NOTIFICATION_RUNTIME_STATE_INVALID",
+            details: {
+              bootstrap_version: "v1",
+              schema_version: 3,
+              channel: "web_push",
+              provided_metadata_revision: 4,
+              expected_metadata_revision: 5,
+            },
+          }),
+          {
+            status: 409,
+            headers: {
+              "Content-Type": "application/json",
+            },
+          }
+        );
+      const createTemporaryFailureResponse = () =>
+        new Response(
+          JSON.stringify({
+            message: "Temporary installation sync failure",
+          }),
+          {
+            status: 503,
+            headers: {
+              "Content-Type": "application/json",
+            },
+          }
+        );
+      const responses = [
+        createBootstrapResponse(
+          4,
+          "BE9tfo-aCxwtPk9QYXKDlAUGBwgJCgsMDQ4PEBESExQVobLD1OX2BxgpMEFSY3SFlgcYKTBLXG1-j5ABAgMEBQA"
+        ),
+        createRuntimeStateInvalidResponse(),
+        createBootstrapResponse(
+          5,
+          "BE9tfo-aCxwtPk9QYXKDlAUGBwgJCgsMDQ4PEBESExQVobLD1OX2BxgpMEFSY3SFlgcYKTBLXG1-j5ABAgMEBQY"
+        ),
+        createTemporaryFailureResponse(),
+        createBootstrapResponse(
+          4,
+          "BE9tfo-aCxwtPk9QYXKDlAUGBwgJCgsMDQ4PEBESExQVobLD1OX2BxgpMEFSY3SFlgcYKTBLXG1-j5ABAgMEBQA"
+        ),
+        createRuntimeStateInvalidResponse(),
+        createBootstrapResponse(
+          5,
+          "BE9tfo-aCxwtPk9QYXKDlAUGBwgJCgsMDQ4PEBESExQVobLD1OX2BxgpMEFSY3SFlgcYKTBLXG1-j5ABAgMEBQY"
+        ),
+        createTemporaryFailureResponse(),
+      ];
+      let responseIndex = 0;
+      const mockFetch = vi.fn(() => {
+        const response = responses[responseIndex];
+        responseIndex += 1;
+
+        if (!response) {
+          throw new Error("Unexpected extra auto-sync retry");
+        }
+
+        return Promise.resolve(response);
+      });
+
+      vi.stubGlobal("fetch", mockFetch);
+
+      const { result } = renderHook(
+        () => useNotifications({ autoSync: true }),
+        {
+          wrapper: AuthenticatedWrapper,
+        }
+      );
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(8);
+        expect(result.current.error?.message).toBe(
+          "Temporary installation sync failure"
+        );
+      });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(8);
+    });
+
     it("revokes the authenticated browser installation and clears local push state when permission is denied", async () => {
       document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
       Object.defineProperty(globalThis.Notification, "permission", {

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -10,6 +10,7 @@ import {
   clearBrowserPushInstallationId,
   getOrCreateBrowserPushInstallationId,
   peekBrowserPushInstallationId,
+  setBrowserPushLogoutInProgress,
 } from "../lib/browserPushState";
 import { AuthContext, type AuthContextType } from "../contexts/auth-context";
 
@@ -125,6 +126,7 @@ describe("useNotifications", () => {
 
   afterEach(() => {
     cleanup();
+    setBrowserPushLogoutInProgress(false);
     clearBrowserPushInstallationId();
     localStorage.clear();
     document.cookie = "XSRF-TOKEN=; Max-Age=0; path=/";
@@ -1913,6 +1915,107 @@ describe("useNotifications", () => {
         isAuthenticated: false,
       };
       rerender();
+
+      await act(async () => {
+        resolveBootstrapResponse?.(
+          new Response(
+            JSON.stringify({
+              data: {
+                client_platform: "browser",
+                compatibility: {
+                  bootstrap_version: "v1",
+                  schema_version: 3,
+                },
+                features: {
+                  notification_channels: {
+                    android_fcm: false,
+                    web_push: true,
+                  },
+                },
+                notification_channels: {
+                  web_push: {
+                    channel: "web_push",
+                    metadata_revision: 5,
+                    public_runtime_metadata: {
+                      vapid_public_key:
+                        "BE9tfo-aCxwtPk9QYXKDlAUGBwgJCgsMDQ4PEBESExQVobLD1OX2BxgpMEFSY3SFlgcYKTBLXG1-j5ABAgMEBQY",
+                    },
+                  },
+                },
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        );
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(peekBrowserPushInstallationId()).toBeNull();
+    });
+
+    it("does not create or upsert a browser push installation while logout revocation is in progress", async () => {
+      document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
+      Object.defineProperty(globalThis.Notification, "permission", {
+        writable: true,
+        value: "granted",
+      });
+
+      let resolveBootstrapResponse: ((response: Response) => void) | null =
+        null;
+
+      mockPushManager.getSubscription.mockResolvedValue(mockPushSubscription);
+
+      const mockFetch = vi.fn((input, init) => {
+        const url = String(input);
+
+        if (url.includes("/v1/bootstrap?client_platform=browser")) {
+          return new Promise<Response>((resolve) => {
+            resolveBootstrapResponse = resolve;
+          });
+        }
+
+        if (
+          /\/v1\/me\/notification-installations\//.test(url) &&
+          init?.method === "PUT"
+        ) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                data: {
+                  installation_id: "installation-id",
+                  channel: "web_push",
+                },
+              }),
+              {
+                status: 200,
+                headers: {
+                  "Content-Type": "application/json",
+                },
+              }
+            )
+          );
+        }
+
+        throw new Error(`Unexpected fetch request: ${url}`);
+      });
+
+      vi.stubGlobal("fetch", mockFetch);
+
+      renderHook(() => useNotifications({ autoSync: true }), {
+        wrapper: AuthenticatedWrapper,
+      });
+
+      await waitFor(() => {
+        expect(resolveBootstrapResponse).not.toBeNull();
+      });
+
+      setBrowserPushLogoutInProgress(true);
 
       await act(async () => {
         resolveBootstrapResponse?.(

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -1673,6 +1673,84 @@ describe("useNotifications", () => {
       expect(peekBrowserPushInstallationId()).toBeNull();
     });
 
+    it("does not re-run denied auto-sync cleanup when auth state changes", async () => {
+      document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
+      Object.defineProperty(globalThis.Notification, "permission", {
+        writable: true,
+        value: "denied",
+      });
+
+      const installationId = getOrCreateBrowserPushInstallationId();
+      let isAuthenticated = true;
+
+      mockPushManager.getSubscription.mockResolvedValue(mockPushSubscription);
+
+      const mockFetch = vi.fn().mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              installation_id: installationId,
+              channel: "web_push",
+            },
+          }),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+            },
+          }
+        )
+      );
+
+      vi.stubGlobal("fetch", mockFetch);
+
+      const AuthStateWrapper = ({ children }: { children: ReactNode }) =>
+        createElement(
+          AuthContext.Provider,
+          {
+            value: {
+              ...authenticatedAuthContextValue,
+              isAuthenticated,
+              user: isAuthenticated ? authenticatedAuthContextValue.user : null,
+            },
+          },
+          children
+        );
+
+      const { rerender } = renderHook(
+        () => useNotifications({ autoSync: true }),
+        {
+          wrapper: AuthStateWrapper,
+        }
+      );
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(mockPushSubscription.unsubscribe).toHaveBeenCalledTimes(1);
+      });
+
+      const getSubscriptionCallCount =
+        mockPushManager.getSubscription.mock.calls.length;
+      const fetchCallCount = mockFetch.mock.calls.length;
+      const unsubscribeCallCount =
+        mockPushSubscription.unsubscribe.mock.calls.length;
+
+      isAuthenticated = false;
+
+      await act(async () => {
+        rerender();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(mockPushManager.getSubscription).toHaveBeenCalledTimes(
+        getSubscriptionCallCount
+      );
+      expect(mockFetch).toHaveBeenCalledTimes(fetchCallCount);
+      expect(mockPushSubscription.unsubscribe).toHaveBeenCalledTimes(
+        unsubscribeCallCount
+      );
+    });
+
     it("clears local push state even when remote revocation fails", async () => {
       document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
       Object.defineProperty(globalThis.Notification, "permission", {

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -1,16 +1,72 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import { createElement, type ReactNode } from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { waitFor } from "@testing-library/dom";
 import { useNotifications } from "./useNotifications";
+import {
+  getOrCreateBrowserPushInstallationId,
+  peekBrowserPushInstallationId,
+} from "../lib/browserPushState";
+import {
+  AuthContext,
+  type AuthContextType,
+} from "../contexts/auth-context";
 
 // Mock Notification API
 const mockNotification = vi.fn();
+const mockPushManager = {
+  getSubscription: vi.fn(),
+  subscribe: vi.fn(),
+};
 const mockServiceWorkerRegistration = {
   showNotification: vi.fn().mockResolvedValue(undefined),
+  pushManager: mockPushManager,
 };
+const mockPushSubscription = {
+  endpoint:
+    "https://fcm.googleapis.com/fcm/send/cVJmVnB1c2g6MTIzNDU2Nzg5MA:APA91bHabcdefghijklmno1234567890",
+  expirationTime: 1782475200000,
+  toJSON: vi.fn().mockReturnValue({
+    endpoint:
+      "https://fcm.googleapis.com/fcm/send/cVJmVnB1c2g6MTIzNDU2Nzg5MA:APA91bHabcdefghijklmno1234567890",
+    expirationTime: 1782475200000,
+    keys: {
+      p256dh: "BElx7P1qA2rS9tUvWxYz0123456789abcdefghijklmnopqrstuv",
+      auth: "K7d9Lm2PqRs",
+    },
+  }),
+  unsubscribe: vi.fn().mockResolvedValue(true),
+};
+
+const authenticatedAuthContextValue: AuthContextType = {
+  user: {
+    id: "1",
+    name: "Notification User",
+    email: "notifications@secpal.dev",
+    emailVerified: true,
+  },
+  isAuthenticated: true,
+  isLoading: false,
+  bootstrapRecoveryReason: null,
+  login: vi.fn(),
+  logout: vi.fn(),
+  retryBootstrap: vi.fn(),
+  hasPermission: vi.fn().mockReturnValue(true),
+  hasOrganizationalAccess: vi.fn().mockReturnValue(true),
+};
+
+function AuthenticatedWrapper({ children }: { children: ReactNode }) {
+  return createElement(
+    AuthContext.Provider,
+    {
+      value: authenticatedAuthContextValue,
+    },
+    children
+  );
+}
 
 describe("useNotifications", () => {
   beforeEach(() => {
@@ -32,15 +88,29 @@ describe("useNotifications", () => {
       writable: true,
       configurable: true,
     });
+
+    Object.defineProperty(window, "PushManager", {
+      value: function PushManager() {},
+      writable: true,
+      configurable: true,
+    });
+
+    mockPushManager.getSubscription.mockResolvedValue(null);
+    mockPushManager.subscribe.mockResolvedValue(mockPushSubscription);
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.clearAllMocks();
   });
 
   describe("initialization", () => {
-    it("should initialize with correct default values", () => {
+    it("should initialize with correct default values", async () => {
       const { result } = renderHook(() => useNotifications());
+
+      await waitFor(() => {
+        expect(mockPushManager.getSubscription).toHaveBeenCalled();
+      });
 
       expect(result.current.permission).toBe("default");
       expect(result.current.isSupported).toBe(true);
@@ -48,13 +118,17 @@ describe("useNotifications", () => {
       expect(result.current.error).toBeNull();
     });
 
-    it("should detect unsupported browsers", () => {
+    it("should detect unsupported browsers", async () => {
       // Remove Notification from window
       const originalNotification = globalThis.Notification;
       // @ts-expect-error - intentionally testing unsupported environment
       delete globalThis.Notification;
 
       const { result } = renderHook(() => useNotifications());
+
+      await waitFor(() => {
+        expect(mockPushManager.getSubscription).toHaveBeenCalled();
+      });
 
       expect(result.current.isSupported).toBe(false);
 
@@ -126,6 +200,96 @@ describe("useNotifications", () => {
       });
 
       expect(result.current.error).toBe(testError);
+    });
+
+    it("bootstraps deployment web push metadata and registers the authenticated browser subscription when permission is granted", async () => {
+      document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
+
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: {
+                client_platform: "browser",
+                compatibility: {
+                  bootstrap_version: "v1",
+                  schema_version: 3,
+                },
+                features: {
+                  notification_channels: {
+                    android_fcm: false,
+                    web_push: true,
+                  },
+                },
+                notification_channels: {
+                  web_push: {
+                    channel: "web_push",
+                    metadata_revision: 5,
+                    public_runtime_metadata: {
+                      vapid_public_key:
+                        "BE9tfo-aCxwtPk9QYXKDlAUGBwgJCgsMDQ4PEBESExQVobLD1OX2BxgpMEFSY3SFlgcYKTBLXG1-j5ABAgMEBQY",
+                    },
+                  },
+                },
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: {
+                installation_id: "installation-id",
+                channel: "web_push",
+              },
+            }),
+            {
+              status: 201,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        );
+
+      vi.stubGlobal("fetch", mockFetch);
+
+      const { result } = renderHook(() => useNotifications(), {
+        wrapper: AuthenticatedWrapper,
+      });
+
+      await act(async () => {
+        await result.current.requestPermission();
+      });
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining("/v1/bootstrap?client_platform=browser"),
+          expect.objectContaining({
+            credentials: "include",
+          })
+        );
+      });
+
+      expect(mockPushManager.subscribe).toHaveBeenCalledWith({
+        userVisibleOnly: true,
+        applicationServerKey: expect.any(Uint8Array),
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringMatching(/\/v1\/me\/notification-installations\//),
+        expect.objectContaining({
+          credentials: "include",
+          method: "PUT",
+        })
+      );
     });
   });
 
@@ -208,7 +372,11 @@ describe("useNotifications", () => {
       // Mock service worker without showNotification
       Object.defineProperty(navigator, "serviceWorker", {
         value: {
-          ready: Promise.resolve({}),
+          ready: Promise.resolve({
+            pushManager: {
+              getSubscription: vi.fn().mockResolvedValue(null),
+            },
+          }),
         },
         writable: true,
         configurable: true,
@@ -309,6 +477,466 @@ describe("useNotifications", () => {
       // After completion, loading should be false
       expect(result.current.isLoading).toBe(false);
       expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe("autoSync", () => {
+    it("reconciles an existing authenticated browser subscription on app load", async () => {
+      document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
+      Object.defineProperty(globalThis.Notification, "permission", {
+        writable: true,
+        value: "granted",
+      });
+      mockPushManager.getSubscription.mockResolvedValue(mockPushSubscription);
+
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: {
+                client_platform: "browser",
+                compatibility: {
+                  bootstrap_version: "v1",
+                  schema_version: 3,
+                },
+                features: {
+                  notification_channels: {
+                    android_fcm: false,
+                    web_push: true,
+                  },
+                },
+                notification_channels: {
+                  web_push: {
+                    channel: "web_push",
+                    metadata_revision: 5,
+                    public_runtime_metadata: {
+                      vapid_public_key:
+                        "BE9tfo-aCxwtPk9QYXKDlAUGBwgJCgsMDQ4PEBESExQVobLD1OX2BxgpMEFSY3SFlgcYKTBLXG1-j5ABAgMEBQY",
+                    },
+                  },
+                },
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: {
+                installation_id: "installation-id",
+                channel: "web_push",
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        );
+
+      vi.stubGlobal("fetch", mockFetch);
+
+      renderHook(() => useNotifications({ autoSync: true }), {
+        wrapper: AuthenticatedWrapper,
+      });
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining("/v1/bootstrap?client_platform=browser"),
+          expect.objectContaining({
+            credentials: "include",
+          })
+        );
+      });
+
+      expect(mockPushManager.subscribe).not.toHaveBeenCalled();
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringMatching(/\/v1\/me\/notification-installations\//),
+        expect.objectContaining({
+          credentials: "include",
+          method: "PUT",
+        })
+      );
+    });
+
+    it("reloads bootstrap and rotates the local subscription when the backend rejects stale runtime metadata", async () => {
+      document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
+      Object.defineProperty(globalThis.Notification, "permission", {
+        writable: true,
+        value: "granted",
+      });
+
+      const rotatedPushSubscription = {
+        endpoint:
+          "https://updates.push.services.mozilla.com/wpush/v2/gAAAAABoQnRhdGVkLWtleS0xMjM0NTY3ODkw",
+        expirationTime: 1782561600000,
+        toJSON: vi.fn().mockReturnValue({
+          endpoint:
+            "https://updates.push.services.mozilla.com/wpush/v2/gAAAAABoQnRhdGVkLWtleS0xMjM0NTY3ODkw",
+          expirationTime: 1782561600000,
+          keys: {
+            p256dh: "BMozillaRotatedP256dh0123456789abcdefghijklmnopqrstu",
+            auth: "Lm9PqRs7TuV",
+          },
+        }),
+        unsubscribe: vi.fn().mockResolvedValue(true),
+      };
+
+      mockPushManager.getSubscription.mockResolvedValue(mockPushSubscription);
+      mockPushManager.subscribe.mockResolvedValue(rotatedPushSubscription);
+
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: {
+                client_platform: "browser",
+                compatibility: {
+                  bootstrap_version: "v1",
+                  schema_version: 3,
+                },
+                features: {
+                  notification_channels: {
+                    android_fcm: false,
+                    web_push: true,
+                  },
+                },
+                notification_channels: {
+                  web_push: {
+                    channel: "web_push",
+                    metadata_revision: 4,
+                    public_runtime_metadata: {
+                      vapid_public_key:
+                        "BE9tfo-aCxwtPk9QYXKDlAUGBwgJCgsMDQ4PEBESExQVobLD1OX2BxgpMEFSY3SFlgcYKTBLXG1-j5ABAgMEBQA",
+                    },
+                  },
+                },
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              message:
+                "Notification runtime metadata changed; refresh bootstrap before retrying this installation update.",
+              code: "NOTIFICATION_RUNTIME_STATE_INVALID",
+              details: {
+                bootstrap_version: "v1",
+                schema_version: 3,
+                channel: "web_push",
+                provided_metadata_revision: 4,
+                expected_metadata_revision: 5,
+              },
+            }),
+            {
+              status: 409,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: {
+                client_platform: "browser",
+                compatibility: {
+                  bootstrap_version: "v1",
+                  schema_version: 3,
+                },
+                features: {
+                  notification_channels: {
+                    android_fcm: false,
+                    web_push: true,
+                  },
+                },
+                notification_channels: {
+                  web_push: {
+                    channel: "web_push",
+                    metadata_revision: 5,
+                    public_runtime_metadata: {
+                      vapid_public_key:
+                        "BE9tfo-aCxwtPk9QYXKDlAUGBwgJCgsMDQ4PEBESExQVobLD1OX2BxgpMEFSY3SFlgcYKTBLXG1-j5ABAgMEBQY",
+                    },
+                  },
+                },
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: {
+                installation_id: "installation-id",
+                channel: "web_push",
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        );
+
+      vi.stubGlobal("fetch", mockFetch);
+
+      const { result } = renderHook(() => useNotifications({ autoSync: true }), {
+        wrapper: AuthenticatedWrapper,
+      });
+
+      await waitFor(() => {
+        expect(mockPushSubscription.unsubscribe).toHaveBeenCalledTimes(1);
+      });
+
+      expect(mockPushManager.subscribe).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+      expect(result.current.error).toBeNull();
+
+      const finalUpsertCall = mockFetch.mock.calls[3];
+      const finalUpsertPayload = JSON.parse(
+        String(finalUpsertCall?.[1]?.body ?? "{}")
+      ) as {
+        lifecycle_event: string;
+        runtime: { metadata_revision: number };
+        registration: { subscription: { endpoint: string } };
+      };
+
+      expect(finalUpsertPayload.lifecycle_event).toBe("credential_rotated");
+      expect(finalUpsertPayload.runtime.metadata_revision).toBe(5);
+      expect(finalUpsertPayload.registration.subscription.endpoint).toBe(
+        rotatedPushSubscription.endpoint
+      );
+    });
+
+    it("revokes the authenticated browser installation and clears local push state when permission is denied", async () => {
+      document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
+      Object.defineProperty(globalThis.Notification, "permission", {
+        writable: true,
+        value: "denied",
+      });
+
+      const installationId = getOrCreateBrowserPushInstallationId();
+
+      mockPushManager.getSubscription.mockResolvedValue(mockPushSubscription);
+
+      const mockFetch = vi.fn().mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              installation_id: installationId,
+              channel: "web_push",
+            },
+          }),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+            },
+          }
+        )
+      );
+
+      vi.stubGlobal("fetch", mockFetch);
+
+      renderHook(() => useNotifications({ autoSync: true }), {
+        wrapper: AuthenticatedWrapper,
+      });
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining(
+            `/v1/me/notification-installations/${installationId}`
+          ),
+          expect.objectContaining({
+            credentials: "include",
+            method: "DELETE",
+          })
+        );
+      });
+
+      expect(mockPushSubscription.unsubscribe).toHaveBeenCalledTimes(1);
+      expect(peekBrowserPushInstallationId()).toBeNull();
+    });
+
+    it("reconciles the authenticated browser subscription again after service worker replacement", async () => {
+      document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
+      Object.defineProperty(globalThis.Notification, "permission", {
+        writable: true,
+        value: "granted",
+      });
+
+      let controllerChangeHandler: (() => void) | null = null;
+
+      Object.defineProperty(navigator, "serviceWorker", {
+        value: {
+          ready: Promise.resolve(mockServiceWorkerRegistration),
+          addEventListener: vi.fn((event: string, callback: () => void) => {
+            if (event === "controllerchange") {
+              controllerChangeHandler = callback;
+            }
+          }),
+          removeEventListener: vi.fn(),
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      mockPushManager.getSubscription.mockResolvedValue(mockPushSubscription);
+
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: {
+                client_platform: "browser",
+                compatibility: {
+                  bootstrap_version: "v1",
+                  schema_version: 3,
+                },
+                features: {
+                  notification_channels: {
+                    android_fcm: false,
+                    web_push: true,
+                  },
+                },
+                notification_channels: {
+                  web_push: {
+                    channel: "web_push",
+                    metadata_revision: 5,
+                    public_runtime_metadata: {
+                      vapid_public_key:
+                        "BE9tfo-aCxwtPk9QYXKDlAUGBwgJCgsMDQ4PEBESExQVobLD1OX2BxgpMEFSY3SFlgcYKTBLXG1-j5ABAgMEBQY",
+                    },
+                  },
+                },
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: {
+                installation_id: "installation-id",
+                channel: "web_push",
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: {
+                client_platform: "browser",
+                compatibility: {
+                  bootstrap_version: "v1",
+                  schema_version: 3,
+                },
+                features: {
+                  notification_channels: {
+                    android_fcm: false,
+                    web_push: true,
+                  },
+                },
+                notification_channels: {
+                  web_push: {
+                    channel: "web_push",
+                    metadata_revision: 5,
+                    public_runtime_metadata: {
+                      vapid_public_key:
+                        "BE9tfo-aCxwtPk9QYXKDlAUGBwgJCgsMDQ4PEBESExQVobLD1OX2BxgpMEFSY3SFlgcYKTBLXG1-j5ABAgMEBQY",
+                    },
+                  },
+                },
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: {
+                installation_id: "installation-id",
+                channel: "web_push",
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        );
+
+      vi.stubGlobal("fetch", mockFetch);
+
+      renderHook(() => useNotifications({ autoSync: true }), {
+        wrapper: AuthenticatedWrapper,
+      });
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      });
+
+      expect(controllerChangeHandler).not.toBeNull();
+
+      await act(async () => {
+        controllerChangeHandler?.();
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(4);
+      });
+
+      expect(mockPushManager.subscribe).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -785,6 +785,46 @@ describe("useNotifications", () => {
       expect(peekBrowserPushInstallationId()).toBeNull();
     });
 
+    it("clears local push state even when remote revocation fails", async () => {
+      document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
+      Object.defineProperty(globalThis.Notification, "permission", {
+        writable: true,
+        value: "denied",
+      });
+
+      const installationId = getOrCreateBrowserPushInstallationId();
+      const networkError = new Error("network down");
+
+      mockPushManager.getSubscription.mockResolvedValue(mockPushSubscription);
+
+      const mockFetch = vi.fn().mockRejectedValueOnce(networkError);
+
+      vi.stubGlobal("fetch", mockFetch);
+
+      const { result } = renderHook(
+        () => useNotifications({ autoSync: true }),
+        {
+          wrapper: AuthenticatedWrapper,
+        }
+      );
+
+      await waitFor(() => {
+        expect(mockPushSubscription.unsubscribe).toHaveBeenCalledTimes(1);
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `/v1/me/notification-installations/${installationId}`
+        ),
+        expect.objectContaining({
+          credentials: "include",
+          method: "DELETE",
+        })
+      );
+      expect(peekBrowserPushInstallationId()).toBeNull();
+      expect(result.current.error).toBe(networkError);
+    });
+
     it("reconciles the authenticated browser subscription again after service worker replacement", async () => {
       document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
       Object.defineProperty(globalThis.Notification, "permission", {
@@ -792,14 +832,14 @@ describe("useNotifications", () => {
         value: "granted",
       });
 
-      let controllerChangeHandler: (() => void) | null = null;
+      const controllerChangeHandlers: Array<() => void> = [];
 
       Object.defineProperty(navigator, "serviceWorker", {
         value: {
           ready: Promise.resolve(mockServiceWorkerRegistration),
           addEventListener: vi.fn((event: string, callback: () => void) => {
             if (event === "controllerchange") {
-              controllerChangeHandler = callback;
+              controllerChangeHandlers.push(callback);
             }
           }),
           removeEventListener: vi.fn(),
@@ -925,10 +965,12 @@ describe("useNotifications", () => {
         expect(mockFetch).toHaveBeenCalledTimes(2);
       });
 
-      expect(controllerChangeHandler).not.toBeNull();
+      expect(controllerChangeHandlers).toHaveLength(1);
 
       await act(async () => {
-        controllerChangeHandler?.();
+        controllerChangeHandlers.forEach((handler) => {
+          handler();
+        });
         await Promise.resolve();
       });
 

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -1559,6 +1559,52 @@ describe("useNotifications", () => {
       expect(result.current.error).toBe(networkError);
     });
 
+    it("surfaces both revoke and unsubscribe failures", async () => {
+      document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
+      Object.defineProperty(globalThis.Notification, "permission", {
+        writable: true,
+        value: "denied",
+      });
+
+      const installationId = getOrCreateBrowserPushInstallationId();
+      const networkError = new Error("network down");
+      const unsubscribeError = new Error("unsubscribe blocked");
+
+      mockPushManager.getSubscription.mockResolvedValue(mockPushSubscription);
+      mockPushSubscription.unsubscribe.mockRejectedValueOnce(unsubscribeError);
+
+      const mockFetch = vi.fn().mockRejectedValueOnce(networkError);
+
+      vi.stubGlobal("fetch", mockFetch);
+
+      const { result } = renderHook(
+        () => useNotifications({ autoSync: true }),
+        {
+          wrapper: AuthenticatedWrapper,
+        }
+      );
+
+      await waitFor(() => {
+        expect(result.current.error).toBeInstanceOf(AggregateError);
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `/v1/me/notification-installations/${installationId}`
+        ),
+        expect.objectContaining({
+          credentials: "include",
+          method: "DELETE",
+        })
+      );
+      expect(mockPushSubscription.unsubscribe).toHaveBeenCalledTimes(1);
+      expect(peekBrowserPushInstallationId()).toBeNull();
+      expect(result.current.error).toMatchObject({
+        errors: [networkError, unsubscribeError],
+        message: "Failed to fully revoke browser push state",
+      });
+    });
+
     it("re-registers after service worker replacement when another hook instance grants permission", async () => {
       document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
 

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -3,14 +3,41 @@
 
 import { createElement, type ReactNode } from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, act } from "@testing-library/react";
+import { cleanup, renderHook, act } from "@testing-library/react";
 import { waitFor } from "@testing-library/dom";
 import { useNotifications } from "./useNotifications";
 import {
+  clearBrowserPushInstallationId,
   getOrCreateBrowserPushInstallationId,
   peekBrowserPushInstallationId,
 } from "../lib/browserPushState";
 import { AuthContext, type AuthContextType } from "../contexts/auth-context";
+
+const originalNotificationDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "Notification"
+);
+const originalPushManagerDescriptor = Object.getOwnPropertyDescriptor(
+  window,
+  "PushManager"
+);
+const originalServiceWorkerDescriptor = Object.getOwnPropertyDescriptor(
+  navigator,
+  "serviceWorker"
+);
+
+function restoreProperty(
+  target: object,
+  property: PropertyKey,
+  descriptor: PropertyDescriptor | undefined
+): void {
+  if (descriptor) {
+    Object.defineProperty(target, property, descriptor);
+    return;
+  }
+
+  Reflect.deleteProperty(target, property);
+}
 
 // Mock Notification API
 const mockNotification = vi.fn();
@@ -97,6 +124,17 @@ describe("useNotifications", () => {
   });
 
   afterEach(() => {
+    cleanup();
+    clearBrowserPushInstallationId();
+    localStorage.clear();
+    document.cookie = "XSRF-TOKEN=; Max-Age=0; path=/";
+    restoreProperty(globalThis, "Notification", originalNotificationDescriptor);
+    restoreProperty(window, "PushManager", originalPushManagerDescriptor);
+    restoreProperty(
+      navigator,
+      "serviceWorker",
+      originalServiceWorkerDescriptor
+    );
     vi.unstubAllGlobals();
     vi.clearAllMocks();
   });

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -702,6 +702,122 @@ describe("useNotifications", () => {
       );
     });
 
+    it("rotates an existing authenticated browser subscription when the bootstrap VAPID key changes", async () => {
+      document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
+      Object.defineProperty(globalThis.Notification, "permission", {
+        writable: true,
+        value: "granted",
+      });
+
+      const existingSubscription = {
+        ...mockPushSubscription,
+        options: {
+          applicationServerKey: new Uint8Array([0x00, 0x01, 0x02]).buffer,
+        },
+        unsubscribe: vi.fn().mockResolvedValue(true),
+      };
+      const rotatedPushSubscription = {
+        endpoint:
+          "https://updates.push.services.mozilla.com/wpush/v2/gAAAAABoVmFwaWRSb3RhdGlvbi1rZXktY2hhbmdlLTEyMzQ1Njc4OTA",
+        expirationTime: 1782561600000,
+        options: {
+          applicationServerKey: new Uint8Array([0x03, 0x04, 0x05]).buffer,
+        },
+        toJSON: vi.fn().mockReturnValue({
+          endpoint:
+            "https://updates.push.services.mozilla.com/wpush/v2/gAAAAABoVmFwaWRSb3RhdGlvbi1rZXktY2hhbmdlLTEyMzQ1Njc4OTA",
+          expirationTime: 1782561600000,
+          keys: {
+            p256dh: "BMozillaRotatedP256dhKeyChange0123456789abcdefghijkl",
+            auth: "Lm9PqRs8UvW",
+          },
+        }),
+        unsubscribe: vi.fn().mockResolvedValue(true),
+      };
+
+      mockPushManager.getSubscription.mockResolvedValue(existingSubscription);
+      mockPushManager.subscribe.mockResolvedValue(rotatedPushSubscription);
+
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: {
+                client_platform: "browser",
+                compatibility: {
+                  bootstrap_version: "v1",
+                  schema_version: 3,
+                },
+                features: {
+                  notification_channels: {
+                    android_fcm: false,
+                    web_push: true,
+                  },
+                },
+                notification_channels: {
+                  web_push: {
+                    channel: "web_push",
+                    metadata_revision: 5,
+                    public_runtime_metadata: {
+                      vapid_public_key:
+                        "BE9tfo-aCxwtPk9QYXKDlAUGBwgJCgsMDQ4PEBESExQVobLD1OX2BxgpMEFSY3SFlgcYKTBLXG1-j5ABAgMEBQY",
+                    },
+                  },
+                },
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: {
+                installation_id: "installation-id",
+                channel: "web_push",
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        );
+
+      vi.stubGlobal("fetch", mockFetch);
+
+      renderHook(() => useNotifications({ autoSync: true }), {
+        wrapper: AuthenticatedWrapper,
+      });
+
+      await waitFor(() => {
+        expect(existingSubscription.unsubscribe).toHaveBeenCalledTimes(1);
+      });
+
+      expect(mockPushManager.subscribe).toHaveBeenCalledTimes(1);
+
+      const finalUpsertCall = mockFetch.mock.calls[1];
+      const finalUpsertPayload = JSON.parse(
+        String(finalUpsertCall?.[1]?.body ?? "{}")
+      ) as {
+        lifecycle_event: string;
+        registration: { subscription: { endpoint: string } };
+      };
+
+      expect(finalUpsertPayload.lifecycle_event).toBe("credential_rotated");
+      expect(finalUpsertPayload.registration.subscription.endpoint).toBe(
+        rotatedPushSubscription.endpoint
+      );
+    });
+
     it("reloads bootstrap and rotates the local subscription when the backend rejects stale runtime metadata", async () => {
       document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
       Object.defineProperty(globalThis.Notification, "permission", {
@@ -1641,6 +1757,126 @@ describe("useNotifications", () => {
         errors: [networkError, unsubscribeError],
         message: "Failed to fully revoke browser push state",
       });
+    });
+
+    it("does not recreate an installation when logout cancels an in-flight auto sync", async () => {
+      document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
+      Object.defineProperty(globalThis.Notification, "permission", {
+        writable: true,
+        value: "granted",
+      });
+
+      let authContextValue: AuthContextType = authenticatedAuthContextValue;
+      let resolveBootstrapResponse: ((response: Response) => void) | null =
+        null;
+
+      function DynamicAuthWrapper({ children }: { children: ReactNode }) {
+        return createElement(
+          AuthContext.Provider,
+          {
+            value: authContextValue,
+          },
+          children
+        );
+      }
+
+      mockPushManager.getSubscription.mockResolvedValue(mockPushSubscription);
+
+      const mockFetch = vi.fn((input, init) => {
+        const url = String(input);
+
+        if (url.includes("/v1/bootstrap?client_platform=browser")) {
+          return new Promise<Response>((resolve) => {
+            resolveBootstrapResponse = resolve;
+          });
+        }
+
+        if (
+          /\/v1\/me\/notification-installations\//.test(url) &&
+          init?.method === "PUT"
+        ) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                data: {
+                  installation_id: "installation-id",
+                  channel: "web_push",
+                },
+              }),
+              {
+                status: 200,
+                headers: {
+                  "Content-Type": "application/json",
+                },
+              }
+            )
+          );
+        }
+
+        throw new Error(`Unexpected fetch request: ${url}`);
+      });
+
+      vi.stubGlobal("fetch", mockFetch);
+
+      const { rerender } = renderHook(
+        () => useNotifications({ autoSync: true }),
+        {
+          wrapper: DynamicAuthWrapper,
+        }
+      );
+
+      await waitFor(() => {
+        expect(resolveBootstrapResponse).not.toBeNull();
+      });
+
+      authContextValue = {
+        ...authenticatedAuthContextValue,
+        user: null,
+        isAuthenticated: false,
+      };
+      rerender();
+
+      await act(async () => {
+        resolveBootstrapResponse?.(
+          new Response(
+            JSON.stringify({
+              data: {
+                client_platform: "browser",
+                compatibility: {
+                  bootstrap_version: "v1",
+                  schema_version: 3,
+                },
+                features: {
+                  notification_channels: {
+                    android_fcm: false,
+                    web_push: true,
+                  },
+                },
+                notification_channels: {
+                  web_push: {
+                    channel: "web_push",
+                    metadata_revision: 5,
+                    public_runtime_metadata: {
+                      vapid_public_key:
+                        "BE9tfo-aCxwtPk9QYXKDlAUGBwgJCgsMDQ4PEBESExQVobLD1OX2BxgpMEFSY3SFlgcYKTBLXG1-j5ABAgMEBQY",
+                    },
+                  },
+                },
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          )
+        );
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(peekBrowserPushInstallationId()).toBeNull();
     });
 
     it("re-registers after service worker replacement when another hook instance grants permission", async () => {

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -921,6 +921,143 @@ describe("useNotifications", () => {
       expect(result.current.error).toBe(networkError);
     });
 
+    it("re-registers after service worker replacement when another hook instance grants permission", async () => {
+      document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
+
+      const controllerChangeHandlers: Array<() => void> = [];
+      let currentSubscription: typeof mockPushSubscription | null = null;
+
+      Object.defineProperty(navigator, "serviceWorker", {
+        value: {
+          ready: Promise.resolve(mockServiceWorkerRegistration),
+          addEventListener: vi.fn((event: string, callback: () => void) => {
+            if (event === "controllerchange") {
+              controllerChangeHandlers.push(callback);
+            }
+          }),
+          removeEventListener: vi.fn(),
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      mockPushManager.getSubscription.mockImplementation(async () => currentSubscription);
+      mockPushManager.subscribe.mockImplementation(async () => {
+        currentSubscription = mockPushSubscription;
+        return mockPushSubscription;
+      });
+
+      globalThis.Notification.requestPermission = vi.fn().mockImplementation(async () => {
+        Object.defineProperty(globalThis.Notification, "permission", {
+          writable: true,
+          value: "granted",
+        });
+        return "granted";
+      });
+
+      const mockFetch = vi.fn((input, init) => {
+        const url = String(input);
+
+        if (url.includes("/v1/bootstrap?client_platform=browser")) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                data: {
+                  client_platform: "browser",
+                  compatibility: {
+                    bootstrap_version: "v1",
+                    schema_version: 3,
+                  },
+                  features: {
+                    notification_channels: {
+                      android_fcm: false,
+                      web_push: true,
+                    },
+                  },
+                  notification_channels: {
+                    web_push: {
+                      channel: "web_push",
+                      metadata_revision: 5,
+                      public_runtime_metadata: {
+                        vapid_public_key:
+                          "BE9tfo-aCxwtPk9QYXKDlAUGBwgJCgsMDQ4PEBESExQVobLD1OX2BxgpMEFSY3SFlgcYKTBLXG1-j5ABAgMEBQY",
+                      },
+                    },
+                  },
+                },
+              }),
+              {
+                status: 200,
+                headers: {
+                  "Content-Type": "application/json",
+                },
+              }
+            )
+          );
+        }
+
+        if (
+          /\/v1\/me\/notification-installations\//.test(url) &&
+          init?.method === "PUT"
+        ) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                data: {
+                  installation_id: "installation-id",
+                  channel: "web_push",
+                },
+              }),
+              {
+                status: 200,
+                headers: {
+                  "Content-Type": "application/json",
+                },
+              }
+            )
+          );
+        }
+
+        throw new Error(`Unexpected fetch request: ${url}`);
+      });
+
+      vi.stubGlobal("fetch", mockFetch);
+
+      renderHook(() => useNotifications({ autoSync: true }), {
+        wrapper: AuthenticatedWrapper,
+      });
+      const { result } = renderHook(() => useNotifications(), {
+        wrapper: AuthenticatedWrapper,
+      });
+
+      await waitFor(() => {
+        expect(mockPushManager.getSubscription).toHaveBeenCalledTimes(2);
+      });
+
+      await act(async () => {
+        await result.current.requestPermission();
+      });
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      });
+
+      expect(controllerChangeHandlers).toHaveLength(2);
+
+      await act(async () => {
+        controllerChangeHandlers.forEach((handler) => {
+          handler();
+        });
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(4);
+      });
+
+      expect(mockPushManager.subscribe).toHaveBeenCalledTimes(1);
+    });
+
     it("reconciles the authenticated browser subscription again after service worker replacement", async () => {
       document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
       Object.defineProperty(globalThis.Notification, "permission", {

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -1675,6 +1675,46 @@ describe("useNotifications", () => {
       expect(peekBrowserPushInstallationId()).toBeNull();
     });
 
+    it("skips denied auto-sync cleanup while unauthenticated", async () => {
+      Object.defineProperty(globalThis.Notification, "permission", {
+        writable: true,
+        value: "denied",
+      });
+
+      const installationId = getOrCreateBrowserPushInstallationId();
+
+      mockPushManager.getSubscription.mockResolvedValue(mockPushSubscription);
+
+      const UnauthenticatedWrapper = ({ children }: { children: ReactNode }) =>
+        createElement(
+          AuthContext.Provider,
+          {
+            value: {
+              ...authenticatedAuthContextValue,
+              isAuthenticated: false,
+              user: null,
+            },
+          },
+          children
+        );
+
+      renderHook(() => useNotifications({ autoSync: true }), {
+        wrapper: UnauthenticatedWrapper,
+      });
+
+      await waitFor(() => {
+        expect(mockPushManager.getSubscription).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(mockPushManager.getSubscription).toHaveBeenCalledTimes(1);
+      expect(mockPushSubscription.unsubscribe).not.toHaveBeenCalled();
+      expect(peekBrowserPushInstallationId()).toBe(installationId);
+    });
+
     it("does not re-run denied auto-sync cleanup when auth state changes", async () => {
       document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
       Object.defineProperty(globalThis.Notification, "permission", {

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -10,10 +10,7 @@ import {
   getOrCreateBrowserPushInstallationId,
   peekBrowserPushInstallationId,
 } from "../lib/browserPushState";
-import {
-  AuthContext,
-  type AuthContextType,
-} from "../contexts/auth-context";
+import { AuthContext, type AuthContextType } from "../contexts/auth-context";
 
 // Mock Notification API
 const mockNotification = vi.fn();
@@ -707,9 +704,12 @@ describe("useNotifications", () => {
 
       vi.stubGlobal("fetch", mockFetch);
 
-      const { result } = renderHook(() => useNotifications({ autoSync: true }), {
-        wrapper: AuthenticatedWrapper,
-      });
+      const { result } = renderHook(
+        () => useNotifications({ autoSync: true }),
+        {
+          wrapper: AuthenticatedWrapper,
+        }
+      );
 
       await waitFor(() => {
         expect(mockPushSubscription.unsubscribe).toHaveBeenCalledTimes(1);

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -1715,6 +1715,90 @@ describe("useNotifications", () => {
       expect(peekBrowserPushInstallationId()).toBe(installationId);
     });
 
+    it("waits for auth bootstrap before denied auto-sync cleanup", async () => {
+      document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
+      Object.defineProperty(globalThis.Notification, "permission", {
+        writable: true,
+        value: "denied",
+      });
+
+      const installationId = getOrCreateBrowserPushInstallationId();
+      let authContextValue: AuthContextType = {
+        ...authenticatedAuthContextValue,
+        isAuthenticated: false,
+        isLoading: true,
+        user: null,
+      };
+
+      mockPushManager.getSubscription.mockResolvedValue(mockPushSubscription);
+
+      const mockFetch = vi.fn().mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              installation_id: installationId,
+              channel: "web_push",
+            },
+          }),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+            },
+          }
+        )
+      );
+
+      vi.stubGlobal("fetch", mockFetch);
+
+      const AuthBootstrapWrapper = ({ children }: { children: ReactNode }) =>
+        createElement(
+          AuthContext.Provider,
+          { value: authContextValue },
+          children
+        );
+
+      const { rerender } = renderHook(
+        () => useNotifications({ autoSync: true }),
+        {
+          wrapper: AuthBootstrapWrapper,
+        }
+      );
+
+      await waitFor(() => {
+        expect(mockPushManager.getSubscription).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(mockPushSubscription.unsubscribe).not.toHaveBeenCalled();
+      expect(peekBrowserPushInstallationId()).toBe(installationId);
+
+      authContextValue = authenticatedAuthContextValue;
+
+      await act(async () => {
+        rerender();
+      });
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining(
+            `/v1/me/notification-installations/${installationId}`
+          ),
+          expect.objectContaining({
+            credentials: "include",
+            method: "DELETE",
+          })
+        );
+      });
+
+      expect(mockPushSubscription.unsubscribe).toHaveBeenCalledTimes(1);
+      expect(peekBrowserPushInstallationId()).toBeNull();
+    });
+
     it("does not re-run denied auto-sync cleanup when auth state changes", async () => {
       document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
       Object.defineProperty(globalThis.Notification, "permission", {
@@ -1793,7 +1877,7 @@ describe("useNotifications", () => {
       );
     });
 
-    it("clears local push state even when remote revocation fails", async () => {
+    it("preserves the local push installation ID when remote revocation fails", async () => {
       document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
       Object.defineProperty(globalThis.Notification, "permission", {
         writable: true,
@@ -1829,7 +1913,7 @@ describe("useNotifications", () => {
           method: "DELETE",
         })
       );
-      expect(peekBrowserPushInstallationId()).toBeNull();
+      expect(peekBrowserPushInstallationId()).toBe(installationId);
       expect(result.current.error).toBe(networkError);
     });
 
@@ -1872,7 +1956,7 @@ describe("useNotifications", () => {
         })
       );
       expect(mockPushSubscription.unsubscribe).toHaveBeenCalledTimes(1);
-      expect(peekBrowserPushInstallationId()).toBeNull();
+      expect(peekBrowserPushInstallationId()).toBe(installationId);
       expect(result.current.error).toMatchObject({
         errors: [networkError, unsubscribeError],
         message: "Failed to fully revoke browser push state",

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -549,9 +549,12 @@ describe("useNotifications", () => {
 
       vi.stubGlobal("fetch", mockFetch);
 
-      const { result } = renderHook(() => useNotifications({ autoSync: true }), {
-        wrapper: AuthenticatedWrapper,
-      });
+      const { result } = renderHook(
+        () => useNotifications({ autoSync: true }),
+        {
+          wrapper: AuthenticatedWrapper,
+        }
+      );
 
       await act(async () => {
         await result.current.requestPermission();
@@ -1173,19 +1176,23 @@ describe("useNotifications", () => {
         configurable: true,
       });
 
-      mockPushManager.getSubscription.mockImplementation(async () => currentSubscription);
+      mockPushManager.getSubscription.mockImplementation(
+        async () => currentSubscription
+      );
       mockPushManager.subscribe.mockImplementation(async () => {
         currentSubscription = mockPushSubscription;
         return mockPushSubscription;
       });
 
-      globalThis.Notification.requestPermission = vi.fn().mockImplementation(async () => {
-        Object.defineProperty(globalThis.Notification, "permission", {
-          writable: true,
-          value: "granted",
+      globalThis.Notification.requestPermission = vi
+        .fn()
+        .mockImplementation(async () => {
+          Object.defineProperty(globalThis.Notification, "permission", {
+            writable: true,
+            value: "granted",
+          });
+          return "granted";
         });
-        return "granted";
-      });
 
       const mockFetch = vi.fn((input, init) => {
         const url = String(input);

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -478,6 +478,102 @@ describe("useNotifications", () => {
   });
 
   describe("autoSync", () => {
+    it("does not re-register immediately after requestPermission grants access", async () => {
+      document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
+
+      const mockFetch = vi.fn((input, init) => {
+        const url = String(input);
+
+        if (url.includes("/v1/bootstrap?client_platform=browser")) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                data: {
+                  client_platform: "browser",
+                  compatibility: {
+                    bootstrap_version: "v1",
+                    schema_version: 3,
+                  },
+                  features: {
+                    notification_channels: {
+                      android_fcm: false,
+                      web_push: true,
+                    },
+                  },
+                  notification_channels: {
+                    web_push: {
+                      channel: "web_push",
+                      metadata_revision: 5,
+                      public_runtime_metadata: {
+                        vapid_public_key:
+                          "BE9tfo-aCxwtPk9QYXKDlAUGBwgJCgsMDQ4PEBESExQVobLD1OX2BxgpMEFSY3SFlgcYKTBLXG1-j5ABAgMEBQY",
+                      },
+                    },
+                  },
+                },
+              }),
+              {
+                status: 200,
+                headers: {
+                  "Content-Type": "application/json",
+                },
+              }
+            )
+          );
+        }
+
+        if (
+          /\/v1\/me\/notification-installations\//.test(url) &&
+          init?.method === "PUT"
+        ) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                data: {
+                  installation_id: "installation-id",
+                  channel: "web_push",
+                },
+              }),
+              {
+                status: 200,
+                headers: {
+                  "Content-Type": "application/json",
+                },
+              }
+            )
+          );
+        }
+
+        throw new Error(`Unexpected fetch request: ${url}`);
+      });
+
+      vi.stubGlobal("fetch", mockFetch);
+
+      const { result } = renderHook(() => useNotifications({ autoSync: true }), {
+        wrapper: AuthenticatedWrapper,
+      });
+
+      await act(async () => {
+        await result.current.requestPermission();
+      });
+
+      await waitFor(() => {
+        const bootstrapCalls = mockFetch.mock.calls.filter(([input]) =>
+          String(input).includes("/v1/bootstrap?client_platform=browser")
+        );
+        const upsertCalls = mockFetch.mock.calls.filter(
+          ([input, init]) =>
+            /\/v1\/me\/notification-installations\//.test(String(input)) &&
+            init?.method === "PUT"
+        );
+
+        expect(bootstrapCalls).toHaveLength(1);
+        expect(upsertCalls).toHaveLength(1);
+      });
+
+      expect(result.current.permission).toBe("granted");
+    });
+
     it("reconciles an existing authenticated browser subscription on app load", async () => {
       document.cookie = "XSRF-TOKEN=test-xsrf-token; path=/";
       Object.defineProperty(globalThis.Notification, "permission", {

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -386,7 +386,12 @@ export function useNotifications(
       } finally {
         setIsLoading(false);
       }
-    }, [autoSync, isSupported, registerBrowserPushInstallation, toNotificationError]);
+    }, [
+      autoSync,
+      isSupported,
+      registerBrowserPushInstallation,
+      toNotificationError,
+    ]);
 
   /**
    * Show a notification to the user

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -24,6 +24,12 @@ import type {
 
 export type NotificationPermissionState = "default" | "granted" | "denied";
 
+function getNotificationPermissionState(): NotificationPermissionState {
+  return typeof window !== "undefined" && "Notification" in window
+    ? Notification.permission
+    : "default";
+}
+
 export interface NotificationOptions {
   title: string;
   body: string;
@@ -71,10 +77,7 @@ export function useNotifications(
 ): UseNotificationsReturn {
   const authContext = useContext(AuthContext);
   const [permission, setPermission] = useState<NotificationPermissionState>(
-    () =>
-      typeof window !== "undefined" && "Notification" in window
-        ? Notification.permission
-        : "default"
+    () => getNotificationPermissionState()
   );
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -96,6 +99,7 @@ export function useNotifications(
   const isAuthenticated = authContext?.isAuthenticated === true;
   const autoSync = options.autoSync === true;
   const skipNextAutoSyncRegistrationRef = useRef(false);
+  const currentPermission = getNotificationPermissionState();
 
   const toNotificationError = useCallback((err: unknown): Error => {
     return err instanceof NotificationInstallationsApiError ||
@@ -299,7 +303,7 @@ export function useNotifications(
       !autoSync ||
       !isAuthenticated ||
       !isSupported ||
-      permission !== "granted" ||
+      currentPermission !== "granted" ||
       !isPushReady
     ) {
       return;
@@ -315,24 +319,24 @@ export function useNotifications(
     );
   }, [
     autoSync,
+    currentPermission,
     isAuthenticated,
     isPushReady,
     isSupported,
-    permission,
     registerBrowserPushInstallation,
     runBackgroundNotificationTask,
   ]);
 
   useEffect(() => {
-    if (!autoSync || !isPushReady || permission !== "denied") {
+    if (!autoSync || !isPushReady || currentPermission !== "denied") {
       return;
     }
 
     return runBackgroundNotificationTask(() => revokeBrowserPushState());
   }, [
     autoSync,
+    currentPermission,
     isPushReady,
-    permission,
     revokeBrowserPushState,
     runBackgroundNotificationTask,
   ]);

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -324,6 +324,13 @@ export function useNotifications(
     }
 
     if (revokeError) {
+      if (unsubscribeError) {
+        throw new AggregateError(
+          [revokeError, unsubscribeError],
+          "Failed to fully revoke browser push state"
+        );
+      }
+
       throw revokeError;
     }
 

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -296,6 +296,7 @@ export function useNotifications(
   const revokeBrowserPushState = useCallback(async () => {
     const installationId = peekBrowserPushInstallationId();
     const currentSubscription = await refreshSubscription();
+    let revokeFailed = false;
 
     if (!installationId && !currentSubscription) {
       return;
@@ -305,13 +306,22 @@ export function useNotifications(
       if (installationId && isAuthenticated) {
         await revokeBrowserNotificationInstallation(installationId);
       }
+    } catch (error) {
+      revokeFailed = true;
+      throw error;
     } finally {
       if (installationId) {
         clearBrowserPushInstallationId();
       }
 
       if (currentSubscription) {
-        await unsubscribe();
+        try {
+          await unsubscribe();
+        } catch (error) {
+          if (!revokeFailed) {
+            throw error;
+          }
+        }
       }
     }
   }, [isAuthenticated, refreshSubscription, unsubscribe]);

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -296,7 +296,8 @@ export function useNotifications(
   const revokeBrowserPushState = useCallback(async () => {
     const installationId = peekBrowserPushInstallationId();
     const currentSubscription = await refreshSubscription();
-    let revokeFailed = false;
+    let revokeError: unknown = null;
+    let unsubscribeError: unknown = null;
 
     if (!installationId && !currentSubscription) {
       return;
@@ -307,8 +308,7 @@ export function useNotifications(
         await revokeBrowserNotificationInstallation(installationId);
       }
     } catch (error) {
-      revokeFailed = true;
-      throw error;
+      revokeError = error;
     } finally {
       if (installationId) {
         clearBrowserPushInstallationId();
@@ -318,11 +318,17 @@ export function useNotifications(
         try {
           await unsubscribe();
         } catch (error) {
-          if (!revokeFailed) {
-            throw error;
-          }
+          unsubscribeError = error;
         }
       }
+    }
+
+    if (revokeError) {
+      throw revokeError;
+    }
+
+    if (unsubscribeError) {
+      throw unsubscribeError;
     }
   }, [isAuthenticated, refreshSubscription, unsubscribe]);
 

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -30,6 +30,62 @@ function getNotificationPermissionState(): NotificationPermissionState {
     : "default";
 }
 
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const rawData = atob(base64);
+
+  return Uint8Array.from(rawData, (char) => char.charCodeAt(0));
+}
+
+function toUint8Array(
+  bufferSource: BufferSource | null | undefined
+): Uint8Array | null {
+  if (!bufferSource) {
+    return null;
+  }
+
+  if (bufferSource instanceof ArrayBuffer) {
+    return new Uint8Array(bufferSource);
+  }
+
+  return new Uint8Array(
+    bufferSource.buffer,
+    bufferSource.byteOffset,
+    bufferSource.byteLength
+  );
+}
+
+function hasDifferentApplicationServerKey(
+  subscription: PushSubscription | null,
+  vapidPublicKey: string
+): boolean {
+  if (!subscription) {
+    return false;
+  }
+
+  const currentApplicationServerKey = toUint8Array(
+    subscription.options?.applicationServerKey ?? null
+  );
+
+  if (!currentApplicationServerKey) {
+    return false;
+  }
+
+  const expectedApplicationServerKey = urlBase64ToUint8Array(vapidPublicKey);
+
+  if (
+    currentApplicationServerKey.byteLength !==
+    expectedApplicationServerKey.byteLength
+  ) {
+    return true;
+  }
+
+  return currentApplicationServerKey.some(
+    (byte, index) => byte !== expectedApplicationServerKey[index]
+  );
+}
+
 export interface NotificationOptions {
   title: string;
   body: string;
@@ -51,6 +107,13 @@ interface UseNotificationsReturn {
 
 interface UseNotificationsOptions {
   autoSync?: boolean;
+}
+
+interface BrowserPushRegistrationOptions {
+  bootstrapData?: BrowserPushBootstrapData | null;
+  forceRotation?: boolean;
+  allowRetry?: boolean;
+  isTaskActive?: () => boolean;
 }
 
 const MAX_AUTO_SYNC_ROTATION_RECOVERY_ATTEMPTS = 1;
@@ -105,6 +168,11 @@ export function useNotifications(
   const skipAutoSyncGenerationRef = useRef<number | null>(null);
   const autoSyncRotationRecoveryAttemptsRef = useRef(0);
   const currentPermission = getNotificationPermissionState();
+  const isAuthenticatedRef = useRef(isAuthenticated);
+
+  useEffect(() => {
+    isAuthenticatedRef.current = isAuthenticated;
+  }, [isAuthenticated]);
 
   const toNotificationError = useCallback((err: unknown): Error => {
     return err instanceof NotificationInstallationsApiError ||
@@ -114,15 +182,16 @@ export function useNotifications(
   }, []);
 
   const runBackgroundNotificationTask = useCallback(
-    (task: () => Promise<void>) => {
+    (task: (isTaskActive: () => boolean) => Promise<void>) => {
       let isActive = true;
+      const isTaskActive = () => isActive;
 
       const execute = async () => {
         setIsLoading(true);
         setError(null);
 
         try {
-          await task();
+          await task(isTaskActive);
         } catch (err) {
           if (isActive) {
             setError(toNotificationError(err));
@@ -144,17 +213,15 @@ export function useNotifications(
   );
 
   const registerBrowserPushInstallation = useCallback(
-    async (runtimeOptions?: {
-      bootstrapData?: BrowserPushBootstrapData | null;
-      forceRotation?: boolean;
-      allowRetry?: boolean;
-    }) => {
-      async function syncInstallation(nextRuntimeOptions?: {
-        bootstrapData?: BrowserPushBootstrapData | null;
-        forceRotation?: boolean;
-        allowRetry?: boolean;
-      }): Promise<void> {
-        if (!isAuthenticated) {
+    async (runtimeOptions?: BrowserPushRegistrationOptions) => {
+      async function syncInstallation(
+        nextRuntimeOptions?: BrowserPushRegistrationOptions
+      ): Promise<void> {
+        const canContinue = () =>
+          isAuthenticatedRef.current &&
+          (nextRuntimeOptions?.isTaskActive?.() ?? true);
+
+        if (!canContinue()) {
           return;
         }
 
@@ -170,19 +237,53 @@ export function useNotifications(
           );
         }
 
+        if (!canContinue()) {
+          return;
+        }
+
         let currentSubscription = await refreshSubscription();
         const hadExistingSubscription = currentSubscription !== null;
+        const forceRotation =
+          nextRuntimeOptions?.forceRotation === true ||
+          hasDifferentApplicationServerKey(
+            currentSubscription,
+            webPushRuntimeMetadata.public_runtime_metadata.vapid_public_key
+          );
 
-        if (nextRuntimeOptions?.forceRotation && currentSubscription) {
+        if (!canContinue()) {
+          return;
+        }
+
+        if (forceRotation && currentSubscription) {
           await unsubscribe();
           currentSubscription = null;
         }
 
-        currentSubscription =
-          currentSubscription ??
-          (await subscribe(
+        if (!canContinue()) {
+          return;
+        }
+
+        let createdSubscription = false;
+
+        if (!currentSubscription) {
+          currentSubscription = await subscribe(
             webPushRuntimeMetadata.public_runtime_metadata.vapid_public_key
-          ));
+          );
+          createdSubscription = true;
+        }
+
+        if (!canContinue()) {
+          if (createdSubscription) {
+            try {
+              await unsubscribe();
+            } catch {
+              // Best-effort rollback for subscriptions created after logout.
+            }
+          }
+
+          return;
+        }
+
         const subscriptionData = getSubscriptionData() ?? {
           endpoint: currentSubscription.endpoint,
           expirationTime: currentSubscription.expirationTime ?? null,
@@ -217,15 +318,17 @@ export function useNotifications(
         let lifecycleEvent: NotificationInstallationLifecycleEvent =
           "registered";
 
-        if (nextRuntimeOptions?.forceRotation) {
+        if (forceRotation) {
           lifecycleEvent = "credential_rotated";
         } else if (hadExistingSubscription) {
           lifecycleEvent = "client_updated";
         }
 
         try {
+          const installationId = getOrCreateBrowserPushInstallationId();
+
           await upsertBrowserNotificationInstallation(
-            getOrCreateBrowserPushInstallationId(),
+            installationId,
             {
               channel: "web_push",
               installation_name: installationName,
@@ -262,13 +365,14 @@ export function useNotifications(
             await syncInstallation({
               allowRetry: false,
               forceRotation: true,
+              isTaskActive: nextRuntimeOptions?.isTaskActive,
             });
             return;
           }
 
           if (
             autoSync &&
-            nextRuntimeOptions?.forceRotation &&
+            forceRotation &&
             nextRuntimeOptions?.allowRetry === false &&
             autoSyncRotationRecoveryAttemptsRef.current <
               MAX_AUTO_SYNC_ROTATION_RECOVERY_ATTEMPTS
@@ -286,7 +390,6 @@ export function useNotifications(
     [
       autoSync,
       getSubscriptionData,
-      isAuthenticated,
       refreshSubscription,
       subscribe,
       unsubscribe,
@@ -361,8 +464,8 @@ export function useNotifications(
       skipAutoSyncGenerationRef.current = null;
     }
 
-    return runBackgroundNotificationTask(() =>
-      registerBrowserPushInstallation()
+    return runBackgroundNotificationTask((isTaskActive) =>
+      registerBrowserPushInstallation({ isTaskActive })
     );
   }, [
     autoSync,

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -100,7 +100,7 @@ export function useNotifications(
   const autoSync = options.autoSync === true;
   const [autoSyncRegistrationGeneration, setAutoSyncRegistrationGeneration] =
     useState(0);
-  const skipNextAutoSyncRegistrationRef = useRef(false);
+  const skipAutoSyncGenerationRef = useRef<number | null>(null);
   const currentPermission = getNotificationPermissionState();
 
   const toNotificationError = useCallback((err: unknown): Error => {
@@ -320,9 +320,15 @@ export function useNotifications(
       return;
     }
 
-    if (skipNextAutoSyncRegistrationRef.current) {
-      skipNextAutoSyncRegistrationRef.current = false;
-      return;
+    if (skipAutoSyncGenerationRef.current !== null) {
+      if (
+        skipAutoSyncGenerationRef.current === autoSyncRegistrationGeneration
+      ) {
+        skipAutoSyncGenerationRef.current = null;
+        return;
+      }
+
+      skipAutoSyncGenerationRef.current = null;
     }
 
     return runBackgroundNotificationTask(() =>
@@ -374,7 +380,9 @@ export function useNotifications(
         setPermission(result);
 
         if (result === "granted") {
-          skipNextAutoSyncRegistrationRef.current = autoSync;
+          if (autoSync) {
+            skipAutoSyncGenerationRef.current = autoSyncRegistrationGeneration;
+          }
           await registerBrowserPushInstallation();
         }
 
@@ -388,6 +396,7 @@ export function useNotifications(
       }
     }, [
       autoSync,
+      autoSyncRegistrationGeneration,
       isSupported,
       registerBrowserPushInstallation,
       toNotificationError,

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -17,6 +17,7 @@ import {
   clearBrowserPushInstallationId,
   getBrowserPushClientMetadata,
   getOrCreateBrowserPushInstallationId,
+  isBrowserPushLogoutInProgress,
   peekBrowserPushInstallationId,
   getServiceWorkerScopePath,
 } from "../lib/browserPushState";
@@ -164,7 +165,6 @@ export function useNotifications(
   const skipAutoSyncGenerationRef = useRef<number | null>(null);
   const autoSyncRotationRecoveryAttemptsRef = useRef(0);
   const currentPermission = getNotificationPermissionState();
-  const isAuthenticatedRef = useRef(isAuthenticated);
 
   useEffect(() => {
     isAuthenticatedRef.current = isAuthenticated;
@@ -176,10 +176,6 @@ export function useNotifications(
       ? err
       : new Error(String(err));
   }, []);
-
-  useEffect(() => {
-    isAuthenticatedRef.current = isAuthenticated;
-  }, [isAuthenticated]);
 
   const runBackgroundNotificationTask = useCallback(
     (task: (isTaskActive: () => boolean) => Promise<void>) => {
@@ -219,6 +215,7 @@ export function useNotifications(
       ): Promise<void> {
         const canContinue = () =>
           isAuthenticatedRef.current &&
+          !isBrowserPushLogoutInProgress() &&
           (nextRuntimeOptions?.isTaskActive?.() ?? true);
 
         if (!canContinue()) {

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -98,6 +98,8 @@ export function useNotifications(
 
   const isAuthenticated = authContext?.isAuthenticated === true;
   const autoSync = options.autoSync === true;
+  const [autoSyncRegistrationGeneration, setAutoSyncRegistrationGeneration] =
+    useState(0);
   const skipNextAutoSyncRegistrationRef = useRef(false);
   const currentPermission = getNotificationPermissionState();
 
@@ -260,6 +262,14 @@ export function useNotifications(
             return;
           }
 
+          if (
+            autoSync &&
+            nextRuntimeOptions?.forceRotation &&
+            nextRuntimeOptions?.allowRetry === false
+          ) {
+            setAutoSyncRegistrationGeneration((generation) => generation + 1);
+          }
+
           throw err;
         }
       }
@@ -267,6 +277,7 @@ export function useNotifications(
       await syncInstallation(runtimeOptions);
     },
     [
+      autoSync,
       getSubscriptionData,
       isAuthenticated,
       refreshSubscription,
@@ -319,6 +330,7 @@ export function useNotifications(
     );
   }, [
     autoSync,
+    autoSyncRegistrationGeneration,
     currentPermission,
     isAuthenticated,
     isPushReady,

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -466,7 +466,12 @@ export function useNotifications(
   ]);
 
   useEffect(() => {
-    if (!autoSync || !isPushReady || currentPermission !== "denied") {
+    if (
+      !autoSync ||
+      !isAuthenticated ||
+      !isPushReady ||
+      currentPermission !== "denied"
+    ) {
       return;
     }
 
@@ -474,6 +479,7 @@ export function useNotifications(
   }, [
     autoSync,
     currentPermission,
+    isAuthenticated,
     isPushReady,
     revokeBrowserPushState,
     runBackgroundNotificationTask,

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -3,7 +3,10 @@
 
 import { useState, useCallback, useContext, useEffect, useRef } from "react";
 import { AuthContext } from "../contexts/auth-context";
-import { usePushSubscription } from "./usePushSubscription";
+import {
+  urlBase64ToUint8Array,
+  usePushSubscription,
+} from "./usePushSubscription";
 import {
   getBrowserPushBootstrapData,
   NotificationInstallationsApiError,
@@ -28,14 +31,6 @@ function getNotificationPermissionState(): NotificationPermissionState {
   return typeof window !== "undefined" && "Notification" in window
     ? Notification.permission
     : "default";
-}
-
-function urlBase64ToUint8Array(base64String: string): Uint8Array {
-  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
-  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
-  const rawData = atob(base64);
-
-  return Uint8Array.from(rawData, (char) => char.charCodeAt(0));
 }
 
 function toUint8Array(

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -327,34 +327,30 @@ export function useNotifications(
         try {
           const installationId = getOrCreateBrowserPushInstallationId();
 
-          await upsertBrowserNotificationInstallation(
-            installationId,
-            {
-              channel: "web_push",
-              installation_name: installationName,
-              lifecycle_event: lifecycleEvent,
-              runtime: {
-                bootstrap_version:
-                  bootstrapData.compatibility.bootstrap_version,
-                schema_version: bootstrapData.compatibility.schema_version,
-                metadata_revision: webPushRuntimeMetadata.metadata_revision,
+          await upsertBrowserNotificationInstallation(installationId, {
+            channel: "web_push",
+            installation_name: installationName,
+            lifecycle_event: lifecycleEvent,
+            runtime: {
+              bootstrap_version: bootstrapData.compatibility.bootstrap_version,
+              schema_version: bootstrapData.compatibility.schema_version,
+              metadata_revision: webPushRuntimeMetadata.metadata_revision,
+            },
+            registration: {
+              browser: {
+                browser_name: browserName,
+                browser_version: browserVersion,
+                service_worker_scope: getServiceWorkerScopePath(
+                  registration.scope
+                ),
               },
-              registration: {
-                browser: {
-                  browser_name: browserName,
-                  browser_version: browserVersion,
-                  service_worker_scope: getServiceWorkerScopePath(
-                    registration.scope
-                  ),
-                },
-                subscription: {
-                  endpoint: subscriptionData.endpoint,
-                  expiration_time: subscriptionData.expirationTime ?? null,
-                  keys: subscriptionData.keys,
-                },
+              subscription: {
+                endpoint: subscriptionData.endpoint,
+                expiration_time: subscriptionData.expirationTime ?? null,
+                keys: subscriptionData.keys,
               },
-            }
-          );
+            },
+          });
           autoSyncRotationRecoveryAttemptsRef.current = 0;
         } catch (err) {
           if (
@@ -387,13 +383,7 @@ export function useNotifications(
 
       await syncInstallation(runtimeOptions);
     },
-    [
-      autoSync,
-      getSubscriptionData,
-      refreshSubscription,
-      subscribe,
-      unsubscribe,
-    ]
+    [autoSync, getSubscriptionData, refreshSubscription, subscribe, unsubscribe]
   );
 
   const revokeBrowserPushState = useCallback(async () => {

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -278,13 +278,18 @@ export function useNotifications(
       return;
     }
 
-    if (installationId && isAuthenticated) {
-      await revokeBrowserNotificationInstallation(installationId);
-      clearBrowserPushInstallationId();
-    }
+    try {
+      if (installationId && isAuthenticated) {
+        await revokeBrowserNotificationInstallation(installationId);
+      }
+    } finally {
+      if (installationId) {
+        clearBrowserPushInstallationId();
+      }
 
-    if (currentSubscription) {
-      await unsubscribe();
+      if (currentSubscription) {
+        await unsubscribe();
+      }
     }
   }, [isAuthenticated, refreshSubscription, unsubscribe]);
 
@@ -323,54 +328,6 @@ export function useNotifications(
     isPushReady,
     permission,
     revokeBrowserPushState,
-    runBackgroundNotificationTask,
-  ]);
-
-  useEffect(() => {
-    if (
-      !autoSync ||
-      !isAuthenticated ||
-      !isSupported ||
-      permission !== "granted" ||
-      typeof navigator === "undefined" ||
-      navigator.serviceWorker === undefined ||
-      typeof navigator.serviceWorker.addEventListener !== "function"
-    ) {
-      return;
-    }
-
-    let cancelSync: (() => void) | null = null;
-
-    const handleControllerChange = () => {
-      cancelSync?.();
-      cancelSync = runBackgroundNotificationTask(async () => {
-        await refreshSubscription();
-        await registerBrowserPushInstallation();
-      });
-    };
-
-    navigator.serviceWorker.addEventListener(
-      "controllerchange",
-      handleControllerChange
-    );
-
-    return () => {
-      cancelSync?.();
-
-      if (typeof navigator.serviceWorker.removeEventListener === "function") {
-        navigator.serviceWorker.removeEventListener(
-          "controllerchange",
-          handleControllerChange
-        );
-      }
-    };
-  }, [
-    autoSync,
-    isAuthenticated,
-    isSupported,
-    permission,
-    refreshSubscription,
-    registerBrowserPushInstallation,
     runBackgroundNotificationTask,
   ]);
 

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -53,6 +53,8 @@ interface UseNotificationsOptions {
   autoSync?: boolean;
 }
 
+const MAX_AUTO_SYNC_ROTATION_RECOVERY_ATTEMPTS = 1;
+
 /**
  * Hook for managing push notifications in the app
  * Handles permission requests, subscription management, and notification display
@@ -101,6 +103,7 @@ export function useNotifications(
   const [autoSyncRegistrationGeneration, setAutoSyncRegistrationGeneration] =
     useState(0);
   const skipAutoSyncGenerationRef = useRef<number | null>(null);
+  const autoSyncRotationRecoveryAttemptsRef = useRef(0);
   const currentPermission = getNotificationPermissionState();
 
   const toNotificationError = useCallback((err: unknown): Error => {
@@ -249,6 +252,7 @@ export function useNotifications(
               },
             }
           );
+          autoSyncRotationRecoveryAttemptsRef.current = 0;
         } catch (err) {
           if (
             err instanceof NotificationInstallationsApiError &&
@@ -265,8 +269,11 @@ export function useNotifications(
           if (
             autoSync &&
             nextRuntimeOptions?.forceRotation &&
-            nextRuntimeOptions?.allowRetry === false
+            nextRuntimeOptions?.allowRetry === false &&
+            autoSyncRotationRecoveryAttemptsRef.current <
+              MAX_AUTO_SYNC_ROTATION_RECOVERY_ATTEMPTS
           ) {
+            autoSyncRotationRecoveryAttemptsRef.current += 1;
             setAutoSyncRegistrationGeneration((generation) => generation + 1);
           }
 

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,7 +1,26 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useContext, useEffect } from "react";
+import { AuthContext } from "../contexts/auth-context";
+import { usePushSubscription } from "./usePushSubscription";
+import {
+  getBrowserPushBootstrapData,
+  NotificationInstallationsApiError,
+  revokeBrowserNotificationInstallation,
+  upsertBrowserNotificationInstallation,
+} from "../services/notificationInstallationsApi";
+import {
+  clearBrowserPushInstallationId,
+  getBrowserPushClientMetadata,
+  getOrCreateBrowserPushInstallationId,
+  peekBrowserPushInstallationId,
+  getServiceWorkerScopePath,
+} from "../lib/browserPushState";
+import type {
+  BrowserPushBootstrapData,
+  NotificationInstallationLifecycleEvent,
+} from "@/types/api";
 
 export type NotificationPermissionState = "default" | "granted" | "denied";
 
@@ -24,6 +43,10 @@ interface UseNotificationsReturn {
   error: Error | null;
 }
 
+interface UseNotificationsOptions {
+  autoSync?: boolean;
+}
+
 /**
  * Hook for managing push notifications in the app
  * Handles permission requests, subscription management, and notification display
@@ -43,7 +66,10 @@ interface UseNotificationsReturn {
  * };
  * ```
  */
-export function useNotifications(): UseNotificationsReturn {
+export function useNotifications(
+  options: UseNotificationsOptions = {}
+): UseNotificationsReturn {
+  const authContext = useContext(AuthContext);
   const [permission, setPermission] = useState<NotificationPermissionState>(
     () =>
       typeof window !== "undefined" && "Notification" in window
@@ -52,12 +78,289 @@ export function useNotifications(): UseNotificationsReturn {
   );
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+  const {
+    subscribe,
+    unsubscribe,
+    getSubscriptionData,
+    isReady: isPushReady,
+    isSupported: isPushSupported,
+    refreshSubscription,
+  } = usePushSubscription();
 
   // Check if notifications are supported
   const isSupported =
     typeof window !== "undefined" &&
     "Notification" in window &&
-    "serviceWorker" in navigator;
+    isPushSupported;
+
+  const isAuthenticated = authContext?.isAuthenticated === true;
+  const autoSync = options.autoSync === true;
+
+  const toNotificationError = useCallback((err: unknown): Error => {
+    return err instanceof NotificationInstallationsApiError || err instanceof Error
+      ? err
+      : new Error(String(err));
+  }, []);
+
+  const runBackgroundNotificationTask = useCallback(
+    (task: () => Promise<void>) => {
+      let isActive = true;
+
+      const execute = async () => {
+        setIsLoading(true);
+        setError(null);
+
+        try {
+          await task();
+        } catch (err) {
+          if (isActive) {
+            setError(toNotificationError(err));
+          }
+        } finally {
+          if (isActive) {
+            setIsLoading(false);
+          }
+        }
+      };
+
+      void execute();
+
+      return () => {
+        isActive = false;
+      };
+    },
+    [toNotificationError]
+  );
+
+  const registerBrowserPushInstallation = useCallback(async (runtimeOptions?: {
+    bootstrapData?: BrowserPushBootstrapData | null;
+    forceRotation?: boolean;
+    allowRetry?: boolean;
+  }) => {
+    async function syncInstallation(nextRuntimeOptions?: {
+      bootstrapData?: BrowserPushBootstrapData | null;
+      forceRotation?: boolean;
+      allowRetry?: boolean;
+    }): Promise<void> {
+      if (!isAuthenticated) {
+        return;
+      }
+
+      const bootstrapData =
+        nextRuntimeOptions?.bootstrapData ?? (await getBrowserPushBootstrapData());
+      const webPushRuntimeMetadata = bootstrapData?.notification_channels?.web_push;
+
+      if (!webPushRuntimeMetadata) {
+        throw new Error(
+          "Web push notifications are not available for this deployment"
+        );
+      }
+
+      let currentSubscription = await refreshSubscription();
+      const hadExistingSubscription = currentSubscription !== null;
+
+      if (nextRuntimeOptions?.forceRotation && currentSubscription) {
+        await unsubscribe();
+        currentSubscription = null;
+      }
+
+      currentSubscription =
+        currentSubscription ??
+        (await subscribe(
+          webPushRuntimeMetadata.public_runtime_metadata.vapid_public_key
+        ));
+      const subscriptionData = getSubscriptionData() ?? {
+        endpoint: currentSubscription.endpoint,
+        expirationTime: currentSubscription.expirationTime ?? null,
+        keys: (() => {
+          const json = currentSubscription.toJSON();
+
+          if (!json.keys?.p256dh || !json.keys?.auth) {
+            throw new Error(
+              "Push subscription is missing required browser credentials"
+            );
+          }
+
+          return {
+            p256dh: json.keys.p256dh,
+            auth: json.keys.auth,
+          };
+        })(),
+      };
+
+      if (
+        typeof navigator === "undefined" ||
+        navigator.serviceWorker === undefined ||
+        !subscriptionData.endpoint
+      ) {
+        throw new Error("Browser push registration is unavailable");
+      }
+
+      const registration = await navigator.serviceWorker.ready;
+      const { browserName, browserVersion, installationName } =
+        getBrowserPushClientMetadata();
+
+      let lifecycleEvent: NotificationInstallationLifecycleEvent = "registered";
+
+      if (nextRuntimeOptions?.forceRotation) {
+        lifecycleEvent = "credential_rotated";
+      } else if (hadExistingSubscription) {
+        lifecycleEvent = "client_updated";
+      }
+
+      try {
+        await upsertBrowserNotificationInstallation(
+          getOrCreateBrowserPushInstallationId(),
+          {
+            channel: "web_push",
+            installation_name: installationName,
+            lifecycle_event: lifecycleEvent,
+            runtime: {
+              bootstrap_version: bootstrapData.compatibility.bootstrap_version,
+              schema_version: bootstrapData.compatibility.schema_version,
+              metadata_revision: webPushRuntimeMetadata.metadata_revision,
+            },
+            registration: {
+              browser: {
+                browser_name: browserName,
+                browser_version: browserVersion,
+                service_worker_scope: getServiceWorkerScopePath(registration.scope),
+              },
+              subscription: {
+                endpoint: subscriptionData.endpoint,
+                expiration_time: subscriptionData.expirationTime ?? null,
+                keys: subscriptionData.keys,
+              },
+            },
+          }
+        );
+      } catch (err) {
+        if (
+          err instanceof NotificationInstallationsApiError &&
+          err.code === "NOTIFICATION_RUNTIME_STATE_INVALID" &&
+          nextRuntimeOptions?.allowRetry !== false
+        ) {
+          await syncInstallation({
+            allowRetry: false,
+            forceRotation: true,
+          });
+          return;
+        }
+
+        throw err;
+      }
+    }
+
+    await syncInstallation(runtimeOptions);
+  }, [
+    getSubscriptionData,
+    isAuthenticated,
+    refreshSubscription,
+    subscribe,
+    unsubscribe,
+  ]);
+
+  const revokeBrowserPushState = useCallback(async () => {
+    const installationId = peekBrowserPushInstallationId();
+    const currentSubscription = await refreshSubscription();
+
+    if (!installationId && !currentSubscription) {
+      return;
+    }
+
+    if (installationId && isAuthenticated) {
+      await revokeBrowserNotificationInstallation(installationId);
+      clearBrowserPushInstallationId();
+    }
+
+    if (currentSubscription) {
+      await unsubscribe();
+    }
+  }, [isAuthenticated, refreshSubscription, unsubscribe]);
+
+  useEffect(() => {
+    if (
+      !autoSync ||
+      !isAuthenticated ||
+      !isSupported ||
+      permission !== "granted" ||
+      !isPushReady
+    ) {
+      return;
+    }
+
+    return runBackgroundNotificationTask(() => registerBrowserPushInstallation());
+  }, [
+    autoSync,
+    isAuthenticated,
+    isPushReady,
+    isSupported,
+    permission,
+    registerBrowserPushInstallation,
+    runBackgroundNotificationTask,
+  ]);
+
+  useEffect(() => {
+    if (!autoSync || !isPushReady || permission !== "denied") {
+      return;
+    }
+
+    return runBackgroundNotificationTask(() => revokeBrowserPushState());
+  }, [
+    autoSync,
+    isPushReady,
+    permission,
+    revokeBrowserPushState,
+    runBackgroundNotificationTask,
+  ]);
+
+  useEffect(() => {
+    if (
+      !autoSync ||
+      !isAuthenticated ||
+      !isSupported ||
+      permission !== "granted" ||
+      typeof navigator === "undefined" ||
+      navigator.serviceWorker === undefined ||
+      typeof navigator.serviceWorker.addEventListener !== "function"
+    ) {
+      return;
+    }
+
+    let cancelSync: (() => void) | null = null;
+
+    const handleControllerChange = () => {
+      cancelSync?.();
+      cancelSync = runBackgroundNotificationTask(async () => {
+        await refreshSubscription();
+        await registerBrowserPushInstallation();
+      });
+    };
+
+    navigator.serviceWorker.addEventListener(
+      "controllerchange",
+      handleControllerChange
+    );
+
+    return () => {
+      cancelSync?.();
+
+      if (typeof navigator.serviceWorker.removeEventListener === "function") {
+        navigator.serviceWorker.removeEventListener(
+          "controllerchange",
+          handleControllerChange
+        );
+      }
+    };
+  }, [
+    autoSync,
+    isAuthenticated,
+    isSupported,
+    permission,
+    refreshSubscription,
+    registerBrowserPushInstallation,
+    runBackgroundNotificationTask,
+  ]);
 
   /**
    * Request notification permission from the user
@@ -78,15 +381,20 @@ export function useNotifications(): UseNotificationsReturn {
       try {
         const result = await Notification.requestPermission();
         setPermission(result);
+
+        if (result === "granted") {
+          await registerBrowserPushInstallation();
+        }
+
         return result;
       } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err));
+        const error = toNotificationError(err);
         setError(error);
         throw error;
       } finally {
         setIsLoading(false);
       }
-    }, [isSupported]);
+    }, [isSupported, registerBrowserPushInstallation, toNotificationError]);
 
   /**
    * Show a notification to the user

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -162,6 +162,7 @@ export function useNotifications(
     isPushSupported;
 
   const isAuthenticated = authContext?.isAuthenticated === true;
+  const isAuthenticatedRef = useRef(isAuthenticated);
   const autoSync = options.autoSync === true;
   const [autoSyncRegistrationGeneration, setAutoSyncRegistrationGeneration] =
     useState(0);
@@ -180,6 +181,10 @@ export function useNotifications(
       ? err
       : new Error(String(err));
   }, []);
+
+  useEffect(() => {
+    isAuthenticatedRef.current = isAuthenticated;
+  }, [isAuthenticated]);
 
   const runBackgroundNotificationTask = useCallback(
     (task: (isTaskActive: () => boolean) => Promise<void>) => {
@@ -231,7 +236,7 @@ export function useNotifications(
         const webPushRuntimeMetadata =
           bootstrapData?.notification_channels?.web_push;
 
-        if (!webPushRuntimeMetadata) {
+        if (!bootstrapData || !webPushRuntimeMetadata) {
           throw new Error(
             "Web push notifications are not available for this deployment"
           );
@@ -397,7 +402,7 @@ export function useNotifications(
     }
 
     try {
-      if (installationId && isAuthenticated) {
+      if (installationId && isAuthenticatedRef.current) {
         await revokeBrowserNotificationInstallation(installationId);
       }
     } catch (error) {
@@ -430,7 +435,7 @@ export function useNotifications(
     if (unsubscribeError) {
       throw unsubscribeError;
     }
-  }, [isAuthenticated, refreshSubscription, unsubscribe]);
+  }, [refreshSubscription, unsubscribe]);
 
   useEffect(() => {
     if (

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -388,6 +388,7 @@ export function useNotifications(
     const currentSubscription = await refreshSubscription();
     let revokeError: unknown = null;
     let unsubscribeError: unknown = null;
+    let revokeSucceeded = false;
 
     if (!installationId && !currentSubscription) {
       return;
@@ -396,11 +397,12 @@ export function useNotifications(
     try {
       if (installationId && isAuthenticatedRef.current) {
         await revokeBrowserNotificationInstallation(installationId);
+        revokeSucceeded = true;
       }
     } catch (error) {
       revokeError = error;
     } finally {
-      if (installationId) {
+      if (installationId && revokeSucceeded) {
         clearBrowserPushInstallationId();
       }
 

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -509,7 +509,20 @@ export function useNotifications(
           if (autoSync) {
             skipAutoSyncGenerationRef.current = autoSyncRegistrationGeneration;
           }
-          await registerBrowserPushInstallation();
+
+          try {
+            await registerBrowserPushInstallation();
+          } catch (err) {
+            if (
+              autoSync &&
+              skipAutoSyncGenerationRef.current ===
+                autoSyncRegistrationGeneration
+            ) {
+              skipAutoSyncGenerationRef.current = null;
+            }
+
+            throw err;
+          }
         }
 
         return result;

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -97,7 +97,8 @@ export function useNotifications(
   const autoSync = options.autoSync === true;
 
   const toNotificationError = useCallback((err: unknown): Error => {
-    return err instanceof NotificationInstallationsApiError || err instanceof Error
+    return err instanceof NotificationInstallationsApiError ||
+      err instanceof Error
       ? err
       : new Error(String(err));
   }, []);
@@ -132,133 +133,142 @@ export function useNotifications(
     [toNotificationError]
   );
 
-  const registerBrowserPushInstallation = useCallback(async (runtimeOptions?: {
-    bootstrapData?: BrowserPushBootstrapData | null;
-    forceRotation?: boolean;
-    allowRetry?: boolean;
-  }) => {
-    async function syncInstallation(nextRuntimeOptions?: {
+  const registerBrowserPushInstallation = useCallback(
+    async (runtimeOptions?: {
       bootstrapData?: BrowserPushBootstrapData | null;
       forceRotation?: boolean;
       allowRetry?: boolean;
-    }): Promise<void> {
-      if (!isAuthenticated) {
-        return;
-      }
-
-      const bootstrapData =
-        nextRuntimeOptions?.bootstrapData ?? (await getBrowserPushBootstrapData());
-      const webPushRuntimeMetadata = bootstrapData?.notification_channels?.web_push;
-
-      if (!webPushRuntimeMetadata) {
-        throw new Error(
-          "Web push notifications are not available for this deployment"
-        );
-      }
-
-      let currentSubscription = await refreshSubscription();
-      const hadExistingSubscription = currentSubscription !== null;
-
-      if (nextRuntimeOptions?.forceRotation && currentSubscription) {
-        await unsubscribe();
-        currentSubscription = null;
-      }
-
-      currentSubscription =
-        currentSubscription ??
-        (await subscribe(
-          webPushRuntimeMetadata.public_runtime_metadata.vapid_public_key
-        ));
-      const subscriptionData = getSubscriptionData() ?? {
-        endpoint: currentSubscription.endpoint,
-        expirationTime: currentSubscription.expirationTime ?? null,
-        keys: (() => {
-          const json = currentSubscription.toJSON();
-
-          if (!json.keys?.p256dh || !json.keys?.auth) {
-            throw new Error(
-              "Push subscription is missing required browser credentials"
-            );
-          }
-
-          return {
-            p256dh: json.keys.p256dh,
-            auth: json.keys.auth,
-          };
-        })(),
-      };
-
-      if (
-        typeof navigator === "undefined" ||
-        navigator.serviceWorker === undefined ||
-        !subscriptionData.endpoint
-      ) {
-        throw new Error("Browser push registration is unavailable");
-      }
-
-      const registration = await navigator.serviceWorker.ready;
-      const { browserName, browserVersion, installationName } =
-        getBrowserPushClientMetadata();
-
-      let lifecycleEvent: NotificationInstallationLifecycleEvent = "registered";
-
-      if (nextRuntimeOptions?.forceRotation) {
-        lifecycleEvent = "credential_rotated";
-      } else if (hadExistingSubscription) {
-        lifecycleEvent = "client_updated";
-      }
-
-      try {
-        await upsertBrowserNotificationInstallation(
-          getOrCreateBrowserPushInstallationId(),
-          {
-            channel: "web_push",
-            installation_name: installationName,
-            lifecycle_event: lifecycleEvent,
-            runtime: {
-              bootstrap_version: bootstrapData.compatibility.bootstrap_version,
-              schema_version: bootstrapData.compatibility.schema_version,
-              metadata_revision: webPushRuntimeMetadata.metadata_revision,
-            },
-            registration: {
-              browser: {
-                browser_name: browserName,
-                browser_version: browserVersion,
-                service_worker_scope: getServiceWorkerScopePath(registration.scope),
-              },
-              subscription: {
-                endpoint: subscriptionData.endpoint,
-                expiration_time: subscriptionData.expirationTime ?? null,
-                keys: subscriptionData.keys,
-              },
-            },
-          }
-        );
-      } catch (err) {
-        if (
-          err instanceof NotificationInstallationsApiError &&
-          err.code === "NOTIFICATION_RUNTIME_STATE_INVALID" &&
-          nextRuntimeOptions?.allowRetry !== false
-        ) {
-          await syncInstallation({
-            allowRetry: false,
-            forceRotation: true,
-          });
+    }) => {
+      async function syncInstallation(nextRuntimeOptions?: {
+        bootstrapData?: BrowserPushBootstrapData | null;
+        forceRotation?: boolean;
+        allowRetry?: boolean;
+      }): Promise<void> {
+        if (!isAuthenticated) {
           return;
         }
 
-        throw err;
-      }
-    }
+        const bootstrapData =
+          nextRuntimeOptions?.bootstrapData ??
+          (await getBrowserPushBootstrapData());
+        const webPushRuntimeMetadata =
+          bootstrapData?.notification_channels?.web_push;
 
-    await syncInstallation(runtimeOptions);
-  }, [
-    getSubscriptionData,
-    isAuthenticated,
-    refreshSubscription,
-    subscribe,
-    unsubscribe,
-  ]);
+        if (!webPushRuntimeMetadata) {
+          throw new Error(
+            "Web push notifications are not available for this deployment"
+          );
+        }
+
+        let currentSubscription = await refreshSubscription();
+        const hadExistingSubscription = currentSubscription !== null;
+
+        if (nextRuntimeOptions?.forceRotation && currentSubscription) {
+          await unsubscribe();
+          currentSubscription = null;
+        }
+
+        currentSubscription =
+          currentSubscription ??
+          (await subscribe(
+            webPushRuntimeMetadata.public_runtime_metadata.vapid_public_key
+          ));
+        const subscriptionData = getSubscriptionData() ?? {
+          endpoint: currentSubscription.endpoint,
+          expirationTime: currentSubscription.expirationTime ?? null,
+          keys: (() => {
+            const json = currentSubscription.toJSON();
+
+            if (!json.keys?.p256dh || !json.keys?.auth) {
+              throw new Error(
+                "Push subscription is missing required browser credentials"
+              );
+            }
+
+            return {
+              p256dh: json.keys.p256dh,
+              auth: json.keys.auth,
+            };
+          })(),
+        };
+
+        if (
+          typeof navigator === "undefined" ||
+          navigator.serviceWorker === undefined ||
+          !subscriptionData.endpoint
+        ) {
+          throw new Error("Browser push registration is unavailable");
+        }
+
+        const registration = await navigator.serviceWorker.ready;
+        const { browserName, browserVersion, installationName } =
+          getBrowserPushClientMetadata();
+
+        let lifecycleEvent: NotificationInstallationLifecycleEvent =
+          "registered";
+
+        if (nextRuntimeOptions?.forceRotation) {
+          lifecycleEvent = "credential_rotated";
+        } else if (hadExistingSubscription) {
+          lifecycleEvent = "client_updated";
+        }
+
+        try {
+          await upsertBrowserNotificationInstallation(
+            getOrCreateBrowserPushInstallationId(),
+            {
+              channel: "web_push",
+              installation_name: installationName,
+              lifecycle_event: lifecycleEvent,
+              runtime: {
+                bootstrap_version:
+                  bootstrapData.compatibility.bootstrap_version,
+                schema_version: bootstrapData.compatibility.schema_version,
+                metadata_revision: webPushRuntimeMetadata.metadata_revision,
+              },
+              registration: {
+                browser: {
+                  browser_name: browserName,
+                  browser_version: browserVersion,
+                  service_worker_scope: getServiceWorkerScopePath(
+                    registration.scope
+                  ),
+                },
+                subscription: {
+                  endpoint: subscriptionData.endpoint,
+                  expiration_time: subscriptionData.expirationTime ?? null,
+                  keys: subscriptionData.keys,
+                },
+              },
+            }
+          );
+        } catch (err) {
+          if (
+            err instanceof NotificationInstallationsApiError &&
+            err.code === "NOTIFICATION_RUNTIME_STATE_INVALID" &&
+            nextRuntimeOptions?.allowRetry !== false
+          ) {
+            await syncInstallation({
+              allowRetry: false,
+              forceRotation: true,
+            });
+            return;
+          }
+
+          throw err;
+        }
+      }
+
+      await syncInstallation(runtimeOptions);
+    },
+    [
+      getSubscriptionData,
+      isAuthenticated,
+      refreshSubscription,
+      subscribe,
+      unsubscribe,
+    ]
+  );
 
   const revokeBrowserPushState = useCallback(async () => {
     const installationId = peekBrowserPushInstallationId();
@@ -289,7 +299,9 @@ export function useNotifications(
       return;
     }
 
-    return runBackgroundNotificationTask(() => registerBrowserPushInstallation());
+    return runBackgroundNotificationTask(() =>
+      registerBrowserPushInstallation()
+    );
   }, [
     autoSync,
     isAuthenticated,

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { useState, useCallback, useContext, useEffect } from "react";
+import { useState, useCallback, useContext, useEffect, useRef } from "react";
 import { AuthContext } from "../contexts/auth-context";
 import { usePushSubscription } from "./usePushSubscription";
 import {
@@ -95,6 +95,7 @@ export function useNotifications(
 
   const isAuthenticated = authContext?.isAuthenticated === true;
   const autoSync = options.autoSync === true;
+  const skipNextAutoSyncRegistrationRef = useRef(false);
 
   const toNotificationError = useCallback((err: unknown): Error => {
     return err instanceof NotificationInstallationsApiError ||
@@ -304,6 +305,11 @@ export function useNotifications(
       return;
     }
 
+    if (skipNextAutoSyncRegistrationRef.current) {
+      skipNextAutoSyncRegistrationRef.current = false;
+      return;
+    }
+
     return runBackgroundNotificationTask(() =>
       registerBrowserPushInstallation()
     );
@@ -352,6 +358,7 @@ export function useNotifications(
         setPermission(result);
 
         if (result === "granted") {
+          skipNextAutoSyncRegistrationRef.current = autoSync;
           await registerBrowserPushInstallation();
         }
 
@@ -363,7 +370,7 @@ export function useNotifications(
       } finally {
         setIsLoading(false);
       }
-    }, [isSupported, registerBrowserPushInstallation, toNotificationError]);
+    }, [autoSync, isSupported, registerBrowserPushInstallation, toNotificationError]);
 
   /**
    * Show a notification to the user

--- a/src/hooks/usePushSubscription.test.ts
+++ b/src/hooks/usePushSubscription.test.ts
@@ -288,6 +288,7 @@ describe("usePushSubscription", () => {
 
       expect(data).toEqual({
         endpoint: "https://push.service.com/endpoint",
+        expirationTime: null,
         keys: {
           p256dh: "mock-p256dh-key",
           auth: "mock-auth-key",

--- a/src/hooks/usePushSubscription.test.ts
+++ b/src/hooks/usePushSubscription.test.ts
@@ -123,6 +123,8 @@ describe("usePushSubscription", () => {
         usePushSubscription({ vapidPublicKey: TEST_VAPID_KEY })
       );
 
+      mockPushManager.getSubscription.mockResolvedValue(mockSubscription);
+
       let subscription = null;
       await act(async () => {
         subscription = await result.current.subscribe();
@@ -267,6 +269,32 @@ describe("usePushSubscription", () => {
       });
 
       expect(result.current.error).toBe(testError);
+    });
+  });
+
+  describe("refreshSubscription", () => {
+    it("clears the subscription when the push manager returns null, even if the hook already held a subscription", async () => {
+      mockPushManager.getSubscription.mockResolvedValue(mockSubscription);
+
+      const { result } = renderHook(() =>
+        usePushSubscription({ vapidPublicKey: TEST_VAPID_KEY })
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSubscribed).toBe(true);
+      });
+
+      // Browser externally invalidated the subscription
+      mockPushManager.getSubscription.mockResolvedValue(null);
+
+      await act(async () => {
+        const refreshed = await result.current.refreshSubscription();
+        expect(refreshed).toBeNull();
+      });
+
+      expect(result.current.isSubscribed).toBe(false);
+      expect(result.current.subscription).toBeNull();
+      expect(result.current.getSubscriptionData()).toBeNull();
     });
   });
 

--- a/src/hooks/usePushSubscription.ts
+++ b/src/hooks/usePushSubscription.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { useState, useEffect, useCallback, useRef } from "react";
@@ -45,7 +45,12 @@ function urlBase64ToUint8Array(base64String: string): Uint8Array {
  *
  * @example
  * ```tsx
- * const { subscribe, unsubscribe, isSubscribed } = usePushSubscription();
+ * const runtimeVapidPublicKey =
+ *   deploymentBootstrap.notification_channels.web_push.public_runtime_metadata.vapid_public_key;
+ *
+ * const { subscribe, unsubscribe, isSubscribed } = usePushSubscription({
+ *   vapidPublicKey: runtimeVapidPublicKey,
+ * });
  *
  * const handleSubscribe = async () => {
  *   try {

--- a/src/hooks/usePushSubscription.ts
+++ b/src/hooks/usePushSubscription.ts
@@ -99,11 +99,9 @@ export function usePushSubscription(
         const registration = await navigator.serviceWorker.ready;
         const existingSubscription =
           await registration.pushManager.getSubscription();
-        const resolvedSubscription =
-          existingSubscription ?? subscriptionRef.current;
 
-        setTrackedSubscription(resolvedSubscription);
-        return resolvedSubscription;
+        setTrackedSubscription(existingSubscription);
+        return existingSubscription;
       } catch (err) {
         console.error("Failed to load push subscription:", err);
         setTrackedSubscription(null);

--- a/src/hooks/usePushSubscription.ts
+++ b/src/hooks/usePushSubscription.ts
@@ -87,27 +87,29 @@ export function usePushSubscription(
     []
   );
 
-  const refreshSubscription = useCallback(async (): Promise<PushSubscription | null> => {
-    if (!isSupported) {
-      setTrackedSubscription(null);
-      setIsReady(true);
-      return null;
-    }
+  const refreshSubscription =
+    useCallback(async (): Promise<PushSubscription | null> => {
+      if (!isSupported) {
+        setTrackedSubscription(null);
+        setIsReady(true);
+        return null;
+      }
 
-    try {
-      const registration = await navigator.serviceWorker.ready;
-      const existingSubscription = await registration.pushManager.getSubscription();
+      try {
+        const registration = await navigator.serviceWorker.ready;
+        const existingSubscription =
+          await registration.pushManager.getSubscription();
 
-      setTrackedSubscription(existingSubscription);
-      return existingSubscription;
-    } catch (err) {
-      console.error("Failed to load push subscription:", err);
-      setTrackedSubscription(null);
-      return null;
-    } finally {
-      setIsReady(true);
-    }
-  }, [isSupported, setTrackedSubscription]);
+        setTrackedSubscription(existingSubscription);
+        return existingSubscription;
+      } catch (err) {
+        console.error("Failed to load push subscription:", err);
+        setTrackedSubscription(null);
+        return null;
+      } finally {
+        setIsReady(true);
+      }
+    }, [isSupported, setTrackedSubscription]);
 
   // Load existing subscription on mount
   useEffect(() => {
@@ -145,51 +147,54 @@ export function usePushSubscription(
   /**
    * Subscribe to push notifications
    */
-  const subscribe = useCallback(async (overrideVapidPublicKey?: string): Promise<PushSubscription> => {
-    if (!isSupported) {
-      const err = new Error("Push notifications are not supported");
-      setError(err);
-      throw err;
-    }
+  const subscribe = useCallback(
+    async (overrideVapidPublicKey?: string): Promise<PushSubscription> => {
+      if (!isSupported) {
+        const err = new Error("Push notifications are not supported");
+        setError(err);
+        throw err;
+      }
 
-    if (subscriptionRef.current) {
-      const err = new Error("Already subscribed");
-      setError(err);
-      throw err;
-    }
+      if (subscriptionRef.current) {
+        const err = new Error("Already subscribed");
+        setError(err);
+        throw err;
+      }
 
-    const vapidPublicKey = overrideVapidPublicKey ?? options.vapidPublicKey;
+      const vapidPublicKey = overrideVapidPublicKey ?? options.vapidPublicKey;
 
-    if (!vapidPublicKey) {
-      const err = new Error("VAPID public key is required");
-      setError(err);
-      throw err;
-    }
+      if (!vapidPublicKey) {
+        const err = new Error("VAPID public key is required");
+        setError(err);
+        throw err;
+      }
 
-    setIsLoading(true);
-    setError(null);
+      setIsLoading(true);
+      setError(null);
 
-    try {
-      const registration = await navigator.serviceWorker.ready;
-      const applicationServerKey = urlBase64ToUint8Array(
-        vapidPublicKey
-      ) as BufferSource;
+      try {
+        const registration = await navigator.serviceWorker.ready;
+        const applicationServerKey = urlBase64ToUint8Array(
+          vapidPublicKey
+        ) as BufferSource;
 
-      const newSubscription = await registration.pushManager.subscribe({
-        userVisibleOnly: true,
-        applicationServerKey,
-      });
+        const newSubscription = await registration.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey,
+        });
 
-      setTrackedSubscription(newSubscription);
-      return newSubscription;
-    } catch (err) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      setError(error);
-      throw error;
-    } finally {
-      setIsLoading(false);
-    }
-  }, [isSupported, options.vapidPublicKey, setTrackedSubscription]);
+        setTrackedSubscription(newSubscription);
+        return newSubscription;
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        setError(error);
+        throw error;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [isSupported, options.vapidPublicKey, setTrackedSubscription]
+  );
 
   /**
    * Unsubscribe from push notifications

--- a/src/hooks/usePushSubscription.ts
+++ b/src/hooks/usePushSubscription.ts
@@ -64,20 +64,20 @@ function urlBase64ToUint8Array(base64String: string): Uint8Array {
 export function usePushSubscription(
   options: UsePushSubscriptionOptions = {}
 ): UsePushSubscriptionReturn {
-  const [subscription, setSubscription] = useState<PushSubscription | null>(
-    null
-  );
-  const subscriptionRef = useRef<PushSubscription | null>(null);
-  const [isReady, setIsReady] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
-
   // Check if push notifications are supported
   const isSupported =
     typeof window !== "undefined" &&
     "serviceWorker" in navigator &&
     navigator.serviceWorker !== undefined &&
     "PushManager" in window;
+
+  const [subscription, setSubscription] = useState<PushSubscription | null>(
+    null
+  );
+  const subscriptionRef = useRef<PushSubscription | null>(null);
+  const [isReady, setIsReady] = useState(!isSupported);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
 
   const setTrackedSubscription = useCallback(
     (nextSubscription: PushSubscription | null) => {
@@ -99,9 +99,11 @@ export function usePushSubscription(
         const registration = await navigator.serviceWorker.ready;
         const existingSubscription =
           await registration.pushManager.getSubscription();
+        const resolvedSubscription =
+          existingSubscription ?? subscriptionRef.current;
 
-        setTrackedSubscription(existingSubscription);
-        return existingSubscription;
+        setTrackedSubscription(resolvedSubscription);
+        return resolvedSubscription;
       } catch (err) {
         console.error("Failed to load push subscription:", err);
         setTrackedSubscription(null);
@@ -111,14 +113,19 @@ export function usePushSubscription(
       }
     }, [isSupported, setTrackedSubscription]);
 
+  const scheduleSubscriptionRefresh = useCallback(() => {
+    queueMicrotask(() => {
+      void refreshSubscription();
+    });
+  }, [refreshSubscription]);
+
   // Load existing subscription on mount
   useEffect(() => {
     if (!isSupported) {
-      setIsReady(true);
       return;
     }
 
-    void refreshSubscription();
+    scheduleSubscriptionRefresh();
 
     if (typeof navigator.serviceWorker.addEventListener !== "function") {
       return;
@@ -126,7 +133,7 @@ export function usePushSubscription(
 
     const handleControllerChange = () => {
       setIsReady(false);
-      void refreshSubscription();
+      scheduleSubscriptionRefresh();
     };
 
     navigator.serviceWorker.addEventListener(
@@ -142,7 +149,7 @@ export function usePushSubscription(
         );
       }
     };
-  }, [isSupported, refreshSubscription]);
+  }, [isSupported, scheduleSubscriptionRefresh]);
 
   /**
    * Subscribe to push notifications

--- a/src/hooks/usePushSubscription.ts
+++ b/src/hooks/usePushSubscription.ts
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: 2025 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 
 export interface PushSubscriptionData {
   endpoint: string;
+  expirationTime?: number | null;
   keys: {
     p256dh: string;
     auth: string;
@@ -19,18 +20,14 @@ interface UsePushSubscriptionReturn {
   subscription: PushSubscription | null;
   isSubscribed: boolean;
   isSupported: boolean;
+  isReady: boolean;
   isLoading: boolean;
   error: Error | null;
-  subscribe: () => Promise<PushSubscription>;
+  subscribe: (overrideVapidPublicKey?: string) => Promise<PushSubscription>;
   unsubscribe: () => Promise<void>;
   getSubscriptionData: () => PushSubscriptionData | null;
+  refreshSubscription: () => Promise<PushSubscription | null>;
 }
-
-/**
- * Default VAPID public key (will be replaced with real key from backend)
- * This is a placeholder - in production, this should come from the backend API
- */
-const DEFAULT_VAPID_PUBLIC_KEY = import.meta.env.VITE_VAPID_PUBLIC_KEY || "";
 
 /**
  * Convert base64 VAPID key to Uint8Array
@@ -70,10 +67,10 @@ export function usePushSubscription(
   const [subscription, setSubscription] = useState<PushSubscription | null>(
     null
   );
+  const subscriptionRef = useRef<PushSubscription | null>(null);
+  const [isReady, setIsReady] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
-
-  const vapidPublicKey = options.vapidPublicKey || DEFAULT_VAPID_PUBLIC_KEY;
 
   // Check if push notifications are supported
   const isSupported =
@@ -82,38 +79,86 @@ export function usePushSubscription(
     navigator.serviceWorker !== undefined &&
     "PushManager" in window;
 
+  const setTrackedSubscription = useCallback(
+    (nextSubscription: PushSubscription | null) => {
+      subscriptionRef.current = nextSubscription;
+      setSubscription(nextSubscription);
+    },
+    []
+  );
+
+  const refreshSubscription = useCallback(async (): Promise<PushSubscription | null> => {
+    if (!isSupported) {
+      setTrackedSubscription(null);
+      setIsReady(true);
+      return null;
+    }
+
+    try {
+      const registration = await navigator.serviceWorker.ready;
+      const existingSubscription = await registration.pushManager.getSubscription();
+
+      setTrackedSubscription(existingSubscription);
+      return existingSubscription;
+    } catch (err) {
+      console.error("Failed to load push subscription:", err);
+      setTrackedSubscription(null);
+      return null;
+    } finally {
+      setIsReady(true);
+    }
+  }, [isSupported, setTrackedSubscription]);
+
   // Load existing subscription on mount
   useEffect(() => {
-    if (!isSupported) return;
+    if (!isSupported) {
+      setIsReady(true);
+      return;
+    }
 
-    const loadSubscription = async () => {
-      try {
-        const registration = await navigator.serviceWorker.ready;
-        const existingSub = await registration.pushManager.getSubscription();
-        setSubscription(existingSub);
-      } catch (err) {
-        console.error("Failed to load push subscription:", err);
-      }
+    void refreshSubscription();
+
+    if (typeof navigator.serviceWorker.addEventListener !== "function") {
+      return;
+    }
+
+    const handleControllerChange = () => {
+      setIsReady(false);
+      void refreshSubscription();
     };
 
-    loadSubscription();
-  }, [isSupported]);
+    navigator.serviceWorker.addEventListener(
+      "controllerchange",
+      handleControllerChange
+    );
+
+    return () => {
+      if (typeof navigator.serviceWorker.removeEventListener === "function") {
+        navigator.serviceWorker.removeEventListener(
+          "controllerchange",
+          handleControllerChange
+        );
+      }
+    };
+  }, [isSupported, refreshSubscription]);
 
   /**
    * Subscribe to push notifications
    */
-  const subscribe = useCallback(async (): Promise<PushSubscription> => {
+  const subscribe = useCallback(async (overrideVapidPublicKey?: string): Promise<PushSubscription> => {
     if (!isSupported) {
       const err = new Error("Push notifications are not supported");
       setError(err);
       throw err;
     }
 
-    if (subscription) {
+    if (subscriptionRef.current) {
       const err = new Error("Already subscribed");
       setError(err);
       throw err;
     }
+
+    const vapidPublicKey = overrideVapidPublicKey ?? options.vapidPublicKey;
 
     if (!vapidPublicKey) {
       const err = new Error("VAPID public key is required");
@@ -135,7 +180,7 @@ export function usePushSubscription(
         applicationServerKey,
       });
 
-      setSubscription(newSubscription);
+      setTrackedSubscription(newSubscription);
       return newSubscription;
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
@@ -144,13 +189,15 @@ export function usePushSubscription(
     } finally {
       setIsLoading(false);
     }
-  }, [isSupported, subscription, vapidPublicKey]);
+  }, [isSupported, options.vapidPublicKey, setTrackedSubscription]);
 
   /**
    * Unsubscribe from push notifications
    */
   const unsubscribe = useCallback(async (): Promise<void> => {
-    if (!subscription) {
+    const currentSubscription = subscriptionRef.current;
+
+    if (!currentSubscription) {
       const err = new Error("Not subscribed");
       setError(err);
       throw err;
@@ -160,8 +207,8 @@ export function usePushSubscription(
     setError(null);
 
     try {
-      await subscription.unsubscribe();
-      setSubscription(null);
+      await currentSubscription.unsubscribe();
+      setTrackedSubscription(null);
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
       setError(error);
@@ -169,35 +216,41 @@ export function usePushSubscription(
     } finally {
       setIsLoading(false);
     }
-  }, [subscription]);
+  }, [setTrackedSubscription]);
 
   /**
    * Get subscription data in format suitable for backend API
    */
   const getSubscriptionData = useCallback((): PushSubscriptionData | null => {
-    if (!subscription) return null;
+    const currentSubscription = subscriptionRef.current;
 
-    const json = subscription.toJSON();
+    if (!currentSubscription) return null;
+
+    const json = currentSubscription.toJSON();
     if (!json.endpoint || !json.keys?.p256dh || !json.keys?.auth) {
       return null;
     }
     return {
       endpoint: json.endpoint,
+      expirationTime:
+        currentSubscription.expirationTime ?? json.expirationTime ?? null,
       keys: {
         p256dh: json.keys.p256dh,
         auth: json.keys.auth,
       },
     };
-  }, [subscription]);
+  }, []);
 
   return {
     subscription,
     isSubscribed: subscription !== null,
     isSupported,
+    isReady,
     isLoading,
     error,
     subscribe,
     unsubscribe,
     getSubscriptionData,
+    refreshSubscription,
   };
 }

--- a/src/hooks/usePushSubscription.ts
+++ b/src/hooks/usePushSubscription.ts
@@ -32,7 +32,7 @@ interface UsePushSubscriptionReturn {
 /**
  * Convert base64 VAPID key to Uint8Array
  */
-function urlBase64ToUint8Array(base64String: string): Uint8Array {
+export function urlBase64ToUint8Array(base64String: string): Uint8Array {
   const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
   const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
   const rawData = atob(base64);

--- a/src/lib/browserPushState.test.ts
+++ b/src/lib/browserPushState.test.ts
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearBrowserPushInstallationId,
+  getOrCreateBrowserPushInstallationId,
+  peekBrowserPushInstallationId,
+} from "./browserPushState";
+
+describe("browserPushState", () => {
+  beforeEach(() => {
+    clearBrowserPushInstallationId();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    clearBrowserPushInstallationId();
+    localStorage.clear();
+  });
+
+  it("reuses the volatile installation id when localStorage writes fail", () => {
+    const setItemSpy = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new DOMException("blocked", "SecurityError");
+      });
+
+    const installationId = getOrCreateBrowserPushInstallationId();
+
+    setItemSpy.mockRestore();
+
+    expect(peekBrowserPushInstallationId()).toBe(installationId);
+    expect(getOrCreateBrowserPushInstallationId()).toBe(installationId);
+  });
+});

--- a/src/lib/browserPushState.test.ts
+++ b/src/lib/browserPushState.test.ts
@@ -16,6 +16,7 @@ describe("browserPushState", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
     clearBrowserPushInstallationId();
     localStorage.clear();
   });
@@ -33,5 +34,27 @@ describe("browserPushState", () => {
 
     expect(peekBrowserPushInstallationId()).toBe(installationId);
     expect(getOrCreateBrowserPushInstallationId()).toBe(installationId);
+  });
+
+  it("uses crypto.getRandomValues when randomUUID is unavailable", () => {
+    const getRandomValues = vi.fn((buffer: Uint8Array) => {
+      buffer.set([
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+        0x0c, 0x0d, 0x0e, 0x0f,
+      ]);
+
+      return buffer;
+    });
+
+    vi.stubGlobal("crypto", {
+      getRandomValues,
+    });
+
+    const installationId = getOrCreateBrowserPushInstallationId();
+
+    expect(getRandomValues).toHaveBeenCalledTimes(1);
+    expect(installationId).toBe(
+      "browser-push-000102030405060708090a0b0c0d0e0f"
+    );
   });
 });

--- a/src/lib/browserPushState.ts
+++ b/src/lib/browserPushState.ts
@@ -74,6 +74,15 @@ export function peekBrowserPushInstallationId(): string | null {
   }
 }
 
+// Multi-tab note: localStorage reads and writes are synchronous within a single
+// tab, but the read-check-write here is not atomic across tabs sharing the same
+// origin. Two tabs opening simultaneously for the first time can each generate a
+// distinct ID, with the second write winning in localStorage. The first tab's
+// registered installation ID becomes orphaned on the server until that tab
+// revokes it (which it will, using its locally-returned ID). This is an
+// acceptable trade-off: installations are low-cost, the server accepts multiple
+// registrations per user, and logout revocation uses the ID returned at creation
+// time (stored in the closure of the registration call), not a re-read.
 export function getOrCreateBrowserPushInstallationId(): string {
   const existingInstallationId = peekBrowserPushInstallationId();
 

--- a/src/lib/browserPushState.ts
+++ b/src/lib/browserPushState.ts
@@ -7,7 +7,10 @@ const BROWSER_PUSH_INSTALLATION_ID_STORAGE_KEY =
 let volatileInstallationId: string | null = null;
 
 function createInstallationId(): string {
-  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
     return crypto.randomUUID();
   }
 
@@ -117,7 +120,9 @@ export function getBrowserPushClientMetadata(
   };
 }
 
-export function getServiceWorkerScopePath(scope: string | undefined): string | null {
+export function getServiceWorkerScopePath(
+  scope: string | undefined
+): string | null {
   if (!scope) {
     return null;
   }

--- a/src/lib/browserPushState.ts
+++ b/src/lib/browserPushState.ts
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+const BROWSER_PUSH_INSTALLATION_ID_STORAGE_KEY =
+  "secpal-browser-push-installation-id";
+
+let volatileInstallationId: string | null = null;
+
+function createInstallationId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  return `browser-push-${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`;
+}
+
+function parseBrowserIdentity(userAgent: string): {
+  browserName: string;
+  browserVersion: string | null;
+} {
+  const candidates: Array<{
+    browserName: string;
+    pattern: RegExp;
+  }> = [
+    { browserName: "Edge", pattern: /Edg\/([\d.]+)/ },
+    { browserName: "Chrome", pattern: /Chrome\/([\d.]+)/ },
+    { browserName: "Firefox", pattern: /Firefox\/([\d.]+)/ },
+    { browserName: "Safari", pattern: /Version\/([\d.]+).*Safari/ },
+  ];
+
+  for (const candidate of candidates) {
+    const match = userAgent.match(candidate.pattern);
+
+    if (match) {
+      return {
+        browserName: candidate.browserName,
+        browserVersion: match[1] ?? null,
+      };
+    }
+  }
+
+  return {
+    browserName: "Browser",
+    browserVersion: null,
+  };
+}
+
+export function peekBrowserPushInstallationId(): string | null {
+  if (typeof localStorage === "undefined") {
+    return volatileInstallationId;
+  }
+
+  try {
+    const storedValue = localStorage.getItem(
+      BROWSER_PUSH_INSTALLATION_ID_STORAGE_KEY
+    );
+
+    return storedValue && storedValue.trim().length > 0 ? storedValue : null;
+  } catch {
+    return volatileInstallationId;
+  }
+}
+
+export function getOrCreateBrowserPushInstallationId(): string {
+  const existingInstallationId = peekBrowserPushInstallationId();
+
+  if (existingInstallationId) {
+    return existingInstallationId;
+  }
+
+  const createdInstallationId = createInstallationId();
+
+  if (typeof localStorage === "undefined") {
+    volatileInstallationId = createdInstallationId;
+    return createdInstallationId;
+  }
+
+  try {
+    localStorage.setItem(
+      BROWSER_PUSH_INSTALLATION_ID_STORAGE_KEY,
+      createdInstallationId
+    );
+  } catch {
+    volatileInstallationId = createdInstallationId;
+  }
+
+  return createdInstallationId;
+}
+
+export function clearBrowserPushInstallationId(): void {
+  volatileInstallationId = null;
+
+  if (typeof localStorage === "undefined") {
+    return;
+  }
+
+  try {
+    localStorage.removeItem(BROWSER_PUSH_INSTALLATION_ID_STORAGE_KEY);
+  } catch {
+    // Ignore storage cleanup failures and rely on the in-memory fallback.
+  }
+}
+
+export function getBrowserPushClientMetadata(
+  userAgent = typeof navigator === "undefined" ? "" : navigator.userAgent
+): {
+  browserName: string;
+  browserVersion: string | null;
+  installationName: string;
+} {
+  const { browserName, browserVersion } = parseBrowserIdentity(userAgent);
+
+  return {
+    browserName,
+    browserVersion,
+    installationName: `${browserName} browser notifications`.slice(0, 120),
+  };
+}
+
+export function getServiceWorkerScopePath(scope: string | undefined): string | null {
+  if (!scope) {
+    return null;
+  }
+
+  try {
+    return new URL(scope).pathname || "/";
+  } catch {
+    return scope;
+  }
+}

--- a/src/lib/browserPushState.ts
+++ b/src/lib/browserPushState.ts
@@ -58,7 +58,9 @@ export function peekBrowserPushInstallationId(): string | null {
       BROWSER_PUSH_INSTALLATION_ID_STORAGE_KEY
     );
 
-    return storedValue && storedValue.trim().length > 0 ? storedValue : null;
+    return storedValue && storedValue.trim().length > 0
+      ? storedValue
+      : volatileInstallationId;
   } catch {
     return volatileInstallationId;
   }

--- a/src/lib/browserPushState.ts
+++ b/src/lib/browserPushState.ts
@@ -7,11 +7,18 @@ const BROWSER_PUSH_INSTALLATION_ID_STORAGE_KEY =
 let volatileInstallationId: string | null = null;
 
 function createInstallationId(): string {
-  if (
-    typeof crypto !== "undefined" &&
-    typeof crypto.randomUUID === "function"
-  ) {
-    return crypto.randomUUID();
+  if (typeof crypto !== "undefined") {
+    if (typeof crypto.randomUUID === "function") {
+      return crypto.randomUUID();
+    }
+
+    if (typeof crypto.getRandomValues === "function") {
+      const randomBytes = new Uint8Array(16);
+
+      crypto.getRandomValues(randomBytes);
+
+      return `browser-push-${Array.from(randomBytes, (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+    }
   }
 
   return `browser-push-${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`;

--- a/src/lib/browserPushState.ts
+++ b/src/lib/browserPushState.ts
@@ -5,6 +5,7 @@ const BROWSER_PUSH_INSTALLATION_ID_STORAGE_KEY =
   "secpal-browser-push-installation-id";
 
 let volatileInstallationId: string | null = null;
+let browserPushLogoutInProgress = false;
 
 function createInstallationId(): string {
   if (typeof crypto !== "undefined") {
@@ -111,6 +112,14 @@ export function clearBrowserPushInstallationId(): void {
   } catch {
     // Ignore storage cleanup failures and rely on the in-memory fallback.
   }
+}
+
+export function isBrowserPushLogoutInProgress(): boolean {
+  return browserPushLogoutInProgress;
+}
+
+export function setBrowserPushLogoutInProgress(inProgress: boolean): void {
+  browserPushLogoutInProgress = inProgress;
 }
 
 export function getBrowserPushClientMetadata(

--- a/src/lib/clientStateCleanup.test.ts
+++ b/src/lib/clientStateCleanup.test.ts
@@ -4,6 +4,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "./db";
 import {
+  getOrCreateBrowserPushInstallationId,
+  peekBrowserPushInstallationId,
+} from "./browserPushState";
+import {
   clearSensitiveClientState,
   SENSITIVE_CACHE_NAMES,
 } from "./clientStateCleanup";
@@ -12,6 +16,14 @@ import { AUTH_VAULT_STORAGE_KEY } from "./offlineVault";
 const mockCaches = {
   keys: vi.fn(),
   delete: vi.fn(),
+};
+
+const mockPushSubscription = {
+  unsubscribe: vi.fn().mockResolvedValue(true),
+};
+
+const mockPushManager = {
+  getSubscription: vi.fn(),
 };
 
 describe("clearSensitiveClientState", () => {
@@ -26,6 +38,20 @@ describe("clearSensitiveClientState", () => {
 
     // @ts-expect-error Test cache API mock
     globalThis.caches = mockCaches;
+
+    Object.defineProperty(navigator, "serviceWorker", {
+      value: {
+        ready: Promise.resolve({
+          pushManager: mockPushManager,
+        }),
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    mockCaches.keys.mockResolvedValue([]);
+    mockCaches.delete.mockResolvedValue(true);
+    mockPushManager.getSubscription.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -151,5 +177,17 @@ describe("clearSensitiveClientState", () => {
     delete globalThis.caches;
 
     await expect(clearSensitiveClientState()).resolves.not.toThrow();
+  });
+
+  it("unsubscribes the existing browser push subscription and clears the local installation id", async () => {
+    const installationId = getOrCreateBrowserPushInstallationId();
+
+    mockPushManager.getSubscription.mockResolvedValueOnce(mockPushSubscription);
+
+    await clearSensitiveClientState();
+
+    expect(mockPushSubscription.unsubscribe).toHaveBeenCalledTimes(1);
+    expect(installationId).not.toBeNull();
+    expect(peekBrowserPushInstallationId()).toBeNull();
   });
 });

--- a/src/lib/clientStateCleanup.ts
+++ b/src/lib/clientStateCleanup.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { db } from "./db";
+import { clearBrowserPushInstallationId } from "./browserPushState";
 import {
   AUTH_VAULT_STORAGE_KEY,
   clearOfflineVaultSession,
@@ -59,6 +60,40 @@ async function clearSensitiveIndexedDbState(): Promise<void> {
   }
 }
 
+async function clearBrowserPushClientState(): Promise<void> {
+  clearBrowserPushInstallationId();
+
+  if (
+    typeof navigator === "undefined" ||
+    navigator.serviceWorker === undefined
+  ) {
+    return;
+  }
+
+  try {
+    const registration = await navigator.serviceWorker.ready;
+
+    if (
+      registration === undefined ||
+      registration.pushManager === undefined ||
+      typeof registration.pushManager.getSubscription !== "function"
+    ) {
+      return;
+    }
+
+    const subscription = await registration.pushManager.getSubscription();
+
+    if (subscription) {
+      await subscription.unsubscribe();
+    }
+  } catch (error) {
+    console.warn(
+      "Failed to clear browser push subscription during logout:",
+      error
+    );
+  }
+}
+
 export async function clearSensitiveClientState(): Promise<void> {
   clearOfflineVaultSession();
 
@@ -68,5 +103,9 @@ export async function clearSensitiveClientState(): Promise<void> {
 
   sessionStorage.clear();
 
-  await Promise.all([clearSensitiveCaches(), clearSensitiveIndexedDbState()]);
+  await Promise.all([
+    clearBrowserPushClientState(),
+    clearSensitiveCaches(),
+    clearSensitiveIndexedDbState(),
+  ]);
 }

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -17,6 +17,7 @@ const {
   mockRevokeBrowserNotificationInstallation,
   mockPeekBrowserPushInstallationId,
   mockClearBrowserPushInstallationId,
+  mockSetBrowserPushLogoutInProgress,
 } = vi.hoisted(() => ({
   mockBrowserLogin: vi.fn(),
   mockBrowserLogout: vi.fn(),
@@ -25,6 +26,7 @@ const {
   mockRevokeBrowserNotificationInstallation: vi.fn(),
   mockPeekBrowserPushInstallationId: vi.fn(),
   mockClearBrowserPushInstallationId: vi.fn(),
+  mockSetBrowserPushLogoutInProgress: vi.fn(),
 }));
 
 vi.mock("./authApi", async () => {
@@ -51,6 +53,7 @@ vi.mock("../lib/browserPushState", async () => {
     ...actual,
     peekBrowserPushInstallationId: mockPeekBrowserPushInstallationId,
     clearBrowserPushInstallationId: mockClearBrowserPushInstallationId,
+    setBrowserPushLogoutInProgress: mockSetBrowserPushLogoutInProgress,
   };
 });
 
@@ -478,6 +481,24 @@ describe("authTransport", () => {
     expect(revokeCallOrder).toBeDefined();
     expect(logoutCallOrder).toBeDefined();
     expect(revokeCallOrder ?? 0).toBeLessThan(logoutCallOrder ?? 0);
+  });
+
+  it("marks browser push logout in progress for browser-session logout", async () => {
+    mockPeekBrowserPushInstallationId.mockReturnValueOnce("installation-1");
+    mockRevokeBrowserNotificationInstallation.mockResolvedValueOnce({
+      installation_id: "installation-1",
+      channel: "web_push",
+    });
+    mockBrowserLogout.mockResolvedValueOnce(undefined);
+
+    const transport = getAuthTransport();
+    await transport.logout();
+
+    expect(mockSetBrowserPushLogoutInProgress).toHaveBeenNthCalledWith(1, true);
+    expect(mockSetBrowserPushLogoutInProgress).toHaveBeenNthCalledWith(
+      2,
+      false
+    );
   });
 
   it("continues browser-session logout when push revocation fails", async () => {

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -458,7 +458,9 @@ describe("authTransport", () => {
   });
 
   it("revokes the browser push installation before browser-session logout", async () => {
-    mockPeekBrowserPushInstallationId.mockReturnValueOnce("installation-1");
+    mockPeekBrowserPushInstallationId
+      .mockReturnValueOnce("installation-1")
+      .mockReturnValueOnce("installation-1");
     mockRevokeBrowserNotificationInstallation.mockResolvedValueOnce({
       installation_id: "installation-1",
       channel: "web_push",
@@ -484,7 +486,9 @@ describe("authTransport", () => {
   });
 
   it("marks browser push logout in progress for browser-session logout", async () => {
-    mockPeekBrowserPushInstallationId.mockReturnValueOnce("installation-1");
+    mockPeekBrowserPushInstallationId
+      .mockReturnValueOnce("installation-1")
+      .mockReturnValueOnce("installation-1");
     mockRevokeBrowserNotificationInstallation.mockResolvedValueOnce({
       installation_id: "installation-1",
       channel: "web_push",
@@ -505,7 +509,9 @@ describe("authTransport", () => {
     const revokeError = new Error("Push revoke failed");
     const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    mockPeekBrowserPushInstallationId.mockReturnValueOnce("installation-1");
+    mockPeekBrowserPushInstallationId
+      .mockReturnValueOnce("installation-1")
+      .mockReturnValueOnce("installation-1");
     mockRevokeBrowserNotificationInstallation.mockRejectedValueOnce(
       revokeError
     );
@@ -559,6 +565,42 @@ describe("authTransport", () => {
     }
   });
 
+  it("does not clear a newer browser push installation after stale logout revocation settles", async () => {
+    let currentInstallationId: string | null = "installation-1";
+    let resolveRevocation: (() => void) | null = null;
+
+    mockPeekBrowserPushInstallationId.mockImplementation(
+      () => currentInstallationId
+    );
+    mockRevokeBrowserNotificationInstallation.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRevocation = resolve;
+        })
+    );
+    mockBrowserLogout.mockResolvedValueOnce(undefined);
+
+    vi.useFakeTimers();
+
+    try {
+      const transport = getAuthTransport();
+      const logoutPromise = transport.logout();
+
+      await vi.advanceTimersByTimeAsync(1000);
+      await expect(logoutPromise).resolves.toBeUndefined();
+
+      currentInstallationId = "installation-2";
+      resolveRevocation?.();
+      await Promise.resolve();
+
+      expect(mockClearBrowserPushInstallationId).not.toHaveBeenCalled();
+      expect(mockBrowserLogout).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+      mockPeekBrowserPushInstallationId.mockReturnValue(undefined);
+    }
+  });
+
   it("delegates browser-session logoutAll to the authApi", async () => {
     mockBrowserLogoutAll.mockResolvedValueOnce(undefined);
 
@@ -569,7 +611,9 @@ describe("authTransport", () => {
   });
 
   it("revokes the browser push installation before browser-session logoutAll", async () => {
-    mockPeekBrowserPushInstallationId.mockReturnValueOnce("installation-2");
+    mockPeekBrowserPushInstallationId
+      .mockReturnValueOnce("installation-2")
+      .mockReturnValueOnce("installation-2");
     mockRevokeBrowserNotificationInstallation.mockResolvedValueOnce({
       installation_id: "installation-2",
       channel: "web_push",
@@ -598,7 +642,9 @@ describe("authTransport", () => {
     const revokeError = new Error("Push revoke failed");
     const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    mockPeekBrowserPushInstallationId.mockReturnValueOnce("installation-2");
+    mockPeekBrowserPushInstallationId
+      .mockReturnValueOnce("installation-2")
+      .mockReturnValueOnce("installation-2");
     mockRevokeBrowserNotificationInstallation.mockRejectedValueOnce(
       revokeError
     );

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -567,7 +567,9 @@ describe("authTransport", () => {
 
   it("does not clear a newer browser push installation after stale logout revocation settles", async () => {
     let currentInstallationId: string | null = "installation-1";
-    let resolveRevocation: (() => void) | null = null;
+    const revocationControls: { resolve: (() => void) | null } = {
+      resolve: null,
+    };
 
     mockPeekBrowserPushInstallationId.mockImplementation(
       () => currentInstallationId
@@ -575,7 +577,7 @@ describe("authTransport", () => {
     mockRevokeBrowserNotificationInstallation.mockImplementationOnce(
       () =>
         new Promise<void>((resolve) => {
-          resolveRevocation = resolve;
+          revocationControls.resolve = resolve;
         })
     );
     mockBrowserLogout.mockResolvedValueOnce(undefined);
@@ -590,7 +592,7 @@ describe("authTransport", () => {
       await expect(logoutPromise).resolves.toBeUndefined();
 
       currentInstallationId = "installation-2";
-      resolveRevocation?.();
+      revocationControls.resolve?.();
       await Promise.resolve();
 
       expect(mockClearBrowserPushInstallationId).not.toHaveBeenCalled();

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -509,6 +509,35 @@ describe("authTransport", () => {
     expect(mockBrowserLogout).toHaveBeenCalledOnce();
   });
 
+  it("does not block browser-session logout when push revocation stalls", async () => {
+    mockPeekBrowserPushInstallationId.mockReturnValueOnce("installation-1");
+    mockRevokeBrowserNotificationInstallation.mockImplementationOnce(
+      () => new Promise(() => {})
+    );
+    mockBrowserLogout.mockResolvedValueOnce(undefined);
+
+    vi.useFakeTimers();
+
+    try {
+      let logoutResolved = false;
+
+      const transport = getAuthTransport();
+      const logoutPromise = transport.logout().then(() => {
+        logoutResolved = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(1000);
+      await Promise.resolve();
+
+      expect(mockBrowserLogout).toHaveBeenCalledOnce();
+      expect(logoutResolved).toBe(true);
+
+      await logoutPromise;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("delegates browser-session logoutAll to the authApi", async () => {
     mockBrowserLogoutAll.mockResolvedValueOnce(undefined);
 

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -489,6 +489,32 @@ describe("authTransport", () => {
     expect(mockBrowserLogoutAll).toHaveBeenCalledOnce();
   });
 
+  it("revokes the browser push installation before browser-session logoutAll", async () => {
+    mockPeekBrowserPushInstallationId.mockReturnValueOnce("installation-2");
+    mockRevokeBrowserNotificationInstallation.mockResolvedValueOnce({
+      installation_id: "installation-2",
+      channel: "web_push",
+    });
+    mockBrowserLogoutAll.mockResolvedValueOnce(undefined);
+
+    const transport = getAuthTransport();
+    await transport.logoutAll();
+
+    expect(mockRevokeBrowserNotificationInstallation).toHaveBeenCalledWith(
+      "installation-2"
+    );
+    expect(mockClearBrowserPushInstallationId).toHaveBeenCalledOnce();
+    expect(mockBrowserLogoutAll).toHaveBeenCalledOnce();
+
+    const revokeCallOrder =
+      mockRevokeBrowserNotificationInstallation.mock.invocationCallOrder[0];
+    const logoutAllCallOrder = mockBrowserLogoutAll.mock.invocationCallOrder[0];
+
+    expect(revokeCallOrder).toBeDefined();
+    expect(logoutAllCallOrder).toBeDefined();
+    expect(revokeCallOrder ?? 0).toBeLessThan(logoutAllCallOrder ?? 0);
+  });
+
   it("delegates browser-session getCurrentUser to the authApi and sanitizes the payload", async () => {
     mockBrowserGetCurrentUser.mockResolvedValueOnce({
       id: 2,

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -480,6 +480,35 @@ describe("authTransport", () => {
     expect(revokeCallOrder ?? 0).toBeLessThan(logoutCallOrder ?? 0);
   });
 
+  it("continues browser-session logout when push revocation fails", async () => {
+    const revokeError = new Error("Push revoke failed");
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    mockPeekBrowserPushInstallationId.mockReturnValueOnce("installation-1");
+    mockRevokeBrowserNotificationInstallation.mockRejectedValueOnce(
+      revokeError
+    );
+    mockBrowserLogout.mockResolvedValueOnce(undefined);
+
+    try {
+      const transport = getAuthTransport();
+
+      await expect(transport.logout()).resolves.toBeUndefined();
+      expect(consoleWarn).toHaveBeenCalledWith(
+        "Failed to revoke browser push installation during logout:",
+        revokeError
+      );
+    } finally {
+      consoleWarn.mockRestore();
+    }
+
+    expect(mockRevokeBrowserNotificationInstallation).toHaveBeenCalledWith(
+      "installation-1"
+    );
+    expect(mockClearBrowserPushInstallationId).toHaveBeenCalledOnce();
+    expect(mockBrowserLogout).toHaveBeenCalledOnce();
+  });
+
   it("delegates browser-session logoutAll to the authApi", async () => {
     mockBrowserLogoutAll.mockResolvedValueOnce(undefined);
 
@@ -513,6 +542,35 @@ describe("authTransport", () => {
     expect(revokeCallOrder).toBeDefined();
     expect(logoutAllCallOrder).toBeDefined();
     expect(revokeCallOrder ?? 0).toBeLessThan(logoutAllCallOrder ?? 0);
+  });
+
+  it("continues browser-session logoutAll when push revocation fails", async () => {
+    const revokeError = new Error("Push revoke failed");
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    mockPeekBrowserPushInstallationId.mockReturnValueOnce("installation-2");
+    mockRevokeBrowserNotificationInstallation.mockRejectedValueOnce(
+      revokeError
+    );
+    mockBrowserLogoutAll.mockResolvedValueOnce(undefined);
+
+    try {
+      const transport = getAuthTransport();
+
+      await expect(transport.logoutAll()).resolves.toBeUndefined();
+      expect(consoleWarn).toHaveBeenCalledWith(
+        "Failed to revoke browser push installation during logout:",
+        revokeError
+      );
+    } finally {
+      consoleWarn.mockRestore();
+    }
+
+    expect(mockRevokeBrowserNotificationInstallation).toHaveBeenCalledWith(
+      "installation-2"
+    );
+    expect(mockClearBrowserPushInstallationId).toHaveBeenCalledOnce();
+    expect(mockBrowserLogoutAll).toHaveBeenCalledOnce();
   });
 
   it("delegates browser-session getCurrentUser to the authApi and sanitizes the payload", async () => {

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -14,11 +14,17 @@ const {
   mockBrowserLogout,
   mockBrowserLogoutAll,
   mockBrowserGetCurrentUser,
+  mockRevokeBrowserNotificationInstallation,
+  mockPeekBrowserPushInstallationId,
+  mockClearBrowserPushInstallationId,
 } = vi.hoisted(() => ({
   mockBrowserLogin: vi.fn(),
   mockBrowserLogout: vi.fn(),
   mockBrowserLogoutAll: vi.fn(),
   mockBrowserGetCurrentUser: vi.fn(),
+  mockRevokeBrowserNotificationInstallation: vi.fn(),
+  mockPeekBrowserPushInstallationId: vi.fn(),
+  mockClearBrowserPushInstallationId: vi.fn(),
 }));
 
 vi.mock("./authApi", async () => {
@@ -30,6 +36,21 @@ vi.mock("./authApi", async () => {
     logout: mockBrowserLogout,
     logoutAll: mockBrowserLogoutAll,
     getCurrentUser: mockBrowserGetCurrentUser,
+  };
+});
+
+vi.mock("./notificationInstallationsApi", () => ({
+  revokeBrowserNotificationInstallation:
+    mockRevokeBrowserNotificationInstallation,
+}));
+
+vi.mock("../lib/browserPushState", async () => {
+  const actual = await vi.importActual("../lib/browserPushState");
+
+  return {
+    ...actual,
+    peekBrowserPushInstallationId: mockPeekBrowserPushInstallationId,
+    clearBrowserPushInstallationId: mockClearBrowserPushInstallationId,
   };
 });
 
@@ -431,6 +452,32 @@ describe("authTransport", () => {
     await transport.logout();
 
     expect(mockBrowserLogout).toHaveBeenCalledOnce();
+  });
+
+  it("revokes the browser push installation before browser-session logout", async () => {
+    mockPeekBrowserPushInstallationId.mockReturnValueOnce("installation-1");
+    mockRevokeBrowserNotificationInstallation.mockResolvedValueOnce({
+      installation_id: "installation-1",
+      channel: "web_push",
+    });
+    mockBrowserLogout.mockResolvedValueOnce(undefined);
+
+    const transport = getAuthTransport();
+    await transport.logout();
+
+    expect(mockRevokeBrowserNotificationInstallation).toHaveBeenCalledWith(
+      "installation-1"
+    );
+    expect(mockClearBrowserPushInstallationId).toHaveBeenCalledOnce();
+    expect(mockBrowserLogout).toHaveBeenCalledOnce();
+
+    const revokeCallOrder =
+      mockRevokeBrowserNotificationInstallation.mock.invocationCallOrder[0];
+    const logoutCallOrder = mockBrowserLogout.mock.invocationCallOrder[0];
+
+    expect(revokeCallOrder).toBeDefined();
+    expect(logoutCallOrder).toBeDefined();
+    expect(revokeCallOrder ?? 0).toBeLessThan(logoutCallOrder ?? 0);
   });
 
   it("delegates browser-session logoutAll to the authApi", async () => {

--- a/src/services/authTransport.ts
+++ b/src/services/authTransport.ts
@@ -122,8 +122,16 @@ async function revokeBrowserPushInstallationForLogout(): Promise<void> {
     return;
   }
 
-  await revokeBrowserNotificationInstallation(installationId);
-  clearBrowserPushInstallationId();
+  try {
+    await revokeBrowserNotificationInstallation(installationId);
+  } catch (error) {
+    console.warn(
+      "Failed to revoke browser push installation during logout:",
+      error
+    );
+  } finally {
+    clearBrowserPushInstallationId();
+  }
 }
 
 const browserSessionAuthTransport: AuthTransport = {

--- a/src/services/authTransport.ts
+++ b/src/services/authTransport.ts
@@ -6,6 +6,7 @@ import type { User } from "../contexts/auth-context";
 import {
   clearBrowserPushInstallationId,
   peekBrowserPushInstallationId,
+  setBrowserPushLogoutInProgress,
 } from "../lib/browserPushState";
 import {
   AuthApiError,
@@ -189,6 +190,7 @@ const browserSessionAuthTransport: AuthTransport = {
     );
   },
   async logout(): Promise<void> {
+    setBrowserPushLogoutInProgress(true);
     const pushRevocation = revokeBrowserPushInstallationForLogout();
 
     try {
@@ -196,10 +198,15 @@ const browserSessionAuthTransport: AuthTransport = {
         await waitForPushRevocationToSettle(pushRevocation);
       }
     } finally {
-      await logoutBrowserSession();
+      try {
+        await logoutBrowserSession();
+      } finally {
+        setBrowserPushLogoutInProgress(false);
+      }
     }
   },
   async logoutAll(): Promise<void> {
+    setBrowserPushLogoutInProgress(true);
     const pushRevocation = revokeBrowserPushInstallationForLogout();
 
     try {
@@ -207,7 +214,11 @@ const browserSessionAuthTransport: AuthTransport = {
         await waitForPushRevocationToSettle(pushRevocation);
       }
     } finally {
-      await logoutAllBrowserSessions();
+      try {
+        await logoutAllBrowserSessions();
+      } finally {
+        setBrowserPushLogoutInProgress(false);
+      }
     }
   },
   async getCurrentUser(): Promise<User> {

--- a/src/services/authTransport.ts
+++ b/src/services/authTransport.ts
@@ -123,12 +123,15 @@ function revokeBrowserPushInstallationForLogout(): Promise<void> | null {
   }
 
   return revokeBrowserNotificationInstallation(installationId)
-    .catch((error: unknown) => {
-      console.warn(
-        "Failed to revoke browser push installation during logout:",
-        error
-      );
-    })
+    .then(
+      () => undefined,
+      (error: unknown) => {
+        console.warn(
+          "Failed to revoke browser push installation during logout:",
+          error
+        );
+      }
+    )
     .finally(() => {
       clearBrowserPushInstallationId();
     });

--- a/src/services/authTransport.ts
+++ b/src/services/authTransport.ts
@@ -59,6 +59,8 @@ export interface AuthTransport {
   isNetworkAvailable(): Promise<boolean>;
 }
 
+const BROWSER_PUSH_LOGOUT_REVOCATION_TIMEOUT_MS = 1000;
+
 async function finalizeAuthenticatedLogin(
   payload: unknown,
   loginOperation: string,
@@ -115,6 +117,28 @@ function sanitizeAuthPayload(payload: unknown, operation: string): User {
   return sanitizedUser;
 }
 
+async function waitForPushRevocationToSettle(
+  pushRevocation: Promise<void>
+): Promise<void> {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  try {
+    await Promise.race([
+      pushRevocation,
+      new Promise<void>((resolve) => {
+        timeoutId = setTimeout(
+          resolve,
+          BROWSER_PUSH_LOGOUT_REVOCATION_TIMEOUT_MS
+        );
+      }),
+    ]);
+  } finally {
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
 function revokeBrowserPushInstallationForLogout(): Promise<void> | null {
   const installationId = peekBrowserPushInstallationId();
 
@@ -169,7 +193,7 @@ const browserSessionAuthTransport: AuthTransport = {
 
     try {
       if (pushRevocation) {
-        await pushRevocation;
+        await waitForPushRevocationToSettle(pushRevocation);
       }
     } finally {
       await logoutBrowserSession();
@@ -180,7 +204,7 @@ const browserSessionAuthTransport: AuthTransport = {
 
     try {
       if (pushRevocation) {
-        await pushRevocation;
+        await waitForPushRevocationToSettle(pushRevocation);
       }
     } finally {
       await logoutAllBrowserSessions();

--- a/src/services/authTransport.ts
+++ b/src/services/authTransport.ts
@@ -158,7 +158,9 @@ function revokeBrowserPushInstallationForLogout(): Promise<void> | null {
       }
     )
     .finally(() => {
-      clearBrowserPushInstallationId();
+      if (peekBrowserPushInstallationId() === installationId) {
+        clearBrowserPushInstallationId();
+      }
     });
 }
 

--- a/src/services/authTransport.ts
+++ b/src/services/authTransport.ts
@@ -115,23 +115,23 @@ function sanitizeAuthPayload(payload: unknown, operation: string): User {
   return sanitizedUser;
 }
 
-async function revokeBrowserPushInstallationForLogout(): Promise<void> {
+function revokeBrowserPushInstallationForLogout(): Promise<void> | null {
   const installationId = peekBrowserPushInstallationId();
 
   if (!installationId) {
-    return;
+    return null;
   }
 
-  try {
-    await revokeBrowserNotificationInstallation(installationId);
-  } catch (error) {
-    console.warn(
-      "Failed to revoke browser push installation during logout:",
-      error
-    );
-  } finally {
-    clearBrowserPushInstallationId();
-  }
+  return revokeBrowserNotificationInstallation(installationId)
+    .catch((error: unknown) => {
+      console.warn(
+        "Failed to revoke browser push installation during logout:",
+        error
+      );
+    })
+    .finally(() => {
+      clearBrowserPushInstallationId();
+    });
 }
 
 const browserSessionAuthTransport: AuthTransport = {
@@ -162,15 +162,23 @@ const browserSessionAuthTransport: AuthTransport = {
     );
   },
   async logout(): Promise<void> {
+    const pushRevocation = revokeBrowserPushInstallationForLogout();
+
     try {
-      await revokeBrowserPushInstallationForLogout();
+      if (pushRevocation) {
+        await pushRevocation;
+      }
     } finally {
       await logoutBrowserSession();
     }
   },
   async logoutAll(): Promise<void> {
+    const pushRevocation = revokeBrowserPushInstallationForLogout();
+
     try {
-      await revokeBrowserPushInstallationForLogout();
+      if (pushRevocation) {
+        await pushRevocation;
+      }
     } finally {
       await logoutAllBrowserSessions();
     }

--- a/src/services/authTransport.ts
+++ b/src/services/authTransport.ts
@@ -161,7 +161,11 @@ const browserSessionAuthTransport: AuthTransport = {
     }
   },
   async logoutAll(): Promise<void> {
-    await logoutAllBrowserSessions();
+    try {
+      await revokeBrowserPushInstallationForLogout();
+    } finally {
+      await logoutAllBrowserSessions();
+    }
   },
   async getCurrentUser(): Promise<User> {
     const user = await getBrowserSessionCurrentUser();

--- a/src/services/authTransport.ts
+++ b/src/services/authTransport.ts
@@ -4,12 +4,17 @@
 import type { LoginMfaChallengeResponse, MfaChallenge } from "@/types/api";
 import type { User } from "../contexts/auth-context";
 import {
+  clearBrowserPushInstallationId,
+  peekBrowserPushInstallationId,
+} from "../lib/browserPushState";
+import {
   AuthApiError,
   getCurrentUser as getBrowserSessionCurrentUser,
   login as loginWithBrowserSession,
   logout as logoutBrowserSession,
   logoutAll as logoutAllBrowserSessions,
 } from "./authApi";
+import { revokeBrowserNotificationInstallation } from "./notificationInstallationsApi";
 import { sanitizeAuthUser } from "./authState";
 import { isOnline } from "./sessionEvents";
 
@@ -110,6 +115,17 @@ function sanitizeAuthPayload(payload: unknown, operation: string): User {
   return sanitizedUser;
 }
 
+async function revokeBrowserPushInstallationForLogout(): Promise<void> {
+  const installationId = peekBrowserPushInstallationId();
+
+  if (!installationId) {
+    return;
+  }
+
+  await revokeBrowserNotificationInstallation(installationId);
+  clearBrowserPushInstallationId();
+}
+
 const browserSessionAuthTransport: AuthTransport = {
   kind: "browser-session",
   async login(credentials): Promise<AuthLoginResult> {
@@ -138,7 +154,11 @@ const browserSessionAuthTransport: AuthTransport = {
     );
   },
   async logout(): Promise<void> {
-    await logoutBrowserSession();
+    try {
+      await revokeBrowserPushInstallationForLogout();
+    } finally {
+      await logoutBrowserSession();
+    }
   },
   async logoutAll(): Promise<void> {
     await logoutAllBrowserSessions();

--- a/src/services/notificationInstallationsApi.ts
+++ b/src/services/notificationInstallationsApi.ts
@@ -90,13 +90,16 @@ async function createNotificationInstallationsApiError(
 }
 
 export async function getBrowserPushBootstrapData(): Promise<BrowserPushBootstrapData | null> {
-  const response = await apiFetch(buildApiUrl("/v1/bootstrap?client_platform=browser"), {
-    method: "GET",
-    cache: "no-store",
-    headers: {
-      Accept: "application/json",
-    },
-  });
+  const response = await apiFetch(
+    buildApiUrl("/v1/bootstrap?client_platform=browser"),
+    {
+      method: "GET",
+      cache: "no-store",
+      headers: {
+        Accept: "application/json",
+      },
+    }
+  );
 
   if (!response.ok) {
     throw await createNotificationInstallationsApiError(
@@ -139,10 +142,11 @@ export async function upsertBrowserNotificationInstallation(
     );
   }
 
-  const result = await parseJsonResponse<BrowserNotificationInstallationResponse>(
-    response,
-    "Browser notification installation update failed"
-  );
+  const result =
+    await parseJsonResponse<BrowserNotificationInstallationResponse>(
+      response,
+      "Browser notification installation update failed"
+    );
 
   return result.data;
 }

--- a/src/services/notificationInstallationsApi.ts
+++ b/src/services/notificationInstallationsApi.ts
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type {
+  BrowserNotificationInstallationRequest,
+  BrowserNotificationInstallationResponse,
+  BrowserNotificationInstallationRevocationResponse,
+  BrowserPushBootstrapData,
+  BrowserPushBootstrapResponse,
+} from "@/types/api";
+import { buildApiUrl } from "../config";
+import { apiFetch } from "./csrf";
+
+interface NotificationApiErrorPayload {
+  message?: string;
+  code?: string;
+  details?: Record<string, unknown>;
+}
+
+function hasJsonContentType(response: Response): boolean {
+  const contentType = response.headers.get("Content-Type");
+
+  return contentType?.toLowerCase().includes("application/json") ?? false;
+}
+
+async function parseJsonResponse<T>(
+  response: Response,
+  operation: string
+): Promise<T> {
+  if (!hasJsonContentType(response)) {
+    throw new NotificationInstallationsApiError(
+      `${operation}: expected application/json response from API`
+    );
+  }
+
+  try {
+    return (await response.json()) as T;
+  } catch {
+    throw new NotificationInstallationsApiError(
+      `${operation}: received malformed JSON from API`
+    );
+  }
+}
+
+async function parseJsonError(
+  response: Response
+): Promise<NotificationApiErrorPayload | null> {
+  if (!hasJsonContentType(response)) {
+    return null;
+  }
+
+  try {
+    return (await response.json()) as NotificationApiErrorPayload;
+  } catch {
+    return null;
+  }
+}
+
+export class NotificationInstallationsApiError extends Error {
+  constructor(
+    message: string,
+    public status?: number,
+    public code?: string,
+    public details?: Record<string, unknown>
+  ) {
+    super(message);
+    this.name = "NotificationInstallationsApiError";
+  }
+}
+
+async function createNotificationInstallationsApiError(
+  response: Response,
+  defaultMessage: string
+): Promise<NotificationInstallationsApiError> {
+  const error = await parseJsonError(response);
+
+  if (!error) {
+    return new NotificationInstallationsApiError(
+      `${defaultMessage}: ${response.status} ${response.statusText}`,
+      response.status
+    );
+  }
+
+  return new NotificationInstallationsApiError(
+    error.message || defaultMessage,
+    response.status,
+    error.code,
+    error.details
+  );
+}
+
+export async function getBrowserPushBootstrapData(): Promise<BrowserPushBootstrapData | null> {
+  const response = await apiFetch(buildApiUrl("/v1/bootstrap?client_platform=browser"), {
+    method: "GET",
+    cache: "no-store",
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw await createNotificationInstallationsApiError(
+      response,
+      "Browser bootstrap fetch failed"
+    );
+  }
+
+  const payload = await parseJsonResponse<BrowserPushBootstrapResponse>(
+    response,
+    "Browser bootstrap fetch failed"
+  );
+
+  return payload.data.features.notification_channels.web_push === true
+    ? payload.data
+    : null;
+}
+
+export async function upsertBrowserNotificationInstallation(
+  installationId: string,
+  payload: BrowserNotificationInstallationRequest
+): Promise<BrowserNotificationInstallationResponse["data"]> {
+  const response = await apiFetch(
+    buildApiUrl(`/v1/me/notification-installations/${installationId}`),
+    {
+      method: "PUT",
+      cache: "no-store",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(payload),
+    }
+  );
+
+  if (!response.ok) {
+    throw await createNotificationInstallationsApiError(
+      response,
+      "Browser notification installation update failed"
+    );
+  }
+
+  const result = await parseJsonResponse<BrowserNotificationInstallationResponse>(
+    response,
+    "Browser notification installation update failed"
+  );
+
+  return result.data;
+}
+
+export async function revokeBrowserNotificationInstallation(
+  installationId: string
+): Promise<BrowserNotificationInstallationRevocationResponse["data"] | null> {
+  const response = await apiFetch(
+    buildApiUrl(`/v1/me/notification-installations/${installationId}`),
+    {
+      method: "DELETE",
+      cache: "no-store",
+      headers: {
+        Accept: "application/json",
+      },
+    }
+  );
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw await createNotificationInstallationsApiError(
+      response,
+      "Browser notification installation revoke failed"
+    );
+  }
+
+  const result =
+    await parseJsonResponse<BrowserNotificationInstallationRevocationResponse>(
+      response,
+      "Browser notification installation revoke failed"
+    );
+
+  return result.data;
+}

--- a/src/services/notificationInstallationsApi.ts
+++ b/src/services/notificationInstallationsApi.ts
@@ -18,6 +18,14 @@ interface NotificationApiErrorPayload {
 }
 
 function hasJsonContentType(response: Response): boolean {
+  if (
+    !("headers" in response) ||
+    !response.headers ||
+    typeof response.headers.get !== "function"
+  ) {
+    return typeof response.json === "function";
+  }
+
   const contentType = response.headers.get("Content-Type");
 
   return contentType?.toLowerCase().includes("application/json") ?? false;

--- a/src/types/api/index.ts
+++ b/src/types/api/index.ts
@@ -5,3 +5,4 @@ export * from "../customers";
 export * from "./android-enrollment";
 export * from "./auth";
 export * from "./employees";
+export * from "./notifications";

--- a/src/types/api/notifications.ts
+++ b/src/types/api/notifications.ts
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * Notification installation and browser bootstrap API types.
+ *
+ * Derived from the shared API contract in `contracts/docs/openapi.yaml` and
+ * aligned with the authenticated browser Web Push lifecycle.
+ */
+
+export type NotificationChannel = "android_fcm" | "web_push";
+
+export interface NotificationChannelFeatureFlags {
+  android_fcm: boolean;
+  web_push: boolean;
+}
+
+export interface BrowserBootstrapCompatibility {
+  bootstrap_version: string;
+  schema_version: number;
+  minimum_supported_app_version?: string;
+  minimum_supported_app_build?: number;
+}
+
+export interface BrowserWebPushRuntimeMetadata {
+  channel: "web_push";
+  metadata_revision: number;
+  public_runtime_metadata: {
+    vapid_public_key: string;
+  };
+}
+
+export interface BrowserPushBootstrapData {
+  client_platform: "browser" | string;
+  compatibility: BrowserBootstrapCompatibility;
+  features: {
+    notification_channels: NotificationChannelFeatureFlags;
+  };
+  notification_channels?: {
+    web_push?: BrowserWebPushRuntimeMetadata;
+  };
+}
+
+export interface BrowserPushBootstrapResponse {
+  data: BrowserPushBootstrapData;
+}
+
+export type NotificationInstallationLifecycleEvent =
+  | "registered"
+  | "credential_rotated"
+  | "client_updated";
+
+export interface BrowserNotificationInstallationRequest {
+  channel: "web_push";
+  installation_name: string;
+  lifecycle_event: NotificationInstallationLifecycleEvent;
+  runtime: {
+    bootstrap_version: string;
+    schema_version: number;
+    metadata_revision: number;
+  };
+  registration: {
+    browser: {
+      browser_name: string;
+      browser_version?: string | null;
+      service_worker_scope?: string | null;
+    };
+    subscription: {
+      endpoint: string;
+      expiration_time?: number | null;
+      keys: {
+        p256dh: string;
+        auth: string;
+      };
+    };
+  };
+}
+
+export interface BrowserNotificationInstallationSummary {
+  installation_id: string;
+  channel: "web_push";
+  installation_name: string;
+  credential_reference: string;
+  last_lifecycle_event: NotificationInstallationLifecycleEvent;
+  registration: {
+    browser: {
+      browser_name: string | null;
+      browser_version: string | null;
+      service_worker_scope: string | null;
+    };
+    subscription_endpoint_origin: string | null;
+    subscription_expires_at: string | null;
+  };
+  runtime: {
+    bootstrap_version: string;
+    schema_version: number;
+    metadata_revision: number;
+  };
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface BrowserNotificationInstallationResponse {
+  data: BrowserNotificationInstallationSummary;
+}
+
+export interface BrowserNotificationInstallationRevocationResponse {
+  data: {
+    installation_id: string;
+    channel: "web_push";
+    revoked_at: string;
+  };
+}


### PR DESCRIPTION
## Summary

- wire bootstrap-driven browser Web Push registration, stale-runtime rotation, service-worker replacement sync, and authenticated revoke flows
- remove the production VITE_VAPID_PUBLIC_KEY fallback and add typed notification-installation API helpers plus stable browser installation identity handling
- clear remote and local browser push state on denied permission, logout, and reset; update the offline-persistence audit and changelog; add focused regression coverage

## Validation

- npm exec -- vitest run src/hooks/usePushSubscription.test.ts src/hooks/useNotifications.test.ts src/services/authTransport.test.ts src/lib/clientStateCleanup.test.ts src/App.test.tsx
- npm exec -- eslint src/hooks/usePushSubscription.ts src/hooks/usePushSubscription.test.ts src/hooks/useNotifications.ts src/hooks/useNotifications.test.ts
- npm run typecheck

## Follow-up

- #1146 Investigate logout cleanup DatabaseClosedError warnings in App tests

Closes #1139

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authenticated session logout, push credential lifecycle, and cross-tab installation identity—areas where mis-sync could leave stale endpoints or block logout if mishandled; mitigated by timeouts, guards, and extensive tests.
> 
> **Overview**
> This PR replaces ad-hoc browser push setup with a **bootstrap-driven, authenticated lifecycle** tied to `/v1/bootstrap` and `/v1/me/notification-installations/{id}`. Runtime **VAPID** keys come from deployment bootstrap; the **`VITE_VAPID_PUBLIC_KEY`** production fallback is removed.
> 
> A root **`NotificationLifecycleCoordinator`** runs **`useNotifications({ autoSync: true })`** so the PWA upserts existing subscriptions on load, rotates when bootstrap metadata or the VAPID key is stale (including **`NOTIFICATION_RUNTIME_STATE_INVALID`** retries), re-syncs after **service worker** replacement, and revokes plus unsubscribes when permission is **denied**. **`authTransport`** revokes the remote installation (with a short timeout) before **`logout` / `logoutAll`**, guarded by a logout-in-progress flag so in-flight sync does not recreate installations. **`clearSensitiveClientState`** also clears the stable **`secpal-browser-push-installation-id`** and local subscription.
> 
> New pieces include **`notificationInstallationsApi`**, **`browserPushState`**, typed notification API models, changelog/audit updates for **#1139**, and broad Vitest coverage for sync, rotation, logout races, and cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77c776852ee40bfd1ca343387b0511b945e6a9e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->