### PR TITLE
Fix nginx template validation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Limited that localhost preview-origin guard to production mode so local
   development keeps honoring an explicit preview `VITE_API_URL` instead of
   falling back to same-origin routing.
+- Updated the shipped `app.secpal.dev` Nginx template to use the current
+  `http2 on;` syntax and to drop the redundant `ssi_types text/html;`
+  override, so production config validation no longer emits known warnings for
+  the frontend host template.
 - Limited the `/source` Android repository block to deployments that publish an
   explicit Android release entry in `/source-offer.json`, so frontend-only
   deployments no longer advertise Android source links without a matching

--- a/deploy/nginx/app.secpal.dev.conf
+++ b/deploy/nginx/app.secpal.dev.conf
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: CC0-1.0
 
 server {
-  listen 443 ssl http2;
-  listen [::]:443 ssl http2;
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  http2 on;
   server_name app.secpal.dev;
 
   root /home/secpal/code/SecPal/frontend/dist;
@@ -22,7 +23,6 @@ server {
   ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
   ssi on;
-  ssi_types text/html;
 
   set $csp_nonce $request_id;
   set $secpal_csp "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self' 'nonce-$csp_nonce'; style-src-attr 'unsafe-inline'; worker-src 'self'; upgrade-insecure-requests";

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -15,6 +15,14 @@ function readRepoFile(relativePath: string): string {
   return readFileSync(path.join(repoRoot, relativePath), "utf8");
 }
 
+function expectWarningFreeShippedNginxConfigSyntax(nginxConfig: string): void {
+  expect(nginxConfig).toMatch(/^\s*http2\s+on;$/mu);
+  expect(nginxConfig).not.toMatch(
+    /^\s*listen\b[^#;\n]*\bhttp2\b[^;\n]*;$/mu
+  );
+  expect(nginxConfig).not.toMatch(/^\s*ssi_types\s+text\/html;$/mu);
+}
+
 /**
  * Build Configuration and Source Verification Tests
  *
@@ -342,10 +350,36 @@ describe("Build Configuration and Source Verification", () => {
   it("keeps the shipped nginx config free of known syntax warnings", () => {
     const nginxConfig = readRepoFile("deploy/nginx/app.secpal.dev.conf");
 
-    expect(nginxConfig).toContain("http2 on;");
-    expect(nginxConfig).not.toContain("listen 443 ssl http2;");
-    expect(nginxConfig).not.toContain("listen [::]:443 ssl http2;");
-    expect(nginxConfig).not.toContain("ssi_types text/html;");
+    expectWarningFreeShippedNginxConfigSyntax(nginxConfig);
+  });
+
+  it("rejects commented http2 toggles", () => {
+    expect(() =>
+      expectWarningFreeShippedNginxConfigSyntax(
+        ["server {", "  listen 443 ssl;", "  # http2 on;", "}"].join("\n")
+      )
+    ).toThrowError();
+  });
+
+  it("rejects deprecated http2 listen parameters with extra flags", () => {
+    expect(() =>
+      expectWarningFreeShippedNginxConfigSyntax(
+        [
+          "server {",
+          "  listen 443 ssl http2 reuseport;",
+          "  http2 on;",
+          "}",
+        ].join("\n")
+      )
+    ).toThrowError(/listen\\b.*http2/u);
+  });
+
+  it("rejects a live ssi_types text/html override", () => {
+    expect(() =>
+      expectWarningFreeShippedNginxConfigSyntax(
+        ["server {", "  http2 on;", "  ssi_types text/html;", "}"].join("\n")
+      )
+    ).toThrowError(/ssi_types/u);
   });
 
   it("ships a live smoke check for deployed PWA security headers", () => {

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -17,9 +17,7 @@ function readRepoFile(relativePath: string): string {
 
 function expectWarningFreeShippedNginxConfigSyntax(nginxConfig: string): void {
   expect(nginxConfig).toMatch(/^\s*http2\s+on;$/mu);
-  expect(nginxConfig).not.toMatch(
-    /^\s*listen\b[^#;\n]*\bhttp2\b[^;\n]*;$/mu
-  );
+  expect(nginxConfig).not.toMatch(/^\s*listen\b[^#;\n]*\bhttp2\b[^;\n]*;$/mu);
   expect(nginxConfig).not.toMatch(/^\s*ssi_types\s+text\/html;$/mu);
 }
 

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -339,6 +339,15 @@ describe("Build Configuration and Source Verification", () => {
     expect(nginxConfig).toContain("default_type application/json");
   });
 
+  it("keeps the shipped nginx config free of known syntax warnings", () => {
+    const nginxConfig = readRepoFile("deploy/nginx/app.secpal.dev.conf");
+
+    expect(nginxConfig).toContain("http2 on;");
+    expect(nginxConfig).not.toContain("listen 443 ssl http2;");
+    expect(nginxConfig).not.toContain("listen [::]:443 ssl http2;");
+    expect(nginxConfig).not.toContain("ssi_types text/html;");
+  });
+
   it("ships a live smoke check for deployed PWA security headers", () => {
     expect(
       existsSync(path.join(repoRoot, "scripts/check-live-pwa-headers.sh"))


### PR DESCRIPTION
## What changed
- switched the shipped `app.secpal.dev` Nginx template from deprecated `listen ... http2` directives to `http2 on;`
- removed the redundant `ssi_types text/html;` override from the same template
- added a build guardrail that fails if those known warning sources reappear
- documented the change in `CHANGELOG.md`

## Why
`nginx -t` on the live host still emitted known warnings after the Issue #1315 rollout because the versioned frontend template itself still carried deprecated and redundant directives. The live system was corrected manually first, but the repository also needed the source template and tests updated so the warning state cannot regress.

## Impact
- production validation for the frontend host template is now warning-free
- future rollouts of `deploy/nginx/app.secpal.dev.conf` keep the cleaned-up syntax
- the repo now has automated coverage for this specific config hygiene regression

## Root cause
The repo-shipped Nginx template had not been updated to match current Nginx syntax expectations, so deployments that synced the template kept reintroducing avoidable validation warnings.

## Validation
- `npx vitest run tests/build.test.ts -t "keeps the shipped nginx config free of known syntax warnings"`
- `npm run build`
- pre-push hook: Prettier, markdownlint, domain policy check, `npm run lint`, `npm run typecheck`
- live host verification: `sudo /usr/sbin/nginx -t` after syncing the template was clean and warning-free

## Follow-up
- tracked the unresolved API deployment metadata gap separately in SecPal/api#1222
