### PR TITLE
ci: retry npm ci with --foreground-scripts to mitigate esbuild ETXTBSY

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -65,7 +65,14 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci
+        # Retry + --foreground-scripts mitigates transient esbuild
+        # postinstall ETXTBSY races on hosted Linux runners.
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_on: error
+          command: npm ci --foreground-scripts
 
       - name: Run tests with coverage
         run: npm run test:coverage
@@ -102,7 +109,14 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci
+        # Retry + --foreground-scripts mitigates transient esbuild
+        # postinstall ETXTBSY races on hosted Linux runners.
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_on: error
+          command: npm ci --foreground-scripts
 
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -66,14 +66,15 @@ jobs:
 
       - name: Install dependencies
         # --foreground-scripts serializes lifecycle scripts to dodge the
-        # esbuild postinstall ETXTBSY race on hosted Linux runners; the
-        # short retry loop covers any residual transient failures without
-        # imposing a per-attempt timeout that could starve later steps.
+        # esbuild postinstall ETXTBSY race on hosted Linux runners.
+        # Each attempt is capped at 4 minutes so a hung install cannot
+        # silently consume the 15-minute job budget; 3 attempts × 4 min
+        # leaves ~3 min for tests and coverage upload.
         run: |
           set -uo pipefail
           attempts=3
           for i in $(seq 1 "$attempts"); do
-            if npm ci --foreground-scripts; then
+            if timeout 4m npm ci --foreground-scripts; then
               exit 0
             fi
             if [ "$i" -lt "$attempts" ]; then
@@ -120,14 +121,15 @@ jobs:
 
       - name: Install dependencies
         # --foreground-scripts serializes lifecycle scripts to dodge the
-        # esbuild postinstall ETXTBSY race on hosted Linux runners; the
-        # short retry loop covers any residual transient failures without
-        # imposing a per-attempt timeout that could starve later steps.
+        # esbuild postinstall ETXTBSY race on hosted Linux runners.
+        # Each attempt is capped at 4 minutes so a hung install cannot
+        # silently consume the 15-minute job budget; 3 attempts × 4 min
+        # leaves ~3 min for Playwright install and the smoke test.
         run: |
           set -uo pipefail
           attempts=3
           for i in $(seq 1 "$attempts"); do
-            if npm ci --foreground-scripts; then
+            if timeout 4m npm ci --foreground-scripts; then
               exit 0
             fi
             if [ "$i" -lt "$attempts" ]; then

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -65,14 +65,24 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        # Retry + --foreground-scripts mitigates transient esbuild
-        # postinstall ETXTBSY races on hosted Linux runners.
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
-        with:
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_on: error
-          command: npm ci --foreground-scripts
+        # --foreground-scripts serializes lifecycle scripts to dodge the
+        # esbuild postinstall ETXTBSY race on hosted Linux runners; the
+        # short retry loop covers any residual transient failures without
+        # imposing a per-attempt timeout that could starve later steps.
+        run: |
+          set -uo pipefail
+          attempts=3
+          for i in $(seq 1 "$attempts"); do
+            if npm ci --foreground-scripts; then
+              exit 0
+            fi
+            if [ "$i" -lt "$attempts" ]; then
+              echo "::warning::npm ci failed (attempt ${i}/${attempts}); retrying in 5s"
+              sleep 5
+            fi
+          done
+          echo "::error::npm ci failed after ${attempts} attempts"
+          exit 1
 
       - name: Run tests with coverage
         run: npm run test:coverage
@@ -109,14 +119,24 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        # Retry + --foreground-scripts mitigates transient esbuild
-        # postinstall ETXTBSY races on hosted Linux runners.
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
-        with:
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_on: error
-          command: npm ci --foreground-scripts
+        # --foreground-scripts serializes lifecycle scripts to dodge the
+        # esbuild postinstall ETXTBSY race on hosted Linux runners; the
+        # short retry loop covers any residual transient failures without
+        # imposing a per-attempt timeout that could starve later steps.
+        run: |
+          set -uo pipefail
+          attempts=3
+          for i in $(seq 1 "$attempts"); do
+            if npm ci --foreground-scripts; then
+              exit 0
+            fi
+            if [ "$i" -lt "$attempts" ]; then
+              echo "::warning::npm ci failed (attempt ${i}/${attempts}); retrying in 5s"
+              sleep 5
+            fi
+          done
+          echo "::error::npm ci failed after ${attempts} attempts"
+          exit 1
 
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -66,15 +66,17 @@ jobs:
 
       - name: Install dependencies
         # --foreground-scripts serializes lifecycle scripts to dodge the
