### PR TITLE
Harden service-worker logout redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Made service-worker explicit logout redirects resilient across multiple open app windows: protected clients are redirected to `/login` independently, so a failed `WindowClient.navigate()` call is logged without blocking remaining protected clients from being redirected.
+
 - Fixed service-worker notification click handler to focus an existing app window when its pathname matches the notification target URL, then navigate it to the full target URL (including query and hash). The handler previously only matched on `pathname` without navigating the window to the specific deep-link, and an intermediate refactor erroneously required an exact `pathname + search + hash` match which prevented focusing any window already open on the same page. The push-notification data builder now also correctly makes the top-level `url` field authoritative over any `url` key nested inside the `data` sub-object.
 
 - Eliminated the gap that appeared below the footer on iOS Safari and PWA standalone installs by adding `viewport-fit=cover` to the viewport meta tag and replacing hardcoded `min-h-dvh` / `min-h: 100vh` values with CSS custom properties (`--app-shell-min-height`, `--app-auth-card-min-height`, `--app-footer-padding-bottom`) that select `100svh` as a baseline, upgrade to `100dvh` where supported, revert to `100svh` in standalone mode, and include `env(safe-area-inset-bottom)` padding on footer elements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Made service-worker explicit logout redirects resilient across multiple open app windows: protected clients are redirected to `/login` independently, so a failed `WindowClient.navigate()` call is logged without blocking remaining protected clients from being redirected.
+- Made service-worker explicit logout redirects resilient across multiple open app windows: protected clients are redirected to `/login` independently, so a failed `WindowClient.navigate()` call is logged without blocking remaining protected clients from being redirected, and the per-client failure log now redacts query strings and fragments from the client URL.
 
 - Fixed service-worker notification click handler to focus an existing app window when its pathname matches the notification target URL, then navigate it to the full target URL (including query and hash). The handler previously only matched on `pathname` without navigating the window to the specific deep-link, and an intermediate refactor erroneously required an exact `pathname + search + hash` match which prevented focusing any window already open on the same page. The push-notification data builder now also correctly makes the top-level `url` field authoritative over any `url` key nested inside the `data` sub-object.
 

--- a/src/lib/serviceWorkerAuthRedirect.test.ts
+++ b/src/lib/serviceWorkerAuthRedirect.test.ts
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  redirectProtectedWindowClientsToLogin,
+  shouldRedirectLoggedOutNavigation,
+  type RedirectableWindowClient,
+} from "./serviceWorkerAuthRedirect";
+
+function createWindowClient(
+  url: string,
+  navigateImpl: RedirectableWindowClient["navigate"] = vi
+    .fn<RedirectableWindowClient["navigate"]>()
+    .mockResolvedValue(null)
+): RedirectableWindowClient {
+  return {
+    url,
+    navigate: navigateImpl,
+  };
+}
+
+describe("serviceWorkerAuthRedirect", () => {
+  describe("shouldRedirectLoggedOutNavigation", () => {
+    it("does not redirect when auth state is unknown or authenticated", () => {
+      expect(shouldRedirectLoggedOutNavigation("/dashboard", true)).toBe(false);
+      expect(shouldRedirectLoggedOutNavigation("/dashboard", null)).toBe(false);
+    });
+
+    it("allows logged-out public paths, including trailing-slash variants", () => {
+      expect(shouldRedirectLoggedOutNavigation("/login", false)).toBe(false);
+      expect(shouldRedirectLoggedOutNavigation("/login/", false)).toBe(false);
+      expect(
+        shouldRedirectLoggedOutNavigation("/onboarding/complete/", false)
+      ).toBe(false);
+    });
+
+    it("redirects logged-out protected paths", () => {
+      expect(shouldRedirectLoggedOutNavigation("/", false)).toBe(true);
+      expect(shouldRedirectLoggedOutNavigation("/dashboard", false)).toBe(true);
+    });
+  });
+
+  describe("redirectProtectedWindowClientsToLogin", () => {
+    it("redirects only protected window clients to the login page", async () => {
+      const protectedNavigate = vi
+        .fn<RedirectableWindowClient["navigate"]>()
+        .mockResolvedValue(null);
+      const loginNavigate = vi
+        .fn<RedirectableWindowClient["navigate"]>()
+        .mockResolvedValue(null);
+
+      const summary = await redirectProtectedWindowClientsToLogin(
+        [
+          createWindowClient(
+            "https://app.secpal.dev/dashboard",
+            protectedNavigate
+          ),
+          createWindowClient("https://app.secpal.dev/login", loginNavigate),
+        ],
+        "https://app.secpal.dev"
+      );
+
+      expect(protectedNavigate).toHaveBeenCalledWith(
+        "https://app.secpal.dev/login"
+      );
+      expect(loginNavigate).not.toHaveBeenCalled();
+      expect(summary).toEqual({ redirected: 1, skipped: 1, failed: 0 });
+    });
+
+    it("continues redirecting remaining clients when one navigation fails", async () => {
+      const logger = {
+        error: vi.fn<Console["error"]>(),
+        warn: vi.fn<Console["warn"]>(),
+      };
+      const failedNavigate = vi
+        .fn<RedirectableWindowClient["navigate"]>()
+        .mockRejectedValue(new Error("navigation failed"));
+      const successfulNavigate = vi
+        .fn<RedirectableWindowClient["navigate"]>()
+        .mockResolvedValue(null);
+
+      const summary = await redirectProtectedWindowClientsToLogin(
+        [
+          createWindowClient("https://app.secpal.dev/reports", failedNavigate),
+          createWindowClient(
+            "https://app.secpal.dev/settings",
+            successfulNavigate
+          ),
+          createWindowClient(
+            "https://app.secpal.dev/login",
+            successfulNavigate
+          ),
+        ],
+        "https://app.secpal.dev",
+        logger
+      );
+
+      expect(failedNavigate).toHaveBeenCalledWith(
+        "https://app.secpal.dev/login"
+      );
+      expect(successfulNavigate).toHaveBeenCalledWith(
+        "https://app.secpal.dev/login"
+      );
+      expect(successfulNavigate).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenCalledWith(
+        "[SW] Failed to redirect protected client to login:",
+        expect.objectContaining({
+          clientUrl: "https://app.secpal.dev/reports",
+          error: expect.any(Error),
+        })
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        "[SW] Completed protected-client login redirects with failures:",
+        {
+          redirected: 1,
+          skipped: 1,
+          failed: 1,
+        }
+      );
+      expect(summary).toEqual({ redirected: 1, skipped: 1, failed: 1 });
+    });
+  });
+});

