### PR TITLE
Fix native logout WebView state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   source-offer page so the frontend's corresponding-source list again
   reflects the Android wrapper that consumes the shared frontend build output.
 - Native-bridge logout now tears down the frontend auth session even when logout is triggered directly through `SecPalNativeAuthBridge.logout()`, so protected routes immediately fall back to `/login` instead of leaving the WebView on the authenticated `/` shell with stale frontend auth state.
+- Native logout events now update the foreground WebView auth state before storage cleanup and avoid service-worker client redirects, preventing stale authenticated shells when Android logout overlaps an in-flight session teardown.
 - Native-bridge auth bootstrap now handles a writable but non-configurable `SecPalNativeAuthBridge.logout()` property without throwing while wiring the direct-logout event dispatch wrapper.
 - Consolidated the shared frontend UI layer on `@/ui`, removed remaining
   legacy shell and auth wrapper paths, replaced productive custom inline UI

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -14,6 +14,8 @@ import {
 } from "../lib/offlineVault";
 import { authStorage } from "../services/storage";
 import { resetPrefetchCache } from "../hooks/usePrefetch";
+import { syncOfflineSessionAccess } from "../lib/serviceWorkerSession";
+import { NATIVE_AUTH_LOGOUT_EVENT_NAME } from "../services/nativeAuthEvents";
 
 vi.mock("../services/authApi", () => ({
   getCurrentUser: vi.fn(),
@@ -28,6 +30,10 @@ vi.mock("../hooks/usePrefetch", async () => {
     resetPrefetchCache: vi.fn(),
   };
 });
+
+vi.mock("../lib/serviceWorkerSession", () => ({
+  syncOfflineSessionAccess: vi.fn().mockResolvedValue(undefined),
+}));
 
 type SessionEventName = "session:expired" | "session:invalid";
 type SessionEventHandler = () => void;
@@ -91,6 +97,7 @@ describe("AuthContext", () => {
     vi.mocked(getCurrentUser).mockReset();
     vi.mocked(isOnline).mockReturnValue(false);
     vi.mocked(resetPrefetchCache).mockClear();
+    vi.mocked(syncOfflineSessionAccess).mockClear();
   });
 
   afterEach(() => {
@@ -434,6 +441,95 @@ describe("AuthContext", () => {
       });
 
       expect(resetPrefetchCache).toHaveBeenCalled();
+    });
+
+    it("tears down native logout events without service-worker client redirects", async () => {
+      await seedStoredUser({
+        id: 1,
+        name: "Test User",
+        email: "test@secpal.dev",
+        permissions: ["employees.read"],
+      });
+
+      render(
+        <AuthProvider>
+          <PermissionTestComponent permission="employees.read" />
+        </AuthProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("hasPermission")).toHaveTextContent("true");
+      });
+
+      vi.mocked(resetPrefetchCache).mockClear();
+      vi.mocked(syncOfflineSessionAccess).mockClear();
+
+      await act(async () => {
+        window.dispatchEvent(new Event(NATIVE_AUTH_LOGOUT_EVENT_NAME));
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("hasPermission")).toHaveTextContent("false");
+      });
+
+      expect(resetPrefetchCache).toHaveBeenCalled();
+      expect(syncOfflineSessionAccess).toHaveBeenCalledWith(false, {
+        redirectOpenClients: false,
+      });
+      expect(syncOfflineSessionAccess).not.toHaveBeenCalledWith(false, {
+        redirectOpenClients: true,
+      });
+    });
+
+    it("updates auth state for native logout even when storage cleanup throws synchronously", async () => {
+      await seedStoredUser({
+        id: 1,
+        name: "Test User",
+        email: "test@secpal.dev",
+        permissions: ["employees.read"],
+      });
+
+      render(
+        <AuthProvider>
+          <PermissionTestComponent permission="employees.read" />
+        </AuthProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("hasPermission")).toHaveTextContent("true");
+      });
+
+      const storageError = new Error("storage unavailable");
+      const clearStorageSpy = vi
+        .spyOn(authStorage, "clear")
+        .mockImplementationOnce(() => {
+          throw storageError;
+        });
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined);
+
+      try {
+        await act(async () => {
+          window.dispatchEvent(new Event(NATIVE_AUTH_LOGOUT_EVENT_NAME));
+          await new Promise((r) => setTimeout(r, 0));
+        });
+
+        await waitFor(() => {
+          expect(screen.getByTestId("hasPermission")).toHaveTextContent(
+            "false"
+          );
+        });
+
+        expect(clearStorageSpy).toHaveBeenCalled();
+        expect(syncOfflineSessionAccess).toHaveBeenCalledWith(false, {
+          redirectOpenClients: false,
+        });
+      } finally {
+        clearStorageSpy.mockRestore();
+        consoleWarnSpy.mockRestore();
+      }
     });
 
     it("clears the prefetch cache when cross-tab storage removal falls back to logout", async () => {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -385,6 +385,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         shouldSkipBarrierVaultTableCleanupRef.current =
           shouldSkipBarrierVaultTableCleanupRef.current || clearSensitiveState;
 
+        hasLogoutBarrierRef.current = true;
+        setBootstrapRecoveryReason(null);
+        setUser(null);
+        setIsVaultLocked(false);
+        setIsLoading(false);
+        syncOfflineAuthState(false, {
+          redirectOpenClients: shouldRedirectOpenClientsRef.current,
+        });
+
         if (shouldUpgradeSensitiveState) {
           beginSensitiveLogoutBarrierCleanup();
         }
@@ -404,6 +413,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         options?.redirectOpenClients === true;
       shouldSkipBarrierVaultTableCleanupRef.current = clearSensitiveState;
 
+      hasLogoutBarrierRef.current = true;
+      setBootstrapRecoveryReason(null);
+      setUser(null);
+      setIsVaultLocked(false);
+      setIsLoading(false);
+      syncOfflineAuthState(false, {
+        redirectOpenClients: shouldRedirectOpenClientsRef.current,
+      });
+
       if (clearSensitiveState) {
         // Drop prefetch warm-up state on every full session teardown
         // (explicit logout, `session:expired` 401, invalid-payload recovery,
@@ -412,21 +430,24 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         // who signs in, weakening the cross-session isolation introduced
         // alongside the prefetch epoch counter in usePrefetch.ts.
         resetPrefetchCache();
-        beginSensitiveLogoutBarrierCleanup();
+
+        try {
+          beginSensitiveLogoutBarrierCleanup();
+        } catch (error: unknown) {
+          console.warn(
+            "Failed to create a sensitive logout barrier before cleanup:",
+            error
+          );
+        }
       }
 
-      hasLogoutBarrierRef.current = true;
-      setBootstrapRecoveryReason(null);
-      const clearAuthStoragePromise = authStorage.clear({
-        clearOfflineVaultTables: !shouldSkipBarrierVaultTableCleanupRef.current,
-      });
+      const clearAuthStoragePromise = Promise.resolve().then(() =>
+        authStorage.clear({
+          clearOfflineVaultTables:
+            !shouldSkipBarrierVaultTableCleanupRef.current,
+        })
+      );
       const resetAnalyticsStatePromise = resetAnalyticsState();
-      setUser(null);
-      setIsVaultLocked(false);
-      setIsLoading(false);
-      syncOfflineAuthState(false, {
-        redirectOpenClients: shouldRedirectOpenClientsRef.current,
-      });
 
       clearAuthenticatedStatePromiseRef.current = Promise.allSettled([
         clearAuthStoragePromise,
@@ -509,24 +530,32 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     await clearAuthenticatedStatePromiseRef.current;
   }, [clearAuthenticatedState]);
 
+  const handleNativeLogout = useCallback(async () => {
+    clearAuthenticatedState(true, { redirectOpenClients: false });
+    await clearAuthenticatedStatePromiseRef.current;
+  }, [clearAuthenticatedState]);
+
   useEffect(() => {
     if (typeof window === "undefined") {
       return;
     }
 
-    const handleNativeLogout = () => {
-      void logout();
+    const handleNativeLogoutEvent = () => {
+      void handleNativeLogout();
     };
 
-    window.addEventListener(NATIVE_AUTH_LOGOUT_EVENT_NAME, handleNativeLogout);
+    window.addEventListener(
+      NATIVE_AUTH_LOGOUT_EVENT_NAME,
+      handleNativeLogoutEvent
+    );
 
     return () => {
       window.removeEventListener(
         NATIVE_AUTH_LOGOUT_EVENT_NAME,
-        handleNativeLogout
+        handleNativeLogoutEvent
       );
     };
-  }, [logout]);
+  }, [handleNativeLogout]);
 
   const lock = useCallback(() => {
     authStorage.lockVault?.();

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -441,12 +441,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
       }
 
-      const clearAuthStoragePromise = Promise.resolve().then(() =>
-        authStorage.clear({
+      let clearAuthStoragePromise: Promise<void>;
+
+      try {
+        clearAuthStoragePromise = authStorage.clear({
           clearOfflineVaultTables:
             !shouldSkipBarrierVaultTableCleanupRef.current,
-        })
-      );
+        });
+      } catch (error: unknown) {
+        clearAuthStoragePromise = Promise.reject(error);
+      }
+
       const resetAnalyticsStatePromise = resetAnalyticsState();
 
       clearAuthenticatedStatePromiseRef.current = Promise.allSettled([

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -373,15 +373,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       if (isClearingSessionRef.current) {
         const shouldUpgradeSensitiveState =
           clearSensitiveState && !shouldClearSensitiveStateRef.current;
-        const shouldUpgradeRedirectOpenClients =
-          options?.redirectOpenClients === true &&
-          !shouldRedirectOpenClientsRef.current;
+        const shouldRedirectOpenClients =
+          shouldRedirectOpenClientsRef.current ||
+          options?.redirectOpenClients === true;
+        const previousShouldSkipBarrierVaultTableCleanup =
+          shouldSkipBarrierVaultTableCleanupRef.current;
 
         shouldClearSensitiveStateRef.current =
           shouldClearSensitiveStateRef.current || clearSensitiveState;
-        shouldRedirectOpenClientsRef.current =
-          shouldRedirectOpenClientsRef.current ||
-          options?.redirectOpenClients === true;
+        shouldRedirectOpenClientsRef.current = shouldRedirectOpenClients;
         shouldSkipBarrierVaultTableCleanupRef.current =
           shouldSkipBarrierVaultTableCleanupRef.current || clearSensitiveState;
 
@@ -391,15 +391,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         setIsVaultLocked(false);
         setIsLoading(false);
         syncOfflineAuthState(false, {
-          redirectOpenClients: shouldRedirectOpenClientsRef.current,
+          redirectOpenClients: shouldRedirectOpenClients,
         });
 
         if (shouldUpgradeSensitiveState) {
-          beginSensitiveLogoutBarrierCleanup();
-        }
-
-        if (shouldUpgradeRedirectOpenClients) {
-          syncOfflineAuthState(false, { redirectOpenClients: true });
+          try {
+            beginSensitiveLogoutBarrierCleanup();
+          } catch (error: unknown) {
+            shouldSkipBarrierVaultTableCleanupRef.current =
+              previousShouldSkipBarrierVaultTableCleanup;
+            console.warn(
+              "Failed to create a sensitive logout barrier before cleanup:",
+              error
+            );
+          }
         }
 
         return;
@@ -434,6 +439,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         try {
           beginSensitiveLogoutBarrierCleanup();
         } catch (error: unknown) {
+          shouldSkipBarrierVaultTableCleanupRef.current = false;
           console.warn(
             "Failed to create a sensitive logout barrier before cleanup:",
             error

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -1480,6 +1480,48 @@ describe("useAuth", () => {
     }
   });
 
+  it("does not skip vault-table cleanup when sensitive logout barrier setup fails", async () => {
+    const mockUser = { id: "1", name: "Test User", email: "test@secpal.dev" };
+    const barrierError = new Error("barrier unavailable");
+    const clearSpy = vi.spyOn(authStorage, "clear").mockResolvedValue();
+    const beginBarrierSpy = vi
+      .spyOn(authStorage, "beginSensitiveLogoutBarrierCleanup")
+      .mockImplementationOnce(() => {
+        throw barrierError;
+      });
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+
+    try {
+      await persistAuthUser(mockUser);
+
+      const { result } = renderHook(() => useAuth(), {
+        wrapper: AuthProvider,
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      await act(async () => {
+        await result.current.logout();
+      });
+
+      expect(clearSpy).toHaveBeenCalledWith({
+        clearOfflineVaultTables: true,
+      });
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "Failed to create a sensitive logout barrier before cleanup:",
+        barrierError
+      );
+    } finally {
+      consoleWarnSpy.mockRestore();
+      beginBarrierSpy.mockRestore();
+      clearSpy.mockRestore();
+    }
+  });
+
   it("logout resolves only after sensitive client cleanup settles", async () => {
     const mockUser = { id: "1", name: "Test User", email: "test@secpal.dev" };
 
@@ -1523,12 +1565,21 @@ describe("useAuth", () => {
   it("upgrades an in-flight non-sensitive auth clear when logout is requested", async () => {
     const storageClear = createDeferredPromise<void>();
     const restoreError = new Error("restore failed");
+    const barrierError = new Error("barrier unavailable");
     const clearSpy = vi
       .spyOn(authStorage, "clear")
       .mockImplementation(() => storageClear.promise);
     const getUserSpy = vi
       .spyOn(authStorage, "getUser")
       .mockRejectedValue(restoreError);
+    const beginBarrierSpy = vi
+      .spyOn(authStorage, "beginSensitiveLogoutBarrierCleanup")
+      .mockImplementationOnce(() => {
+        throw barrierError;
+      });
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
 
     try {
       const { result } = renderHook(() => useAuth(), {
@@ -1550,13 +1601,22 @@ describe("useAuth", () => {
         result.current.logout();
       });
 
-      storageClear.resolve();
-
-      await waitForSensitiveClientCleanup();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "Failed to create a sensitive logout barrier before cleanup:",
+        barrierError
+      );
+      expect(syncOfflineSessionAccess).toHaveBeenCalledTimes(2);
       expect(syncOfflineSessionAccess).toHaveBeenNthCalledWith(2, false, {
         redirectOpenClients: true,
       });
+
+      storageClear.resolve();
+
+      await waitForSensitiveClientCleanup();
+      expect(syncOfflineSessionAccess).toHaveBeenCalledTimes(2);
     } finally {
+      consoleWarnSpy.mockRestore();
+      beginBarrierSpy.mockRestore();
       clearSpy.mockRestore();
       getUserSpy.mockRestore();
     }


### PR DESCRIPTION
## Summary

Fixes the foreground WebView auth state transition for native Android logout events.

Native logout now clears the React auth state before storage/analytics cleanup can block or throw, including re-entrant cleanup paths. Native logout events also avoid service-worker client redirects so the visible Android WebView owns the transition to `/login` instead of relying on a full client navigation.

## Root cause

The prior behavior could leave the Android WebView on the authenticated `/` shell after `SecPalNativeAuthBridge.logout()` because the native token state was cleared while the frontend auth state stayed authenticated during an overlapping or failing cleanup path. The service-worker redirect path could mask this by navigating clients, but it also introduced a transient blank document state.

## Impact

Direct native logout from Android now immediately invalidates the foreground frontend auth state and routes protected screens back to `/login` without depending on a service-worker redirect.

## Validation

- `npm test -- --run src/contexts/AuthContext.test.tsx src/App.test.tsx src/services/authTransport.test.ts`
- `npm test -- --run src/contexts/AuthContext.test.tsx`
- `npm run cap:sync` in `SecPal/android`
- `npm run native:assemble:debug` in `SecPal/android`
- Installed the debug APK on the attached Android device
- Live WebView auth smoke against `https://api.secpal.dev` with `test@example.com`
- Direct CDP check: SPA navigated to `/`, `SecPalNativeAuthBridge.logout()` set `nativeAuthActive=false`, kept the no-reload marker, and rendered `/login` with the login form