### PR TITLE
Fix localized auth bootstrap 401 handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Treated HTTP `401` status from auth bootstrap revalidation as an invalid session regardless of the localized API error message, so stale browser-session snapshots now clear and return to login when Laravel responds with messages such as German `"Nicht authentifiziert."` instead of leaving protected routes stuck behind the bootstrap recovery screen.
 - Bumped the transitive `undici` dependency from `7.25.0` to `7.28.0` in `package-lock.json` (via `jsdom`), clearing the high-severity `GHSA-vmh5-mc38-953g` and `GHSA-pr7r-676h-xcf6` npm audit findings so `npm audit` again reports zero vulnerabilities.
 - Prevented auth bootstrap recovery from forcing a full page navigation through the service worker when the browser has no valid session or when a stored session fails startup revalidation. The offline session state is still persisted for PWA navigation gating, but open clients are now redirected by the service worker only for explicit logout/barrier teardown paths, keeping the first protected-route-to-login transition inside the React router while preserving offline logout privacy.
 - Auth bootstrap now skips the automatic silent retry for deterministic API client failures such as a non-JSON `404` from a misrouted preview API host, while preserving the retry for transient network, timeout, rate-limit, and server-error cases. This prevents protected routes from issuing a duplicate session check when the response cannot succeed without a configuration fix.

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -87,6 +87,12 @@ function getBootstrapErrorStatus(error: unknown): number | null {
 }
 
 function isInvalidBootstrapSessionError(error: unknown): boolean {
+  const status = getBootstrapErrorStatus(error);
+
+  if (status === 401) {
+    return true;
+  }
+
   const code = getBootstrapErrorCode(error)?.toUpperCase();
 
   if (code === "HTTP_401" || code === "NO_STORED_TOKEN") {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -885,6 +885,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         return;
       }
 
+      // Stop any startup restore/revalidation that may have observed this
+      // storage write before the cross-tab storage handler adopts it.
+      invalidateBootstrapRevalidation();
+
       void (async () => {
         try {
           const nextUser = await authStorage.getUser();
@@ -906,7 +910,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           hasLogoutBarrierRef.current = false;
           shouldSkipBarrierVaultTableCleanupRef.current = false;
           setBootstrapRecoveryReason(null);
-          invalidateBootstrapRevalidation();
           setUser(nextUser);
           setIsVaultLocked(false);
           setIsLoading(false);

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -604,6 +604,39 @@ describe("useAuth", () => {
     });
   });
 
+  it("clears stale stored auth data when localized API revalidation returns 401", async () => {
+    const mockUser = {
+      id: "1",
+      name: "Test User",
+      email: "test@secpal.dev",
+    };
+
+    await authStorage.setUser(mockUser);
+    mockGetCurrentUser.mockRejectedValue(
+      new AuthApiError("Nicht authentifiziert.", undefined, 401)
+    );
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.user).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.bootstrapRecoveryReason).toBeNull();
+    expectNoStoredAuthState();
+    await waitForSensitiveClientCleanup();
+    expect(syncOfflineSessionAccess).toHaveBeenCalledWith(false, {
+      redirectOpenClients: false,
+    });
+    await authStorage.waitForInFlightVaultTableCleanup();
+  });
+
   it("keeps cached auth state when bootstrap revalidation fails for a transient error after an automatic retry", async () => {
     const mockUser = {
       id: "1",


### PR DESCRIPTION
## Defect

Auth bootstrap revalidation reproduced a stale-session recovery screen when the API returned a localized `401` response:

`Auth bootstrap revalidation failed with a non-retriable response; holding protected routes behind recovery UI. AuthApiError: Nicht authentifiziert.`

The previous invalid-session classifier depended on `HTTP_401` codes or English error text such as `unauthenticated`, so a numeric `401` carried in an `AuthApiError` with localized Laravel copy was treated as a deterministic API failure instead of an expired browser session.

## Change

- Treat numeric HTTP `401` status as an invalid bootstrap session before checking localized message text.
- Add regression coverage for the German `Nicht authentifiziert.` response shape.
- Document the user-visible auth-bootstrap fix in `CHANGELOG.md`.

## Validation

- `npm test -- --run src/hooks/useAuth.test.ts src/contexts/AuthContext.test.tsx src/components/ProtectedRoute.test.tsx src/components/FeatureRoute.bootstrap.test.tsx`
- `npm test -- --run src/config.test.ts tests/playwright-target-resolution.test.ts`
- `git diff --check`

## Linked Workspaces

The linked `.github` workspace already contains the Polyscope linked-preview provisioning fix in `SecPal/.github#494`. This frontend PR addresses the remaining localized auth-bootstrap handling issue surfaced while validating frontend issue #1241.

## Follow-Up

No out-of-scope findings were identified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auth bootstrap session-invalid classification and cross-tab revalidation cancellation—security-sensitive paths—but the scope is small and covered by targeted tests.
> 
> **Overview**
> Fixes protected routes getting stuck on the bootstrap **recovery UI** when startup `GET /v1/me` returns **401** with localized Laravel copy (e.g. German `"Nicht authentifiziert."`) instead of English `"unauthenticated"`.
> 
> **Invalid-session detection** in `isInvalidBootstrapSessionError` now checks the error’s numeric **HTTP 401 status** before message/code heuristics, so stale encrypted session snapshots clear and the app returns to login instead of being classified as a non-retriable API failure.
> 
> **Cross-tab auth sync**: when another tab writes `auth_user` / vault storage, `invalidateBootstrapRevalidation()` runs immediately so any in-flight bootstrap restore/revalidation from before that write is abandoned before the handler adopts the new state.
> 
> Regression coverage adds a `useAuth` test for the German `AuthApiError` 401 shape; **CHANGELOG** documents the user-visible fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3071fa8f4a56df4651d3ecb508ad3fc74defe4e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->