### PR TITLE
Fix authApi ineffective dynamic import warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Split the browser-session `src/services/authApi.ts` login/bootstrap client from the statically imported account/MFA helpers so Vite/Rolldown no longer emits the `INEFFECTIVE_DYNAMIC_IMPORT` warning for `authApi` during `npm run build`. Shared auth API error/JSON parsing now lives in `src/services/authApiShared.ts`, account-scoped calls live in `src/services/authAccountApi.ts`, and the login/bootstrap lazy-import boundary remains effective.
 - Reworked the public browser-session bootstrap path so `/login` no longer issues an unauthenticated `/v1/me` probe when there is no local auth snapshot and no `XSRF-TOKEN` cookie, eliminating the spurious 401 console error on logged-out refreshes while keeping protected-route recovery and authenticated session restoration intact.
 - Split the public login flow from the authenticated shell so logged-out loads no longer flash post-login navigation skeletons, heavy private route chunks, or browser passkey capability rows after first paint. The login route now uses dedicated public loading states, lazy-loads MFA/passkey/auth modules where safe, and keeps the visible card stable during session completion to remove mobile reload jitter.
 - Restored the visible login logo while preserving the Lighthouse image fixes by rendering higher-resolution raster assets with their real intrinsic aspect ratios instead of stretching the small square PNG placeholders.

--- a/src/components/ProtectedRoute.test.tsx
+++ b/src/components/ProtectedRoute.test.tsx
@@ -17,7 +17,7 @@ import {
   AuthProvider,
   BOOTSTRAP_REVALIDATION_TIMEOUT_MS,
 } from "../contexts/AuthContext";
-import { AuthApiError } from "../services/authApi";
+import { AuthApiError } from "../services/AuthApiError";
 import { sanitizePersistedAuthUser } from "../services/authState";
 import { authStorage } from "../services/storage";
 import { db } from "../lib/db";
@@ -37,6 +37,13 @@ vi.mock("../services/authApi", async () => {
   return {
     ...actual,
     getCurrentUser: mockGetCurrentUser,
+  };
+});
+
+vi.mock("../services/authAccountApi", async () => {
+  const actual = await vi.importActual("../services/authAccountApi");
+  return {
+    ...actual,
     sendVerificationNotification: mockSendVerificationNotification,
   };
 });

--- a/src/components/RouteGuardState.tsx
+++ b/src/components/RouteGuardState.tsx
@@ -9,7 +9,7 @@ import { Link } from "react-router-dom";
 import {
   AuthApiError,
   sendVerificationNotification,
-} from "../services/authApi";
+} from "../services/authAccountApi";
 import { Button, buttonVariants } from "@/ui";
 import { RouteLoader } from "./RouteLoader";
 

--- a/src/components/RouteGuardState.tsx
+++ b/src/components/RouteGuardState.tsx
@@ -6,10 +6,7 @@ import { useState } from "react";
 import { useLingui } from "@lingui/react";
 import { Trans } from "@lingui/react/macro";
 import { Link } from "react-router-dom";
-import {
-  AuthApiError,
-  sendVerificationNotification,
-} from "../services/authAccountApi";
+import { AuthApiError } from "../services/AuthApiError";
 import { Button, buttonVariants } from "@/ui";
 import { RouteLoader } from "./RouteLoader";
 
