### PR TITLE
Adopt provider-neutral AI instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,6 +15,7 @@ for path-specific or stack-specific rules.
 - `AGENTS.md`
 - `.github/instructions/org-shared.instructions.md`
 - `.github/instructions/react-typescript.instructions.md`
+- `.github/instructions/github-workflows.instructions.md`
 
 ## Core Runtime Baseline
 

--- a/.github/instructions/org-shared.instructions.md
+++ b/.github/instructions/org-shared.instructions.md
@@ -10,12 +10,16 @@ applyTo: "**"
 
 This file auto-applies to all files in this repo so strict SecPal governance stays always present at runtime.
 
-- `.github/copilot-instructions.md` is the authoritative runtime baseline for this repo.
+- `AGENTS.md` is the authoritative runtime baseline for this repo.
+  `.github/copilot-instructions.md` is only a compatibility mirror.
 - Non-negotiable: TDD first, quality first, 1 topic = 1 PR = 1 branch,
   immediate GitHub issue creation for every real out-of-scope finding, and no
   bypass.
-- If work needs more than one PR, or probably will, create an EPIC with linked sub-issues before implementation.
+- If work needs more than one PR, or probably will, create an EPIC with linked
+  sub-issues before implementation.
 - Design discipline is always-on: DRY, KISS, YAGNI, SOLID, and fail fast.
 - GitHub communication stays in English and uses file and line references instead of large verbatim code quotes.
+- Do not add AI self-references, generated-by text, tool promotion, or AI
+  attribution unless the task explicitly requires documenting AI tooling.
 - Keep changes repo-local, minimal, and consistent with React, strict TypeScript, and generated API type conventions.
 - Apply the SecPal domain policy and immediate warning and issue triage rules from the repo baseline.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -31,9 +31,9 @@ jobs:
     name: Markdown Lint
     uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@main
 
-  copilot-instructions:
-    name: Copilot Instructions
-    uses: SecPal/.github/.github/workflows/reusable-copilot-instructions.yml@main
+  ai-instructions:
+    name: AI Instructions
+    uses: SecPal/.github/.github/workflows/reusable-ai-instructions.yml@main
 
   eslint:
     name: ESLint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,16 +3,13 @@ SPDX-FileCopyrightText: 2026 SecPal
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# SecPal/frontend Copilot Instructions
+# SecPal/frontend Agent Instructions
 
-This file mirrors the authoritative root `AGENTS.md` for tooling
-that automatically loads `.github/copilot-instructions.md`.
-Edit `AGENTS.md` first. Keep the focused overlay files aligned
-for path-specific or stack-specific rules.
+This file is the authoritative, provider-neutral runtime baseline for this repository.
+Edit this file first. Keep the focused overlay files below aligned when a rule also needs path-specific or stack-specific enforcement.
 
-## Authoritative Sources
+## Focused Overlays
 
-- `AGENTS.md`
 - `.github/instructions/org-shared.instructions.md`
 - `.github/instructions/react-typescript.instructions.md`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ Edit this file first. Keep the focused overlay files below aligned when a rule a
 
 - `.github/instructions/org-shared.instructions.md`
 - `.github/instructions/react-typescript.instructions.md`
+- `.github/instructions/github-workflows.instructions.md`
 
 ## Core Runtime Baseline
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Included `.github/instructions/github-workflows.instructions.md` in the frontend AI-governance baseline so provider-neutral agents and Copilot-derived tooling load the same workflow-policy overlay when reviewing or editing GitHub automation.
 - `/login` no longer renders the legacy split brand-panel layout on large viewports; the `login-05` centered card is now the single layout across breakpoints. The `LoginBrandPanel` primitive remains available in `src/pages/Auth/ui/primitives.tsx` for future use but is no longer composed on the login route.
 - Swapped the three icons on the login surface from the legacy outline icon package to `lucide-react`: passkey-action `KeyIcon` → `KeyRound`, AGPL-license `ScaleIcon` → `Scale`, source-code `CodeBracketIcon` → `Code2`.
 - Migrated every remaining non-shadcn surface on the login route to true Radix-backed shadcn primitives, fulfilling the "Login uses shadcn exclusively" requirement:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Included `.github/instructions/github-workflows.instructions.md` in the frontend AI-governance baseline so provider-neutral agents and Copilot-derived tooling load the same workflow-policy overlay when reviewing or editing GitHub automation.
