### PR TITLE
Retry auth bootstrap before recovery UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   automatic bootstrap retry after a transient timeout or network failure before
   showing the manual session-recovery screen, and so the loading spinner no
   longer hangs when the browser goes offline between the timeout and the
-  automatic retry's bootstrap re-run.
+  automatic retry's bootstrap re-run (the dead synchronous-body offline
+  shortcut that previously swallowed the re-run without clearing
+  `isLoading` is now removed; the existing `restoreAndRevalidate` offline
+  branch handles the browser-session + offline case uniformly).
 - Fixed the offline app-lock flow so locking no longer downgrades the service-worker session gate to a logout, cross-tab `auth_vault_state` refreshes no longer get misread as an empty logout while the vault is still locked, and unlocking no longer drops the local session when the browser-session CSRF token rotates while the vault is locked, including focused storage and `useAuth` regression coverage for the lock -> background-tab activity -> unlock path.
 - Fixed the public login route so already authenticated users no longer keep seeing the login form when they hit `/login`; the app now waits for auth bootstrap, preserves the vault-unlock state there, and redirects authenticated sessions back into the app instead.
 - Fixed browser-session bootstrap persistence on authenticated `/login` loads when the `XSRF-TOKEN` cookie is missing: the frontend now refreshes the CSRF cookie before rewriting the offline auth vault, preventing the restored session from running without persisted vault state and avoiding the follow-on `Offline vault is not available` analytics noise. Added focused App and Playwright regression coverage for the missing-cookie recovery path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed protected-route browser-session recovery so the app now performs one
+  automatic bootstrap retry after a transient timeout or network failure before
+  showing the manual session-recovery screen.
 - Fixed the offline app-lock flow so locking no longer downgrades the service-worker session gate to a logout, cross-tab `auth_vault_state` refreshes no longer get misread as an empty logout while the vault is still locked, and unlocking no longer drops the local session when the browser-session CSRF token rotates while the vault is locked, including focused storage and `useAuth` regression coverage for the lock -> background-tab activity -> unlock path.
 - Fixed the public login route so already authenticated users no longer keep seeing the login form when they hit `/login`; the app now waits for auth bootstrap, preserves the vault-unlock state there, and redirects authenticated sessions back into the app instead.
 - Fixed browser-session bootstrap persistence on authenticated `/login` loads when the `XSRF-TOKEN` cookie is missing: the frontend now refreshes the CSRF cookie before rewriting the offline auth vault, preventing the restored session from running without persisted vault state and avoiding the follow-on `Offline vault is not available` analytics noise. Added focused App and Playwright regression coverage for the missing-cookie recovery path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed protected-route browser-session recovery so the app now performs one
   automatic bootstrap retry after a transient timeout or network failure before
-  showing the manual session-recovery screen.
+  showing the manual session-recovery screen, and so the loading spinner no
+  longer hangs when the browser goes offline between the timeout and the
+  automatic retry's bootstrap re-run.
 - Fixed the offline app-lock flow so locking no longer downgrades the service-worker session gate to a logout, cross-tab `auth_vault_state` refreshes no longer get misread as an empty logout while the vault is still locked, and unlocking no longer drops the local session when the browser-session CSRF token rotates while the vault is locked, including focused storage and `useAuth` regression coverage for the lock -> background-tab activity -> unlock path.
 - Fixed the public login route so already authenticated users no longer keep seeing the login form when they hit `/login`; the app now waits for auth bootstrap, preserves the vault-unlock state there, and redirects authenticated sessions back into the app instead.
 - Fixed browser-session bootstrap persistence on authenticated `/login` loads when the `XSRF-TOKEN` cookie is missing: the frontend now refreshes the CSRF cookie before rewriting the offline auth vault, preventing the restored session from running without persisted vault state and avoiding the follow-on `Offline vault is not available` analytics noise. Added focused App and Playwright regression coverage for the missing-cookie recovery path.

