### PR TITLE
fix: harden CSP handling for runtime UI styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Tightened runtime-style CSP delivery on the nginx PWA host with SSI-injected
+  nonces, moved third-party runtime style shims into app CSS where possible,
+  kept Apache `.htaccess` deployments on a functional inline-style fallback
+  instead of emitting an invalid empty nonce, and stopped precaching
+  nonce-bearing HTML shells so service-worker-controlled navigations fetch a
+  fresh CSP nonce online.
 - Aligned the root/all-units organizational-unit select options with the rest of the hierarchical unit rows, keeping their icons from shrinking and their labels truncatable in narrow menus.
 - Reworked the Activity Logs overview to avoid unnecessary horizontal page scrolling on narrow viewports. Below the `sm` breakpoint the page now renders each activity as a stacked card instead of forcing the desktop table layout into the available width, and the pagination controls wrap vertically on mobile. The responsive layout switch now reads the breakpoint once on mount, listens only via `MediaQueryList.addEventListener("change")`, and updates on viewport resize without redundant state writes. Added `tests/e2e/activity-logs.spec.ts` to assert that the mobile card layout is active, the desktop table stays unmounted, and the overview stays free of horizontal overflow across multiple narrow viewport widths (`320`, `360`, `390`, `412`, `430`).
 - Restored API-required organizational-unit and type fields in site creation payloads and aligned the sites table loading skeleton with the added customer/contact columns.