+- Updated `docs/development/TDD_WORKFLOW.md` to keep the SPDX copyright year current after the 2026 governance-link refresh.
 - `/login` no longer renders the legacy split brand-panel layout on large viewports; the `login-05` centered card is now the single layout across breakpoints. The `LoginBrandPanel` primitive remains available in `src/pages/Auth/ui/primitives.tsx` for future use but is no longer composed on the login route.
 - Swapped the three icons on the login surface from the legacy outline icon package to `lucide-react`: passkey-action `KeyIcon` → `KeyRound`, AGPL-license `ScaleIcon` → `Scale`, source-code `CodeBracketIcon` → `Code2`.
 - Migrated every remaining non-shadcn surface on the login route to true Radix-backed shadcn primitives, fulfilling the "Login uses shadcn exclusively" requirement:

--- a/README.md
+++ b/README.md
@@ -282,7 +282,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 **Quick Links:**
 
 - **TDD Workflow**: [docs/development/TDD_WORKFLOW.md](docs/development/TDD_WORKFLOW.md) - Learn how to practice Test-Driven Development with Git verification
-- **Copilot Instructions**: [.github/copilot-instructions.md](.github/copilot-instructions.md) - AI development guidelines
+- **AI Instructions**: [AGENTS.md](AGENTS.md) - authoritative AI development guidelines
+- **Copilot Compatibility Mirror**: [.github/copilot-instructions.md](.github/copilot-instructions.md) - compatibility path for tools that auto-load GitHub Copilot instructions
 
 **Key Requirements:**
 

--- a/docs/development/TDD_WORKFLOW.md
+++ b/docs/development/TDD_WORKFLOW.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2025-2026 SecPal
 SPDX-License-Identifier: CC0-1.0
 -->
 

--- a/docs/development/TDD_WORKFLOW.md
+++ b/docs/development/TDD_WORKFLOW.md
@@ -317,4 +317,4 @@ git log --oneline
 - [Growing Object-Oriented Software, Guided by Tests](http://www.growing-object-oriented-software.com/)
 - [Martin Fowler: Test-Driven Development](https://martinfowler.com/bliki/TestDrivenDevelopment.html)
 - [SecPal Contributing Guide](../../CONTRIBUTING.md)
-- [Organization-wide Copilot Instructions](../../.github/copilot-instructions.md)
+- [Repository AI Instructions](../../AGENTS.md)


### PR DESCRIPTION
## Summary
- add root `AGENTS.md` as the provider-neutral instruction baseline for `frontend`
- refresh `.github/copilot-instructions.md` into an explicit compatibility mirror of `AGENTS.md`
- align the repo-local instruction overlays and quality workflow wiring with the new AI-instructions validation path

## TDD / Validate-First Evidence
- Failing proof before implementation: `bash /home/secpal/code/SecPal/.github/scripts/validate-ai-instructions.sh /home/secpal/code/SecPal/frontend` on `main` failed because `AGENTS.md` was missing and the Copilot instructions did not satisfy the new mirror contract.
- Passing proof after implementation: `bash /home/secpal/code/SecPal/.github/scripts/validate-ai-instructions.sh /home/secpal/code/SecPal/frontend` on `ai-instructions/provider-neutral-rollout`
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Testing
- bash /home/secpal/code/SecPal/.github/scripts/validate-ai-instructions.sh /home/secpal/code/SecPal/frontend
