### PR TITLE
Align root organizational unit select icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Aligned the root/all-units organizational-unit select options with the rest of the hierarchical unit rows, keeping their icons from shrinking and their labels truncatable in narrow menus.
 - Reworked the Activity Logs overview to avoid unnecessary horizontal page scrolling on narrow viewports. Below the `sm` breakpoint the page now renders each activity as a stacked card instead of forcing the desktop table layout into the available width, and the pagination controls wrap vertically on mobile. The responsive layout switch now reads the breakpoint once on mount, listens only via `MediaQueryList.addEventListener("change")`, and updates on viewport resize without redundant state writes. Added `tests/e2e/activity-logs.spec.ts` to assert that the mobile card layout is active, the desktop table stays unmounted, and the overview stays free of horizontal overflow across multiple narrow viewport widths (`320`, `360`, `390`, `412`, `430`).
 - Restored API-required organizational-unit and type fields in site creation payloads and aligned the sites table loading skeleton with the added customer/contact columns.
 

--- a/src/components/MoveOrganizationalUnitDialog.test.tsx
+++ b/src/components/MoveOrganizationalUnitDialog.test.tsx
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import {
+  render,
+  screen,
+  waitFor,
+  fireEvent,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
@@ -309,6 +315,44 @@ describe("MoveOrganizationalUnitDialog", () => {
         },
         { timeout: 5000 }
       );
+    }, 15000);
+
+    it("keeps the root option icon aligned and label truncatable", async () => {
+      renderWithI18n(
+        <MoveOrganizationalUnitDialog
+          open={true}
+          unit={mockUnitWithParent}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      );
+
+      await waitFor(
+        () => {
+          expect(getParentSelectTrigger()).toBeInTheDocument();
+        },
+        { timeout: 5000 }
+      );
+
+      openParentSelect();
+
+      const option = await screen.findByRole(
+        "option",
+        { name: /Make root unit/i },
+        { timeout: 5000 }
+      );
+      const label = within(option).getByText(/Make root unit/i);
+      const contentRow = label.parentElement;
+
+      expect(contentRow).toHaveClass(
+        "flex",
+        "w-full",
+        "min-w-0",
+        "items-center",
+        "gap-2"
+      );
+      expect(contentRow?.querySelector("svg")).toHaveClass("shrink-0");
+      expect(label).toHaveClass("min-w-0", "truncate");
     }, 15000);
 
     it("allows selecting a new parent from the list", async () => {

--- a/src/components/MoveOrganizationalUnitDialog.tsx
+++ b/src/components/MoveOrganizationalUnitDialog.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { useState, useMemo } from "react";
@@ -337,9 +337,11 @@ function MoveOrganizationalUnitDialogContent({
               <SelectContent>
                 {/* Root option */}
                 <SelectItem value={ROOT_PARENT_SELECT_VALUE}>
-                  <RootIcon className="h-4 w-4" />
-                  <span className="ml-2.5 truncate first:ml-0 sm:ml-2 sm:first:ml-0">
-                    {t`Make root unit (no parent)`}
+                  <span className="flex w-full min-w-0 items-center gap-2">
+                    <RootIcon className="h-4 w-4 shrink-0" />
+                    <span className="min-w-0 truncate">
+                      {t`Make root unit (no parent)`}
+                    </span>
                   </span>
                 </SelectItem>
 

--- a/src/components/OrganizationalUnitPicker.tsx
+++ b/src/components/OrganizationalUnitPicker.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { useMemo } from "react";
@@ -196,9 +196,11 @@ export function OrganizationalUnitPicker({
       <SelectContent>
         {/* "All Units" option */}
         <SelectItem value={ALL_UNITS_SELECT_VALUE}>
-          <RootIcon className="h-4 w-4" />
-          <span className="ml-2.5 truncate first:ml-0 sm:ml-2 sm:first:ml-0">
-            {allUnitsLabel || <Trans>All Units</Trans>}
+          <span className="flex w-full min-w-0 items-center gap-2">
+            <RootIcon className="h-4 w-4 shrink-0" />
+            <span className="min-w-0 truncate">
+              {allUnitsLabel || <Trans>All Units</Trans>}
+            </span>
           </span>
         </SelectItem>
 

--- a/tests/unit/OrganizationalUnitPicker.test.tsx
+++ b/tests/unit/OrganizationalUnitPicker.test.tsx
@@ -1,8 +1,8 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, test, expect, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
@@ -154,6 +154,37 @@ describe("OrganizationalUnitPicker", () => {
     );
 
     expect(screen.getByText("All Organizations")).toBeInTheDocument();
+  });
+
+  test("keeps All Units icon aligned and label truncatable after opening", () => {
+    const onChange = vi.fn();
+    const allUnitsLabel =
+      "All organizational units with a deliberately long label";
+
+    renderWithI18n(
+      <OrganizationalUnitPicker
+        units={mockUnits}
+        value=""
+        onChange={onChange}
+        allUnitsLabel={allUnitsLabel}
+      />
+    );
+
+    openOrganizationalUnitPicker();
+
+    const option = screen.getByRole("option", { name: allUnitsLabel });
+    const label = within(option).getByText(allUnitsLabel);
+    const contentRow = label.parentElement;
+
+    expect(contentRow).toHaveClass(
+      "flex",
+      "w-full",
+      "min-w-0",
+      "items-center",
+      "gap-2"
+    );
+    expect(contentRow?.querySelector("svg")).toHaveClass("shrink-0");
+    expect(label).toHaveClass("min-w-0", "truncate");
   });
 
   test("handles disabled state", () => {


### PR DESCRIPTION
## Reproduced defect

The root organizational-unit select rows rendered differently from the regular unit rows:

- `All Units` in `OrganizationalUnitPicker`
- `Make root unit (no parent)` in `MoveOrganizationalUnitDialog`

Those root options rendered the home icon outside the same flex row used by the regular organizational-unit options, so the icon could sit off-line while entries such as `Holding` stayed aligned.

## What changed

- wrapped the root-option icon and label in the same full-width flex row pattern used for the regular unit entries
- added `min-w-0` and `truncate` handling so long root labels still shrink cleanly in narrow menus
- kept the icon `shrink-0` so it remains aligned instead of collapsing under text pressure
- added focused regression tests for both affected surfaces
- updated `CHANGELOG.md`

## Validation already run

- `vitest run src/components/MoveOrganizationalUnitDialog.test.tsx tests/unit/OrganizationalUnitPicker.test.tsx`
- `npx prettier --check CHANGELOG.md src/components/OrganizationalUnitPicker.tsx src/components/MoveOrganizationalUnitDialog.tsx src/components/MoveOrganizationalUnitDialog.test.tsx tests/unit/OrganizationalUnitPicker.test.tsx`
- `npx eslint src/components/OrganizationalUnitPicker.tsx src/components/MoveOrganizationalUnitDialog.tsx src/components/MoveOrganizationalUnitDialog.test.tsx tests/unit/OrganizationalUnitPicker.test.tsx --max-warnings 0`
- `npm run typecheck`

## Scope notes

- This PR stays limited to the root-option icon alignment fix and its regression coverage.
- The separate CSP/runtime-style topic is tracked in #1269 and is intentionally out of scope here.

## Linked workspaces and remaining follow-up before ready

- No linked Polyscope workspaces were needed for this change.
- GitHub Actions and preview checks still need to complete.
- Draft self-review in the PR view still needs to confirm zero issues before marking this PR ready.