--- a/src/lib/serviceWorkerAuthRedirect.test.ts
+++ b/src/lib/serviceWorkerAuthRedirect.test.ts
@@ -120,5 +120,34 @@ describe("serviceWorkerAuthRedirect", () => {
       );
       expect(summary).toEqual({ redirected: 1, skipped: 1, failed: 1 });
     });
+
+    it("redacts query strings and fragments from logged client URLs", async () => {
+      const logger = {
+        error: vi.fn<Console["error"]>(),
+        warn: vi.fn<Console["warn"]>(),
+      };
+      const failedNavigate = vi
+        .fn<RedirectableWindowClient["navigate"]>()
+        .mockRejectedValue(new Error("navigation failed"));
+
+      await redirectProtectedWindowClientsToLogin(
+        [
+          createWindowClient(
+            "https://app.secpal.dev/reports?token=secret#filters",
+            failedNavigate
+          ),
+        ],
+        "https://app.secpal.dev",
+        logger
+      );
+
+      expect(logger.error).toHaveBeenCalledWith(
+        "[SW] Failed to redirect protected client to login:",
+        expect.objectContaining({
+          clientUrl: "https://app.secpal.dev/reports",
+          error: expect.any(Error),
+        })
+      );
+    });
   });
 });

--- a/src/lib/serviceWorkerAuthRedirect.ts
+++ b/src/lib/serviceWorkerAuthRedirect.ts
@@ -30,6 +30,15 @@ export function shouldRedirectLoggedOutNavigation(
   return !PUBLIC_LOGGED_OUT_PATHS.has(normalizedPathname);
 }
 