--- a/deploy/nginx/app.secpal.dev.conf
+++ b/deploy/nginx/app.secpal.dev.conf
@@ -21,7 +21,11 @@ server {
   include /etc/letsencrypt/options-ssl-nginx.conf;
   ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
-  set $secpal_csp "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self'; style-src-attr 'unsafe-inline'; worker-src 'self'; upgrade-insecure-requests";
+  ssi on;
+  ssi_types text/html;
+
+  set $csp_nonce $request_id;
+  set $secpal_csp "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self' 'nonce-$csp_nonce'; style-src-attr 'unsafe-inline'; worker-src 'self'; upgrade-insecure-requests";
   set $secpal_permissions_policy "accelerometer=(), autoplay=(), camera=(), clipboard-read=(), clipboard-write=(), display-capture=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
   set $secpal_hsts "max-age=63072000; includeSubDomains";
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "test:live:assetlinks": "bash ./scripts/check-live-assetlinks.sh",
     "test:live:auth-routes": "bash ./scripts/check-live-auth-route-separation.sh",
     "test:live:pwa-headers": "bash ./scripts/check-live-pwa-headers.sh",
+    "test:preview:pwa-headers": "node ./scripts/check-workspace-preview-pwa-headers.mjs",
     "format": "prettier --write --cache '**/*.{md,yml,yaml,json,ts,tsx,js,jsx}'",
     "format:check": "prettier --check '**/*.{md,yml,yaml,json,ts,tsx,js,jsx}'",
     "lingui:extract": "lingui extract",

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -27,8 +27,11 @@
 # Security headers
 <IfModule mod_headers.c>
   # Restrict script execution to same-origin assets. connect-src stays HTTPS-only
-  # because deployments may point at customer-specific API origins.
-  Header always set Content-Security-Policy "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self'; style-src-attr 'unsafe-inline'; worker-src 'self'; upgrade-insecure-requests"
+  # because deployments may point at customer-specific API origins. Apache
+  # .htaccess cannot reliably mint a valid per-response CSP nonce, so this
+  # fallback keeps runtime style libraries working without emitting a broken
+  # nonce source. The canonical nginx deployment carries the strict nonce CSP.
+  Header always set Content-Security-Policy "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; worker-src 'self'; upgrade-insecure-requests"
 
   # Explicitly deny browser capabilities the app does not require.
   Header always set Permissions-Policy "accelerometer=(), autoplay=(), camera=(), clipboard-read=(), clipboard-write=(), display-capture=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()"

--- a/scripts/check-live-pwa-headers.sh
+++ b/scripts/check-live-pwa-headers.sh
@@ -26,13 +26,17 @@ get_header_value() {
     local header_name="$2"
 
     printf '%s\n' "$headers" | awk -v target="$header_name" '
-        BEGIN {
-            FS = ": "
-        }
-        tolower($1) == tolower(target) {
-            gsub(/\r/, "", $2)
-            print $2
-            exit
+        {
+            line = $0
+            sub(/\r$/, "", line)
+            lower = tolower(line)
+            prefix = tolower(target) ":"
+            if (index(lower, prefix) == 1) {
+                value = substr(line, length(target) + 2)
+                sub(/^ /, "", value)
+                print value
+                exit
+            }
         }
     '
 }
@@ -103,6 +107,8 @@ assert_common_hardening() {
     echo "Checking hardening headers on ${label}"
 
     assert_header_contains "$headers" "Content-Security-Policy" "default-src 'self'"
+    assert_header_contains "$headers" "Content-Security-Policy" "style-src 'self'"
+    assert_header_contains "$headers" "Content-Security-Policy" "style-src-elem 'self' 'nonce-"
     assert_header_contains "$headers" "Permissions-Policy" "camera=()"
     assert_header_contains "$headers" "Strict-Transport-Security" "max-age=63072000"
     assert_header_contains "$headers" "Referrer-Policy" "strict-origin-when-cross-origin"

--- a/scripts/check-workspace-preview-pwa-headers.mjs
+++ b/scripts/check-workspace-preview-pwa-headers.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import {
+  detectPolyscopeWorkspaceName,
+  getResolvableWorkspacePreviewName,
+} from "./polyscope-workspace.mjs";
+
+const workspaceFromCwd = detectPolyscopeWorkspaceName();
+const workspaceFromBaseUrl = getResolvableWorkspacePreviewName(
+  process.env.PLAYWRIGHT_BASE_URL?.trim() ?? ""
+);
+const workspace = workspaceFromCwd || workspaceFromBaseUrl;
+
+if (!workspace) {
+  console.error(
+    "test:preview:pwa-headers must run inside a Polyscope workspace clone, or with POLYSCOPE_WORKSPACE set, or with PLAYWRIGHT_BASE_URL pointing at a workspace-preview frontend URL."
+  );
+  process.exit(1);
+}
+
+const scriptPath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "check-live-pwa-headers.sh"
+);
+const appUrl = `https://frontend-${workspace}.preview.secpal.dev`;
+
+const result = spawnSync("bash", [scriptPath], {
+  stdio: "inherit",
+  env: {
+    ...process.env,
+    APP_URL: appUrl,
+  },
+});
+
+if (typeof result.status === "number") {
+  process.exit(result.status);
+}
+
+process.exit(1);

--- a/src/index.css
+++ b/src/index.css
@@ -97,3 +97,46 @@ header h1 {
   font-size: 3.2em;
   line-height: 1.1;
 }
+
+/* Keep static library CSS in first-class app styles so strict CSP does not
+   depend on runtime-injected <style> tags for fixed rules. */
+[data-radix-select-viewport] {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  -webkit-overflow-scrolling: touch;
+}
+
+[data-radix-select-viewport]::-webkit-scrollbar {
+  display: none;
+}
+
+[data-input-otp]::selection {
+  background: transparent !important;
+  color: transparent !important;
+}
+
+[data-input-otp]:autofill,
+[data-input-otp]:-webkit-autofill {
+  background: transparent !important;
+  color: transparent !important;
+  border-color: transparent !important;
+  opacity: 0 !important;
+  box-shadow: none !important;
+  -webkit-box-shadow: none !important;
+  -webkit-text-fill-color: transparent !important;
+}
+
+@supports (-webkit-touch-callout: none) {
+  [data-input-otp] {
+    letter-spacing: -0.6em !important;
+    font-weight: 100 !important;
+    font-stretch: ultra-condensed;
+    font-optical-sizing: none !important;
+    left: -1px !important;
+    right: 1px !important;
+  }
+}
+
+[data-input-otp] + * {
+  pointer-events: all !important;
+}

--- a/src/lib/RuntimeStyleCspSupport.tsx
+++ b/src/lib/RuntimeStyleCspSupport.tsx
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { getCspNonce, INPUT_OTP_STYLE_MARKER_ID } from "./cspNonce";
+
+export function RuntimeStyleCspSupport() {
+  getCspNonce();
+
+  return (
+    <span
+      hidden
+      aria-hidden="true"
+      id={INPUT_OTP_STYLE_MARKER_ID}
+      data-secpal-runtime-style-marker=""
+    />
+  );
+}

--- a/src/lib/cspNonce.test.tsx
+++ b/src/lib/cspNonce.test.tsx
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { getNonce } from "get-nonce";
+import { describe, expect, it } from "vitest";
+import { LoginOtpInput } from "@/pages/Auth/ui";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/ui";
+import {
+  getCspNonce,
+  INPUT_OTP_STYLE_MARKER_ID,
+} from "./cspNonce";
+import { RuntimeStyleCspSupport } from "./RuntimeStyleCspSupport";
+
+function installCspNonceCarrier(nonce: string) {
+  const existing = document.querySelector("script[data-csp-nonce-carrier]");
+  existing?.remove();
+
+  const script = document.createElement("script");
+  script.setAttribute("data-csp-nonce-carrier", "");
+  script.setAttribute("nonce", nonce);
+  document.head.appendChild(script);
+}
+
+describe("runtime CSP nonce support", () => {
+  it("applies the HTML-shell nonce synchronously before runtime style effects mount", () => {
+    installCspNonceCarrier("nonce-sync");
+
+    expect(getCspNonce()).toBe("nonce-sync");
+    expect(getNonce()).toBe("nonce-sync");
+    expect((globalThis as { __webpack_nonce__?: string }).__webpack_nonce__).toBe(
+      "nonce-sync"
+    );
+  });
+
+  it("reads the nonce property when browsers hide the nonce attribute value", () => {
+    installCspNonceCarrier("nonce-property");
+
+    const carrier = document.querySelector(
+      "script[data-csp-nonce-carrier]"
+    ) as HTMLScriptElement;
+    const originalGetAttribute = carrier.getAttribute.bind(carrier);
+
+    carrier.nonce = "nonce-property";
+    carrier.getAttribute = ((name: string) =>
+      name === "nonce" ? "" : originalGetAttribute(name)) as typeof carrier.getAttribute;
+
+    expect(getCspNonce()).toBe("nonce-property");
+    expect(getNonce()).toBe("nonce-property");
+  });
+
+  it("adds the CSP nonce to style elements created at runtime", () => {
+    installCspNonceCarrier("nonce-style");
+
+    const style = document.createElement("style");
+
+    expect(style).toHaveAttribute("nonce", "nonce-style");
+    expect(style.nonce).toBe("nonce-style");
+  });
+
+  it("adds the CSP nonce when a runtime style is inserted without one", () => {
+    installCspNonceCarrier("nonce-insert");
+
+    const style = document.createElement("style");
+    style.removeAttribute("nonce");
+
+    document.head.appendChild(style);
+
+    expect(style).toHaveAttribute("nonce", "nonce-insert");
+  });
+
+  it("bridges the HTML-shell nonce into runtime style helpers and blocks input-otp reinjection", () => {
+    installCspNonceCarrier("nonce-otp");
+
+    render(
+      <>
+        <RuntimeStyleCspSupport />
+        <LoginOtpInput
+          value=""
+          onChange={() => undefined}
+          aria-label="Authenticator code"
+        />
+      </>
+    );
+
+    expect(getNonce()).toBe("nonce-otp");
+    expect(document.getElementById(INPUT_OTP_STYLE_MARKER_ID)).toHaveAttribute(
+      "data-secpal-runtime-style-marker",
+      ""
+    );
+    expect(document.querySelector("style#input-otp-style")).toBeNull();
+  });
+
+  it("passes the CSP nonce through to Radix Select viewport styles at runtime", async () => {
+    installCspNonceCarrier("nonce-select");
+    const user = userEvent.setup();
+
+    render(
+      <Select defaultValue="de">
+        <SelectTrigger aria-label="Language">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="de">German</SelectItem>
+          <SelectItem value="en">English</SelectItem>
+        </SelectContent>
+      </Select>
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "Language" }));
+
+    const style = Array.from(document.querySelectorAll("style")).find((node) =>
+      node.textContent?.includes("data-radix-select-viewport")
+    );
+
+    expect(style).toHaveAttribute("nonce", "nonce-select");
+  });
+
+  it("gives scroll-lock runtime styles a CSP nonce when dialogs mount", () => {
+    installCspNonceCarrier("nonce-dialog");
+
+    render(
+      <>
+        <RuntimeStyleCspSupport />
+        <Dialog open onClose={() => undefined}>
+          <DialogPortal>
+            <DialogOverlay />
+            <DialogContent>
+              <DialogTitle>Confirm action</DialogTitle>
+              <DialogDescription>Review before continuing.</DialogDescription>
+            </DialogContent>
+          </DialogPortal>
+        </Dialog>
+      </>
+    );
+
+    const style = Array.from(document.querySelectorAll("style")).find((node) =>
+      node.textContent?.includes("data-scroll-locked")
+    );
+
+    expect(style).toHaveAttribute("nonce", "nonce-dialog");
+  });
+
+  it("ignores an unexpanded SSI nonce placeholder", () => {
+    installCspNonceCarrier("<!--#echo var='csp_nonce' encoding='none' -->");
+
+    render(<RuntimeStyleCspSupport />);
+
+    expect(getNonce()).not.toContain("<!--#echo");
+  });
+});