--- a/src/components/ProtectedRoute.test.tsx
+++ b/src/components/ProtectedRoute.test.tsx
@@ -279,8 +279,12 @@ describe("ProtectedRoute", () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it("shows a retry recovery state instead of spinning forever when bootstrap stalls", async () => {
-    mockGetCurrentUser.mockReturnValueOnce(new Promise(() => undefined));
+  it("retries bootstrap recovery automatically before showing the recovery state", async () => {
+    const stalledBootstrap = new Promise(() => undefined);
+
+    mockGetCurrentUser
+      .mockReturnValueOnce(stalledBootstrap)
+      .mockReturnValueOnce(stalledBootstrap);
 
     await persistAuthUser({
       id: 1,
@@ -291,11 +295,13 @@ describe("ProtectedRoute", () => {
 
     renderProtectedRoute();
 
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+
     expect(
       await screen.findByRole(
         "heading",
         { name: /still loading your secure session/i },
-        { timeout: BOOTSTRAP_REVALIDATION_TIMEOUT_MS + 2_000 }
+        { timeout: BOOTSTRAP_REVALIDATION_TIMEOUT_MS * 2 + 2_000 }
       )
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
@@ -304,12 +310,48 @@ describe("ProtectedRoute", () => {
     ).toBeInTheDocument();
     expect(screen.queryByText("Protected Content")).not.toBeInTheDocument();
     expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockGetCurrentUser).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps bootstrap recovery hidden when the automatic retry succeeds", async () => {
+    mockGetCurrentUser
+      .mockReturnValueOnce(new Promise(() => undefined))
+      .mockResolvedValueOnce({
+        id: 1,
+        name: "Recovered User",
+        email: "recovered@secpal.dev",
+        emailVerified: true,
+      });
+
+    await persistAuthUser({
+      id: 1,
+      name: "Test",
+      email: "test@secpal.dev",
+      emailVerified: true,
+    });
+
+    renderProtectedRoute();
+
+    await waitFor(
+      () => {
+        expect(screen.getByText("Protected Content")).toBeInTheDocument();
+      },
+      BOOTSTRAP_REVALIDATION_TIMEOUT_MS + 2_000
+    );
+
+    expect(
+      screen.queryByRole("heading", {
+        name: /still loading your secure session/i,
+      })
+    ).not.toBeInTheDocument();
+    expect(mockGetCurrentUser).toHaveBeenCalledTimes(2);
   });
 
   it("retries bootstrap recovery when the user requests it", async () => {
     const pendingBootstrap = new Promise(() => undefined);
 
     mockGetCurrentUser
+      .mockReturnValueOnce(pendingBootstrap)
       .mockReturnValueOnce(pendingBootstrap)
       .mockResolvedValueOnce({
         id: 1,
@@ -330,7 +372,7 @@ describe("ProtectedRoute", () => {
     await screen.findByRole(
       "button",
       { name: /retry/i },
-      { timeout: BOOTSTRAP_REVALIDATION_TIMEOUT_MS + 2_000 }
+      { timeout: BOOTSTRAP_REVALIDATION_TIMEOUT_MS * 2 + 2_000 }
     );
 
     await act(async () => {
@@ -340,7 +382,7 @@ describe("ProtectedRoute", () => {
     await waitFor(() => {
       expect(screen.getByText("Protected Content")).toBeInTheDocument();
     });
-    expect(mockGetCurrentUser).toHaveBeenCalledTimes(2);
+    expect(mockGetCurrentUser).toHaveBeenCalledTimes(3);
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 

--- a/src/components/ProtectedRoute.test.tsx
+++ b/src/components/ProtectedRoute.test.tsx
@@ -332,12 +332,9 @@ describe("ProtectedRoute", () => {
 
     renderProtectedRoute();
 
-    await waitFor(
-      () => {
-        expect(screen.getByText("Protected Content")).toBeInTheDocument();
-      },
-      BOOTSTRAP_REVALIDATION_TIMEOUT_MS + 2_000
-    );
+    await waitFor(() => {
+      expect(screen.getByText("Protected Content")).toBeInTheDocument();
+    }, BOOTSTRAP_REVALIDATION_TIMEOUT_MS + 2_000);
 
     expect(
       screen.queryByRole("heading", {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -157,6 +157,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     null
   );
   const bootstrapRequestVersionRef = useRef(0);
+  const hasAutomaticallyRetriedBootstrapRef = useRef(false);
   const hasLogoutBarrierRef = useRef(authStorage.hasLogoutBarrier());
 
   const invalidateBootstrapRevalidation = useCallback(() => {
@@ -423,6 +424,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       return;
     }
 
+    hasAutomaticallyRetriedBootstrapRef.current = false;
     setBootstrapRecoveryReason(null);
     setIsLoading(true);
     setBootstrapRetryKey((currentValue) => currentValue + 1);
@@ -477,6 +479,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const startBootstrapRevalidation = (
       clearSensitiveStateOnInvalidSession: boolean
     ) => {
+      const retryBootstrapAutomatically = () => {
+        hasAutomaticallyRetriedBootstrapRef.current = true;
+        setBootstrapRecoveryReason(null);
+        setIsLoading(true);
+        setBootstrapRetryKey((currentValue) => currentValue + 1);
+      };
+
       timeoutId = globalThis.setTimeout(() => {
         if (
           !isActive ||
@@ -487,6 +496,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
 
         didTimeout = true;
+        if (!hasAutomaticallyRetriedBootstrapRef.current) {
+          retryBootstrapAutomatically();
+          return;
+        }
+
         setIsLoading(false);
         setBootstrapRecoveryReason("timeout");
         console.warn(
@@ -562,6 +576,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           if (isOfflineBootstrapError(error)) {
             setIsLoading(false);
             setBootstrapRecoveryReason(null);
+            return;
+          }
+
+          if (!hasAutomaticallyRetriedBootstrapRef.current) {
+            retryBootstrapAutomatically();
             return;
           }
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -465,16 +465,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     let timeoutId: ReturnType<typeof globalThis.setTimeout> | null = null;
     const requestVersion = bootstrapRequestVersionRef.current + 1;
     bootstrapRequestVersionRef.current = requestVersion;
-    const snapshotUser = authStorage.getUserSnapshot();
-
-    if (
-      snapshotUser &&
-      authTransport.kind === "browser-session" &&
-      !isOnline()
-    ) {
-      syncOfflineAuthState(true);
-      return;
-    }
 
     const startBootstrapRevalidation = (
       clearSensitiveStateOnInvalidSession: boolean
@@ -594,6 +584,26 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
 
     const restoreAndRevalidate = async () => {
+      // Offline browser-session shortcut: trust the persisted snapshot user
+      // and skip vault decryption + revalidation. This also resets the
+      // loading/recovery state in case this effect run was triggered by
+      // `retryBootstrapAutomatically` (which forces `isLoading=true` and
+      // bumps `bootstrapRetryKey`) before the browser went offline —
+      // otherwise protected routes would spin forever instead of falling
+      // back to the offline session view.
+      const snapshotUser = authStorage.getUserSnapshot();
+      if (
+        snapshotUser &&
+        authTransport.kind === "browser-session" &&
+        !isOnline() &&
+        !authStorage.hasVaultLock?.()
+      ) {
+        setBootstrapRecoveryReason(null);
+        setIsLoading(false);
+        syncOfflineAuthState(true);
+        return;
+      }
+
       if (authStorage.hasVaultLock?.()) {
         setBootstrapRecoveryReason(null);
         setUser(null);

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -470,6 +470,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       clearSensitiveStateOnInvalidSession: boolean
     ) => {
       const retryBootstrapAutomatically = () => {
+        invalidateBootstrapRevalidation();
         hasAutomaticallyRetriedBootstrapRef.current = true;
         setBootstrapRecoveryReason(null);
         setIsLoading(true);
@@ -710,6 +711,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     authTransport,
     bootstrapRetryKey,
     clearAuthenticatedState,
+    invalidateBootstrapRevalidation,
     persistAuthenticatedUser,
     reconcileActiveBarrierState,
     syncBarrierStateFromStorage,

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -585,26 +585,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
 
     const restoreAndRevalidate = async () => {
-      // Offline browser-session shortcut: trust the persisted snapshot user
-      // and skip vault decryption + revalidation. This also resets the
-      // loading/recovery state in case this effect run was triggered by
-      // `retryBootstrapAutomatically` (which forces `isLoading=true` and
-      // bumps `bootstrapRetryKey`) before the browser went offline —
-      // otherwise protected routes would spin forever instead of falling
-      // back to the offline session view.
-      const snapshotUser = authStorage.getUserSnapshot();
-      if (
-        snapshotUser &&
-        authTransport.kind === "browser-session" &&
-        !isOnline() &&
-        !authStorage.hasVaultLock?.()
-      ) {
-        setBootstrapRecoveryReason(null);
-        setIsLoading(false);
-        syncOfflineAuthState(true);
-        return;
-      }
-
       if (authStorage.hasVaultLock?.()) {
         setBootstrapRecoveryReason(null);
         setUser(null);

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -157,6 +157,7 @@ describe("useAuth", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     clearOfflineVaultSession();
   });
 
@@ -726,6 +727,59 @@ describe("useAuth", () => {
       },
       BOOTSTRAP_REVALIDATION_TIMEOUT_MS * 2 + 2_000
     );
+  });
+
+  it("keeps the silent timeout retry in control when the original bootstrap request rejects afterward", async () => {
+    const mockUser = {
+      id: "1",
+      name: "Test User",
+      email: "test@secpal.dev",
+      emailVerified: false,
+    };
+    const firstAttempt = createDeferredPromise<typeof mockUser>();
+    const secondAttempt = createDeferredPromise<typeof mockUser>();
+
+    await authStorage.setUser(mockUser);
+    vi.useFakeTimers();
+    mockGetCurrentUser
+      .mockImplementationOnce(() => firstAttempt.promise)
+      .mockImplementationOnce(() => secondAttempt.promise);
+
+    const { result, unmount } = renderHook(() => useAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    await act(async () => {
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        await Promise.resolve();
+      }
+    });
+
+    expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
+    expect(result.current.isLoading).toBe(true);
+
+    await act(async () => {
+      vi.advanceTimersByTime(BOOTSTRAP_REVALIDATION_TIMEOUT_MS);
+      firstAttempt.reject(new Error("Simulated stale bootstrap failure"));
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        await Promise.resolve();
+      }
+    });
+
+    expect(mockGetCurrentUser).toHaveBeenCalledTimes(2);
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.bootstrapRecoveryReason).toBeNull();
+
+    unmount();
+
+    await act(async () => {
+      secondAttempt.resolve(mockUser);
+      await Promise.resolve();
+    });
   });
 
   it("grants a fresh silent retry for each manual retryBootstrap cycle after the recovery UI was shown", async () => {

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -763,6 +763,56 @@ describe("useAuth", () => {
     }, BOOTSTRAP_REVALIDATION_TIMEOUT_MS * 2 + 2_000);
   });
 
+  it("stops the loading spinner when the browser goes offline during the automatic bootstrap retry", async () => {
+    const mockUser = {
+      id: "1",
+      name: "Test User",
+      email: "test@secpal.dev",
+      emailVerified: false,
+    };
+
+    await persistAuthUser(mockUser);
+
+    // First bootstrap attempt stalls so the bootstrap timeout fires and
+    // schedules an automatic silent retry (which sets `isLoading=true` and
+    // bumps `bootstrapRetryKey`). Once that re-runs the bootstrap effect,
+    // the browser is offline, so revalidation must be skipped without
+    // leaving protected routes spinning.
+    mockGetCurrentUser.mockReturnValueOnce(new Promise(() => undefined));
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
+    });
+
+    const onLineSpy = vi
+      .spyOn(window.navigator, "onLine", "get")
+      .mockReturnValue(false);
+
+    try {
+      await waitFor(
+        () => {
+          expect(result.current.isLoading).toBe(false);
+        },
+        BOOTSTRAP_REVALIDATION_TIMEOUT_MS + 2_000
+      );
+
+      expect(result.current.user).toEqual(mockUser);
+      expect(result.current.isAuthenticated).toBe(true);
+      expect(result.current.bootstrapRecoveryReason).toBeNull();
+      // The offline shortcut must not issue another revalidation after the
+      // automatic retry re-runs the bootstrap effect.
+      expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
+    } finally {
+      onLineSpy.mockRestore();
+    }
+  });
+
   it("keeps stored auth when offline without revalidation", async () => {
     const mockUser = {
       id: "1",

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -740,46 +740,54 @@ describe("useAuth", () => {
     const secondAttempt = createDeferredPromise<typeof mockUser>();
 
     await authStorage.setUser(mockUser);
-    vi.useFakeTimers();
+    const getUserSpy = vi
+      .spyOn(authStorage, "getUser")
+      .mockResolvedValue(mockUser);
     mockGetCurrentUser
       .mockImplementationOnce(() => firstAttempt.promise)
       .mockImplementationOnce(() => secondAttempt.promise);
+    vi.useFakeTimers();
 
     const { result, unmount } = renderHook(() => useAuth(), {
       wrapper: AuthProvider,
     });
 
-    await act(async () => {
-      for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      await act(async () => {
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+          await Promise.resolve();
+        }
+      });
+
+      expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
+      expect(result.current.isLoading).toBe(true);
+
+      await act(async () => {
+        vi.advanceTimersByTime(BOOTSTRAP_REVALIDATION_TIMEOUT_MS);
+        firstAttempt.reject(new Error("Simulated stale bootstrap failure"));
         await Promise.resolve();
-      }
-    });
+      });
 
-    expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
-    expect(result.current.isLoading).toBe(true);
+      await act(async () => {
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+          await Promise.resolve();
+        }
+      });
 
-    await act(async () => {
-      vi.advanceTimersByTime(BOOTSTRAP_REVALIDATION_TIMEOUT_MS);
-      firstAttempt.reject(new Error("Simulated stale bootstrap failure"));
-      await Promise.resolve();
-    });
+      expect(mockGetCurrentUser).toHaveBeenCalledTimes(2);
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.bootstrapRecoveryReason).toBeNull();
 
-    await act(async () => {
-      for (let attempt = 0; attempt < 20; attempt += 1) {
+      unmount();
+
+      await act(async () => {
+        secondAttempt.resolve(mockUser);
         await Promise.resolve();
-      }
-    });
-
-    expect(mockGetCurrentUser).toHaveBeenCalledTimes(2);
-    expect(result.current.isLoading).toBe(true);
-    expect(result.current.bootstrapRecoveryReason).toBeNull();
-
-    unmount();
-
-    await act(async () => {
-      secondAttempt.resolve(mockUser);
-      await Promise.resolve();
-    });
+      });
+    } finally {
+      getUserSpy.mockRestore();
+      vi.useRealTimers();
+    }
   });
 
   it("grants a fresh silent retry for each manual retryBootstrap cycle after the recovery UI was shown", async () => {
@@ -791,39 +799,88 @@ describe("useAuth", () => {
     };
     const deferred = createDeferredPromise<typeof mockUser>();
 
-    await persistAuthUser(mockUser);
+    await authStorage.setUser(mockUser);
+    const getUserSpy = vi
+      .spyOn(authStorage, "getUser")
+      .mockResolvedValue(mockUser);
     // All attempts stall so each cycle hits the timeout twice (auto-retry + final timeout).
     mockGetCurrentUser.mockImplementation(() => deferred.promise);
+    vi.useFakeTimers();
 
-    const { result } = renderHook(() => useAuth(), {
+    const { result, unmount } = renderHook(() => useAuth(), {
       wrapper: AuthProvider,
     });
 
-    // Wait for the first recovery UI to appear (two timeout cycles: initial + auto-retry).
-    await waitFor(
-      () => {
-        expect(result.current.bootstrapRecoveryReason).toBe("timeout");
-        expect(mockGetCurrentUser).toHaveBeenCalledTimes(2);
-      },
-      BOOTSTRAP_REVALIDATION_TIMEOUT_MS * 2 + 2_000
-    );
+    try {
+      await act(async () => {
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+          await Promise.resolve();
+        }
+      });
 
-    // User clicks Retry — this should reset the silent-retry flag and issue a
-    // third call, then a fourth (auto-retry), before showing recovery again.
-    act(() => {
-      result.current.retryBootstrap();
-    });
+      expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
 
-    expect(result.current.isLoading).toBe(true);
-    expect(result.current.bootstrapRecoveryReason).toBeNull();
+      await act(async () => {
+        vi.advanceTimersByTime(BOOTSTRAP_REVALIDATION_TIMEOUT_MS);
+        await Promise.resolve();
+      });
 
-    await waitFor(
-      () => {
-        expect(result.current.bootstrapRecoveryReason).toBe("timeout");
-        expect(mockGetCurrentUser).toHaveBeenCalledTimes(4);
-      },
-      BOOTSTRAP_REVALIDATION_TIMEOUT_MS * 2 + 2_000
-    );
+      await act(async () => {
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+          await Promise.resolve();
+        }
+      });
+
+      expect(mockGetCurrentUser).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        vi.advanceTimersByTime(BOOTSTRAP_REVALIDATION_TIMEOUT_MS);
+        await Promise.resolve();
+      });
+
+      expect(result.current.bootstrapRecoveryReason).toBe("timeout");
+
+      // User clicks Retry — this should reset the silent-retry flag and issue a
+      // third call, then a fourth (auto-retry), before showing recovery again.
+      act(() => {
+        result.current.retryBootstrap();
+      });
+
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.bootstrapRecoveryReason).toBeNull();
+
+      await act(async () => {
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+          await Promise.resolve();
+        }
+      });
+
+      expect(mockGetCurrentUser).toHaveBeenCalledTimes(3);
+
+      await act(async () => {
+        vi.advanceTimersByTime(BOOTSTRAP_REVALIDATION_TIMEOUT_MS);
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+          await Promise.resolve();
+        }
+      });
+
+      expect(mockGetCurrentUser).toHaveBeenCalledTimes(4);
+
+      await act(async () => {
+        vi.advanceTimersByTime(BOOTSTRAP_REVALIDATION_TIMEOUT_MS);
+        await Promise.resolve();
+      });
+
+      expect(result.current.bootstrapRecoveryReason).toBe("timeout");
+    } finally {
+      unmount();
+      getUserSpy.mockRestore();
+      vi.useRealTimers();
+    }
   });
 
   it("stops the loading spinner when the browser goes offline during the automatic bootstrap retry", async () => {

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -716,13 +716,16 @@ describe("useAuth", () => {
       expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
     });
 
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.user).toEqual(mockUser);
-      expect(result.current.isAuthenticated).toBe(true);
-      expect(result.current.bootstrapRecoveryReason).toBe("timeout");
-      expect(mockGetCurrentUser).toHaveBeenCalledTimes(2);
-    }, BOOTSTRAP_REVALIDATION_TIMEOUT_MS * 2 + 2_000);
+    await waitFor(
+      () => {
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.user).toEqual(mockUser);
+        expect(result.current.isAuthenticated).toBe(true);
+        expect(result.current.bootstrapRecoveryReason).toBe("timeout");
+        expect(mockGetCurrentUser).toHaveBeenCalledTimes(2);
+      },
+      BOOTSTRAP_REVALIDATION_TIMEOUT_MS * 2 + 2_000
+    );
   });
 
   it("grants a fresh silent retry for each manual retryBootstrap cycle after the recovery UI was shown", async () => {
@@ -743,10 +746,13 @@ describe("useAuth", () => {
     });
 
     // Wait for the first recovery UI to appear (two timeout cycles: initial + auto-retry).
-    await waitFor(() => {
-      expect(result.current.bootstrapRecoveryReason).toBe("timeout");
-      expect(mockGetCurrentUser).toHaveBeenCalledTimes(2);
-    }, BOOTSTRAP_REVALIDATION_TIMEOUT_MS * 2 + 2_000);
+    await waitFor(
+      () => {
+        expect(result.current.bootstrapRecoveryReason).toBe("timeout");
+        expect(mockGetCurrentUser).toHaveBeenCalledTimes(2);
+      },
+      BOOTSTRAP_REVALIDATION_TIMEOUT_MS * 2 + 2_000
+    );
 
     // User clicks Retry — this should reset the silent-retry flag and issue a
     // third call, then a fourth (auto-retry), before showing recovery again.
@@ -757,10 +763,13 @@ describe("useAuth", () => {
     expect(result.current.isLoading).toBe(true);
     expect(result.current.bootstrapRecoveryReason).toBeNull();
 
-    await waitFor(() => {
-      expect(result.current.bootstrapRecoveryReason).toBe("timeout");
-      expect(mockGetCurrentUser).toHaveBeenCalledTimes(4);
-    }, BOOTSTRAP_REVALIDATION_TIMEOUT_MS * 2 + 2_000);
+    await waitFor(
+      () => {
+        expect(result.current.bootstrapRecoveryReason).toBe("timeout");
+        expect(mockGetCurrentUser).toHaveBeenCalledTimes(4);
+      },
+      BOOTSTRAP_REVALIDATION_TIMEOUT_MS * 2 + 2_000
+    );
   });
 
   it("stops the loading spinner when the browser goes offline during the automatic bootstrap retry", async () => {
@@ -795,12 +804,9 @@ describe("useAuth", () => {
       .mockReturnValue(false);
 
     try {
-      await waitFor(
-        () => {
-          expect(result.current.isLoading).toBe(false);
-        },
-        BOOTSTRAP_REVALIDATION_TIMEOUT_MS + 2_000
-      );
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      }, BOOTSTRAP_REVALIDATION_TIMEOUT_MS + 2_000);
 
       expect(result.current.user).toEqual(mockUser);
       expect(result.current.isAuthenticated).toBe(true);

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -586,7 +586,7 @@ describe("useAuth", () => {
     await waitForSensitiveClientCleanup();
   });
 
-  it("keeps cached auth state when bootstrap revalidation fails for a transient error", async () => {
+  it("keeps cached auth state when bootstrap revalidation fails for a transient error after an automatic retry", async () => {
     const mockUser = {
       id: "1",
       name: "Test User",
@@ -610,6 +610,7 @@ describe("useAuth", () => {
     expect(result.current.user).toEqual(mockUser);
     expect(result.current.isAuthenticated).toBe(true);
     expect(result.current.bootstrapRecoveryReason).toBe("network");
+    expect(mockGetCurrentUser).toHaveBeenCalledTimes(2);
     await expect(authStorage.getUser()).resolves.toEqual(mockUser);
     expect(clearSensitiveClientState).not.toHaveBeenCalled();
   });
@@ -693,7 +694,7 @@ describe("useAuth", () => {
     }
   });
 
-  it("stops blocking protected routes when bootstrap revalidation exceeds the startup deadline", async () => {
+  it("stops blocking protected routes when bootstrap revalidation exceeds the startup deadline after an automatic retry", async () => {
     const mockUser = {
       id: "1",
       name: "Test User",
@@ -720,7 +721,46 @@ describe("useAuth", () => {
       expect(result.current.user).toEqual(mockUser);
       expect(result.current.isAuthenticated).toBe(true);
       expect(result.current.bootstrapRecoveryReason).toBe("timeout");
-    }, BOOTSTRAP_REVALIDATION_TIMEOUT_MS + 2_000);
+      expect(mockGetCurrentUser).toHaveBeenCalledTimes(2);
+    }, BOOTSTRAP_REVALIDATION_TIMEOUT_MS * 2 + 2_000);
+  });
+
+  it("grants a fresh silent retry for each manual retryBootstrap cycle after the recovery UI was shown", async () => {
+    const mockUser = {
+      id: "1",
+      name: "Test User",
+      email: "test@secpal.dev",
+      emailVerified: false,
+    };
+    const deferred = createDeferredPromise<typeof mockUser>();
+
+    await persistAuthUser(mockUser);
+    // All attempts stall so each cycle hits the timeout twice (auto-retry + final timeout).
+    mockGetCurrentUser.mockImplementation(() => deferred.promise);
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    // Wait for the first recovery UI to appear (two timeout cycles: initial + auto-retry).
+    await waitFor(() => {
+      expect(result.current.bootstrapRecoveryReason).toBe("timeout");
+      expect(mockGetCurrentUser).toHaveBeenCalledTimes(2);
+    }, BOOTSTRAP_REVALIDATION_TIMEOUT_MS * 2 + 2_000);
+
+    // User clicks Retry — this should reset the silent-retry flag and issue a
+    // third call, then a fourth (auto-retry), before showing recovery again.
+    act(() => {
+      result.current.retryBootstrap();
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.bootstrapRecoveryReason).toBeNull();
+
+    await waitFor(() => {
+      expect(result.current.bootstrapRecoveryReason).toBe("timeout");
+      expect(mockGetCurrentUser).toHaveBeenCalledTimes(4);
+    }, BOOTSTRAP_REVALIDATION_TIMEOUT_MS * 2 + 2_000);
   });
 
   it("keeps stored auth when offline without revalidation", async () => {


### PR DESCRIPTION
## Reproduced defect / validation lead

The selected protected-route screen showed the manual session-recovery UI (`Still loading your secure session` / `Retry` / `Go to Login`) after the first bootstrap timeout or transient failure, even though clicking `Retry` could immediately recover the browser session. Focused regression coverage now proves the guard performs a silent retry first and only shows the recovery UI after the second failed/stalled bootstrap attempt.

## Summary

- Add one automatic auth-bootstrap retry before setting `bootstrapRecoveryReason` for transient network failures or bootstrap timeouts.
- Reset that automatic-retry allowance when the user manually invokes `retryBootstrap`, so each manual retry cycle still gets one silent retry before the recovery UI returns.
- Update protected-route and `useAuth` tests for the two-step recovery behavior.
- Add the user-visible behavior fix to `CHANGELOG.md`.

## Validation already run

- `npm test -- --run src/hooks/useAuth.test.ts src/components/ProtectedRoute.test.tsx src/components/PermissionRoute.test.tsx src/components/FeatureRoute.test.tsx src/components/OrganizationalRoute.test.tsx`
- `npm run lint`
- `npm run typecheck`
- `git diff --check`
- `git log -1 --show-signature --format=fuller`

## Scope and governance notes

- Topic: protected-route auth-bootstrap recovery UX only.
- Linked workspaces: none used for this change.
- Out-of-scope findings: none identified.
- Complex-work tracking: not used; this is a single-PR behavioral fix.
- Draft status: opened as draft first, per repository policy.

## Unresolved before ready

- Final PR-view self-review must still find zero issues before marking ready.
- Local REUSE check could not be executed because `npx reuse lint` returned `npm error could not determine executable to run`; changed files either already carry SPDX headers or use the existing `CHANGELOG.md` license header.
- TDD order caveat: the defect was reproduced from the selected UI state first, and focused regression tests were added during implementation rather than before the first code edit in this workspace.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches protected-route auth bootstrap and loading/offline edge cases; behavior is UX-focused but affects every authenticated app load and must not weaken invalid-session or logout handling.
> 
> **Overview**
> Protected-route **auth bootstrap** now performs **one silent automatic retry** after a stalled `getCurrentUser()` (timeout) or a transient network failure, and only then sets `bootstrapRecoveryReason` and shows the manual “Still loading your secure session” recovery UI.
> 
> **`retryBootstrap`** resets the one-shot auto-retry flag so each user-driven retry cycle gets the same silent attempt before recovery returns. The bootstrap effect no longer bails out early on offline browser-session at the top level in a way that could leave **`isLoading` stuck** when the device goes offline during an automatic retry; offline handling stays in **`restoreAndRevalidate`**.
> 
> **`CHANGELOG.md`** documents the fix. **`ProtectedRoute`** and **`useAuth`** tests were expanded for double-timeout timing, successful silent recovery, manual retry call counts, stale rejection after timeout retry, and offline-during-auto-retry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63199396938f3bdddd5c01ae5d3572144f6f3ae4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->