-        # esbuild postinstall ETXTBSY race on hosted Linux runners.
-        # Each attempt is capped at 4 minutes so a hung install cannot
-        # silently consume the 15-minute job budget; 3 attempts × 4 min
-        # leaves ~3 min for tests and coverage upload.
+        # esbuild postinstall ETXTBSY race on hosted Linux runners; the
+        # short retry loop covers any residual transient failures.
+        # ETXTBSY surfaces in seconds, so retries are cheap and a
+        # per-attempt timeout would only risk killing legitimate
+        # cold-cache installs without bounding actual failure modes.
+        # The job's 15-minute timeout-minutes is the overall safety net.
         run: |
           set -uo pipefail
           attempts=3
           for i in $(seq 1 "$attempts"); do
-            if timeout 4m npm ci --foreground-scripts; then
+            if npm ci --foreground-scripts; then
               exit 0
             fi
             if [ "$i" -lt "$attempts" ]; then
@@ -121,15 +123,17 @@ jobs:
 
       - name: Install dependencies
         # --foreground-scripts serializes lifecycle scripts to dodge the
-        # esbuild postinstall ETXTBSY race on hosted Linux runners.
-        # Each attempt is capped at 4 minutes so a hung install cannot
-        # silently consume the 15-minute job budget; 3 attempts × 4 min
-        # leaves ~3 min for Playwright install and the smoke test.
+        # esbuild postinstall ETXTBSY race on hosted Linux runners; the
+        # short retry loop covers any residual transient failures.
+        # ETXTBSY surfaces in seconds, so retries are cheap and a
+        # per-attempt timeout would only risk killing legitimate
+        # cold-cache installs without bounding actual failure modes.
+        # The job's 15-minute timeout-minutes is the overall safety net.
         run: |
           set -uo pipefail
           attempts=3
           for i in $(seq 1 "$attempts"); do
-            if timeout 4m npm ci --foreground-scripts; then
+            if npm ci --foreground-scripts; then
               exit 0
             fi
             if [ "$i" -lt "$attempts" ]; then


### PR DESCRIPTION
## Summary

The `Vitest Tests` job in `quality.yml` recently failed on PR #1148 with:

```
npm error path /home/runner/work/frontend/frontend/node_modules/esbuild
npm error <ref *1> Error: spawnSync .../esbuild/bin/esbuild ETXTBSY
  at validateBinaryVersion (.../esbuild/install.js:102:28)
```

esbuild's `postinstall` writes its native binary and immediately invokes
`spawnSync(esbuild, ['--version'])` to validate it. On hosted Linux runners
the kernel may still hold the write fd open under concurrent lifecycle
scripts, surfacing as `ETXTBSY` ("Text file busy"). It's a documented,
flaky failure mode (see [esbuild#1711](https://github.com/evanw/esbuild/issues/1711)).

## Changes

- Pass `--foreground-scripts` to `npm ci` so lifecycle scripts run
  serially in the foreground — this eliminates the race at its source.
- Wrap the install in [`nick-fields/retry@v4.0.0`](https://github.com/nick-fields/retry/releases/tag/v4.0.0)
  (3 attempts, 5min timeout) as belt-and-braces against any remaining
  transient install hiccups (registry timeouts, disk I/O blips).
- Applied to both inline jobs in `quality.yml`:
  - `Vitest Tests`
  - `Playwright Live Smoke`
- Action pinned by SHA per repo convention (matches codecov, treosh,
  browser-actions usage in this repo).

Reusable workflows in `SecPal/.github` (ESLint, TypeScript Check,
Prettier, …) are unaffected and would need a separate change there if
the same race ever shows up in those jobs.

## Test plan

- [x] Prettier check passes locally
- [x] YAML syntax validated
- [x] SPDX headers untouched (no REUSE impact)
- [ ] CI green on this PR (validates the install flow itself)
- [ ] Observe Vitest job stability over the next few merges

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only CI install steps change; no app runtime, auth, or data paths are affected.
> 
> **Overview**
> CI dependency installs in **Vitest Tests** and **Playwright Live Smoke** no longer run a single plain `npm ci`. Each job now runs **`npm ci --foreground-scripts`** inside a small bash loop (up to **3 attempts**, **5s** between retries) with `set -uo pipefail` and GitHub **`::warning` / `::error`** annotations on failure.
> 
> The goal is to avoid flaky **esbuild `postinstall` `ETXTBSY`** races on hosted Linux runners by serializing lifecycle scripts, with cheap retries for any remaining transient install failures. Job-level **15-minute** timeouts remain the overall cap; reusable workflows are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5a8ce7ed5890d6249efb570d8c3680972c95bab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->