+function redactClientUrlForLog(clientUrl: string): string {
+  try {
+    const { origin, pathname } = new URL(clientUrl);
+    return `${origin}${pathname}`;
+  } catch {
+    return "[invalid-client-url]";
+  }
+}
+
 export async function redirectProtectedWindowClientsToLogin(
   windowClients: readonly RedirectableWindowClient[],
   origin: string,
@@ -50,7 +59,7 @@ export async function redirectProtectedWindowClientsToLogin(
         return "redirected" as const;
       } catch (error) {
         logger.error("[SW] Failed to redirect protected client to login:", {
-          clientUrl: client.url,
+          clientUrl: redactClientUrlForLog(client.url),
           error,
         });
         return "failed" as const;

--- a/src/lib/serviceWorkerAuthRedirect.ts
+++ b/src/lib/serviceWorkerAuthRedirect.ts
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+const PUBLIC_LOGGED_OUT_PATHS = new Set(["/login", "/onboarding/complete"]);
+
+export interface RedirectableWindowClient {
+  url: string;
+  navigate(url: string): Promise<WindowClient | null>;
+}
+
+export interface ProtectedClientRedirectSummary {
+  redirected: number;
+  skipped: number;
+  failed: number;
+}
+
+export function shouldRedirectLoggedOutNavigation(
+  pathname: string,
+  isAuthenticated: boolean | null
+): boolean {
+  if (isAuthenticated !== false) {
+    return false;
+  }
+
+  const normalizedPathname =
+    pathname !== "/" && pathname.endsWith("/")
+      ? pathname.slice(0, -1)
+      : pathname;
+
+  return !PUBLIC_LOGGED_OUT_PATHS.has(normalizedPathname);
+}
+
+export async function redirectProtectedWindowClientsToLogin(
+  windowClients: readonly RedirectableWindowClient[],
+  origin: string,
+  logger: Pick<Console, "error" | "warn"> = console
+): Promise<ProtectedClientRedirectSummary> {
+  const loginUrl = new URL("/login", origin).toString();
+
+  const results = await Promise.all(
+    windowClients.map(async (client) => {
+      try {
+        const pathname = new URL(client.url).pathname;
+
+        if (!shouldRedirectLoggedOutNavigation(pathname, false)) {
+          return "skipped" as const;
+        }
+
+        await client.navigate(loginUrl);
+        return "redirected" as const;
+      } catch (error) {
+        logger.error("[SW] Failed to redirect protected client to login:", {
+          clientUrl: client.url,
+          error,
+        });
+        return "failed" as const;
+      }
+    })
+  );
+
+  const summary = results.reduce<ProtectedClientRedirectSummary>(
+    (accumulator, result) => {
+      accumulator[result] += 1;
+      return accumulator;
+    },
+    { redirected: 0, skipped: 0, failed: 0 }
+  );
+
+  if (summary.failed > 0) {
+    logger.warn(
+      "[SW] Completed protected-client login redirects with failures:",
+      summary
+    );
+  }
+
+  return summary;
+}

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -23,26 +23,12 @@ import {
   focusOrNavigateClient,
   getNotificationNavigationTarget,
 } from "./lib/notificationNavigation";
+import {
+  redirectProtectedWindowClientsToLogin,
+  shouldRedirectLoggedOutNavigation,
+} from "./lib/serviceWorkerAuthRedirect";
 
 declare const self: ServiceWorkerGlobalScope;
-
-const PUBLIC_LOGGED_OUT_PATHS = new Set(["/login", "/onboarding/complete"]);
-
-function shouldRedirectLoggedOutNavigation(
-  pathname: string,
-  isAuthenticated: boolean | null
-): boolean {
-  if (isAuthenticated !== false) {
-    return false;
-  }
-
-  const normalizedPathname =
-    pathname !== "/" && pathname.endsWith("/")
-      ? pathname.slice(0, -1)
-      : pathname;
-
-  return !PUBLIC_LOGGED_OUT_PATHS.has(normalizedPathname);
-}
 
 async function redirectProtectedClientsToLogin(): Promise<void> {
   const windowClients = await self.clients.matchAll({
@@ -50,16 +36,9 @@ async function redirectProtectedClientsToLogin(): Promise<void> {
     includeUncontrolled: true,
   });
 
-  await Promise.all(
-    windowClients.map(async (client) => {
-      const pathname = new URL(client.url).pathname;
-
-      if (!shouldRedirectLoggedOutNavigation(pathname, false)) {
-        return;
-      }
-
-      await client.navigate(new URL("/login", self.location.origin).toString());
-    })
+  await redirectProtectedWindowClientsToLogin(
+    windowClients,
+    self.location.origin
   );
 }
 


### PR DESCRIPTION
## Summary

Reproduced defect: `redirectProtectedClientsToLogin()` in `src/sw.ts` used `Promise.all(...)` across every matched window client, so one rejected `client.navigate(...)` aborted the whole redirect batch and only surfaced a generic top-level service-worker error.

This change hardens the explicit logout redirect flow by extracting the protected-route redirect logic into a dedicated helper, continuing to redirect the remaining protected clients after an individual navigation failure, and logging both per-client failures and a final redirect summary when partial failures occur.

It also adds focused regression coverage for the protected-path classification and the partial-failure redirect case, and updates `CHANGELOG.md` for the observable service-worker logout behavior change.

## Validation

- `npm test -- --run src/lib/serviceWorkerAuthRedirect.test.ts`
- `npm run typecheck`
- `npm run lint`

## Before Ready

- Linked workspaces: none used for this change.
- Remaining follow-up before marking ready: GitHub Actions must pass, and the final self-review in the PR view must still find zero issues.

Closes #1255
