### PR TITLE
Fix onboarding route gating and move dialog layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Gave the move organizational unit dialog more horizontal room and tightened
+  truncation handling so long unit names and hierarchy labels stay contained in
+  the move flow.
+- Redirected pre-contract users away from normal app routes before the email
+  verification gate, so deep links such as `/profile`, `/settings`, or feature
+  sections land in the onboarding flow first.
 - Tightened runtime-style CSP delivery on the nginx PWA host with SSI-injected
   nonces, moved third-party runtime style shims into app CSS where possible,
   kept Apache `.htaccess` deployments on a functional inline-style fallback

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1051,6 +1051,56 @@ describe("App", () => {
     ).toBeInTheDocument();
   });
 
+  it.each([
+    "/",
+    "/profile",
+    "/settings",
+    "/customers",
+    "/sites",
+    "/employees",
+    "/organization",
+    "/activity-logs",
+    "/android-provisioning",
+  ])(
+    "redirects unverified pre-contract users from %s to onboarding before email verification",
+    async (path) => {
+      window.history.replaceState({}, "", path);
+
+      await seedPersistedAuthUser({
+        id: 1,
+        name: "Pre-Contract User",
+        email: "new.hire@secpal.dev",
+        emailVerified: false,
+        hasCustomerAccess: true,
+        hasOrganizationalScopes: true,
+        hasSiteAccess: true,
+        permissions: [
+          "customers.view",
+          "sites.view",
+          "employees.view",
+          "activity_logs.view",
+          "android_provisioning.view",
+        ],
+        employee: {
+          id: "employee-1",
+          status: "pre_contract",
+          onboarding_workflow: {
+            status: "account_initialized",
+          },
+        },
+      });
+
+      await renderWithI18n(<App />);
+
+      await waitFor(
+        () => {
+          expect(window.location.pathname).toBe("/onboarding");
+        },
+        { timeout: ROUTE_NAVIGATION_TIMEOUT_MS }
+      );
+    }
+  );
+
   it("renders onboarding-only routes without the normal application navigation for pre-contract users", async () => {
     window.history.replaceState({}, "", "/onboarding");
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1101,6 +1101,55 @@ describe("App", () => {
     }
   );
 
+  it("preserves the original deep link when snapshot revalidation clears a stale pre-contract redirect", async () => {
+    window.history.replaceState({}, "", "/settings");
+
+    await seedPersistedAuthUser({
+      id: 1,
+      name: "Stale Snapshot User",
+      email: "stale.snapshot@secpal.dev",
+      emailVerified: false,
+      employee: {
+        id: "employee-1",
+        status: "pre_contract",
+        onboarding_workflow: {
+          status: "account_initialized",
+        },
+      },
+    });
+
+    mockGetCurrentUser.mockResolvedValue(
+      sanitizePersistedAuthUser({
+        id: 1,
+        name: "Active User",
+        email: "guard@secpal.dev",
+        emailVerified: true,
+        employee: {
+          id: "employee-2",
+          status: "active",
+          onboarding_workflow: {
+            status: "active",
+          },
+        },
+      })
+    );
+
+    await renderWithI18n(<App />);
+
+    await waitFor(
+      () => {
+        expect(window.location.pathname).toBe("/settings");
+      },
+      { timeout: ROUTE_NAVIGATION_TIMEOUT_MS }
+    );
+
+    expect(
+      await screen.findByRole("heading", {
+        name: /settings/i,
+      })
+    ).toBeInTheDocument();
+  });
+
   it("renders onboarding-only routes without the normal application navigation for pre-contract users", async () => {
     window.history.replaceState({}, "", "/onboarding");
 

--- a/src/AuthenticatedApp.tsx
+++ b/src/AuthenticatedApp.tsx
@@ -92,19 +92,17 @@ function HiddenAppRouteState() {
 
 function AppLayoutRoute({ children }: { children: React.ReactNode }) {
   return (
-    <ProtectedRoute
-      revalidatingFallback={
-        <AppAccessRoute>
+    <AppAccessRoute>
+      <ProtectedRoute
+        revalidatingFallback={
           <ApplicationLayout>
             <RouteContentFallback />
           </ApplicationLayout>
-        </AppAccessRoute>
-      }
-    >
-      <AppAccessRoute>
+        }
+      >
         <ApplicationLayout>{children}</ApplicationLayout>
-      </AppAccessRoute>
-    </ProtectedRoute>
+      </ProtectedRoute>
+    </AppAccessRoute>
   );
 }
 

--- a/src/components/MoveOrganizationalUnitDialog.test.tsx
+++ b/src/components/MoveOrganizationalUnitDialog.test.tsx
@@ -171,6 +171,19 @@ describe("MoveOrganizationalUnitDialog", () => {
       expect(screen.getByText(/Move "Berlin Mitte"/)).toBeInTheDocument();
     });
 
+    it("uses the larger dialog width for the move flow", () => {
+      renderWithI18n(
+        <MoveOrganizationalUnitDialog
+          open={true}
+          unit={mockUnit}
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      );
+
+      expect(screen.getByRole("dialog")).toHaveClass("sm:max-w-lg");
+    });
+
     it("does not render when unit is null", () => {
       renderWithI18n(
         <MoveOrganizationalUnitDialog

--- a/src/components/MoveOrganizationalUnitDialog.tsx
+++ b/src/components/MoveOrganizationalUnitDialog.tsx
@@ -256,11 +256,11 @@ function MoveOrganizationalUnitDialogContent({
 
   return (
     <>
-      <div className="flex items-center gap-4">
+      <div className="flex min-w-0 items-center gap-4">
         <div className="shrink-0 rounded-full bg-blue-100 p-2 dark:bg-blue-900/50">
           <MoveHorizontal className="h-6 w-6 text-blue-600 dark:text-blue-400" />
         </div>
-        <div className="flex-1">
+        <div className="min-w-0 flex-1">
           <DialogTitle>
             <Trans>Move "{unit.name}"</Trans>
           </DialogTitle>
@@ -271,7 +271,7 @@ function MoveOrganizationalUnitDialogContent({
         <Trans>Select a new parent for this organizational unit.</Trans>
       </DialogDescription>
 
-      <DialogBody>
+      <DialogBody className="min-w-0">
         {/* Offline warning banner - mutations not possible */}
         {isOffline && (
           <div className="mb-4 rounded-lg bg-red-50 p-4 text-sm text-red-800 dark:bg-red-900/20 dark:text-red-400">
@@ -398,7 +398,7 @@ export function MoveOrganizationalUnitDialog({
     <Dialog open={open} onClose={onClose}>
       <DialogPortal>
         <DialogOverlay />
-        <DialogContent size="md">
+        <DialogContent size="lg">
           {!unit ? (
             <>
               <DialogTitle className="sr-only">

--- a/src/components/OnboardingAccessRoute.test.tsx
+++ b/src/components/OnboardingAccessRoute.test.tsx
@@ -16,7 +16,18 @@ vi.mock("react-router-dom", async () => {
 
   return {
     ...actual,
-    Navigate: ({ to }: { to: string }) => <div>Redirected to {to}</div>,
+    Navigate: ({
+      to,
+      state,
+    }: {
+      to: string;
+      state?: { returnTo?: string };
+    }) => (
+      <div>
+        Redirected to {to}
+        {state?.returnTo ? ` (returnTo: ${state.returnTo})` : ""}
+      </div>
+    ),
   };
 });
 
@@ -93,7 +104,9 @@ describe("OnboardingAccessRoute", () => {
       </AppAccessRoute>
     );
 
-    expect(screen.getByText("Redirected to /onboarding")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Redirected to \/onboarding \(returnTo: \/\)/)
+    ).toBeInTheDocument();
     expect(screen.queryByText("Protected App Content")).not.toBeInTheDocument();
   });
 
@@ -131,6 +144,30 @@ describe("OnboardingAccessRoute", () => {
     );
 
     expect(screen.getByText("Redirected to /")).toBeInTheDocument();
+    expect(screen.queryByText("Onboarding Content")).not.toBeInTheDocument();
+  });
+
+  it("restores the original deep link after onboarding redirect state is cleared by revalidation", () => {
+    mockAuthenticatedUser("active");
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: "/onboarding",
+            state: { returnTo: "/settings" },
+          },
+        ]}
+      >
+        <I18nProvider i18n={i18n}>
+          <OnboardingOnlyRoute>
+            <div>Onboarding Content</div>
+          </OnboardingOnlyRoute>
+        </I18nProvider>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Redirected to /settings")).toBeInTheDocument();
     expect(screen.queryByText("Onboarding Content")).not.toBeInTheDocument();
   });
 
@@ -176,7 +213,7 @@ describe("OnboardingAccessRoute", () => {
     );
 
     expect(
-      screen.getByText("Redirected to /onboarding/submitted")
+      screen.getByText(/Redirected to \/onboarding\/submitted \(returnTo: \/\)/)
     ).toBeInTheDocument();
     expect(screen.queryByText("Protected App Content")).not.toBeInTheDocument();
   });
@@ -200,7 +237,9 @@ describe("OnboardingAccessRoute", () => {
       </AppAccessRoute>
     );
 
-    expect(screen.getByText("Redirected to /onboarding")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Redirected to \/onboarding \(returnTo: \/\)/)
+    ).toBeInTheDocument();
     expect(screen.queryByText("Protected App Content")).not.toBeInTheDocument();
   });
 

--- a/src/components/OnboardingAccessRoute.test.tsx
+++ b/src/components/OnboardingAccessRoute.test.tsx
@@ -171,6 +171,30 @@ describe("OnboardingAccessRoute", () => {
     expect(screen.queryByText("Onboarding Content")).not.toBeInTheDocument();
   });
 
+  it("rejects protocol-relative return targets when leaving onboarding-only routes", () => {
+    mockAuthenticatedUser("active");
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: "/onboarding",
+            state: { returnTo: "//attacker.example/path" },
+          },
+        ]}
+      >
+        <I18nProvider i18n={i18n}>
+          <OnboardingOnlyRoute>
+            <div>Onboarding Content</div>
+          </OnboardingOnlyRoute>
+        </I18nProvider>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Redirected to /")).toBeInTheDocument();
+    expect(screen.queryByText("Onboarding Content")).not.toBeInTheDocument();
+  });
+
   it("allows access to app routes when employee status is unknown (offline/stale user)", () => {
     vi.mocked(authHook.useAuth).mockReturnValue({
       ...authContext,

--- a/src/components/OnboardingAccessRoute.tsx
+++ b/src/components/OnboardingAccessRoute.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { useAuth } from "../hooks/useAuth";
 import {
   getAuthOnboardingWorkflowStatus,
@@ -10,6 +10,11 @@ import {
 
 interface OnboardingAccessRouteProps {
   children: React.ReactNode;
+}
+
+interface OnboardingRedirectState {
+  onboardingRequired?: boolean;
+  returnTo?: string;
 }
 
 function isPreContractUser(user: ReturnType<typeof useAuth>["user"]): boolean {
@@ -33,8 +38,37 @@ function hasKnownEmployeeStatus(
   );
 }
 
+function buildReturnTo(
+  pathname: string,
+  search: string,
+  hash: string
+): string | null {
+  const target = `${pathname}${search}${hash}`;
+
+  if (!target.startsWith("/")) {
+    return null;
+  }
+
+  return target;
+}
+
+function getSafeOnboardingReturnTarget(state: unknown): string | null {
+  if (typeof state !== "object" || state === null) {
+    return null;
+  }
+
+  const returnTo = (state as OnboardingRedirectState).returnTo;
+
+  if (typeof returnTo !== "string" || !returnTo.startsWith("/")) {
+    return null;
+  }
+
+  return returnTo;
+}
+
 export function AppAccessRoute({ children }: OnboardingAccessRouteProps) {
   const { user } = useAuth();
+  const location = useLocation();
   const onboardingWorkflowStatus = getAuthOnboardingWorkflowStatus(user);
 
   if (isPreContractUser(user)) {
@@ -46,7 +80,14 @@ export function AppAccessRoute({ children }: OnboardingAccessRouteProps) {
             : "/onboarding"
         }
         replace
-        state={{ onboardingRequired: true }}
+        state={{
+          onboardingRequired: true,
+          returnTo: buildReturnTo(
+            location.pathname,
+            location.search,
+            location.hash
+          ),
+        }}
       />
     );
   }
@@ -56,6 +97,7 @@ export function AppAccessRoute({ children }: OnboardingAccessRouteProps) {
 
 export function OnboardingOnlyRoute({ children }: OnboardingAccessRouteProps) {
   const { user } = useAuth();
+  const location = useLocation();
 
   // Allow access when employee status is unknown (offline / stale persisted
   // user): a pre-contract user who cannot reach the API should stay at
@@ -64,5 +106,10 @@ export function OnboardingOnlyRoute({ children }: OnboardingAccessRouteProps) {
     return <>{children}</>;
   }
 
-  return <Navigate to="/" replace />;
+  return (
+    <Navigate
+      to={getSafeOnboardingReturnTarget(location.state) ?? "/"}
+      replace
+    />
+  );
 }

--- a/src/components/OnboardingAccessRoute.tsx
+++ b/src/components/OnboardingAccessRoute.tsx
@@ -3,6 +3,7 @@
 
 import { Navigate, useLocation } from "react-router-dom";
 import { useAuth } from "../hooks/useAuth";
+import { sanitizeOnboardingReturnTarget } from "../lib/onboardingRouteState";
 import {
   getAuthOnboardingWorkflowStatus,
   isSubmittedOnboardingWorkflowStatus,
@@ -10,11 +11,6 @@ import {
 
 interface OnboardingAccessRouteProps {
   children: React.ReactNode;
-}
-
-interface OnboardingRedirectState {
-  onboardingRequired?: boolean;
-  returnTo?: string;
 }
 
 function isPreContractUser(user: ReturnType<typeof useAuth>["user"]): boolean {
@@ -43,13 +39,7 @@ function buildReturnTo(
   search: string,
   hash: string
 ): string | null {
-  const target = `${pathname}${search}${hash}`;
-
-  if (!target.startsWith("/")) {
-    return null;
-  }
-
-  return target;
+  return sanitizeOnboardingReturnTarget(`${pathname}${search}${hash}`);
 }
 
 function getSafeOnboardingReturnTarget(state: unknown): string | null {
@@ -57,13 +47,9 @@ function getSafeOnboardingReturnTarget(state: unknown): string | null {
     return null;
   }
 
-  const returnTo = (state as OnboardingRedirectState).returnTo;
-
-  if (typeof returnTo !== "string" || !returnTo.startsWith("/")) {
-    return null;
-  }
-
-  return returnTo;
+  return sanitizeOnboardingReturnTarget(
+    (state as { returnTo?: unknown }).returnTo
+  );
 }
 
 export function AppAccessRoute({ children }: OnboardingAccessRouteProps) {

--- a/src/lib/onboardingRouteState.ts
+++ b/src/lib/onboardingRouteState.ts
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+export interface OnboardingRouteState {
+  onboardingRequired?: boolean;
+  message?: string;
+  returnTo?: string;
+}
+
+export function sanitizeOnboardingReturnTarget(value: unknown): string | null {
+  if (typeof value !== "string" || !value.startsWith("/")) {
+    return null;
+  }
+
+  if (value.startsWith("//")) {
+    return null;
+  }
+
+  return value;
+}
+
+export function getEntryOnboardingRouteState(
+  routeState: OnboardingRouteState | null
+): OnboardingRouteState | null {
+  if (!routeState) {
+    return null;
+  }
+
+  const entryState: OnboardingRouteState = {};
+
+  if (routeState.onboardingRequired === true) {
+    entryState.onboardingRequired = true;
+  }
+
+  if (typeof routeState.message === "string") {
+    const trimmedMessage = routeState.message.trim();
+    if (trimmedMessage.length > 0) {
+      entryState.message = trimmedMessage;
+    }
+  }
+
+  const returnTo = sanitizeOnboardingReturnTarget(routeState.returnTo);
+  if (returnTo) {
+    entryState.returnTo = returnTo;
+  }
+
+  return Object.keys(entryState).length > 0 ? entryState : null;
+}
+
+export function getPersistentOnboardingNavigationState(
+  routeState: OnboardingRouteState | null
+): Pick<OnboardingRouteState, "returnTo"> | null {
+  const returnTo = sanitizeOnboardingReturnTarget(routeState?.returnTo);
+
+  return returnTo ? { returnTo } : null;
+}
+
+export function hasNormalizedOnboardingNavigationState(
+  routeState: OnboardingRouteState
+): boolean {
+  const persistentState = getPersistentOnboardingNavigationState(routeState);
+
+  if (!persistentState) {
+    return false;
+  }
+
+  const keys = Object.keys(routeState);
+
+  return (
+    keys.length === 1 &&
+    keys[0] === "returnTo" &&
+    routeState.returnTo === persistentState.returnTo
+  );
+}

--- a/src/pages/Onboarding/OnboardingWizard.tsx
+++ b/src/pages/Onboarding/OnboardingWizard.tsx
@@ -34,6 +34,12 @@ import {
   getAuthOnboardingWorkflowStatus,
   isSubmittedOnboardingWorkflowStatus,
 } from "../../lib/onboardingWorkflow";
+import {
+  getEntryOnboardingRouteState,
+  getPersistentOnboardingNavigationState,
+  hasNormalizedOnboardingNavigationState,
+  type OnboardingRouteState,
+} from "../../lib/onboardingRouteState";
 import { AuthContext } from "../../contexts/auth-context";
 import { getAuthTransport } from "../../services/authTransport";
 import {
@@ -103,64 +109,6 @@ interface WizardFeedback {
   tone: "success" | "error";
   message: string;
 }
-
-interface OnboardingRouteState {
-  onboardingRequired?: boolean;
-  message?: string;
-  returnTo?: string;
-}
-
-function getPersistentOnboardingRouteState(
-  routeState: OnboardingRouteState | null
-): OnboardingRouteState | null {
-  if (!routeState) {
-    return null;
-  }
-
-  if (routeState.onboardingRequired === true) {
-    return { onboardingRequired: true };
-  }
-
-  if (typeof routeState.message === "string") {
-    const trimmedMessage = routeState.message.trim();
-    if (trimmedMessage.length > 0) {
-      return { message: trimmedMessage };
-    }
-  }
-
-  return null;
-}
-
-function getPersistentOnboardingNavigationState(
-  routeState: OnboardingRouteState | null
-): Pick<OnboardingRouteState, "returnTo"> | null {
-  if (!routeState) {
-    return null;
-  }
-
-  if (
-    typeof routeState.returnTo === "string" &&
-    routeState.returnTo.startsWith("/")
-  ) {
-    return { returnTo: routeState.returnTo };
-  }
-
-  return null;
-}
-
-function hasPersistentOnboardingNavigationState(
-  routeState: OnboardingRouteState | null
-): boolean {
-  const persistentNavigationState =
-    getPersistentOnboardingNavigationState(routeState);
-
-  return (
-    persistentNavigationState != null &&
-    Object.keys(routeState).length === 1 &&
-    persistentNavigationState.returnTo === routeState.returnTo
-  );
-}
-
 function getEntryFeedbackFromRouteState(
   routeState: OnboardingRouteState | null,
   translate: ReturnType<typeof useLingui>["_"]
@@ -1801,7 +1749,7 @@ export function OnboardingWizard() {
   const location = useLocation();
   const routeState = location.state as OnboardingRouteState | null;
   const [entryRouteState] = useState<OnboardingRouteState | null>(() =>
-    getPersistentOnboardingRouteState(routeState)
+    getEntryOnboardingRouteState(routeState)
   );
   const persistentNavigationState = useMemo(
     () => getPersistentOnboardingNavigationState(routeState),
@@ -2176,15 +2124,15 @@ export function OnboardingWizard() {
       return;
     }
 
-    if (hasPersistentOnboardingNavigationState(routeState)) {
+    if (hasNormalizedOnboardingNavigationState(routeState)) {
       return;
     }
 
     navigate(location.pathname, {
       replace: true,
-      state: persistentNavigationState,
+      state: getPersistentOnboardingNavigationState(routeState),
     });
-  }, [location.pathname, navigate, persistentNavigationState, routeState]);
+  }, [location.pathname, navigate, routeState]);
 
   useEffect(() => {
     if (feedback?.tone !== "error" && !error) {
@@ -2212,9 +2160,9 @@ export function OnboardingWizard() {
 
     navigate("/onboarding/submitted", {
       replace: true,
-      state: persistentNavigationState,
+      state: getPersistentOnboardingNavigationState(entryRouteState),
     });
-  }, [currentOnboardingWorkflowStatus, navigate, persistentNavigationState]);
+  }, [currentOnboardingWorkflowStatus, entryRouteState, navigate]);
 
   useEffect(() => {
     let active = true;

--- a/src/pages/Onboarding/OnboardingWizard.tsx
+++ b/src/pages/Onboarding/OnboardingWizard.tsx
@@ -107,6 +107,7 @@ interface WizardFeedback {
 interface OnboardingRouteState {
   onboardingRequired?: boolean;
   message?: string;
+  returnTo?: string;
 }
 
 function getPersistentOnboardingRouteState(
@@ -128,6 +129,34 @@ function getPersistentOnboardingRouteState(
   }
 
   return null;
+}
+
+function getPersistentOnboardingNavigationState(
+  routeState: OnboardingRouteState | null
+): Pick<OnboardingRouteState, "returnTo"> | null {
+  if (!routeState) {
+    return null;
+  }
+
+  if (
+    typeof routeState.returnTo === "string" &&
+    routeState.returnTo.startsWith("/")
+  ) {
+    return { returnTo: routeState.returnTo };
+  }
+
+  return null;
+}
+
+function hasPersistentOnboardingNavigationState(
+  routeState: OnboardingRouteState | null
+): boolean {
+  return (
+    routeState != null &&
+    Object.keys(routeState).length === 1 &&
+    getPersistentOnboardingNavigationState(routeState)?.returnTo ===
+      routeState.returnTo
+  );
 }
 
 function getEntryFeedbackFromRouteState(
@@ -1768,10 +1797,13 @@ export function OnboardingWizard() {
   const translateRef = useRef(_);
   const navigate = useNavigate();
   const location = useLocation();
+  const routeState = location.state as OnboardingRouteState | null;
   const [entryRouteState] = useState<OnboardingRouteState | null>(() =>
-    getPersistentOnboardingRouteState(
-      location.state as OnboardingRouteState | null
-    )
+    getPersistentOnboardingRouteState(routeState)
+  );
+  const persistentNavigationState = useMemo(
+    () => getPersistentOnboardingNavigationState(routeState),
+    [routeState]
   );
   const [steps, setSteps] = useState<OnboardingStep[]>([]);
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
@@ -1977,7 +2009,10 @@ export function OnboardingWizard() {
 
       if (isOnboardingAwaitingHrReview(data)) {
         setLoading(false);
-        navigate("/onboarding/submitted", { replace: true });
+        navigate("/onboarding/submitted", {
+          replace: true,
+          state: persistentNavigationState,
+        });
         return;
       }
 
@@ -1994,7 +2029,7 @@ export function OnboardingWizard() {
       setTemplate(null);
       setTemplateResetKey((k) => k + 1);
     },
-    [navigate]
+    [navigate, persistentNavigationState]
   );
 
   const resetUploadState = useCallback(() => {
@@ -2043,7 +2078,10 @@ export function OnboardingWizard() {
 
     if (isSubmittedOnboardingWorkflowStatus(refreshedStatus)) {
       setLoading(false);
-      navigate("/onboarding/submitted", { replace: true });
+      navigate("/onboarding/submitted", {
+        replace: true,
+        state: persistentNavigationState,
+      });
       return;
     }
 
@@ -2072,6 +2110,7 @@ export function OnboardingWizard() {
     authContext?.user,
     applyLoadedSteps,
     navigate,
+    persistentNavigationState,
     resetUploadState,
     syncAuthenticatedUser,
   ]);
@@ -2131,13 +2170,19 @@ export function OnboardingWizard() {
   }, [_]);
 
   useEffect(() => {
-    const routeState = location.state as OnboardingRouteState | null;
     if (!routeState) {
       return;
     }
 
-    navigate(location.pathname, { replace: true, state: null });
-  }, [location.pathname, location.state, navigate]);
+    if (hasPersistentOnboardingNavigationState(routeState)) {
+      return;
+    }
+
+    navigate(location.pathname, {
+      replace: true,
+      state: persistentNavigationState,
+    });
+  }, [location.pathname, navigate, persistentNavigationState, routeState]);
 
   useEffect(() => {
     if (feedback?.tone !== "error" && !error) {
@@ -2163,8 +2208,11 @@ export function OnboardingWizard() {
       return;
     }
 
-    navigate("/onboarding/submitted", { replace: true });
-  }, [currentOnboardingWorkflowStatus, navigate]);
+    navigate("/onboarding/submitted", {
+      replace: true,
+      state: persistentNavigationState,
+    });
+  }, [currentOnboardingWorkflowStatus, navigate, persistentNavigationState]);
 
   useEffect(() => {
     let active = true;
@@ -2924,7 +2972,10 @@ export function OnboardingWizard() {
 
     if (await persistCurrentStep("submitted")) {
       if (currentStepIndex >= steps.length - 1) {
-        navigate("/onboarding/submitted", { replace: true });
+        navigate("/onboarding/submitted", {
+          replace: true,
+          state: persistentNavigationState,
+        });
         return;
       }
 

--- a/src/pages/Onboarding/OnboardingWizard.tsx
+++ b/src/pages/Onboarding/OnboardingWizard.tsx
@@ -151,11 +151,13 @@ function getPersistentOnboardingNavigationState(
 function hasPersistentOnboardingNavigationState(
   routeState: OnboardingRouteState | null
 ): boolean {
+  const persistentNavigationState =
+    getPersistentOnboardingNavigationState(routeState);
+
   return (
-    routeState != null &&
+    persistentNavigationState != null &&
     Object.keys(routeState).length === 1 &&
-    getPersistentOnboardingNavigationState(routeState)?.returnTo ===
-      routeState.returnTo
+    persistentNavigationState.returnTo === routeState.returnTo
   );
 }
 

--- a/tests/unit/pages/Onboarding/OnboardingWizard.test.tsx
+++ b/tests/unit/pages/Onboarding/OnboardingWizard.test.tsx
@@ -16,6 +16,10 @@ import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
 import { messages as deMessages } from "../../../../src/locales/de/messages.mjs";
 import { OnboardingWizard } from "../../../../src/pages/Onboarding/OnboardingWizard";
+import {
+  AuthContext,
+  type AuthContextType,
+} from "../../../../src/contexts/auth-context";
 import * as onboardingApi from "../../../../src/services/onboardingApi";
 import * as employeeApi from "../../../../src/services/employeeApi";
 import { ApiError } from "../../../../src/services/ApiError";
@@ -89,34 +93,46 @@ function makeSubmission(
 
 function OnboardingCompletionStub() {
   const location = useLocation();
-  const returnTo =
-    typeof location.state === "object" &&
-    location.state !== null &&
-    typeof (location.state as { returnTo?: string }).returnTo === "string"
-      ? (location.state as { returnTo: string }).returnTo
-      : null;
 
   return (
     <div>
       <h1>You&apos;re all set</h1>
-      {returnTo ? <p>Return to {returnTo}</p> : null}
+      <pre data-testid="completion-route-state">
+        {JSON.stringify(location.state)}
+      </pre>
     </div>
   );
 }
 
-function RouteStateProbe() {
+const defaultAuthContext: AuthContextType = {
+  user: null,
+  isAuthenticated: true,
+  isLoading: false,
+  bootstrapRecoveryReason: null,
+  login: vi.fn(async () => undefined),
+  logout: vi.fn(async () => undefined),
+  retryBootstrap: vi.fn(),
+  hasPermission: vi.fn(() => false),
+  hasOrganizationalAccess: vi.fn(() => false),
+};
+
+function WizardRouteStateProbe() {
   const location = useLocation();
 
   return (
-    <output data-testid="route-state">
-      {location.state == null ? "null" : JSON.stringify(location.state)}
-    </output>
+    <pre data-testid="wizard-route-state">{JSON.stringify(location.state)}</pre>
   );
 }
 
 function renderWizard(
   routeState?: Record<string, unknown>,
-  { includeRouteStateProbe = false }: { includeRouteStateProbe?: boolean } = {}
+  {
+    authContext,
+    includeRouteStateProbe = true,
+  }: {
+    authContext?: AuthContextType;
+    includeRouteStateProbe?: boolean;
+  } = {}
 ) {
   const initialEntries = routeState
     ? [{ pathname: "/onboarding", state: routeState }]
@@ -124,27 +140,25 @@ function renderWizard(
 
   return render(
     <MemoryRouter initialEntries={initialEntries}>
-      <I18nProvider i18n={i18n}>
-        <Routes>
-          <Route
-            path="/onboarding"
-            element={
-              includeRouteStateProbe ? (
+      <AuthContext.Provider value={authContext}>
+        <I18nProvider i18n={i18n}>
+          <Routes>
+            <Route
+              path="/onboarding"
+              element={
                 <>
+                  {includeRouteStateProbe ? <WizardRouteStateProbe /> : null}
                   <OnboardingWizard />
-                  <RouteStateProbe />
                 </>
-              ) : (
-                <OnboardingWizard />
-              )
-            }
-          />
-          <Route
-            path="/onboarding/submitted"
-            element={<OnboardingCompletionStub />}
-          />
-        </Routes>
-      </I18nProvider>
+              }
+            />
+            <Route
+              path="/onboarding/submitted"
+              element={<OnboardingCompletionStub />}
+            />
+          </Routes>
+        </I18nProvider>
+      </AuthContext.Provider>
     </MemoryRouter>
   );
 }
@@ -547,6 +561,72 @@ describe("OnboardingWizard", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("keeps only a safe return target in route state after onboarding entry cleanup", async () => {
+    renderWizard({
+      onboardingRequired: true,
+      message: "Complete onboarding now",
+      returnTo: "/settings?tab=security",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Personal Information")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("wizard-route-state")).toHaveTextContent(
+        JSON.stringify({ returnTo: "/settings?tab=security" })
+      );
+    });
+  });
+
+  it("drops unsafe protocol-relative return targets during onboarding entry cleanup", async () => {
+    renderWizard({
+      onboardingRequired: true,
+      returnTo: "//attacker.example/path",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Personal Information")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("wizard-route-state")).toHaveTextContent(
+        "null"
+      );
+    });
+  });
+
+  it("preserves the return target when routing to the submitted screen", async () => {
+    renderWizard(
+      {
+        onboardingRequired: true,
+        returnTo: "/settings",
+      },
+      {
+        authContext: {
+          ...defaultAuthContext,
+          user: {
+            id: "1",
+            name: "Pre-Contract User",
+            email: "user@secpal.dev",
+            employeeStatus: "pre_contract",
+            onboardingWorkflowStatus: "submitted_for_review",
+          },
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /you're all set/i })
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("completion-route-state")).toHaveTextContent(
+      JSON.stringify({ returnTo: "/settings" })
+    );
+  });
+
   it("cleans transient route state after mount when returnTo is absent", async () => {
     renderWizard(
       { onboardingRequired: true },
@@ -558,7 +638,9 @@ describe("OnboardingWizard", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId("route-state")).toHaveTextContent("null");
+      expect(screen.getByTestId("wizard-route-state")).toHaveTextContent(
+        "null"
+      );
     });
   });
 
@@ -593,7 +675,9 @@ describe("OnboardingWizard", () => {
     expect(
       await screen.findByRole("heading", { name: /you're all set/i })
     ).toBeInTheDocument();
-    expect(screen.getByText("Return to /settings")).toBeInTheDocument();
+    expect(screen.getByTestId("completion-route-state")).toHaveTextContent(
+      JSON.stringify({ returnTo: "/settings" })
+    );
   });
 
   it("blocks moving to the next step until required fields are filled", async () => {

--- a/tests/unit/pages/Onboarding/OnboardingWizard.test.tsx
+++ b/tests/unit/pages/Onboarding/OnboardingWizard.test.tsx
@@ -104,7 +104,20 @@ function OnboardingCompletionStub() {
   );
 }
 
-function renderWizard(routeState?: Record<string, unknown>) {
+function RouteStateProbe() {
+  const location = useLocation();
+
+  return (
+    <output data-testid="route-state">
+      {location.state == null ? "null" : JSON.stringify(location.state)}
+    </output>
+  );
+}
+
+function renderWizard(
+  routeState?: Record<string, unknown>,
+  { includeRouteStateProbe = false }: { includeRouteStateProbe?: boolean } = {}
+) {
   const initialEntries = routeState
     ? [{ pathname: "/onboarding", state: routeState }]
     : ["/onboarding"];
@@ -113,7 +126,19 @@ function renderWizard(routeState?: Record<string, unknown>) {
     <MemoryRouter initialEntries={initialEntries}>
       <I18nProvider i18n={i18n}>
         <Routes>
-          <Route path="/onboarding" element={<OnboardingWizard />} />
+          <Route
+            path="/onboarding"
+            element={
+              includeRouteStateProbe ? (
+                <>
+                  <OnboardingWizard />
+                  <RouteStateProbe />
+                </>
+              ) : (
+                <OnboardingWizard />
+              )
+            }
+          />
           <Route
             path="/onboarding/submitted"
             element={<OnboardingCompletionStub />}
@@ -520,6 +545,21 @@ describe("OnboardingWizard", () => {
         /your onboarding is not complete yet\. please complete onboarding/i
       )
     ).not.toBeInTheDocument();
+  });
+
+  it("cleans transient route state after mount when returnTo is absent", async () => {
+    renderWizard(
+      { onboardingRequired: true },
+      { includeRouteStateProbe: true }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Personal Information")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("route-state")).toHaveTextContent("null");
+    });
   });
 
   it("preserves the original deep link when the wizard redirects to the submitted screen", async () => {

--- a/tests/unit/pages/Onboarding/OnboardingWizard.test.tsx
+++ b/tests/unit/pages/Onboarding/OnboardingWizard.test.tsx
@@ -11,7 +11,7 @@ import {
 } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
 import { messages as deMessages } from "../../../../src/locales/de/messages.mjs";
@@ -88,9 +88,18 @@ function makeSubmission(
 }
 
 function OnboardingCompletionStub() {
+  const location = useLocation();
+  const returnTo =
+    typeof location.state === "object" &&
+    location.state !== null &&
+    typeof (location.state as { returnTo?: string }).returnTo === "string"
+      ? (location.state as { returnTo: string }).returnTo
+      : null;
+
   return (
     <div>
       <h1>You&apos;re all set</h1>
+      {returnTo ? <p>Return to {returnTo}</p> : null}
     </div>
   );
 }
@@ -511,6 +520,40 @@ describe("OnboardingWizard", () => {
         /your onboarding is not complete yet\. please complete onboarding/i
       )
     ).not.toBeInTheDocument();
+  });
+
+  it("preserves the original deep link when the wizard redirects to the submitted screen", async () => {
+    vi.mocked(onboardingApi.createOnboardingSubmission).mockResolvedValueOnce(
+      makeSubmission("template-1")
+    );
+    vi.mocked(onboardingApi.updateOnboardingSubmission)
+      .mockResolvedValueOnce({
+        ...makeSubmission("template-1"),
+        status: "submitted",
+      })
+      .mockResolvedValueOnce({
+        ...makeSubmission("template-2"),
+        status: "submitted",
+      });
+
+    renderWizard({ onboardingRequired: true, returnTo: "/settings" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Personal Information")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Tax Details")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /submit for review/i }));
+
+    expect(
+      await screen.findByRole("heading", { name: /you're all set/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Return to /settings")).toBeInTheDocument();
   });
 
   it("blocks moving to the next step until required fields are filled", async () => {


### PR DESCRIPTION
## Summary
- Reproduced the protected-route regression with a new `src/App.test.tsx` case that deep-links unverified pre-contract users into app routes and expects an onboarding redirect first.
- Kept the protected app shell behind `AppAccessRoute` before `ProtectedRoute` revalidation so pre-contract users are redirected into onboarding before normal app content or verification gates.
- Expanded the move organizational unit dialog width and tightened `min-w-0` handling so long labels stay contained in the regular browser move flow.
- Added dialog coverage in `src/components/MoveOrganizationalUnitDialog.test.tsx` and documented both fixes in `CHANGELOG.md`.

## Validation
- `npm run build`
- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `npm test`

## Before Ready
- GitHub Actions still need to pass on this draft PR.
- Final PR self-review is still required before marking this draft ready.
- No linked workspace follow-up is required for this change set.