--- a/src/lib/cspNonce.test.tsx
+++ b/src/lib/cspNonce.test.tsx
@@ -19,10 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/ui";
-import {
-  getCspNonce,
-  INPUT_OTP_STYLE_MARKER_ID,
-} from "./cspNonce";
+import { getCspNonce, INPUT_OTP_STYLE_MARKER_ID } from "./cspNonce";
 import { RuntimeStyleCspSupport } from "./RuntimeStyleCspSupport";
 
 function installCspNonceCarrier(nonce: string) {
@@ -41,9 +38,9 @@ describe("runtime CSP nonce support", () => {
 
     expect(getCspNonce()).toBe("nonce-sync");
     expect(getNonce()).toBe("nonce-sync");
-    expect((globalThis as { __webpack_nonce__?: string }).__webpack_nonce__).toBe(
-      "nonce-sync"
-    );
+    expect(
+      (globalThis as { __webpack_nonce__?: string }).__webpack_nonce__
+    ).toBe("nonce-sync");
   });
 
   it("reads the nonce property when browsers hide the nonce attribute value", () => {
@@ -56,7 +53,9 @@ describe("runtime CSP nonce support", () => {
 
     carrier.nonce = "nonce-property";
     carrier.getAttribute = ((name: string) =>
-      name === "nonce" ? "" : originalGetAttribute(name)) as typeof carrier.getAttribute;
+      name === "nonce"
+        ? ""
+        : originalGetAttribute(name)) as typeof carrier.getAttribute;
 
     expect(getCspNonce()).toBe("nonce-property");
     expect(getNonce()).toBe("nonce-property");

--- a/src/lib/cspNonce.tsx
+++ b/src/lib/cspNonce.tsx
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { setNonce } from "get-nonce";
+
+export const INPUT_OTP_STYLE_MARKER_ID = "input-otp-style";
+const NONCE_ATTR_SELECTOR = [
+  "script[nonce]",
+  'link[rel="stylesheet"][nonce]',
+  'link[rel="modulepreload"][nonce]',
+].join(", ");
+let appliedRuntimeStyleNonce: string | undefined;
+let patchedStyleElementFactory = false;
+let patchedStyleElementInsertion = false;
+
+type WebpackNonceGlobal = typeof globalThis & {
+  __webpack_nonce__?: string;
+};
+
+function normalizeCspNonce(candidate: string | null | undefined) {
+  if (!candidate) {
+    return undefined;
+  }
+
+  const nonce = candidate.trim();
+  if (nonce.length === 0 || nonce.includes("<!--#echo")) {
+    return undefined;
+  }
+
+  return nonce;
+}
+
+function readCspNonce(): string | undefined {
+  if (typeof document === "undefined") {
+    return undefined;
+  }
+
+  const carrier = document.querySelector(NONCE_ATTR_SELECTOR) as
+    | (Element & { nonce?: string })
+    | null;
+
+  return normalizeCspNonce(carrier?.nonce || carrier?.getAttribute("nonce"));
+}
+
+function applyRuntimeStyleNonce(nonce: string | undefined) {
+  if (!nonce || nonce === appliedRuntimeStyleNonce) {
+    return nonce;
+  }
+
+  setNonce(nonce);
+  (globalThis as WebpackNonceGlobal).__webpack_nonce__ = nonce;
+  appliedRuntimeStyleNonce = nonce;
+
+  return nonce;
+}
+
+function applyNonceToStyleElement(node: Node | null | undefined) {
+  if (!(node instanceof HTMLStyleElement)) {
+    return;
+  }
+
+  const nonce = getCspNonce();
+  if (nonce && !node.getAttribute("nonce")) {
+    node.setAttribute("nonce", nonce);
+  }
+}
+
+function patchStyleElementFactory() {
+  if (
+    patchedStyleElementFactory ||
+    typeof document === "undefined" ||
+    typeof document.createElement !== "function"
+  ) {
+    return;
+  }
+
+  const originalCreateElement = document.createElement.bind(document);
+
+  document.createElement = function patchedCreateElement(
+    tagName: string,
+    options?: ElementCreationOptions
+  ) {
+    const element = originalCreateElement(tagName, options);
+
+    if (tagName.toLowerCase() === "style") {
+      const nonce = getCspNonce();
+      if (nonce && !(element as HTMLStyleElement).nonce) {
+        (element as HTMLStyleElement).nonce = nonce;
+        element.setAttribute("nonce", nonce);
+      }
+    }
+
+    return element;
+  };
+
+  patchedStyleElementFactory = true;
+}
+
+function patchStyleElementInsertion() {
+  if (
+    patchedStyleElementInsertion ||
+    typeof Node === "undefined" ||
+    typeof Node.prototype.appendChild !== "function" ||
+    typeof Node.prototype.insertBefore !== "function"
+  ) {
+    return;
+  }
+
+  const originalAppendChild = Node.prototype.appendChild;
+  const originalInsertBefore = Node.prototype.insertBefore;
+
+  Node.prototype.appendChild = function patchedAppendChild<T extends Node>(
+    node: T
+  ) {
+    applyNonceToStyleElement(node);
+    return originalAppendChild.call(this, node) as T;
+  };
+
+  Node.prototype.insertBefore = function patchedInsertBefore<T extends Node>(
+    node: T,
+    child: Node | null
+  ) {
+    applyNonceToStyleElement(node);
+    return originalInsertBefore.call(this, node, child) as T;
+  };
+
+  patchedStyleElementInsertion = true;
+}
+
+applyRuntimeStyleNonce(readCspNonce());
+patchStyleElementFactory();
+patchStyleElementInsertion();
+
+export function getCspNonce(): string | undefined {
+  return applyRuntimeStyleNonce(readCspNonce());
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal
+// SPDX-FileCopyrightText: 2025-2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { StrictMode, useEffect } from "react";
@@ -7,6 +7,7 @@ import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
 import App from "./App";
 import { activateLocale, detectLocale } from "./i18n";
+import { RuntimeStyleCspSupport } from "./lib/RuntimeStyleCspSupport";
 import { initWebVitals } from "./lib/webVitals";
 import "./index.css";
 
@@ -25,6 +26,7 @@ export function AppWithI18n() {
 
   return (
     <I18nProvider i18n={i18n}>
+      <RuntimeStyleCspSupport />
       <App />
     </I18nProvider>
   );

--- a/src/pages/Auth/ui/primitives.tsx
+++ b/src/pages/Auth/ui/primitives.tsx
@@ -34,6 +34,7 @@ import {
   type ButtonVariant,
   uiControlBase,
 } from "@/ui";
+import { getCspNonce } from "@/lib/cspNonce";
 import { cn } from "./utils";
 
 export type LoginButtonVariant = NonNullable<
@@ -393,6 +394,8 @@ export const LoginSelectContent = forwardRef<
   { className, children, position = "popper", ...props },
   ref
 ) {
+  const cspNonce = getCspNonce();
+
   return (
     <SelectPrimitive.Portal>
       <SelectPrimitive.Content
@@ -409,6 +412,7 @@ export const LoginSelectContent = forwardRef<
       >
         <LoginSelectScrollUpButton />
         <SelectPrimitive.Viewport
+          nonce={cspNonce}
           data-slot="login-select-viewport"
           className={cn(
             "p-1",
@@ -547,6 +551,7 @@ export function LoginInputOtp({
         containerClassName
       )}
       className={cn("disabled:cursor-not-allowed", className)}
+      noScriptCSSFallback={null}
       onFocus={(event) => {
         onFocus?.(event);
         // Keep the OTP cells visible above mobile soft keyboards. The

--- a/src/pages/Onboarding/ui/onboarding-ui.test.tsx
+++ b/src/pages/Onboarding/ui/onboarding-ui.test.tsx
@@ -5,6 +5,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
 import { describe, expect, it, vi } from "vitest";
+import { RuntimeStyleCspSupport } from "@/lib/RuntimeStyleCspSupport";
 import {
   Alert,
   AlertDescription,
@@ -212,6 +213,35 @@ describe("onboarding shadcn primitives", () => {
         target: expect.objectContaining({ value: "contractor" }),
       })
     );
+  });
+
+  it("passes the CSP nonce through to the onboarding Radix select viewport style", async () => {
+    const user = userEvent.setup();
+    const nonceCarrier = document.createElement("script");
+    nonceCarrier.setAttribute("nonce", "nonce-onboarding");
+    document.head.appendChild(nonceCarrier);
+
+    render(
+      <>
+        <RuntimeStyleCspSupport />
+        <Field>
+          <FieldLabel htmlFor="contract-type-csp">Contract type</FieldLabel>
+          <Select id="contract-type-csp" defaultValue="">
+            <option value="">Select an option</option>
+            <option value="contractor">Contractor</option>
+          </Select>
+        </Field>
+      </>
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "Contract type" }));
+
+    const style = Array.from(document.querySelectorAll("style")).find((node) =>
+      node.textContent?.includes("data-radix-select-viewport")
+    );
+
+    expect(style).toHaveAttribute("nonce", "nonce-onboarding");
+    nonceCarrier.remove();
   });
 
   it("hands the Select onChange callback a React-style synthetic event whose preventDefault and stopPropagation flags stay consistent after they are called", async () => {

--- a/src/pages/Onboarding/ui/primitives.tsx
+++ b/src/pages/Onboarding/ui/primitives.tsx
@@ -49,6 +49,7 @@ import {
   Textarea as AppTextarea,
   uiControlBase,
 } from "@/ui";
+import { getCspNonce } from "@/lib/cspNonce";
 import { cn } from "./utils";
 
 export const Button = AppButton;
@@ -185,6 +186,7 @@ export const Select = forwardRef(function Select(
   const initialValue =
     defaultValue === undefined ? undefined : toRadixSelectValue(defaultValue);
   const emptyOption = options.find((option) => option.value === "");
+  const cspNonce = getCspNonce();
 
   return (
     <SelectPrimitive.Root
@@ -241,6 +243,7 @@ export const Select = forwardRef(function Select(
             <ChevronUp className="size-4" aria-hidden="true" />
           </SelectPrimitive.ScrollUpButton>
           <SelectPrimitive.Viewport
+            nonce={cspNonce}
             data-slot="onboarding-select-viewport"
             className="h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] p-1"
           >

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -4,13 +4,9 @@
 /// <reference lib="webworker" />
 
 import { clientsClaim } from "workbox-core";
-import {
-  precacheAndRoute,
-  cleanupOutdatedCaches,
-  createHandlerBoundToURL,
-} from "workbox-precaching";
+import { precacheAndRoute, cleanupOutdatedCaches } from "workbox-precaching";
 import { registerRoute, NavigationRoute } from "workbox-routing";
-import { CacheFirst } from "workbox-strategies";
+import { CacheFirst, NetworkFirst } from "workbox-strategies";
 import {
   isAuthSessionChangedMessage,
   readOfflineSessionState,
@@ -84,11 +80,9 @@ registerRoute(
   })
 );
 
-/**
- * Navigation fallback: serve cached index.html for SPA navigation
- * This enables offline navigation and page reloads
- */
-const navigationHandler = createHandlerBoundToURL("/index.html");
+const navigationHandler = new NetworkFirst({
+  cacheName: "html-shell",
+});
 const navigationRoute = new NavigationRoute(
   async (context) => {
     let sessionState = null;
@@ -113,7 +107,7 @@ const navigationRoute = new NavigationRoute(
       );
     }
 
-    return navigationHandler(context);
+    return navigationHandler.handle(context);
   },
   {
     // Exclude API routes and special paths

--- a/src/ui/primitives.tsx
+++ b/src/ui/primitives.tsx
@@ -18,6 +18,7 @@ import * as ProgressPrimitive from "@radix-ui/react-progress";
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
 import * as SelectPrimitive from "@radix-ui/react-select";
 import { Check, ChevronDown, ChevronUp, Circle, Loader2 } from "lucide-react";
+import { getCspNonce } from "@/lib/cspNonce";
 import { cn } from "@/lib/utils";
 import { buttonVariants, type ButtonVariant, uiControlBase } from "./styles";
 
@@ -232,6 +233,8 @@ export const SelectContent = forwardRef<
   { className, children, position = "popper", onCloseAutoFocus, ...props },
   ref
 ) {
+  const cspNonce = getCspNonce();
+
   return (
     <SelectPrimitive.Portal>
       <SelectPrimitive.Content
@@ -254,6 +257,7 @@ export const SelectContent = forwardRef<
       >
         <SelectScrollUpButton />
         <SelectPrimitive.Viewport
+          nonce={cspNonce}
           data-slot="ui-select-viewport"
           className={cn(
             "p-1",

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -268,7 +268,9 @@ describe("Build Configuration and Source Verification", () => {
     expect(nginxConfig).not.toContain("style-src 'self' 'unsafe-inline'");
     expect(viteConfig).toContain("html: {");
     expect(viteConfig).toContain("cspNonce: cspNonceSsiPlaceholder");
-    expect(viteConfig).toContain("<!--#echo var='csp_nonce' encoding='none' -->");
+    expect(viteConfig).toContain(
+      "<!--#echo var='csp_nonce' encoding='none' -->"
+    );
     expect(viteConfig).toContain(
       'globPatterns: ["**/*.{js,css,ico,png,svg,woff,woff2}"]'
     );
@@ -286,7 +288,9 @@ describe("Build Configuration and Source Verification", () => {
     expect(viteConfig).not.toContain("html,ico");
     expect(serviceWorker).toContain("new NetworkFirst");
     expect(serviceWorker).toContain('cacheName: "html-shell"');
-    expect(serviceWorker).not.toContain('createHandlerBoundToURL("/index.html")');
+    expect(serviceWorker).not.toContain(
+      'createHandlerBoundToURL("/index.html")'
+    );
   });
 
   it("uses an external theme-color bootstrap so CSP can block inline scripts", () => {

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -241,6 +241,7 @@ describe("Build Configuration and Source Verification", () => {
   it("ships an enforceable CSP that fits the PWA runtime", () => {
     const htaccess = readRepoFile("public/.htaccess");
     const nginxConfig = readRepoFile("deploy/nginx/app.secpal.dev.conf");
+    const viteConfig = readRepoFile("vite.config.ts");
 
     expect(htaccess).toContain("default-src 'self'");
     expect(htaccess).toContain("script-src 'self'");
@@ -249,6 +250,11 @@ describe("Build Configuration and Source Verification", () => {
     expect(htaccess).toContain("worker-src 'self'");
     expect(htaccess).toContain("manifest-src 'self'");
     expect(htaccess).toContain("connect-src 'self'");
+    expect(htaccess).toContain("style-src 'self'");
+    expect(htaccess).toContain("style-src 'self' 'unsafe-inline'");
+    expect(htaccess).toContain("style-src-elem 'self' 'unsafe-inline'");
+    expect(htaccess).not.toContain("nonce-%{csp_nonce}e");
+    expect(htaccess).not.toContain("UNIQUE_ID");
 
     expect(nginxConfig).toContain("default-src 'self'");
     expect(nginxConfig).toContain("script-src 'self'");
@@ -257,6 +263,30 @@ describe("Build Configuration and Source Verification", () => {
     expect(nginxConfig).toContain("worker-src 'self'");
     expect(nginxConfig).toContain("manifest-src 'self'");
     expect(nginxConfig).toContain("connect-src 'self'");
+    expect(nginxConfig).toContain("style-src 'self'");
+    expect(nginxConfig).toContain("style-src-elem 'self' 'nonce-$csp_nonce'");
+    expect(nginxConfig).not.toContain("style-src 'self' 'unsafe-inline'");
+    expect(viteConfig).toContain("html: {");
+    expect(viteConfig).toContain("cspNonce: cspNonceSsiPlaceholder");
+    expect(viteConfig).toContain("<!--#echo var='csp_nonce' encoding='none' -->");
+    expect(viteConfig).toContain(
+      'globPatterns: ["**/*.{js,css,ico,png,svg,woff,woff2}"]'
+    );
+    expect(viteConfig).toContain('globIgnores: ["**/*.html"]');
+    expect(viteConfig).toContain("navigateFallback: null");
+    expect(viteConfig).toContain("nonceBearingHtmlShellPattern");
+    expect(viteConfig).toContain("manifestTransforms");
+    expect(viteConfig).not.toContain("js,css,html,ico");
+  });
+
+  it("does not precache nonce-bearing HTML shells", () => {
+    const serviceWorker = readRepoFile("src/sw.ts");
+    const viteConfig = readRepoFile("vite.config.ts");
+
+    expect(viteConfig).not.toContain("html,ico");
+    expect(serviceWorker).toContain("new NetworkFirst");
+    expect(serviceWorker).toContain('cacheName: "html-shell"');
+    expect(serviceWorker).not.toContain('createHandlerBoundToURL("/index.html")');
   });
 
   it("uses an external theme-color bootstrap so CSP can block inline scripts", () => {
@@ -271,6 +301,14 @@ describe("Build Configuration and Source Verification", () => {
     expect(themeColorJs.trim().length).toBeGreaterThan(0);
     expect(themeColorJs).toContain("theme-color");
     expect(themeColorJs).not.toContain("<script");
+  });
+
+  it("reads CSP nonces from emitted script/link tags instead of a custom meta carrier", () => {
+    const nonceHelper = readRepoFile("src/lib/cspNonce.tsx");
+
+    expect(nonceHelper).toContain("script[nonce]");
+    expect(nonceHelper).toContain('link[rel="stylesheet"][nonce]');
+    expect(nonceHelper).not.toContain('property="csp-nonce"');
   });
 
   it("adds dedicated delivery rules for service worker and manifest files", () => {
@@ -292,11 +330,19 @@ describe("Build Configuration and Source Verification", () => {
     expect(
       existsSync(path.join(repoRoot, "scripts/check-live-pwa-headers.sh"))
     ).toBe(true);
+    expect(
+      existsSync(
+        path.join(repoRoot, "scripts/check-workspace-preview-pwa-headers.mjs")
+      )
+    ).toBe(true);
 
     const packageJson = readRepoFile("package.json");
 
     expect(packageJson).toContain(
       '"test:live:pwa-headers": "bash ./scripts/check-live-pwa-headers.sh"'
+    );
+    expect(packageJson).toContain(
+      '"test:preview:pwa-headers": "node ./scripts/check-workspace-preview-pwa-headers.mjs"'
     );
   });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,8 +19,7 @@ import { buildPwaRuntimeCaching } from "./src/lib/pwaRuntimeCaching";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const { lingui } = resolveLinguiVitePluginExports(linguiVitePlugin);
 const linguiMacroImportPattern = /@lingui\/(?:core|react)\/macro/;
-const cspNonceSsiPlaceholder =
-  "<!--#echo var='csp_nonce' encoding='none' -->";
+const cspNonceSsiPlaceholder = "<!--#echo var='csp_nonce' encoding='none' -->";
 const nonceBearingHtmlShellPattern = /\.html$/;
 const linguiMacroBabelPreset = defineRolldownBabelPreset({
   preset: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,9 @@ import { buildPwaRuntimeCaching } from "./src/lib/pwaRuntimeCaching";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const { lingui } = resolveLinguiVitePluginExports(linguiVitePlugin);
 const linguiMacroImportPattern = /@lingui\/(?:core|react)\/macro/;
+const cspNonceSsiPlaceholder =
+  "<!--#echo var='csp_nonce' encoding='none' -->";
+const nonceBearingHtmlShellPattern = /\.html$/;
 const linguiMacroBabelPreset = defineRolldownBabelPreset({
   preset: [
     () => ({
@@ -84,6 +87,18 @@ export default defineConfig(({ mode }) => {
   const isCi = Boolean(process.env.CI);
   return {
     plugins: [
+      {
+        name: "strip-vite-csp-meta-carrier",
+        transformIndexHtml: {
+          order: "post",
+          handler(html) {
+            return html.replace(
+              /\s*<meta property="csp-nonce" nonce="[^"]*">\s*/g,
+              "\n"
+            );
+          },
+        },
+      },
       react({}),
       babel({
         presets: [linguiMacroBabelPreset],
@@ -121,6 +136,18 @@ export default defineConfig(({ mode }) => {
         strategies: "injectManifest",
         integration: {
           configureCustomSWViteBuild: applyInjectManifestCodeSplittingFix,
+        },
+        injectManifest: {
+          globPatterns: ["**/*.{js,css,ico,png,svg,woff,woff2}"],
+          globIgnores: ["**/*.html"],
+          manifestTransforms: [
+            async (entries) => ({
+              manifest: entries.filter(
+                (entry) => !nonceBearingHtmlShellPattern.test(entry.url)
+              ),
+              warnings: [],
+            }),
+          ],
         },
         srcDir: "src",
         filename: "sw.ts",
@@ -171,10 +198,9 @@ export default defineConfig(({ mode }) => {
           ],
         },
         workbox: {
-          globPatterns: ["**/*.{js,css,html,ico,png,svg,woff,woff2}"],
-          // Enable navigation fallback for SPA offline support
-          navigateFallback: "/index.html",
-          navigateFallbackDenylist: [/^\/v1\//, /^\/__/], // Exclude API and Vite internal routes from SPA fallback
+          globPatterns: ["**/*.{js,css,ico,png,svg,woff,woff2}"],
+          globIgnores: ["**/*.html"],
+          navigateFallback: null,
           cleanupOutdatedCaches: true,
           runtimeCaching: buildPwaRuntimeCaching(),
         },
@@ -192,6 +218,9 @@ export default defineConfig(({ mode }) => {
       alias: {
         "@": path.resolve(__dirname, "src"),
       },
+    },
+    html: {
+      cspNonce: cspNonceSsiPlaceholder,
     },
     build: {
       rollupOptions: {


### PR DESCRIPTION
## Reproduced Defect

Preview routes such as `/organization` were emitting runtime CSP violations like:

```text
Applying inline style violates the following Content Security Policy directive 'style-src-elem 'self' ...'
```

The remaining blocked styles were coming from runtime-generated UI styles, including Radix Select viewport styles, OTP fallback styles, and scroll-lock styles generated through `react-remove-scroll` / `react-remove-scroll-bar`.

Closes #1269.

## What Changed

- added a runtime CSP nonce bridge so style-injecting libraries can read the current nonce consistently
- moved static runtime-injected UI rules into maintained application CSS where we control them
- passed CSP nonces through the affected Select primitives and disabled `input-otp` runtime fallback injection
- hardened preview and production CSP/header plumbing, including workspace-preview header checks
- added focused runtime-style regression coverage for nonce propagation, Radix Select, OTP, and dialog scroll-lock behavior

## Validation

- `npm test -- --run src/lib/cspNonce.test.tsx src/pages/Onboarding/ui/onboarding-ui.test.tsx tests/build.test.ts`
- `npm run typecheck`
- `npm run build`
- `node scripts/check-workspace-preview-pwa-headers.mjs`
- verified the current preview now serves the updated asset set and hardened headers

## Follow-up Before Marking Ready

- final manual browser-console verification is still required on representative interaction flows:
  - organization/select flow
  - login / MFA flow
  - settings flow that mounts OTP inputs
  - dialog / overlay flow that activates scroll locking
- `/employees` still shows a separate activity-log fetch failure in preview; tracked in #1273

## Linked Workspaces

- no linked workspace code changes were required for this branch