@@ -28,6 +25,10 @@ interface RouteEmailVerificationStateProps {
   email: string;
   onRetry: () => void;
   onSignInAgain: () => void;
+}
+
+async function loadAuthAccountApiModule() {
+  return await import("../services/authAccountApi");
 }
 
 export function RouteLoadingState() {
@@ -159,6 +160,7 @@ export function RouteEmailVerificationState({
     setIsSending(true);
 
     try {
+      const { sendVerificationNotification } = await loadAuthAccountApiModule();
       const response = await sendVerificationNotification();
       setStatusMessage(response.message);
     } catch (error) {

--- a/src/lib/errorUtils.test.ts
+++ b/src/lib/errorUtils.test.ts
@@ -5,7 +5,7 @@ import type { MacroMessageDescriptor } from "@lingui/core/macro";
 import { describe, expect, it } from "vitest";
 
 import { ApiError, type ApiValidationErrors } from "../services/ApiError";
-import { AuthApiError } from "../services/authApi";
+import { AuthApiError } from "../services/AuthApiError";
 import {
   getErrorRetryAfterSeconds,
   getErrorValidationErrors,

--- a/src/lib/errorUtils.ts
+++ b/src/lib/errorUtils.ts
@@ -4,7 +4,7 @@
 import { msg, type MacroMessageDescriptor } from "@lingui/core/macro";
 import type { ApiValidationErrors } from "../services/ApiError";
 import { ApiError } from "../services/ApiError";
-import { AuthApiError } from "../services/authApi";
+import { AuthApiError } from "../services/AuthApiError";
 
 type TranslatableDescriptor = { id: string; message?: string };
 type Translate = (descriptor: TranslatableDescriptor) => string;

--- a/src/pages/Settings/SettingsPage.test.tsx
+++ b/src/pages/Settings/SettingsPage.test.tsx
@@ -16,7 +16,7 @@ import { SettingsPage } from "./SettingsPage";
 import { messages as deMessages } from "../../locales/de/messages.mjs";
 import { messages as enMessages } from "../../locales/en/messages.mjs";
 import * as i18nModule from "../../i18n";
-import * as authApi from "../../services/authAccountApi";
+import * as authAccountApi from "../../services/authAccountApi";
 import * as passkeyBrowser from "../../services/passkeyBrowser";
 
 vi.mock("../../components/MfaQrCode", () => ({
@@ -220,10 +220,10 @@ describe("SettingsPage", () => {
     vi.mocked(passkeyBrowser.isPasskeyRegistrationSupported).mockReturnValue(
       true
     );
-    vi.mocked(authApi.getMfaStatus).mockResolvedValue(
+    vi.mocked(authAccountApi.getMfaStatus).mockResolvedValue(
       createDisabledMfaStatusResponse()
     );
-    vi.mocked(authApi.getPasskeys).mockResolvedValue(
+    vi.mocked(authAccountApi.getPasskeys).mockResolvedValue(
       createPasskeyListResponse()
     );
   });
@@ -237,10 +237,10 @@ describe("SettingsPage", () => {
   });
 
   it("keeps settings sections and controls visible during initial MFA and passkey loads", () => {
-    vi.mocked(authApi.getMfaStatus).mockImplementation(
+    vi.mocked(authAccountApi.getMfaStatus).mockImplementation(
       () => new Promise(() => {})
     );
-    vi.mocked(authApi.getPasskeys).mockImplementation(
+    vi.mocked(authAccountApi.getPasskeys).mockImplementation(
       () => new Promise(() => {})
     );
 
@@ -281,7 +281,7 @@ describe("SettingsPage", () => {
   });
 
   it("shows an empty passkey state when no credentials are enrolled", async () => {
-    vi.mocked(authApi.getPasskeys).mockResolvedValueOnce({ data: [] });
+    vi.mocked(authAccountApi.getPasskeys).mockResolvedValueOnce({ data: [] });
 
     await renderSettingsPage();
 
@@ -291,8 +291,8 @@ describe("SettingsPage", () => {
   });
 
   it("shows passkey loading errors returned by the API", async () => {
-    vi.mocked(authApi.getPasskeys).mockRejectedValueOnce(
-      new authApi.AuthApiError("Failed to load passkeys.")
+    vi.mocked(authAccountApi.getPasskeys).mockRejectedValueOnce(
+      new authAccountApi.AuthApiError("Failed to load passkeys.")
     );
 
     await renderSettingsPage();
@@ -303,7 +303,7 @@ describe("SettingsPage", () => {
   });
 
   it("shows a fallback passkey loading error for unexpected failures", async () => {
-    vi.mocked(authApi.getPasskeys).mockRejectedValueOnce("unexpected");
+    vi.mocked(authAccountApi.getPasskeys).mockRejectedValueOnce("unexpected");
 
     await renderSettingsPage();
 
@@ -328,7 +328,7 @@ describe("SettingsPage", () => {
   });
 
   it("registers a passkey and appends it to the enrolled list", async () => {
-    vi.mocked(authApi.getPasskeys)
+    vi.mocked(authAccountApi.getPasskeys)
       .mockResolvedValueOnce(createPasskeyListResponse())
       .mockResolvedValueOnce({
         data: [
@@ -336,7 +336,7 @@ describe("SettingsPage", () => {
           createPasskeyRegistrationVerificationResponse().data.credential,
         ],
       });
-    vi.mocked(authApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
       createPasskeyRegistrationChallengeResponse()
     );
     vi.mocked(passkeyBrowser.getPasskeyAttestation).mockResolvedValueOnce({
@@ -350,7 +350,7 @@ describe("SettingsPage", () => {
       },
       client_extension_results: {},
     });
-    vi.mocked(authApi.verifyPasskeyRegistrationChallenge).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.verifyPasskeyRegistrationChallenge).mockResolvedValueOnce(
       createPasskeyRegistrationVerificationResponse()
     );
 
@@ -362,28 +362,28 @@ describe("SettingsPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /add passkey/i }));
 
     await waitFor(() => {
-      expect(authApi.startPasskeyRegistrationChallenge).toHaveBeenCalledTimes(
+      expect(authAccountApi.startPasskeyRegistrationChallenge).toHaveBeenCalledTimes(
         1
       );
       expect(passkeyBrowser.getPasskeyAttestation).toHaveBeenCalledTimes(1);
-      expect(authApi.verifyPasskeyRegistrationChallenge).toHaveBeenCalledWith(
+      expect(authAccountApi.verifyPasskeyRegistrationChallenge).toHaveBeenCalledWith(
         "550e8400-e29b-41d4-a716-446655440099",
         expect.objectContaining({
           label: "Security Key",
           credential: expect.objectContaining({ id: "new-credential-id" }),
         })
       );
-      expect(authApi.getPasskeys).toHaveBeenCalledTimes(2);
+      expect(authAccountApi.getPasskeys).toHaveBeenCalledTimes(2);
     });
 
     expect(await screen.findByText(/security key/i)).toBeInTheDocument();
   });
 
   it("keeps passkey rows visible while refreshing after registration", async () => {
-    vi.mocked(authApi.getPasskeys)
+    vi.mocked(authAccountApi.getPasskeys)
       .mockResolvedValueOnce(createPasskeyListResponse())
       .mockImplementationOnce(() => new Promise(() => {}));
-    vi.mocked(authApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
       createPasskeyRegistrationChallengeResponse()
     );
     vi.mocked(passkeyBrowser.getPasskeyAttestation).mockResolvedValueOnce({
@@ -396,7 +396,7 @@ describe("SettingsPage", () => {
         transports: ["usb"],
       },
     });
-    vi.mocked(authApi.verifyPasskeyRegistrationChallenge).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.verifyPasskeyRegistrationChallenge).mockResolvedValueOnce(
       createPasskeyRegistrationVerificationResponse()
     );
 
@@ -415,7 +415,7 @@ describe("SettingsPage", () => {
   });
 
   it("shows a browser-check prompt while waiting for the credential provider", async () => {
-    vi.mocked(authApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
       createPasskeyRegistrationChallengeResponse()
     );
 
@@ -455,7 +455,7 @@ describe("SettingsPage", () => {
   });
 
   it("shows a saving prompt while the passkey registration is being verified", async () => {
-    vi.mocked(authApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
       createPasskeyRegistrationChallengeResponse()
     );
     vi.mocked(passkeyBrowser.getPasskeyAttestation).mockResolvedValueOnce({
@@ -473,7 +473,7 @@ describe("SettingsPage", () => {
     let resolveVerification!: (
       value: ReturnType<typeof createPasskeyRegistrationVerificationResponse>
     ) => void;
-    vi.mocked(authApi.verifyPasskeyRegistrationChallenge).mockReturnValueOnce(
+    vi.mocked(authAccountApi.verifyPasskeyRegistrationChallenge).mockReturnValueOnce(
       new Promise((resolve) => {
         resolveVerification = resolve;
       })
@@ -502,8 +502,8 @@ describe("SettingsPage", () => {
   });
 
   it("shows passkey enrollment errors inline", async () => {
-    vi.mocked(authApi.startPasskeyRegistrationChallenge).mockRejectedValueOnce(
-      new authApi.AuthApiError("Passkey registration failed.")
+    vi.mocked(authAccountApi.startPasskeyRegistrationChallenge).mockRejectedValueOnce(
+      new authAccountApi.AuthApiError("Passkey registration failed.")
     );
 
     await renderSettingsPage();
@@ -519,7 +519,7 @@ describe("SettingsPage", () => {
   });
 
   it("shows cancellation message when user dismisses the browser passkey dialog", async () => {
-    vi.mocked(authApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
       createPasskeyRegistrationChallengeResponse()
     );
     vi.mocked(passkeyBrowser.getPasskeyAttestation).mockRejectedValueOnce(
@@ -545,7 +545,7 @@ describe("SettingsPage", () => {
   });
 
   it("shows timeout message when passkey registration is aborted", async () => {
-    vi.mocked(authApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
       createPasskeyRegistrationChallengeResponse()
     );
     vi.mocked(passkeyBrowser.getPasskeyAttestation).mockRejectedValueOnce(
@@ -568,7 +568,7 @@ describe("SettingsPage", () => {
   });
 
   it("shows generic error when browser attestation fails unexpectedly", async () => {
-    vi.mocked(authApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
       createPasskeyRegistrationChallengeResponse()
     );
     vi.mocked(passkeyBrowser.getPasskeyAttestation).mockRejectedValueOnce(
@@ -591,7 +591,7 @@ describe("SettingsPage", () => {
   });
 
   it("shows credential provider guidance when the platform reports a credential manager error", async () => {
-    vi.mocked(authApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
       createPasskeyRegistrationChallengeResponse()
     );
     vi.mocked(passkeyBrowser.getPasskeyAttestation).mockRejectedValueOnce(
@@ -657,11 +657,11 @@ describe("SettingsPage", () => {
   });
 
   it("removes an enrolled passkey and refreshes the list", async () => {
-    vi.mocked(authApi.deletePasskey).mockResolvedValueOnce({
+    vi.mocked(authAccountApi.deletePasskey).mockResolvedValueOnce({
       message: "Passkey deleted successfully.",
       data: { remaining_passkeys: 0 },
     });
-    vi.mocked(authApi.getPasskeys)
+    vi.mocked(authAccountApi.getPasskeys)
       .mockResolvedValueOnce(createPasskeyListResponse())
       .mockResolvedValueOnce({ data: [] });
 
@@ -669,8 +669,8 @@ describe("SettingsPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /remove/i }));
 
     await waitFor(() => {
-      expect(authApi.deletePasskey).toHaveBeenCalledWith("credential-id");
-      expect(authApi.getPasskeys).toHaveBeenCalledTimes(2);
+      expect(authAccountApi.deletePasskey).toHaveBeenCalledWith("credential-id");
+      expect(authAccountApi.getPasskeys).toHaveBeenCalledTimes(2);
       expect(
         screen.queryByText(/work macbook touch id/i)
       ).not.toBeInTheDocument();
@@ -689,13 +689,13 @@ describe("SettingsPage", () => {
         }) => void)
       | undefined;
 
-    vi.mocked(authApi.deletePasskey).mockImplementationOnce(
+    vi.mocked(authAccountApi.deletePasskey).mockImplementationOnce(
       () =>
         new Promise((resolve) => {
           resolveDeletion = resolve;
         })
     );
-    vi.mocked(authApi.getPasskeys).mockResolvedValueOnce({
+    vi.mocked(authAccountApi.getPasskeys).mockResolvedValueOnce({
       data: [
         {
           id: "credential-id",
@@ -736,7 +736,7 @@ describe("SettingsPage", () => {
       });
 
       await waitFor(() => {
-        expect(authApi.getPasskeys).toHaveBeenCalledTimes(2);
+        expect(authAccountApi.getPasskeys).toHaveBeenCalledTimes(2);
         expect(screen.getAllByRole("button", { name: /remove/i })).toHaveLength(
           1
         );
@@ -765,13 +765,13 @@ describe("SettingsPage", () => {
         }) => void)
       | undefined;
 
-    vi.mocked(authApi.deletePasskey).mockImplementationOnce(
+    vi.mocked(authAccountApi.deletePasskey).mockImplementationOnce(
       () =>
         new Promise((resolve) => {
           resolveDeletion = resolve;
         })
     );
-    vi.mocked(authApi.getPasskeys)
+    vi.mocked(authAccountApi.getPasskeys)
       .mockResolvedValueOnce(createPasskeyListResponse())
       .mockResolvedValueOnce({ data: [] });
 
@@ -792,7 +792,7 @@ describe("SettingsPage", () => {
   });
 
   it("shows generic Error removal failures inline", async () => {
-    vi.mocked(authApi.deletePasskey).mockRejectedValueOnce(
+    vi.mocked(authAccountApi.deletePasskey).mockRejectedValueOnce(
       new Error("Deletion exploded.")
     );
 
@@ -804,7 +804,7 @@ describe("SettingsPage", () => {
   });
 
   it("shows fallback removal errors for unexpected failures", async () => {
-    vi.mocked(authApi.deletePasskey).mockRejectedValueOnce("unexpected");
+    vi.mocked(authAccountApi.deletePasskey).mockRejectedValueOnce("unexpected");
 
     await renderSettingsPage();
 
@@ -816,8 +816,8 @@ describe("SettingsPage", () => {
   });
 
   it("shows passkey removal errors inline", async () => {
-    vi.mocked(authApi.deletePasskey).mockRejectedValueOnce(
-      new authApi.AuthApiError("Passkey deletion failed.")
+    vi.mocked(authAccountApi.deletePasskey).mockRejectedValueOnce(
+      new authAccountApi.AuthApiError("Passkey deletion failed.")
     );
 
     await renderSettingsPage();
@@ -886,10 +886,10 @@ describe("SettingsPage", () => {
   });
 
   it("regenerates recovery codes for an enabled MFA account", async () => {
-    vi.mocked(authApi.getMfaStatus).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.getMfaStatus).mockResolvedValueOnce(
       createEnabledMfaStatusResponse()
     );
-    vi.mocked(authApi.regenerateRecoveryCodes).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.regenerateRecoveryCodes).mockResolvedValueOnce(
       createRecoveryRevealResponse()
     );
 
@@ -915,7 +915,7 @@ describe("SettingsPage", () => {
     );
 
     await waitFor(() => {
-      expect(authApi.regenerateRecoveryCodes).toHaveBeenCalledWith({
+      expect(authAccountApi.regenerateRecoveryCodes).toHaveBeenCalledWith({
         method: "totp",
         code: "123456",
       });
@@ -928,7 +928,7 @@ describe("SettingsPage", () => {
   });
 
   it("starts MFA enrollment for a disabled account and shows QR plus manual setup details", async () => {
-    vi.mocked(authApi.startTotpEnrollment).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.startTotpEnrollment).mockResolvedValueOnce(
       createTotpEnrollmentPreparationResponse()
     );
 
@@ -938,7 +938,7 @@ describe("SettingsPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /set up mfa/i }));
 
     await waitFor(() => {
-      expect(authApi.startTotpEnrollment).toHaveBeenCalledTimes(1);
+      expect(authAccountApi.startTotpEnrollment).toHaveBeenCalledTimes(1);
     });
 
     expect(
@@ -952,10 +952,10 @@ describe("SettingsPage", () => {
   });
 
   it("confirms MFA enrollment and reveals recovery codes", async () => {
-    vi.mocked(authApi.startTotpEnrollment).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.startTotpEnrollment).mockResolvedValueOnce(
       createTotpEnrollmentPreparationResponse()
     );
-    vi.mocked(authApi.confirmTotpEnrollment).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.confirmTotpEnrollment).mockResolvedValueOnce(
       createRecoveryRevealResponse()
     );
 
@@ -977,7 +977,7 @@ describe("SettingsPage", () => {
     );
 
     await waitFor(() => {
-      expect(authApi.confirmTotpEnrollment).toHaveBeenCalledWith({
+      expect(authAccountApi.confirmTotpEnrollment).toHaveBeenCalledWith({
         code: "123456",
       });
     });
@@ -990,10 +990,10 @@ describe("SettingsPage", () => {
   });
 
   it("shows inline error when MFA enrollment confirmation fails", async () => {
-    vi.mocked(authApi.startTotpEnrollment).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.startTotpEnrollment).mockResolvedValueOnce(
       createTotpEnrollmentPreparationResponse()
     );
-    vi.mocked(authApi.confirmTotpEnrollment).mockRejectedValueOnce(
+    vi.mocked(authAccountApi.confirmTotpEnrollment).mockRejectedValueOnce(
       new Error("Invalid authenticator code")
     );
 
@@ -1020,7 +1020,7 @@ describe("SettingsPage", () => {
   });
 
   it("shows enrollment preparation error and retries on demand", async () => {
-    vi.mocked(authApi.startTotpEnrollment)
+    vi.mocked(authAccountApi.startTotpEnrollment)
       .mockRejectedValueOnce(new Error("Service unavailable"))
       .mockResolvedValueOnce(createTotpEnrollmentPreparationResponse());
 
@@ -1040,7 +1040,7 @@ describe("SettingsPage", () => {
   });
 
   it("cancels the enrollment dialog without submitting", async () => {
-    vi.mocked(authApi.startTotpEnrollment).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.startTotpEnrollment).mockResolvedValueOnce(
       createTotpEnrollmentPreparationResponse()
     );
 
@@ -1058,14 +1058,14 @@ describe("SettingsPage", () => {
         screen.queryByRole("heading", { name: /set up mfa/i })
       ).not.toBeInTheDocument();
     });
-    expect(authApi.confirmTotpEnrollment).not.toHaveBeenCalled();
+    expect(authAccountApi.confirmTotpEnrollment).not.toHaveBeenCalled();
   });
 
   it("disables MFA after code confirmation", async () => {
-    vi.mocked(authApi.getMfaStatus).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.getMfaStatus).mockResolvedValueOnce(
       createEnabledMfaStatusResponse()
     );
-    vi.mocked(authApi.disableMfa).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.disableMfa).mockResolvedValueOnce(
       createDisabledMfaStatusResponse()
     );
 
@@ -1089,7 +1089,7 @@ describe("SettingsPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /^disable mfa$/i }));
 
     await waitFor(() => {
-      expect(authApi.disableMfa).toHaveBeenCalledWith({
+      expect(authAccountApi.disableMfa).toHaveBeenCalledWith({
         method: "totp",
         code: "123456",
       });
@@ -1098,7 +1098,7 @@ describe("SettingsPage", () => {
   });
 
   it("shows error message when MFA status fails to load", async () => {
-    vi.mocked(authApi.getMfaStatus).mockRejectedValueOnce(
+    vi.mocked(authAccountApi.getMfaStatus).mockRejectedValueOnce(
       new Error("Network error")
     );
 
@@ -1108,10 +1108,10 @@ describe("SettingsPage", () => {
   });
 
   it("shows API error in dialog when disabling MFA fails", async () => {
-    vi.mocked(authApi.getMfaStatus).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.getMfaStatus).mockResolvedValueOnce(
       createEnabledMfaStatusResponse()
     );
-    vi.mocked(authApi.disableMfa).mockRejectedValueOnce(
+    vi.mocked(authAccountApi.disableMfa).mockRejectedValueOnce(
       new Error("Invalid authenticator code")
     );
 
@@ -1134,7 +1134,7 @@ describe("SettingsPage", () => {
   });
 
   it("shows the canonical raw recovery-code placeholder for sensitive MFA actions", async () => {
-    vi.mocked(authApi.getMfaStatus).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.getMfaStatus).mockResolvedValueOnce(
       createEnabledMfaStatusResponse()
     );
 
@@ -1154,10 +1154,10 @@ describe("SettingsPage", () => {
   });
 
   it("requires acknowledgment before closing recovery codes dialog", async () => {
-    vi.mocked(authApi.getMfaStatus).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.getMfaStatus).mockResolvedValueOnce(
       createEnabledMfaStatusResponse()
     );
-    vi.mocked(authApi.regenerateRecoveryCodes).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.regenerateRecoveryCodes).mockResolvedValueOnce(
       createRecoveryRevealResponse()
     );
 
@@ -1204,7 +1204,7 @@ describe("SettingsPage", () => {
   });
 
   it("cancels the sensitive action dialog without submitting", async () => {
-    vi.mocked(authApi.getMfaStatus).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.getMfaStatus).mockResolvedValueOnce(
       createEnabledMfaStatusResponse()
     );
 
@@ -1222,17 +1222,17 @@ describe("SettingsPage", () => {
         screen.queryByRole("heading", { name: /disable mfa/i })
       ).not.toBeInTheDocument();
     });
-    expect(authApi.disableMfa).not.toHaveBeenCalled();
+    expect(authAccountApi.disableMfa).not.toHaveBeenCalled();
   });
 
   it("shows processing state while a sensitive action is submitting", async () => {
-    vi.mocked(authApi.getMfaStatus).mockResolvedValueOnce(
+    vi.mocked(authAccountApi.getMfaStatus).mockResolvedValueOnce(
       createEnabledMfaStatusResponse()
     );
     let resolveDisable!: (
       value: ReturnType<typeof createDisabledMfaStatusResponse>
     ) => void;
-    vi.mocked(authApi.disableMfa).mockReturnValueOnce(
+    vi.mocked(authAccountApi.disableMfa).mockReturnValueOnce(
       new Promise<ReturnType<typeof createDisabledMfaStatusResponse>>((res) => {
         resolveDisable = res;
       })

--- a/src/pages/Settings/SettingsPage.test.tsx
+++ b/src/pages/Settings/SettingsPage.test.tsx
@@ -16,7 +16,7 @@ import { SettingsPage } from "./SettingsPage";
 import { messages as deMessages } from "../../locales/de/messages.mjs";
 import { messages as enMessages } from "../../locales/en/messages.mjs";
 import * as i18nModule from "../../i18n";
-import * as authApi from "../../services/authApi";
+import * as authApi from "../../services/authAccountApi";
 import * as passkeyBrowser from "../../services/passkeyBrowser";
 
 vi.mock("../../components/MfaQrCode", () => ({
@@ -38,8 +38,8 @@ vi.mock("../../i18n", async () => {
   };
 });
 
-vi.mock("../../services/authApi", async () => {
-  const actual = await vi.importActual("../../services/authApi");
+vi.mock("../../services/authAccountApi", async () => {
+  const actual = await vi.importActual("../../services/authAccountApi");
   return {
     ...actual,
     deletePasskey: vi.fn(),

--- a/src/pages/Settings/SettingsPage.test.tsx
+++ b/src/pages/Settings/SettingsPage.test.tsx
@@ -336,9 +336,9 @@ describe("SettingsPage", () => {
           createPasskeyRegistrationVerificationResponse().data.credential,
         ],
       });
-    vi.mocked(authAccountApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
-      createPasskeyRegistrationChallengeResponse()
-    );
+    vi.mocked(
+      authAccountApi.startPasskeyRegistrationChallenge
+    ).mockResolvedValueOnce(createPasskeyRegistrationChallengeResponse());
     vi.mocked(passkeyBrowser.getPasskeyAttestation).mockResolvedValueOnce({
       id: "new-credential-id",
       raw_id: "bmV3LWNyZWRlbnRpYWwtaWQ",
@@ -350,9 +350,9 @@ describe("SettingsPage", () => {
       },
       client_extension_results: {},
     });
-    vi.mocked(authAccountApi.verifyPasskeyRegistrationChallenge).mockResolvedValueOnce(
-      createPasskeyRegistrationVerificationResponse()
-    );
+    vi.mocked(
+      authAccountApi.verifyPasskeyRegistrationChallenge
+    ).mockResolvedValueOnce(createPasskeyRegistrationVerificationResponse());
 
     await renderSettingsPage();
 
@@ -362,11 +362,13 @@ describe("SettingsPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /add passkey/i }));
 
     await waitFor(() => {
-      expect(authAccountApi.startPasskeyRegistrationChallenge).toHaveBeenCalledTimes(
-        1
-      );
+      expect(
+        authAccountApi.startPasskeyRegistrationChallenge
+      ).toHaveBeenCalledTimes(1);
       expect(passkeyBrowser.getPasskeyAttestation).toHaveBeenCalledTimes(1);
-      expect(authAccountApi.verifyPasskeyRegistrationChallenge).toHaveBeenCalledWith(
+      expect(
+        authAccountApi.verifyPasskeyRegistrationChallenge
+      ).toHaveBeenCalledWith(
         "550e8400-e29b-41d4-a716-446655440099",
         expect.objectContaining({
           label: "Security Key",
@@ -383,9 +385,9 @@ describe("SettingsPage", () => {
     vi.mocked(authAccountApi.getPasskeys)
       .mockResolvedValueOnce(createPasskeyListResponse())
       .mockImplementationOnce(() => new Promise(() => {}));
-    vi.mocked(authAccountApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
-      createPasskeyRegistrationChallengeResponse()
-    );
+    vi.mocked(
+      authAccountApi.startPasskeyRegistrationChallenge
+    ).mockResolvedValueOnce(createPasskeyRegistrationChallengeResponse());
     vi.mocked(passkeyBrowser.getPasskeyAttestation).mockResolvedValueOnce({
       id: "new-credential-id",
       raw_id: "bmV3LWNyZWRlbnRpYWwtaWQ",
@@ -396,9 +398,9 @@ describe("SettingsPage", () => {
         transports: ["usb"],
       },
     });
-    vi.mocked(authAccountApi.verifyPasskeyRegistrationChallenge).mockResolvedValueOnce(
-      createPasskeyRegistrationVerificationResponse()
-    );
+    vi.mocked(
+      authAccountApi.verifyPasskeyRegistrationChallenge
+    ).mockResolvedValueOnce(createPasskeyRegistrationVerificationResponse());
 
     await renderSettingsPage();
 
@@ -415,9 +417,9 @@ describe("SettingsPage", () => {
   });
 
   it("shows a browser-check prompt while waiting for the credential provider", async () => {
-    vi.mocked(authAccountApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
-      createPasskeyRegistrationChallengeResponse()
-    );
+    vi.mocked(
+      authAccountApi.startPasskeyRegistrationChallenge
+    ).mockResolvedValueOnce(createPasskeyRegistrationChallengeResponse());
 
     let resolveAttestation!: (value: unknown) => void;
     vi.mocked(passkeyBrowser.getPasskeyAttestation).mockReturnValue(
@@ -455,9 +457,9 @@ describe("SettingsPage", () => {
   });
 
   it("shows a saving prompt while the passkey registration is being verified", async () => {
-    vi.mocked(authAccountApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
-      createPasskeyRegistrationChallengeResponse()
-    );
+    vi.mocked(
+      authAccountApi.startPasskeyRegistrationChallenge
+    ).mockResolvedValueOnce(createPasskeyRegistrationChallengeResponse());
     vi.mocked(passkeyBrowser.getPasskeyAttestation).mockResolvedValueOnce({
       id: "new-credential-id",
       raw_id: "bmV3LWNyZWRlbnRpYWwtaWQ",
@@ -473,7 +475,9 @@ describe("SettingsPage", () => {
     let resolveVerification!: (
       value: ReturnType<typeof createPasskeyRegistrationVerificationResponse>
     ) => void;
-    vi.mocked(authAccountApi.verifyPasskeyRegistrationChallenge).mockReturnValueOnce(
+    vi.mocked(
+      authAccountApi.verifyPasskeyRegistrationChallenge
+    ).mockReturnValueOnce(
       new Promise((resolve) => {
         resolveVerification = resolve;
       })
@@ -502,7 +506,9 @@ describe("SettingsPage", () => {
   });
 
   it("shows passkey enrollment errors inline", async () => {
-    vi.mocked(authAccountApi.startPasskeyRegistrationChallenge).mockRejectedValueOnce(
+    vi.mocked(
+      authAccountApi.startPasskeyRegistrationChallenge
+    ).mockRejectedValueOnce(
       new authAccountApi.AuthApiError("Passkey registration failed.")
     );
 
@@ -519,9 +525,9 @@ describe("SettingsPage", () => {
   });
 
   it("shows cancellation message when user dismisses the browser passkey dialog", async () => {
-    vi.mocked(authAccountApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
-      createPasskeyRegistrationChallengeResponse()
-    );
+    vi.mocked(
+      authAccountApi.startPasskeyRegistrationChallenge
+    ).mockResolvedValueOnce(createPasskeyRegistrationChallengeResponse());
     vi.mocked(passkeyBrowser.getPasskeyAttestation).mockRejectedValueOnce(
       new DOMException(
         "The operation either timed out or was not allowed.",
@@ -545,9 +551,9 @@ describe("SettingsPage", () => {
   });
 
   it("shows timeout message when passkey registration is aborted", async () => {
-    vi.mocked(authAccountApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
-      createPasskeyRegistrationChallengeResponse()
-    );
+    vi.mocked(
+      authAccountApi.startPasskeyRegistrationChallenge
+    ).mockResolvedValueOnce(createPasskeyRegistrationChallengeResponse());
     vi.mocked(passkeyBrowser.getPasskeyAttestation).mockRejectedValueOnce(
       new DOMException("The operation was aborted.", "AbortError")
     );
@@ -568,9 +574,9 @@ describe("SettingsPage", () => {
   });
 
   it("shows generic error when browser attestation fails unexpectedly", async () => {
-    vi.mocked(authAccountApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
-      createPasskeyRegistrationChallengeResponse()
-    );
+    vi.mocked(
+      authAccountApi.startPasskeyRegistrationChallenge
+    ).mockResolvedValueOnce(createPasskeyRegistrationChallengeResponse());
     vi.mocked(passkeyBrowser.getPasskeyAttestation).mockRejectedValueOnce(
       new Error("Unexpected credential error")
     );
@@ -591,9 +597,9 @@ describe("SettingsPage", () => {
   });
 
   it("shows credential provider guidance when the platform reports a credential manager error", async () => {
-    vi.mocked(authAccountApi.startPasskeyRegistrationChallenge).mockResolvedValueOnce(
-      createPasskeyRegistrationChallengeResponse()
-    );
+    vi.mocked(
+      authAccountApi.startPasskeyRegistrationChallenge
+    ).mockResolvedValueOnce(createPasskeyRegistrationChallengeResponse());
     vi.mocked(passkeyBrowser.getPasskeyAttestation).mockRejectedValueOnce(
       new Error(
         "An unknown error occurred while talking to the credential manager."
@@ -669,7 +675,9 @@ describe("SettingsPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /remove/i }));
 
     await waitFor(() => {
-      expect(authAccountApi.deletePasskey).toHaveBeenCalledWith("credential-id");
+      expect(authAccountApi.deletePasskey).toHaveBeenCalledWith(
+        "credential-id"
+      );
       expect(authAccountApi.getPasskeys).toHaveBeenCalledTimes(2);
       expect(
         screen.queryByText(/work macbook touch id/i)

--- a/src/pages/Settings/SettingsPage.tsx
+++ b/src/pages/Settings/SettingsPage.tsx
@@ -56,7 +56,7 @@ import {
   startPasskeyRegistrationChallenge,
   startTotpEnrollment,
   verifyPasskeyRegistrationChallenge,
-} from "../../services/authApi";
+} from "../../services/authAccountApi";
 import { MfaQrCode } from "../../components/MfaQrCode";
 import { formatDateTime } from "../../lib/dateUtils";
 import {

--- a/src/services/authAccountApi.ts
+++ b/src/services/authAccountApi.ts
@@ -1,0 +1,265 @@
+// SPDX-FileCopyrightText: 2025-2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type {
+  MfaRecoveryCodeRevealResponse,
+  MfaStatusResponse,
+  MfaTotpEnrollmentResponse,
+  MfaVerificationCodeRequest,
+  PasskeyDeletionResponse,
+  PasskeyListResponse,
+  PasskeyRegistrationChallengeResponse,
+  PasskeyRegistrationResponse,
+  PasskeyRegistrationVerificationRequest,
+  TotpCodeRequest,
+  VerificationNotificationResponse,
+} from "@/types/api";
+import { buildApiUrl } from "../config";
+import { createAuthApiError, parseJsonResponse } from "./authApiShared";
+import { apiFetch, fetchCsrfToken } from "./csrf";
+
+export { AuthApiError } from "./AuthApiError";
+
+export async function sendVerificationNotification(): Promise<VerificationNotificationResponse> {
+  await fetchCsrfToken();
+
+  const response = await apiFetch(
+    buildApiUrl("/v1/auth/email/verification-notification"),
+    {
+      method: "POST",
+      cache: "no-store",
+      headers: {
+        Accept: "application/json",
+      },
+    }
+  );
+
+  if (!response.ok) {
+    throw await createAuthApiError(
+      response,
+      "Verification email request failed"
+    );
+  }
+
+  return parseJsonResponse<VerificationNotificationResponse>(
+    response,
+    "Verification email request failed"
+  );
+}
+
+export async function getMfaStatus(): Promise<MfaStatusResponse> {
+  const response = await apiFetch(buildApiUrl("/v1/me/mfa"), {
+    method: "GET",
+    cache: "no-store",
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw await createAuthApiError(response, "MFA status fetch failed");
+  }
+
+  return parseJsonResponse<MfaStatusResponse>(
+    response,
+    "MFA status fetch failed"
+  );
+}
+
+export async function getPasskeys(): Promise<PasskeyListResponse> {
+  const response = await apiFetch(buildApiUrl("/v1/me/passkeys"), {
+    method: "GET",
+    cache: "no-store",
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw await createAuthApiError(response, "Passkey list fetch failed");
+  }
+
+  return parseJsonResponse<PasskeyListResponse>(
+    response,
+    "Passkey list fetch failed"
+  );
+}
+
+export async function startPasskeyRegistrationChallenge(): Promise<PasskeyRegistrationChallengeResponse> {
+  await fetchCsrfToken();
+
+  const response = await apiFetch(
+    buildApiUrl("/v1/me/passkeys/challenges/registration"),
+    {
+      method: "POST",
+      cache: "no-store",
+      headers: {
+        Accept: "application/json",
+      },
+    }
+  );
+
+  if (!response.ok) {
+    throw await createAuthApiError(
+      response,
+      "Passkey registration challenge start failed"
+    );
+  }
+
+  return parseJsonResponse<PasskeyRegistrationChallengeResponse>(
+    response,
+    "Passkey registration challenge start failed"
+  );
+}
+
+export async function verifyPasskeyRegistrationChallenge(
+  challengeId: string,
+  payload: PasskeyRegistrationVerificationRequest
+): Promise<PasskeyRegistrationResponse> {
+  await fetchCsrfToken();
+
+  const response = await apiFetch(
+    buildApiUrl(
+      `/v1/me/passkeys/challenges/registration/${challengeId}/verify`
+    ),
+    {
+      method: "POST",
+      cache: "no-store",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(payload),
+    }
+  );
+
+  if (!response.ok) {
+    throw await createAuthApiError(response, "Passkey registration failed");
+  }
+
+  return parseJsonResponse<PasskeyRegistrationResponse>(
+    response,
+    "Passkey registration failed"
+  );
+}
+
+export async function deletePasskey(
+  credentialId: string
+): Promise<PasskeyDeletionResponse> {
+  const response = await apiFetch(
+    buildApiUrl(`/v1/me/passkeys/${credentialId}`),
+    {
+      method: "DELETE",
+      cache: "no-store",
+      headers: {
+        Accept: "application/json",
+      },
+    }
+  );
+
+  if (!response.ok) {
+    throw await createAuthApiError(response, "Passkey deletion failed");
+  }
+
+  return parseJsonResponse<PasskeyDeletionResponse>(
+    response,
+    "Passkey deletion failed"
+  );
+}
+
+export async function startTotpEnrollment(): Promise<MfaTotpEnrollmentResponse> {
+  const response = await apiFetch(buildApiUrl("/v1/me/mfa/totp/enrollment"), {
+    method: "POST",
+    cache: "no-store",
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw await createAuthApiError(response, "TOTP enrollment start failed");
+  }
+
+  return parseJsonResponse<MfaTotpEnrollmentResponse>(
+    response,
+    "TOTP enrollment start failed"
+  );
+}
+
+export async function confirmTotpEnrollment(
+  payload: TotpCodeRequest
+): Promise<MfaRecoveryCodeRevealResponse> {
+  const response = await apiFetch(
+    buildApiUrl("/v1/me/mfa/totp/enrollment/confirm"),
+    {
+      method: "POST",
+      cache: "no-store",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(payload),
+    }
+  );
+
+  if (!response.ok) {
+    throw await createAuthApiError(
+      response,
+      "TOTP enrollment confirmation failed"
+    );
+  }
+
+  return parseJsonResponse<MfaRecoveryCodeRevealResponse>(
+    response,
+    "TOTP enrollment confirmation failed"
+  );
+}
+
+export async function regenerateRecoveryCodes(
+  payload: MfaVerificationCodeRequest
+): Promise<MfaRecoveryCodeRevealResponse> {
+  const response = await apiFetch(
+    buildApiUrl("/v1/me/mfa/recovery-codes/regenerate"),
+    {
+      method: "POST",
+      cache: "no-store",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(payload),
+    }
+  );
+
+  if (!response.ok) {
+    throw await createAuthApiError(
+      response,
+      "Recovery code regeneration failed"
+    );
+  }
+
+  return parseJsonResponse<MfaRecoveryCodeRevealResponse>(
+    response,
+    "Recovery code regeneration failed"
+  );
+}
+
+export async function disableMfa(
+  payload: MfaVerificationCodeRequest
+): Promise<MfaStatusResponse> {
+  const response = await apiFetch(buildApiUrl("/v1/me/mfa"), {
+    method: "DELETE",
+    cache: "no-store",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw await createAuthApiError(response, "MFA disable failed");
+  }
+
+  return parseJsonResponse<MfaStatusResponse>(response, "MFA disable failed");
+}

--- a/src/services/authApi.test.ts
+++ b/src/services/authApi.test.ts
@@ -4,25 +4,27 @@
 import { describe, it, expect, vi, beforeEach, assert } from "vitest";
 import * as config from "../config";
 import {
-  startPasskeyAuthenticationChallenge,
-  verifyPasskeyAuthenticationChallenge,
-  deletePasskey,
-  startPasskeyRegistrationChallenge,
-  verifyPasskeyRegistrationChallenge,
-  getPasskeys,
+  AuthApiError,
+  getCurrentUser,
   login,
   logout,
   logoutAll,
-  getCurrentUser,
-  sendVerificationNotification,
-  getMfaStatus,
-  startTotpEnrollment,
-  confirmTotpEnrollment,
-  regenerateRecoveryCodes,
-  disableMfa,
-  AuthApiError,
   verifyMfaChallenge,
+  startPasskeyAuthenticationChallenge,
+  verifyPasskeyAuthenticationChallenge,
 } from "./authApi";
+import {
+  confirmTotpEnrollment,
+  deletePasskey,
+  disableMfa,
+  getMfaStatus,
+  getPasskeys,
+  regenerateRecoveryCodes,
+  sendVerificationNotification,
+  startPasskeyRegistrationChallenge,
+  startTotpEnrollment,
+  verifyPasskeyRegistrationChallenge,
+} from "./authAccountApi";
 
 const mockFetch = vi.fn();
 

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -25,18 +25,6 @@ export type BrowserLoginResponse =
   | LoginMfaChallengeResponse;
 
 export { AuthApiError } from "./AuthApiError";
-export {
-  confirmTotpEnrollment,
-  deletePasskey,
-  disableMfa,
-  getMfaStatus,
-  getPasskeys,
-  regenerateRecoveryCodes,
-  sendVerificationNotification,
-  startPasskeyRegistrationChallenge,
-  startTotpEnrollment,
-  verifyPasskeyRegistrationChallenge,
-} from "./authAccountApi";
 
 /**
  * Login with email and password

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -4,23 +4,14 @@
 import type {
   CompletedLoginResponse,
   LoginMfaChallengeResponse,
-  MfaRecoveryCodeRevealResponse,
-  MfaStatusResponse,
-  MfaTotpEnrollmentResponse,
   MfaVerificationCodeRequest,
-  PasskeyDeletionResponse,
   PasskeyAuthenticationChallengeResponse,
   PasskeyAuthenticationVerificationRequest,
-  PasskeyListResponse,
-  PasskeyRegistrationChallengeResponse,
-  PasskeyRegistrationResponse,
-  PasskeyRegistrationVerificationRequest,
   SessionLoginResponse,
-  TotpCodeRequest,
-  VerificationNotificationResponse,
 } from "@/types/api";
 import { ApiBaseUrlConfigurationError, buildApiUrl } from "../config";
 import { AuthApiError } from "./AuthApiError";
+import { createAuthApiError, parseJsonResponse } from "./authApiShared";
 import { fetchCsrfToken, apiFetch } from "./csrf";
 
 interface LoginCredentials {
@@ -33,102 +24,19 @@ export type BrowserLoginResponse =
   | SessionLoginResponse
   | LoginMfaChallengeResponse;
 
-interface ApiError {
-  message: string;
-  errors?: Record<string, string[]>;
-  code?: string;
-}
-
-function hasJsonContentType(response: Response): boolean {
-  if (
-    !("headers" in response) ||
-    !response.headers ||
-    typeof response.headers.get !== "function"
-  ) {
-    return typeof response.json === "function";
-  }
-
-  const contentType = response.headers.get("Content-Type");
-
-  return contentType?.toLowerCase().includes("application/json") ?? false;
-}
-
-async function parseJsonResponse<T>(
-  response: Response,
-  operation: string
-): Promise<T> {
-  if (!hasJsonContentType(response)) {
-    throw new AuthApiError(
-      `${operation}: expected application/json response from API`
-    );
-  }
-
-  try {
-    return (await response.json()) as T;
-  } catch {
-    throw new AuthApiError(`${operation}: received malformed JSON from API`);
-  }
-}
-
-async function parseJsonError(response: Response): Promise<ApiError | null> {
-  if (!hasJsonContentType(response)) {
-    return null;
-  }
-
-  try {
-    return (await response.json()) as ApiError;
-  } catch {
-    return null;
-  }
-}
-
-function parseRetryAfterSeconds(response: Response): number | undefined {
-  if (
-    !("headers" in response) ||
-    !response.headers ||
-    typeof response.headers.get !== "function"
-  ) {
-    return undefined;
-  }
-
-  const retryAfterHeader = response.headers.get("Retry-After");
-  const retryAfterSeconds = retryAfterHeader
-    ? Number.parseInt(retryAfterHeader, 10)
-    : Number.NaN;
-
-  return Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0
-    ? retryAfterSeconds
-    : undefined;
-}
-
 export { AuthApiError } from "./AuthApiError";
-
-async function createAuthApiError(
-  response: Response,
-  defaultMessage: string,
-  nonJsonMessage = `${defaultMessage}: ${response.status} ${response.statusText}`
-): Promise<AuthApiError> {
-  const error = await parseJsonError(response);
-  const retryAfterSeconds = parseRetryAfterSeconds(response);
-
-  if (!error) {
-    return new AuthApiError(
-      nonJsonMessage,
-      undefined,
-      response.status,
-      undefined,
-      retryAfterSeconds
-    );
-  }
-
-  return new AuthApiError(
-    error.message || defaultMessage,
-    error.errors,
-    response.status,
-    error.code,
-    retryAfterSeconds
-  );
-}
+export {
+  confirmTotpEnrollment,
+  deletePasskey,
+  disableMfa,
+  getMfaStatus,
+  getPasskeys,
+  regenerateRecoveryCodes,
+  sendVerificationNotification,
+  startPasskeyRegistrationChallenge,
+  startTotpEnrollment,
+  verifyPasskeyRegistrationChallenge,
+} from "./authAccountApi";
 
 /**
  * Login with email and password
@@ -314,248 +222,4 @@ export async function getCurrentUser(): Promise<SessionLoginResponse["user"]> {
     response,
     "Current user fetch failed"
   );
-}
-
-export async function sendVerificationNotification(): Promise<VerificationNotificationResponse> {
-  await fetchCsrfToken();
-
-  const response = await apiFetch(
-    buildApiUrl("/v1/auth/email/verification-notification"),
-    {
-      method: "POST",
-      cache: "no-store",
-      headers: {
-        Accept: "application/json",
-      },
-    }
-  );
-
-  if (!response.ok) {
-    throw await createAuthApiError(
-      response,
-      "Verification email request failed"
-    );
-  }
-
-  return parseJsonResponse<VerificationNotificationResponse>(
-    response,
-    "Verification email request failed"
-  );
-}
-
-export async function getMfaStatus(): Promise<MfaStatusResponse> {
-  const response = await apiFetch(buildApiUrl("/v1/me/mfa"), {
-    method: "GET",
-    cache: "no-store",
-    headers: {
-      Accept: "application/json",
-    },
-  });
-
-  if (!response.ok) {
-    throw await createAuthApiError(response, "MFA status fetch failed");
-  }
-
-  return parseJsonResponse<MfaStatusResponse>(
-    response,
-    "MFA status fetch failed"
-  );
-}
-
-export async function getPasskeys(): Promise<PasskeyListResponse> {
-  const response = await apiFetch(buildApiUrl("/v1/me/passkeys"), {
-    method: "GET",
-    cache: "no-store",
-    headers: {
-      Accept: "application/json",
-    },
-  });
-
-  if (!response.ok) {
-    throw await createAuthApiError(response, "Passkey list fetch failed");
-  }
-
-  return parseJsonResponse<PasskeyListResponse>(
-    response,
-    "Passkey list fetch failed"
-  );
-}
-
-export async function startPasskeyRegistrationChallenge(): Promise<PasskeyRegistrationChallengeResponse> {
-  await fetchCsrfToken();
-
-  const response = await apiFetch(
-    buildApiUrl("/v1/me/passkeys/challenges/registration"),
-    {
-      method: "POST",
-      cache: "no-store",
-      headers: {
-        Accept: "application/json",
-      },
-    }
-  );
-
-  if (!response.ok) {
-    throw await createAuthApiError(
-      response,
-      "Passkey registration challenge start failed"
-    );
-  }
-
-  return parseJsonResponse<PasskeyRegistrationChallengeResponse>(
-    response,
-    "Passkey registration challenge start failed"
-  );
-}
-
-export async function verifyPasskeyRegistrationChallenge(
-  challengeId: string,
-  payload: PasskeyRegistrationVerificationRequest
-): Promise<PasskeyRegistrationResponse> {
-  await fetchCsrfToken();
-
-  const response = await apiFetch(
-    buildApiUrl(
-      `/v1/me/passkeys/challenges/registration/${challengeId}/verify`
-    ),
-    {
-      method: "POST",
-      cache: "no-store",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-      },
-      body: JSON.stringify(payload),
-    }
-  );
-
-  if (!response.ok) {
-    throw await createAuthApiError(response, "Passkey registration failed");
-  }
-
-  return parseJsonResponse<PasskeyRegistrationResponse>(
-    response,
-    "Passkey registration failed"
-  );
-}
-
-export async function deletePasskey(
-  credentialId: string
-): Promise<PasskeyDeletionResponse> {
-  const response = await apiFetch(
-    buildApiUrl(`/v1/me/passkeys/${credentialId}`),
-    {
-      method: "DELETE",
-      cache: "no-store",
-      headers: {
-        Accept: "application/json",
-      },
-    }
-  );
-
-  if (!response.ok) {
-    throw await createAuthApiError(response, "Passkey deletion failed");
-  }
-
-  return parseJsonResponse<PasskeyDeletionResponse>(
-    response,
-    "Passkey deletion failed"
-  );
-}
-
-export async function startTotpEnrollment(): Promise<MfaTotpEnrollmentResponse> {
-  const response = await apiFetch(buildApiUrl("/v1/me/mfa/totp/enrollment"), {
-    method: "POST",
-    cache: "no-store",
-    headers: {
-      Accept: "application/json",
-    },
-  });
-
-  if (!response.ok) {
-    throw await createAuthApiError(response, "TOTP enrollment start failed");
-  }
-
-  return parseJsonResponse<MfaTotpEnrollmentResponse>(
-    response,
-    "TOTP enrollment start failed"
-  );
-}
-
-export async function confirmTotpEnrollment(
-  payload: TotpCodeRequest
-): Promise<MfaRecoveryCodeRevealResponse> {
-  const response = await apiFetch(
-    buildApiUrl("/v1/me/mfa/totp/enrollment/confirm"),
-    {
-      method: "POST",
-      cache: "no-store",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-      },
-      body: JSON.stringify(payload),
-    }
-  );
-
-  if (!response.ok) {
-    throw await createAuthApiError(
-      response,
-      "TOTP enrollment confirmation failed"
-    );
-  }
-
-  return parseJsonResponse<MfaRecoveryCodeRevealResponse>(
-    response,
-    "TOTP enrollment confirmation failed"
-  );
-}
-
-export async function regenerateRecoveryCodes(
-  payload: MfaVerificationCodeRequest
-): Promise<MfaRecoveryCodeRevealResponse> {
-  const response = await apiFetch(
-    buildApiUrl("/v1/me/mfa/recovery-codes/regenerate"),
-    {
-      method: "POST",
-      cache: "no-store",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-      },
-      body: JSON.stringify(payload),
-    }
-  );
-
-  if (!response.ok) {
-    throw await createAuthApiError(
-      response,
-      "Recovery code regeneration failed"
-    );
-  }
-
-  return parseJsonResponse<MfaRecoveryCodeRevealResponse>(
-    response,
-    "Recovery code regeneration failed"
-  );
-}
-
-export async function disableMfa(
-  payload: MfaVerificationCodeRequest
-): Promise<MfaStatusResponse> {
-  const response = await apiFetch(buildApiUrl("/v1/me/mfa"), {
-    method: "DELETE",
-    cache: "no-store",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify(payload),
-  });
-
-  if (!response.ok) {
-    throw await createAuthApiError(response, "MFA disable failed");
-  }
-
-  return parseJsonResponse<MfaStatusResponse>(response, "MFA disable failed");
 }

--- a/src/services/authApiShared.ts
+++ b/src/services/authApiShared.ts
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2025-2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { AuthApiError } from "./AuthApiError";
+
+interface ApiError {
+  message: string;
+  errors?: Record<string, string[]>;
+  code?: string;
+}
+
+function hasJsonContentType(response: Response): boolean {
+  if (
+    !("headers" in response) ||
+    !response.headers ||
+    typeof response.headers.get !== "function"
+  ) {
+    return typeof response.json === "function";
+  }
+
+  const contentType = response.headers.get("Content-Type");
+
+  return contentType?.toLowerCase().includes("application/json") ?? false;
+}
+
+export async function parseJsonResponse<T>(
+  response: Response,
+  operation: string
+): Promise<T> {
+  if (!hasJsonContentType(response)) {
+    throw new AuthApiError(
+      `${operation}: expected application/json response from API`
+    );
+  }
+
+  try {
+    return (await response.json()) as T;
+  } catch {
+    throw new AuthApiError(`${operation}: received malformed JSON from API`);
+  }
+}
+
+async function parseJsonError(response: Response): Promise<ApiError | null> {
+  if (!hasJsonContentType(response)) {
+    return null;
+  }
+
+  try {
+    return (await response.json()) as ApiError;
+  } catch {
+    return null;
+  }
+}
+
+function parseRetryAfterSeconds(response: Response): number | undefined {
+  if (
+    !("headers" in response) ||
+    !response.headers ||
+    typeof response.headers.get !== "function"
+  ) {
+    return undefined;
+  }
+
+  const retryAfterHeader = response.headers.get("Retry-After");
+  const retryAfterSeconds = retryAfterHeader
+    ? Number.parseInt(retryAfterHeader, 10)
+    : Number.NaN;
+
+  return Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0
+    ? retryAfterSeconds
+    : undefined;
+}
+
+export async function createAuthApiError(
+  response: Response,
+  defaultMessage: string,
+  nonJsonMessage = `${defaultMessage}: ${response.status} ${response.statusText}`
+): Promise<AuthApiError> {
+  const error = await parseJsonError(response);
+  const retryAfterSeconds = parseRetryAfterSeconds(response);
+
+  if (!error) {
+    return new AuthApiError(
+      nonJsonMessage,
+      undefined,
+      response.status,
+      undefined,
+      retryAfterSeconds
+    );
+  }
+
+  return new AuthApiError(
+    error.message || defaultMessage,
+    error.errors,
+    response.status,
+    error.code,
+    retryAfterSeconds
+  );
+}


### PR DESCRIPTION
## Reproduced defect

`npm run build` emitted `[INEFFECTIVE_DYNAMIC_IMPORT] src/services/authApi.ts` because the login/bootstrap path lazy-loaded `authApi` while settings, email-verification, and shared error handling still imported the same module statically.

## What changed

- split account-scoped MFA and verification endpoints into `src/services/authAccountApi.ts`
- moved shared auth API response/error parsing into `src/services/authApiShared.ts`
- kept `src/services/authApi.ts` focused on the browser-session login/bootstrap surface and re-exported the account helpers for compatibility
- updated the static consumers and affected tests to import the smaller modules directly
- added an Unreleased changelog entry for the build-warning fix

## Validation

- `npm test -- --run src/pages/Settings/SettingsPage.test.tsx`
- `npm test -- --run src/components/ProtectedRoute.test.tsx`
- `npm test -- --run src/lib/errorUtils.test.ts src/services/authApi.test.ts`
- `npm run lint`
- `npm run build`

## Follow-up before ready

- linked workspaces: none
- unresolved checks: GitHub Actions have not run yet in this draft PR
- ready-state gate: perform the final PR-view self-review and mark ready only if it still finds zero issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth client boundaries and import graph for login vs account APIs; behavior is largely moved code, but mistakes in exports or lazy boundaries could affect bundle splitting or runtime imports.
> 
> **Overview**
> Resolves the Vite/Rolldown **`INEFFECTIVE_DYNAMIC_IMPORT`** warning on `authApi` by carving the monolithic client into smaller entry points so login/bootstrap can stay behind `import()` without pulling account/MFA code on the public path.
> 
> **Shared parsing** (`createAuthApiError`, `parseJsonResponse`, etc.) moves to `authApiShared.ts`. **Account-scoped** calls (MFA, passkeys, email verification) move to new `authAccountApi.ts`. **`authApi.ts`** is trimmed to session login/bootstrap (login, logout, `getCurrentUser`, MFA verify, passkey *authentication* challenges).
> 
> Call sites switch to the right module: **Settings** and related tests import `authAccountApi`; **`errorUtils`** and several tests import `AuthApiError` from `AuthApiError` directly. **Email verification** in `RouteGuardState` now lazy-loads `authAccountApi` when the user sends a verification email. **`ProtectedRoute` tests** mock `authApi` and `authAccountApi` separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d4b2d62eb3519197694283a5943ece70cb92009. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->