### PR TITLE
Handle native bridge logout teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the missing `SecPal/android` repository to the `/source` AGPL
   source-offer page so the frontend's corresponding-source list again
   reflects the Android wrapper that consumes the shared frontend build output.
+- Native-bridge logout now tears down the frontend auth session even when logout is triggered directly through `SecPalNativeAuthBridge.logout()`, so protected routes immediately fall back to `/login` instead of leaving the WebView on the authenticated `/` shell with stale frontend auth state.
 - Consolidated the shared frontend UI layer on `@/ui`, removed remaining
   legacy shell and auth wrapper paths, replaced productive custom inline UI
   icon usage with Lucide components, and added guardrails so migrated routes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   source-offer page so the frontend's corresponding-source list again
   reflects the Android wrapper that consumes the shared frontend build output.
 - Native-bridge logout now tears down the frontend auth session even when logout is triggered directly through `SecPalNativeAuthBridge.logout()`, so protected routes immediately fall back to `/login` instead of leaving the WebView on the authenticated `/` shell with stale frontend auth state.
+- Native-bridge auth bootstrap now handles a writable but non-configurable `SecPalNativeAuthBridge.logout()` property without throwing while wiring the direct-logout event dispatch wrapper.
 - Consolidated the shared frontend UI layer on `@/ui`, removed remaining
   legacy shell and auth wrapper paths, replaced productive custom inline UI
   icon usage with Lucide components, and added guardrails so migrated routes

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -216,6 +216,8 @@ describe("App", () => {
     await authStorage.clear();
     localStorage.clear();
     sessionStorage.clear();
+    delete (globalThis as { SecPalNativeAuthBridge?: unknown })
+      .SecPalNativeAuthBridge;
     clearXsrfCookie();
     setXsrfCookie();
     window.history.replaceState({}, "", "/login");
@@ -1365,6 +1367,63 @@ describe("App", () => {
         { timeout: ROUTE_NAVIGATION_TIMEOUT_MS }
       )
     ).toBeInTheDocument();
+  });
+
+  it("redirects native-bridge users to login after a native logout event", async () => {
+    window.history.replaceState({}, "", "/");
+
+    const persistedUser = await seedPersistedAuthUser({
+      id: 1,
+      name: "Native User",
+      email: "native@secpal.dev",
+      emailVerified: true,
+      employee: {
+        id: "employee-3",
+        status: "active",
+      },
+    });
+
+    (
+      globalThis as {
+        SecPalNativeAuthBridge?: {
+          login(credentials: {
+            email: string;
+            password: string;
+          }): Promise<unknown>;
+          logout(): Promise<void>;
+          getCurrentUser(): Promise<unknown>;
+        };
+      }
+    ).SecPalNativeAuthBridge = {
+      login: vi.fn(),
+      logout: vi.fn(),
+      getCurrentUser: vi.fn().mockResolvedValue(persistedUser),
+    };
+
+    await renderWithI18n(<App />);
+
+    expect(
+      await screen.findByRole(
+        "heading",
+        { name: /welcome to secpal/i },
+        { timeout: ROUTE_NAVIGATION_TIMEOUT_MS }
+      )
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      window.dispatchEvent(new Event("secpal:native-auth-logout"));
+      await Promise.resolve();
+      await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
+    });
+
+    await waitFor(
+      () => {
+        expect(window.location.pathname).toBe("/login");
+      },
+      { timeout: ROUTE_NAVIGATION_TIMEOUT_MS }
+    );
+
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
   });
 
   it("redirects unauthenticated users from the protected onboarding route to login", async () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -10,8 +10,8 @@ import App from "./App";
 import { AuthApiError } from "./services/authApi";
 import { sanitizePersistedAuthUser } from "./services/authState";
 import { authStorage } from "./services/storage";
+import { NATIVE_AUTH_LOGOUT_EVENT_NAME } from "./services/nativeAuthEvents";
 import { createRecoverableLazyModuleError } from "./lib/lazyModuleErrors";
-import { NATIVE_AUTH_LOGOUT_EVENT_NAME } from "./contexts/AuthContext";
 
 const ROUTE_NAVIGATION_TIMEOUT_MS = 20_000;
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -11,6 +11,7 @@ import { AuthApiError } from "./services/authApi";
 import { sanitizePersistedAuthUser } from "./services/authState";
 import { authStorage } from "./services/storage";
 import { createRecoverableLazyModuleError } from "./lib/lazyModuleErrors";
+import { NATIVE_AUTH_LOGOUT_EVENT_NAME } from "./contexts/AuthContext";
 
 const ROUTE_NAVIGATION_TIMEOUT_MS = 20_000;
 
@@ -1411,7 +1412,7 @@ describe("App", () => {
     ).toBeInTheDocument();
 
     await act(async () => {
-      window.dispatchEvent(new Event("secpal:native-auth-logout"));
+      window.dispatchEvent(new Event(NATIVE_AUTH_LOGOUT_EVENT_NAME));
       await Promise.resolve();
       await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
     });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -10,7 +10,6 @@ import App from "./App";
 import { AuthApiError } from "./services/authApi";
 import { sanitizePersistedAuthUser } from "./services/authState";
 import { authStorage } from "./services/storage";
-import { NATIVE_AUTH_LOGOUT_EVENT_NAME } from "./services/nativeAuthEvents";
 import { createRecoverableLazyModuleError } from "./lib/lazyModuleErrors";
 
 const ROUTE_NAVIGATION_TIMEOUT_MS = 20_000;
@@ -1370,7 +1369,7 @@ describe("App", () => {
     ).toBeInTheDocument();
   });
 
-  it("redirects native-bridge users to login after a native logout event", async () => {
+  it("redirects native-bridge users to login after a direct bridge logout", async () => {
     window.history.replaceState({}, "", "/");
 
     const persistedUser = await seedPersistedAuthUser({
@@ -1412,7 +1411,13 @@ describe("App", () => {
     ).toBeInTheDocument();
 
     await act(async () => {
-      window.dispatchEvent(new Event(NATIVE_AUTH_LOGOUT_EVENT_NAME));
+      await (
+        globalThis as {
+          SecPalNativeAuthBridge?: {
+            logout(): Promise<void>;
+          };
+        }
+      ).SecPalNativeAuthBridge?.logout();
       await Promise.resolve();
       await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
     });

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -29,6 +29,7 @@ import {
 } from "../lib/offlineVaultKeys";
 
 export const BOOTSTRAP_REVALIDATION_TIMEOUT_MS = 3500;
+const NATIVE_AUTH_LOGOUT_EVENT_NAME = "secpal:native-auth-logout";
 
 async function loadOfflineVaultModule() {
   return await import("../lib/offlineVault");
@@ -507,6 +508,25 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     clearAuthenticatedState(true, { redirectOpenClients: true });
     await clearAuthenticatedStatePromiseRef.current;
   }, [clearAuthenticatedState]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleNativeLogout = () => {
+      void logout();
+    };
+
+    window.addEventListener(NATIVE_AUTH_LOGOUT_EVENT_NAME, handleNativeLogout);
+
+    return () => {
+      window.removeEventListener(
+        NATIVE_AUTH_LOGOUT_EVENT_NAME,
+        handleNativeLogout
+      );
+    };
+  }, [logout]);
 
   const lock = useCallback(() => {
     authStorage.lockVault?.();

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -15,6 +15,7 @@ import {
 } from "./auth-context";
 import { getAuthTransport } from "../services/authTransport";
 import { sanitizeAuthUser } from "../services/authState";
+import { NATIVE_AUTH_LOGOUT_EVENT_NAME } from "../services/nativeAuthEvents";
 import { authStorage } from "../services/storage";
 import { fetchCsrfToken, getCsrfTokenFromCookie } from "../services/csrf";
 import { sessionEvents, isOnline } from "../services/sessionEvents";
@@ -29,7 +30,6 @@ import {
 } from "../lib/offlineVaultKeys";
 
 export const BOOTSTRAP_REVALIDATION_TIMEOUT_MS = 3500;
-export const NATIVE_AUTH_LOGOUT_EVENT_NAME = "secpal:native-auth-logout";
 
 async function loadOfflineVaultModule() {
   return await import("../lib/offlineVault");

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -29,7 +29,7 @@ import {
 } from "../lib/offlineVaultKeys";
 
 export const BOOTSTRAP_REVALIDATION_TIMEOUT_MS = 3500;
-const NATIVE_AUTH_LOGOUT_EVENT_NAME = "secpal:native-auth-logout";
+export const NATIVE_AUTH_LOGOUT_EVENT_NAME = "secpal:native-auth-logout";
 
 async function loadOfflineVaultModule() {
   return await import("../lib/offlineVault");

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -789,13 +789,61 @@ describe("authTransport", () => {
         | undefined;
 
       expect(transport.kind).toBe("native-bridge");
-      expect(resolvedBridge).toBe(nativeBridge);
-      expect(resolvedBridge?.createPasskeyAttestation).toBe(
-        createPasskeyAttestation
-      );
+      expect(resolvedBridge).not.toBe(nativeBridge);
+      await resolvedBridge?.createPasskeyAttestation();
 
       await resolvedBridge?.logout();
 
+      expect(createPasskeyAttestation).toHaveBeenCalledOnce();
+      expect(nativeLogout).toHaveBeenCalledOnce();
+      expect(handleNativeLogout).toHaveBeenCalledOnce();
+    } finally {
+      window.removeEventListener(
+        NATIVE_AUTH_LOGOUT_EVENT_NAME,
+        handleNativeLogout
+      );
+    }
+  });
+
+  it("supports native bridges with a non-writable logout property", async () => {
+    const createPasskeyAttestation = vi.fn().mockResolvedValue(undefined);
+    const nativeLogout = vi.fn().mockResolvedValue(undefined);
+    const nativeBridge = {
+      login: vi.fn().mockResolvedValue(undefined),
+      logout: nativeLogout,
+      getCurrentUser: vi.fn().mockResolvedValue(undefined),
+      createPasskeyAttestation,
+    } as NativeAuthBridge & {
+      createPasskeyAttestation: typeof createPasskeyAttestation;
+      logout(): Promise<void>;
+    };
+    const handleNativeLogout = vi.fn();
+
+    Object.defineProperty(nativeBridge, "logout", {
+      configurable: true,
+      enumerable: true,
+      value: nativeLogout,
+      writable: false,
+    });
+
+    authTransportGlobal.SecPalNativeAuthBridge = nativeBridge;
+    window.addEventListener(NATIVE_AUTH_LOGOUT_EVENT_NAME, handleNativeLogout);
+
+    try {
+      const transport = getAuthTransport();
+      const resolvedBridge = authTransportGlobal.SecPalNativeAuthBridge as
+        | (NativeAuthBridge & {
+            createPasskeyAttestation: typeof createPasskeyAttestation;
+          })
+        | undefined;
+
+      expect(transport.kind).toBe("native-bridge");
+      expect(resolvedBridge).not.toBe(nativeBridge);
+
+      await resolvedBridge?.createPasskeyAttestation();
+      await resolvedBridge?.logout();
+
+      expect(createPasskeyAttestation).toHaveBeenCalledOnce();
       expect(nativeLogout).toHaveBeenCalledOnce();
       expect(handleNativeLogout).toHaveBeenCalledOnce();
     } finally {

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -8,6 +8,7 @@ import {
   getAuthTransport,
   resolveAuthTransport,
 } from "./authTransport";
+import { NATIVE_AUTH_LOGOUT_EVENT_NAME } from "./nativeAuthEvents";
 
 const {
   mockBrowserLogin,
@@ -736,6 +737,34 @@ describe("authTransport", () => {
 
     expect(nativeBridge.logout).toHaveBeenCalledOnce();
     expect(mockBrowserLogout).not.toHaveBeenCalled();
+  });
+
+  it("dispatches the native logout event after a successful bridge logout", async () => {
+    const nativeBridge: NativeAuthBridge = {
+      login: vi.fn().mockResolvedValue(undefined),
+      logout: vi.fn().mockResolvedValue(undefined),
+      getCurrentUser: vi.fn().mockResolvedValue(undefined),
+    };
+    const handleNativeLogout = vi.fn();
+
+    window.addEventListener(
+      NATIVE_AUTH_LOGOUT_EVENT_NAME,
+      handleNativeLogout
+    );
+
+    try {
+      const transport = resolveAuthTransport({ nativeBridge });
+
+      await transport.logout();
+
+      expect(nativeBridge.logout).toHaveBeenCalledOnce();
+      expect(handleNativeLogout).toHaveBeenCalledOnce();
+    } finally {
+      window.removeEventListener(
+        NATIVE_AUTH_LOGOUT_EVENT_NAME,
+        handleNativeLogout
+      );
+    }
   });
 
   it("delegates native bridge logoutAll to the bridge when supported", async () => {

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -764,6 +764,38 @@ describe("authTransport", () => {
     }
   });
 
+  it("wraps the global native bridge so direct logout calls dispatch the event", async () => {
+    const nativeBridge: NativeAuthBridge = {
+      login: vi.fn().mockResolvedValue(undefined),
+      logout: vi.fn().mockResolvedValue(undefined),
+      getCurrentUser: vi.fn().mockResolvedValue(undefined),
+    };
+    const handleNativeLogout = vi.fn();
+
+    authTransportGlobal.SecPalNativeAuthBridge = nativeBridge;
+    window.addEventListener(NATIVE_AUTH_LOGOUT_EVENT_NAME, handleNativeLogout);
+
+    try {
+      const transport = getAuthTransport();
+      const resolvedBridge = authTransportGlobal.SecPalNativeAuthBridge as
+        | NativeAuthBridge
+        | undefined;
+
+      expect(transport.kind).toBe("native-bridge");
+      expect(resolvedBridge).not.toBe(nativeBridge);
+
+      await resolvedBridge?.logout();
+
+      expect(nativeBridge.logout).toHaveBeenCalledOnce();
+      expect(handleNativeLogout).toHaveBeenCalledOnce();
+    } finally {
+      window.removeEventListener(
+        NATIVE_AUTH_LOGOUT_EVENT_NAME,
+        handleNativeLogout
+      );
+    }
+  });
+
   it("delegates native bridge logoutAll to the bridge when supported", async () => {
     const nativeBridge: NativeAuthBridge = {
       login: vi.fn().mockResolvedValue(undefined),

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -789,7 +789,7 @@ describe("authTransport", () => {
         | undefined;
 
       expect(transport.kind).toBe("native-bridge");
-      expect(resolvedBridge).not.toBe(nativeBridge);
+      expect(resolvedBridge).toBe(nativeBridge);
       await resolvedBridge?.createPasskeyAttestation();
 
       await resolvedBridge?.logout();
@@ -838,7 +838,7 @@ describe("authTransport", () => {
         | undefined;
 
       expect(transport.kind).toBe("native-bridge");
-      expect(resolvedBridge).not.toBe(nativeBridge);
+      expect(resolvedBridge).toBe(nativeBridge);
 
       await resolvedBridge?.createPasskeyAttestation();
       await resolvedBridge?.logout();
@@ -846,6 +846,55 @@ describe("authTransport", () => {
       expect(createPasskeyAttestation).toHaveBeenCalledOnce();
       expect(nativeLogout).toHaveBeenCalledOnce();
       expect(handleNativeLogout).toHaveBeenCalledOnce();
+    } finally {
+      window.removeEventListener(
+        NATIVE_AUTH_LOGOUT_EVENT_NAME,
+        handleNativeLogout
+      );
+    }
+  });
+
+  it("warns and leaves direct logout untouched when the bridge is fully immutable", async () => {
+    const nativeLogout = vi.fn().mockResolvedValue(undefined);
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const nativeBridge = {
+      login: vi.fn().mockResolvedValue(undefined),
+      logout: nativeLogout,
+      getCurrentUser: vi.fn().mockResolvedValue(undefined),
+    } as NativeAuthBridge;
+    const handleNativeLogout = vi.fn();
+
+    Object.defineProperty(nativeBridge, "logout", {
+      configurable: false,
+      enumerable: true,
+      value: nativeLogout,
+      writable: false,
+    });
+    Object.defineProperty(authTransportGlobal, "SecPalNativeAuthBridge", {
+      configurable: true,
+      enumerable: true,
+      value: nativeBridge,
+      writable: false,
+    });
+    window.addEventListener(NATIVE_AUTH_LOGOUT_EVENT_NAME, handleNativeLogout);
+
+    try {
+      const transport = getAuthTransport();
+      const resolvedBridge = authTransportGlobal.SecPalNativeAuthBridge as
+        | NativeAuthBridge
+        | undefined;
+
+      expect(transport.kind).toBe("native-bridge");
+      expect(resolvedBridge).toBe(nativeBridge);
+
+      await transport.logout();
+      await resolvedBridge?.logout();
+
+      expect(nativeLogout).toHaveBeenCalledTimes(2);
+      expect(handleNativeLogout).toHaveBeenCalledOnce();
+      expect(consoleWarn).toHaveBeenCalledWith(
+        "SecPalNativeAuthBridge is immutable; direct logout calls must dispatch secpal:native-auth-logout from the native runtime."
+      );
     } finally {
       window.removeEventListener(
         NATIVE_AUTH_LOGOUT_EVENT_NAME,

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -854,6 +854,55 @@ describe("authTransport", () => {
     }
   });
 
+  it("supports native bridges with a writable but non-configurable logout property", async () => {
+    const createPasskeyAttestation = vi.fn().mockResolvedValue(undefined);
+    const nativeLogout = vi.fn().mockResolvedValue(undefined);
+    const nativeBridge = {
+      login: vi.fn().mockResolvedValue(undefined),
+      logout: nativeLogout,
+      getCurrentUser: vi.fn().mockResolvedValue(undefined),
+      createPasskeyAttestation,
+    } as NativeAuthBridge & {
+      createPasskeyAttestation: typeof createPasskeyAttestation;
+      logout(): Promise<void>;
+    };
+    const handleNativeLogout = vi.fn();
+
+    Object.defineProperty(nativeBridge, "logout", {
+      configurable: false,
+      enumerable: true,
+      value: nativeLogout,
+      writable: true,
+    });
+
+    authTransportGlobal.SecPalNativeAuthBridge = nativeBridge;
+    window.addEventListener(NATIVE_AUTH_LOGOUT_EVENT_NAME, handleNativeLogout);
+
+    try {
+      const transport = getAuthTransport();
+      const resolvedBridge = authTransportGlobal.SecPalNativeAuthBridge as
+        | (NativeAuthBridge & {
+            createPasskeyAttestation: typeof createPasskeyAttestation;
+          })
+        | undefined;
+
+      expect(transport.kind).toBe("native-bridge");
+      expect(resolvedBridge).toBe(nativeBridge);
+
+      await resolvedBridge?.createPasskeyAttestation();
+      await resolvedBridge?.logout();
+
+      expect(createPasskeyAttestation).toHaveBeenCalledOnce();
+      expect(nativeLogout).toHaveBeenCalledOnce();
+      expect(handleNativeLogout).toHaveBeenCalledOnce();
+    } finally {
+      window.removeEventListener(
+        NATIVE_AUTH_LOGOUT_EVENT_NAME,
+        handleNativeLogout
+      );
+    }
+  });
+
   it("warns and leaves direct logout untouched when the bridge is fully immutable", async () => {
     const nativeLogout = vi.fn().mockResolvedValue(undefined);
     const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -747,10 +747,7 @@ describe("authTransport", () => {
     };
     const handleNativeLogout = vi.fn();
 
-    window.addEventListener(
-      NATIVE_AUTH_LOGOUT_EVENT_NAME,
-      handleNativeLogout
-    );
+    window.addEventListener(NATIVE_AUTH_LOGOUT_EVENT_NAME, handleNativeLogout);
 
     try {
       const transport = resolveAuthTransport({ nativeBridge });

--- a/src/services/authTransport.test.ts
+++ b/src/services/authTransport.test.ts
@@ -765,10 +765,15 @@ describe("authTransport", () => {
   });
 
   it("wraps the global native bridge so direct logout calls dispatch the event", async () => {
-    const nativeBridge: NativeAuthBridge = {
+    const createPasskeyAttestation = vi.fn().mockResolvedValue(undefined);
+    const nativeLogout = vi.fn().mockResolvedValue(undefined);
+    const nativeBridge: NativeAuthBridge & {
+      createPasskeyAttestation: typeof createPasskeyAttestation;
+    } = {
       login: vi.fn().mockResolvedValue(undefined),
-      logout: vi.fn().mockResolvedValue(undefined),
+      logout: nativeLogout,
       getCurrentUser: vi.fn().mockResolvedValue(undefined),
+      createPasskeyAttestation,
     };
     const handleNativeLogout = vi.fn();
 
@@ -778,15 +783,20 @@ describe("authTransport", () => {
     try {
       const transport = getAuthTransport();
       const resolvedBridge = authTransportGlobal.SecPalNativeAuthBridge as
-        | NativeAuthBridge
+        | (NativeAuthBridge & {
+            createPasskeyAttestation: typeof createPasskeyAttestation;
+          })
         | undefined;
 
       expect(transport.kind).toBe("native-bridge");
-      expect(resolvedBridge).not.toBe(nativeBridge);
+      expect(resolvedBridge).toBe(nativeBridge);
+      expect(resolvedBridge?.createPasskeyAttestation).toBe(
+        createPasskeyAttestation
+      );
 
       await resolvedBridge?.logout();
 
-      expect(nativeBridge.logout).toHaveBeenCalledOnce();
+      expect(nativeLogout).toHaveBeenCalledOnce();
       expect(handleNativeLogout).toHaveBeenCalledOnce();
     } finally {
       window.removeEventListener(

--- a/src/services/authTransport.ts
+++ b/src/services/authTransport.ts
@@ -11,6 +11,7 @@ import {
 import { isTransientModuleLoadError } from "../lib/lazyModuleErrors";
 import { AuthApiError } from "./AuthApiError";
 import { sanitizeAuthUser } from "./authState";
+import { NATIVE_AUTH_LOGOUT_EVENT_NAME } from "./nativeAuthEvents";
 import { isOnline } from "./sessionEvents";
 
 export { AuthApiError } from "./AuthApiError";
@@ -21,6 +22,14 @@ async function loadAuthApiModule() {
 
 async function loadNotificationInstallationsModule() {
   return await import("./notificationInstallationsApi");
+}
+
+function dispatchNativeAuthLogoutEvent(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.dispatchEvent(new Event(NATIVE_AUTH_LOGOUT_EVENT_NAME));
 }
 
 export interface AuthCredentials {
@@ -299,6 +308,7 @@ function createNativeBridgeAuthTransport(
     },
     async logout(): Promise<void> {
       await nativeAuthBridge.logout();
+      dispatchNativeAuthLogoutEvent();
     },
     async logoutAll(): Promise<void> {
       if (typeof nativeAuthBridge.logoutAll !== "function") {

--- a/src/services/authTransport.ts
+++ b/src/services/authTransport.ts
@@ -16,6 +16,10 @@ import { isOnline } from "./sessionEvents";
 
 export { AuthApiError } from "./AuthApiError";
 
+const NATIVE_AUTH_BRIDGE_DISPATCHES_LOGOUT_EVENT = Symbol(
+  "nativeAuthBridgeDispatchesLogoutEvent"
+);
+
 async function loadAuthApiModule() {
   return await import("./authApi");
 }
@@ -308,7 +312,9 @@ function createNativeBridgeAuthTransport(
     },
     async logout(): Promise<void> {
       await nativeAuthBridge.logout();
-      dispatchNativeAuthLogoutEvent();
+      if (!bridgeDispatchesLogoutEvent(nativeAuthBridge)) {
+        dispatchNativeAuthLogoutEvent();
+      }
     },
     async logoutAll(): Promise<void> {
       if (typeof nativeAuthBridge.logoutAll !== "function") {
@@ -352,11 +358,71 @@ function isNativeAuthBridge(value: unknown): value is NativeAuthBridge {
   );
 }
 
-function getNativeAuthBridge(): NativeAuthBridge | null {
-  const candidate = (globalThis as { SecPalNativeAuthBridge?: unknown })
-    .SecPalNativeAuthBridge;
+function bridgeDispatchesLogoutEvent(bridge: NativeAuthBridge): boolean {
+  return (
+    (
+      bridge as NativeAuthBridge & {
+        [NATIVE_AUTH_BRIDGE_DISPATCHES_LOGOUT_EVENT]?: boolean;
+      }
+    )[NATIVE_AUTH_BRIDGE_DISPATCHES_LOGOUT_EVENT] === true
+  );
+}
 
-  return isNativeAuthBridge(candidate) ? candidate : null;
+function wrapNativeAuthBridge(
+  nativeAuthBridge: NativeAuthBridge
+): NativeAuthBridge {
+  if (bridgeDispatchesLogoutEvent(nativeAuthBridge)) {
+    return nativeAuthBridge;
+  }
+
+  const wrappedBridge: NativeAuthBridge & {
+    [NATIVE_AUTH_BRIDGE_DISPATCHES_LOGOUT_EVENT]: true;
+  } = {
+    login(credentials) {
+      return nativeAuthBridge.login.call(nativeAuthBridge, credentials);
+    },
+    async logout() {
+      await nativeAuthBridge.logout.call(nativeAuthBridge);
+      dispatchNativeAuthLogoutEvent();
+    },
+    getCurrentUser() {
+      return nativeAuthBridge.getCurrentUser.call(nativeAuthBridge);
+    },
+    [NATIVE_AUTH_BRIDGE_DISPATCHES_LOGOUT_EVENT]: true,
+  };
+
+  if (typeof nativeAuthBridge.loginWithPasskey === "function") {
+    wrappedBridge.loginWithPasskey = () =>
+      nativeAuthBridge.loginWithPasskey!.call(nativeAuthBridge);
+  }
+
+  if (typeof nativeAuthBridge.logoutAll === "function") {
+    wrappedBridge.logoutAll = () =>
+      nativeAuthBridge.logoutAll!.call(nativeAuthBridge);
+  }
+
+  if (typeof nativeAuthBridge.isNetworkAvailable === "function") {
+    wrappedBridge.isNetworkAvailable = () =>
+      nativeAuthBridge.isNetworkAvailable!.call(nativeAuthBridge);
+  }
+
+  return wrappedBridge;
+}
+
+function getNativeAuthBridge(): NativeAuthBridge | null {
+  const bridgeGlobal = globalThis as {
+    SecPalNativeAuthBridge?: unknown;
+  };
+  const candidate = bridgeGlobal.SecPalNativeAuthBridge;
+
+  if (!isNativeAuthBridge(candidate)) {
+    return null;
+  }
+
+  const wrappedBridge = wrapNativeAuthBridge(candidate);
+  bridgeGlobal.SecPalNativeAuthBridge = wrappedBridge;
+
+  return wrappedBridge;
 }
 
 export function resolveAuthTransport(options?: {

--- a/src/services/authTransport.ts
+++ b/src/services/authTransport.ts
@@ -16,9 +16,11 @@ import { isOnline } from "./sessionEvents";
 
 export { AuthApiError } from "./AuthApiError";
 
-const NATIVE_AUTH_BRIDGE_DISPATCHES_LOGOUT_EVENT = Symbol(
-  "nativeAuthBridgeDispatchesLogoutEvent"
-);
+const nativeAuthBridgeLogoutEventProxies = new WeakSet<NativeAuthBridge>();
+const nativeAuthBridgeLogoutEventProxyCache = new WeakMap<
+  NativeAuthBridge,
+  NativeAuthBridge
+>();
 
 async function loadAuthApiModule() {
   return await import("./authApi");
@@ -359,30 +361,46 @@ function isNativeAuthBridge(value: unknown): value is NativeAuthBridge {
 }
 
 function bridgeDispatchesLogoutEvent(bridge: NativeAuthBridge): boolean {
-  return (
-    (
-      bridge as NativeAuthBridge & {
-        [NATIVE_AUTH_BRIDGE_DISPATCHES_LOGOUT_EVENT]?: boolean;
-      }
-    )[NATIVE_AUTH_BRIDGE_DISPATCHES_LOGOUT_EVENT] === true
-  );
+  return nativeAuthBridgeLogoutEventProxies.has(bridge);
 }
 
-function wrapNativeAuthBridgeLogout(nativeAuthBridge: NativeAuthBridge): void {
+function wrapNativeAuthBridgeLogout(
+  nativeAuthBridge: NativeAuthBridge
+): NativeAuthBridge {
   if (bridgeDispatchesLogoutEvent(nativeAuthBridge)) {
-    return;
+    return nativeAuthBridge;
   }
 
-  const bridgeWithMetadata = nativeAuthBridge as NativeAuthBridge & {
-    [NATIVE_AUTH_BRIDGE_DISPATCHES_LOGOUT_EVENT]?: boolean;
-  };
-  const originalLogout = nativeAuthBridge.logout;
+  const cachedProxy =
+    nativeAuthBridgeLogoutEventProxyCache.get(nativeAuthBridge);
 
-  bridgeWithMetadata.logout = async function logoutWithEventDispatch() {
-    await originalLogout.call(nativeAuthBridge);
-    dispatchNativeAuthLogoutEvent();
-  };
-  bridgeWithMetadata[NATIVE_AUTH_BRIDGE_DISPATCHES_LOGOUT_EVENT] = true;
+  if (cachedProxy) {
+    return cachedProxy;
+  }
+
+  const proxy = new Proxy(nativeAuthBridge, {
+    get(target, property, receiver) {
+      const value = Reflect.get(target, property, receiver);
+
+      if (property === "logout") {
+        return async () => {
+          await target.logout.call(target);
+          dispatchNativeAuthLogoutEvent();
+        };
+      }
+
+      if (typeof value === "function") {
+        return value.bind(target);
+      }
+
+      return value;
+    },
+  });
+
+  nativeAuthBridgeLogoutEventProxies.add(proxy);
+  nativeAuthBridgeLogoutEventProxyCache.set(nativeAuthBridge, proxy);
+
+  return proxy;
 }
 
 function getNativeAuthBridge(): NativeAuthBridge | null {
@@ -395,10 +413,16 @@ function getNativeAuthBridge(): NativeAuthBridge | null {
     return null;
   }
 
-  wrapNativeAuthBridgeLogout(candidate);
-  bridgeGlobal.SecPalNativeAuthBridge = candidate;
+  const wrappedBridge = wrapNativeAuthBridgeLogout(candidate);
 
-  return candidate;
+  try {
+    bridgeGlobal.SecPalNativeAuthBridge = wrappedBridge;
+  } catch {
+    // Read-only host globals still need a usable auth transport even if direct
+    // callers cannot be redirected through the proxied bridge handle.
+  }
+
+  return wrappedBridge;
 }
 
 export function resolveAuthTransport(options?: {

--- a/src/services/authTransport.ts
+++ b/src/services/authTransport.ts
@@ -368,45 +368,21 @@ function bridgeDispatchesLogoutEvent(bridge: NativeAuthBridge): boolean {
   );
 }
 
-function wrapNativeAuthBridge(
-  nativeAuthBridge: NativeAuthBridge
-): NativeAuthBridge {
+function wrapNativeAuthBridgeLogout(nativeAuthBridge: NativeAuthBridge): void {
   if (bridgeDispatchesLogoutEvent(nativeAuthBridge)) {
-    return nativeAuthBridge;
+    return;
   }
 
-  const wrappedBridge: NativeAuthBridge & {
-    [NATIVE_AUTH_BRIDGE_DISPATCHES_LOGOUT_EVENT]: true;
-  } = {
-    login(credentials) {
-      return nativeAuthBridge.login.call(nativeAuthBridge, credentials);
-    },
-    async logout() {
-      await nativeAuthBridge.logout.call(nativeAuthBridge);
-      dispatchNativeAuthLogoutEvent();
-    },
-    getCurrentUser() {
-      return nativeAuthBridge.getCurrentUser.call(nativeAuthBridge);
-    },
-    [NATIVE_AUTH_BRIDGE_DISPATCHES_LOGOUT_EVENT]: true,
+  const bridgeWithMetadata = nativeAuthBridge as NativeAuthBridge & {
+    [NATIVE_AUTH_BRIDGE_DISPATCHES_LOGOUT_EVENT]?: boolean;
   };
+  const originalLogout = nativeAuthBridge.logout;
 
-  if (typeof nativeAuthBridge.loginWithPasskey === "function") {
-    wrappedBridge.loginWithPasskey = () =>
-      nativeAuthBridge.loginWithPasskey!.call(nativeAuthBridge);
-  }
-
-  if (typeof nativeAuthBridge.logoutAll === "function") {
-    wrappedBridge.logoutAll = () =>
-      nativeAuthBridge.logoutAll!.call(nativeAuthBridge);
-  }
-
-  if (typeof nativeAuthBridge.isNetworkAvailable === "function") {
-    wrappedBridge.isNetworkAvailable = () =>
-      nativeAuthBridge.isNetworkAvailable!.call(nativeAuthBridge);
-  }
-
-  return wrappedBridge;
+  bridgeWithMetadata.logout = async function logoutWithEventDispatch() {
+    await originalLogout.call(nativeAuthBridge);
+    dispatchNativeAuthLogoutEvent();
+  };
+  bridgeWithMetadata[NATIVE_AUTH_BRIDGE_DISPATCHES_LOGOUT_EVENT] = true;
 }
 
 function getNativeAuthBridge(): NativeAuthBridge | null {
@@ -419,10 +395,10 @@ function getNativeAuthBridge(): NativeAuthBridge | null {
     return null;
   }
 
-  const wrappedBridge = wrapNativeAuthBridge(candidate);
-  bridgeGlobal.SecPalNativeAuthBridge = wrappedBridge;
+  wrapNativeAuthBridgeLogout(candidate);
+  bridgeGlobal.SecPalNativeAuthBridge = candidate;
 
-  return wrappedBridge;
+  return candidate;
 }
 
 export function resolveAuthTransport(options?: {

--- a/src/services/authTransport.ts
+++ b/src/services/authTransport.ts
@@ -477,18 +477,28 @@ function patchNativeAuthBridgeLogout(nativeAuthBridge: NativeAuthBridge): void {
     return;
   }
 
+  const logoutDescriptor = getLogoutPropertyDescriptor(nativeAuthBridge);
   const originalLogout = nativeAuthBridge.logout;
   const logoutWithEventDispatch = async function logoutWithEventDispatch() {
     await originalLogout.call(nativeAuthBridge);
     dispatchNativeAuthLogoutEvent();
   };
 
-  Object.defineProperty(nativeAuthBridge, "logout", {
-    configurable: true,
-    enumerable: true,
-    value: logoutWithEventDispatch,
-    writable: true,
-  });
+  if (
+    !logoutDescriptor ||
+    ("value" in logoutDescriptor && logoutDescriptor.writable === true) ||
+    logoutDescriptor.set !== undefined
+  ) {
+    nativeAuthBridge.logout = logoutWithEventDispatch;
+  } else {
+    Object.defineProperty(nativeAuthBridge, "logout", {
+      configurable: true,
+      enumerable: logoutDescriptor.enumerable ?? true,
+      value: logoutWithEventDispatch,
+      writable: true,
+    });
+  }
+
   nativeAuthBridgePatchedLogouts.add(nativeAuthBridge);
 }
 

--- a/src/services/authTransport.ts
+++ b/src/services/authTransport.ts
@@ -17,10 +17,12 @@ import { isOnline } from "./sessionEvents";
 export { AuthApiError } from "./AuthApiError";
 
 const nativeAuthBridgeLogoutEventProxies = new WeakSet<NativeAuthBridge>();
+const nativeAuthBridgePatchedLogouts = new WeakSet<NativeAuthBridge>();
 const nativeAuthBridgeLogoutEventProxyCache = new WeakMap<
   NativeAuthBridge,
   NativeAuthBridge
 >();
+const nativeAuthBridgeImmutableWarnings = new WeakSet<NativeAuthBridge>();
 
 async function loadAuthApiModule() {
   return await import("./authApi");
@@ -361,7 +363,133 @@ function isNativeAuthBridge(value: unknown): value is NativeAuthBridge {
 }
 
 function bridgeDispatchesLogoutEvent(bridge: NativeAuthBridge): boolean {
-  return nativeAuthBridgeLogoutEventProxies.has(bridge);
+  return (
+    nativeAuthBridgeLogoutEventProxies.has(bridge) ||
+    nativeAuthBridgePatchedLogouts.has(bridge)
+  );
+}
+
+function getLogoutPropertyDescriptor(
+  nativeAuthBridge: NativeAuthBridge
+): PropertyDescriptor | undefined {
+  return Object.getOwnPropertyDescriptor(nativeAuthBridge, "logout");
+}
+
+function canProxyNativeAuthBridgeLogout(
+  nativeAuthBridge: NativeAuthBridge
+): boolean {
+  const logoutDescriptor = getLogoutPropertyDescriptor(nativeAuthBridge);
+
+  return !(
+    logoutDescriptor &&
+    "value" in logoutDescriptor &&
+    logoutDescriptor.configurable === false &&
+    logoutDescriptor.writable === false
+  );
+}
+
+function canPatchNativeAuthBridgeLogout(
+  nativeAuthBridge: NativeAuthBridge
+): boolean {
+  const logoutDescriptor = getLogoutPropertyDescriptor(nativeAuthBridge);
+
+  if (!logoutDescriptor) {
+    return Object.isExtensible(nativeAuthBridge);
+  }
+
+  if ("value" in logoutDescriptor) {
+    return (
+      logoutDescriptor.writable === true ||
+      logoutDescriptor.configurable === true
+    );
+  }
+
+  return (
+    logoutDescriptor.set !== undefined || logoutDescriptor.configurable === true
+  );
+}
+
+function canReplaceGlobalNativeAuthBridge(): boolean {
+  const bridgeDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "SecPalNativeAuthBridge"
+  );
+
+  if (!bridgeDescriptor) {
+    return true;
+  }
+
+  if ("value" in bridgeDescriptor) {
+    return (
+      bridgeDescriptor.writable === true ||
+      bridgeDescriptor.configurable === true
+    );
+  }
+
+  return (
+    bridgeDescriptor.set !== undefined || bridgeDescriptor.configurable === true
+  );
+}
+
+function setGlobalNativeAuthBridge(bridge: NativeAuthBridge): boolean {
+  const bridgeDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "SecPalNativeAuthBridge"
+  );
+
+  if (!bridgeDescriptor || bridgeDescriptor.writable === true) {
+    (
+      globalThis as {
+        SecPalNativeAuthBridge?: NativeAuthBridge;
+      }
+    ).SecPalNativeAuthBridge = bridge;
+    return true;
+  }
+
+  if (bridgeDescriptor.configurable === true) {
+    Object.defineProperty(globalThis, "SecPalNativeAuthBridge", {
+      configurable: true,
+      enumerable: bridgeDescriptor.enumerable ?? true,
+      value: bridge,
+      writable: true,
+    });
+    return true;
+  }
+
+  return false;
+}
+
+function warnImmutableNativeAuthBridge(
+  nativeAuthBridge: NativeAuthBridge
+): void {
+  if (nativeAuthBridgeImmutableWarnings.has(nativeAuthBridge)) {
+    return;
+  }
+
+  nativeAuthBridgeImmutableWarnings.add(nativeAuthBridge);
+  console.warn(
+    "SecPalNativeAuthBridge is immutable; direct logout calls must dispatch secpal:native-auth-logout from the native runtime."
+  );
+}
+
+function patchNativeAuthBridgeLogout(nativeAuthBridge: NativeAuthBridge): void {
+  if (bridgeDispatchesLogoutEvent(nativeAuthBridge)) {
+    return;
+  }
+
+  const originalLogout = nativeAuthBridge.logout;
+  const logoutWithEventDispatch = async function logoutWithEventDispatch() {
+    await originalLogout.call(nativeAuthBridge);
+    dispatchNativeAuthLogoutEvent();
+  };
+
+  Object.defineProperty(nativeAuthBridge, "logout", {
+    configurable: true,
+    enumerable: true,
+    value: logoutWithEventDispatch,
+    writable: true,
+  });
+  nativeAuthBridgePatchedLogouts.add(nativeAuthBridge);
 }
 
 function wrapNativeAuthBridgeLogout(
@@ -371,11 +499,21 @@ function wrapNativeAuthBridgeLogout(
     return nativeAuthBridge;
   }
 
+  if (canPatchNativeAuthBridgeLogout(nativeAuthBridge)) {
+    patchNativeAuthBridgeLogout(nativeAuthBridge);
+    return nativeAuthBridge;
+  }
+
   const cachedProxy =
     nativeAuthBridgeLogoutEventProxyCache.get(nativeAuthBridge);
 
   if (cachedProxy) {
     return cachedProxy;
+  }
+
+  if (!canProxyNativeAuthBridgeLogout(nativeAuthBridge)) {
+    warnImmutableNativeAuthBridge(nativeAuthBridge);
+    return nativeAuthBridge;
   }
 
   const proxy = new Proxy(nativeAuthBridge, {
@@ -415,11 +553,14 @@ function getNativeAuthBridge(): NativeAuthBridge | null {
 
   const wrappedBridge = wrapNativeAuthBridgeLogout(candidate);
 
-  try {
-    bridgeGlobal.SecPalNativeAuthBridge = wrappedBridge;
-  } catch {
-    // Read-only host globals still need a usable auth transport even if direct
-    // callers cannot be redirected through the proxied bridge handle.
+  if (wrappedBridge !== candidate) {
+    if (
+      !canReplaceGlobalNativeAuthBridge() ||
+      !setGlobalNativeAuthBridge(wrappedBridge)
+    ) {
+      warnImmutableNativeAuthBridge(candidate);
+      return candidate;
+    }
   }
 
   return wrappedBridge;

--- a/src/services/nativeAuthEvents.ts
+++ b/src/services/nativeAuthEvents.ts
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+export const NATIVE_AUTH_LOGOUT_EVENT_NAME = "secpal:native-auth-logout";


### PR DESCRIPTION
## What changed
- listen for a native logout browser event in the frontend auth provider and run the same full session teardown path as the regular UI logout
- add an App regression test that proves a native-bridge logout redirects protected sessions back to `/login`
- document the fix in the frontend changelog

## Why this changed
Direct `SecPalNativeAuthBridge.logout()` calls cleared native auth state, but the frontend auth provider was never notified. That left the WebView on protected routes with stale frontend session state until some later revalidation path corrected it.

## User impact
Android users who are logged out through the native bridge are now redirected back to `/login` immediately instead of remaining on the authenticated shell.

## Root cause
The frontend only cleared its own auth state when logout originated from the web UI. Native logout completed out-of-band and had no frontend event bridge into `AuthContext`.

## Validation
- `npm test -- --run src/App.test.tsx`
- live Android WebView verification after rebuild/install: direct `SecPalNativeAuthBridge.logout()` moved the app from `https://app.secpal.dev/` to `https://app.secpal.dev/login`
