### PR TITLE
fix: recover from stale cached entry bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,7 +246,10 @@ SecPal` notice, and keep the tagline plus `https://secpal.app` as preferred
   updates no longer strand users on a blank dark screen. The bootstrap now
   ships on short cache rules, and recovery aborts before reloading when it
   cannot persist the one-shot `sessionStorage` latch, preventing reload loops
-  on storage failures.
+  on storage failures. The recovery bootstrap is also excluded from service
+  worker precache and runtime script caches so already-controlled clients can
+  fetch the fresh recovery code, and early built CSS/modulepreload failures now
+  trigger the same one-shot cleanup.
 - Removed the duplicate `AGPL v3+` and `Source Code` footer links from the
   vault-locked login shell now that the interactive login `Legal` menu already
   exposes those notices there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,7 +243,10 @@ SecPal` notice, and keep the tagline plus `https://secpal.app` as preferred
   `/assets/index-*.js`, `public/theme-color.js` now clears the affected
   runtime caches, unregisters stale service workers, reloads once, and resets
   the recovery latch after `src/main.tsx` finishes bootstrapping so deployed
-  updates no longer strand users on a blank dark screen.
+  updates no longer strand users on a blank dark screen. That recovery now
+  also aborts before reloading when it cannot persist the one-shot
+  `sessionStorage` latch, preventing storage failures from causing a reload
+  loop.
 - Removed the duplicate `AGPL v3+` and `Source Code` footer links from the
   vault-locked login shell now that the interactive login `Legal` menu already
   exposes those notices there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,10 +243,10 @@ SecPal` notice, and keep the tagline plus `https://secpal.app` as preferred
   `/assets/index-*.js`, `public/theme-color.js` now clears the affected
   runtime caches, unregisters stale service workers, reloads once, and resets
   the recovery latch after `src/main.tsx` finishes bootstrapping so deployed
-  updates no longer strand users on a blank dark screen. That recovery now
-  also aborts before reloading when it cannot persist the one-shot
-  `sessionStorage` latch, preventing storage failures from causing a reload
-  loop.
+  updates no longer strand users on a blank dark screen. The bootstrap now
+  ships on short cache rules, and recovery aborts before reloading when it
+  cannot persist the one-shot `sessionStorage` latch, preventing reload loops
+  on storage failures.
 - Removed the duplicate `AGPL v3+` and `Source Code` footer links from the
   vault-locked login shell now that the interactive login `Legal` menu already
   exposes those notices there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,6 +238,12 @@ SecPal` notice, and keep the tagline plus `https://secpal.app` as preferred
 
 ### Fixed
 
+- Added an early bootstrap recovery path for stale hashed entry bundles: when a
+  cached HTML shell or service worker still points at a deleted
+  `/assets/index-*.js`, `public/theme-color.js` now clears the affected
+  runtime caches, unregisters stale service workers, reloads once, and resets
+  the recovery latch after `src/main.tsx` finishes bootstrapping so deployed
+  updates no longer strand users on a blank dark screen.
 - Removed the duplicate `AGPL v3+` and `Source Code` footer links from the
   vault-locked login shell now that the interactive login `Legal` menu already
   exposes those notices there.

--- a/deploy/nginx/app.secpal.dev.conf
+++ b/deploy/nginx/app.secpal.dev.conf
@@ -153,6 +153,22 @@ server {
     try_files $uri =404;
   }
 
+  location = /theme-color.js {
+    add_header Content-Security-Policy $secpal_csp always;
+    add_header Permissions-Policy $secpal_permissions_policy always;
+    add_header Strict-Transport-Security $secpal_hsts always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "0" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    add_header Cross-Origin-Resource-Policy "same-origin" always;
+    add_header Origin-Agent-Cluster "?1" always;
+    add_header X-Permitted-Cross-Domain-Policies "none" always;
+    add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+    try_files $uri =404;
+  }
+
   location / {
     try_files $uri $uri/ /index.html;
   }

--- a/docs/deployment-spa-routing.md
+++ b/docs/deployment-spa-routing.md
@@ -30,7 +30,7 @@ It also now carries the baseline browser hardening for the shipped PWA:
 - enforcing a production CSP without inline scripts
 - explicitly denying unused browser capabilities via `Permissions-Policy`
 - setting `COOP` / `CORP` and related response headers consistently
-- keeping `index.html`, `sw.js`, and `manifest.webmanifest` on short cache rules so security and PWA updates land quickly
+- keeping `index.html`, `sw.js`, `manifest.webmanifest`, and `theme-color.js` on short cache rules so security and PWA updates land quickly
 
 **File:** `public/.htaccess`
 
@@ -95,7 +95,7 @@ The file already covers:
 - the production CSP and `Permissions-Policy`
 - `Strict-Transport-Security`, `Referrer-Policy`, and framing protection
 - explicit `404` handling for `/v1/*`, `/sanctum/*`, and `/health*`
-- exact-match delivery rules for `/`, `/index.html`, `/sw.js`, and `/manifest.webmanifest`
+- exact-match delivery rules for `/`, `/index.html`, `/sw.js`, `/manifest.webmanifest`, and `/theme-color.js`
 - the manifest MIME fix (`application/manifest+json`) and update-safe cache headers
 
 Use this file as your site config or merge its contents into the live server block:
@@ -330,7 +330,7 @@ Before deploying to production:
 - ✅ `/source-offer.json` publishes immutable corresponding-source URLs for the deployed `frontend` / `contracts` set, with optional `android`
 - ✅ `GET /v1/release` publishes the immutable corresponding-source URL for the deployed `api`
 - ✅ CSP, permissions, and modern cross-origin headers enabled
-- ✅ `index.html`, `sw.js`, `manifest.webmanifest`, and `/source-offer.json` use short cache rules
+- ✅ `index.html`, `sw.js`, `manifest.webmanifest`, `/theme-color.js`, and `/source-offer.json` use short cache rules
 
 ---
 

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -62,8 +62,9 @@
   Header always set Origin-Agent-Cluster "?1"
   Header always set X-Permitted-Cross-Domain-Policies "none"
 
-  # Keep the HTML shell, service worker, and manifest fresh so security and PWA
-  # updates activate quickly instead of sitting behind intermediary caches.
+  # Keep the HTML shell, recovery bootstrap, service worker, and manifest fresh
+  # so security and PWA updates activate quickly instead of sitting behind
+  # intermediary caches.
   <Files "index.html">
     Header always set Cache-Control "no-cache, no-store, must-revalidate"
   </Files>
@@ -79,6 +80,10 @@
 
   <Files "source-offer.json">
     Header always set Cache-Control "no-cache, must-revalidate"
+  </Files>
+
+  <Files "theme-color.js">
+    Header always set Cache-Control "no-cache, no-store, must-revalidate"
   </Files>
 </IfModule>
 

--- a/public/theme-color.js
+++ b/public/theme-color.js
@@ -21,8 +21,7 @@
   function hasPendingAssetLoadRecovery() {
     try {
       return (
-        window.sessionStorage.getItem(assetLoadRecoveryStorageKey) ===
-        "pending"
+        window.sessionStorage.getItem(assetLoadRecoveryStorageKey) === "pending"
       );
     } catch {
       return false;
@@ -32,8 +31,9 @@
   function markPendingAssetLoadRecovery() {
     try {
       window.sessionStorage.setItem(assetLoadRecoveryStorageKey, "pending");
+      return true;
     } catch {
-      // Ignore storage access failures; recovery remains best-effort.
+      return false;
     }
   }
 
@@ -90,7 +90,8 @@
         .filter((cacheName) =>
           cacheNameAllowlist.some(
             (allowedName) =>
-              cacheName === allowedName || cacheName.indexOf(allowedName + "-") === 0
+              cacheName === allowedName ||
+              cacheName.indexOf(allowedName + "-") === 0
           )
         )
         .map((cacheName) => window.caches.delete(cacheName))
@@ -102,7 +103,9 @@
       return;
     }
 
-    markPendingAssetLoadRecovery();
+    if (!markPendingAssetLoadRecovery()) {
+      return;
+    }
 
     Promise.all([
       unregisterServiceWorkers().catch(function () {}),

--- a/public/theme-color.js
+++ b/public/theme-color.js
@@ -6,7 +6,23 @@
   var appBootstrapReadyEvent = "app-bootstrap-ready";
   const themeColorMeta = document.querySelector('meta[name="theme-color"]');
 
+  function hasPendingAssetLoadRecovery() {
+    try {
+      return (
+        window.sessionStorage.getItem(assetLoadRecoveryStorageKey) === "pending"
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  const pageStartedWithPendingAssetLoadRecovery = hasPendingAssetLoadRecovery();
+
   function clearAssetLoadRecoveryFlag() {
+    if (!pageStartedWithPendingAssetLoadRecovery) {
+      return;
+    }
+
     try {
       window.sessionStorage.removeItem(assetLoadRecoveryStorageKey);
     } catch {
@@ -17,16 +33,6 @@
   window.addEventListener(appBootstrapReadyEvent, clearAssetLoadRecoveryFlag, {
     once: true,
   });
-
-  function hasPendingAssetLoadRecovery() {
-    try {
-      return (
-        window.sessionStorage.getItem(assetLoadRecoveryStorageKey) === "pending"
-      );
-    } catch {
-      return false;
-    }
-  }
 
   function markPendingAssetLoadRecovery() {
     try {

--- a/public/theme-color.js
+++ b/public/theme-color.js
@@ -40,21 +40,26 @@
 
   function isRecoverableBootstrapAssetError(event) {
     const target = event && event.target;
+    let assetUrl;
 
-    if (!(target instanceof HTMLScriptElement) || !target.src) {
+    if (target instanceof HTMLScriptElement && target.src) {
+      assetUrl = target.src;
+    } else if (target instanceof HTMLLinkElement && target.href) {
+      assetUrl = target.href;
+    } else {
       return false;
     }
 
     let targetUrl;
     try {
-      targetUrl = new URL(target.src, window.location.href);
+      targetUrl = new URL(assetUrl, window.location.href);
     } catch {
       return false;
     }
 
     return (
       targetUrl.origin === window.location.origin &&
-      /\/assets\/.+\.js$/.test(targetUrl.pathname)
+      /\/assets\/.+\.(?:css|js)$/.test(targetUrl.pathname)
     );
   }
 

--- a/public/theme-color.js
+++ b/public/theme-color.js
@@ -2,29 +2,147 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 (function () {
+  var assetLoadRecoveryStorageKey = "secpal.asset-load-recovery";
+  var appBootstrapReadyEvent = "app-bootstrap-ready";
   const themeColorMeta = document.querySelector('meta[name="theme-color"]');
 
-  if (!themeColorMeta) {
-    return;
+  function clearAssetLoadRecoveryFlag() {
+    try {
+      window.sessionStorage.removeItem(assetLoadRecoveryStorageKey);
+    } catch {
+      // Ignore storage access failures; recovery remains best-effort.
+    }
   }
 
-  const updateThemeColor = function (isDark) {
-    themeColorMeta.setAttribute("content", isDark ? "#18181b" : "#ffffff");
-  };
+  window.addEventListener(appBootstrapReadyEvent, clearAssetLoadRecoveryFlag, {
+    once: true,
+  });
 
-  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-  const handleChange = function (event) {
-    updateThemeColor(event.matches);
-  };
-
-  updateThemeColor(mediaQuery.matches);
-
-  if (typeof mediaQuery.addEventListener === "function") {
-    mediaQuery.addEventListener("change", handleChange);
-    return;
+  function hasPendingAssetLoadRecovery() {
+    try {
+      return (
+        window.sessionStorage.getItem(assetLoadRecoveryStorageKey) ===
+        "pending"
+      );
+    } catch {
+      return false;
+    }
   }
 
-  if (typeof mediaQuery.addListener === "function") {
-    mediaQuery.addListener(handleChange);
+  function markPendingAssetLoadRecovery() {
+    try {
+      window.sessionStorage.setItem(assetLoadRecoveryStorageKey, "pending");
+    } catch {
+      // Ignore storage access failures; recovery remains best-effort.
+    }
+  }
+
+  function isRecoverableBootstrapAssetError(event) {
+    const target = event && event.target;
+
+    if (!(target instanceof HTMLScriptElement) || !target.src) {
+      return false;
+    }
+
+    let targetUrl;
+    try {
+      targetUrl = new URL(target.src, window.location.href);
+    } catch {
+      return false;
+    }
+
+    return (
+      targetUrl.origin === window.location.origin &&
+      /\/assets\/.+\.js(?:\?.*)?$/.test(targetUrl.pathname)
+    );
+  }
+
+  async function unregisterServiceWorkers() {
+    if (
+      !("serviceWorker" in navigator) ||
+      typeof navigator.serviceWorker.getRegistrations !== "function"
+    ) {
+      return;
+    }
+
+    const registrations = await navigator.serviceWorker.getRegistrations();
+
+    await Promise.all(
+      registrations.map((registration) => registration.unregister())
+    );
+  }
+
+  async function clearRelevantCaches() {
+    if (!window.caches || typeof window.caches.keys !== "function") {
+      return;
+    }
+
+    const cacheNames = await window.caches.keys();
+    const cacheNameAllowlist = [
+      "html-shell",
+      "static-assets",
+      "workbox-precache",
+      "workbox-runtime",
+    ];
+
+    await Promise.all(
+      cacheNames
+        .filter((cacheName) =>
+          cacheNameAllowlist.some(
+            (allowedName) =>
+              cacheName === allowedName || cacheName.indexOf(allowedName + "-") === 0
+          )
+        )
+        .map((cacheName) => window.caches.delete(cacheName))
+    );
+  }
+
+  function recoverFromStaleHashedAsset() {
+    if (hasPendingAssetLoadRecovery()) {
+      return;
+    }
+
+    markPendingAssetLoadRecovery();
+
+    Promise.all([
+      unregisterServiceWorkers().catch(function () {}),
+      clearRelevantCaches().catch(function () {}),
+    ]).finally(function () {
+      window.location.reload();
+    });
+  }
+
+  window.addEventListener(
+    "error",
+    function (event) {
+      if (!isRecoverableBootstrapAssetError(event)) {
+        return;
+      }
+
+      recoverFromStaleHashedAsset();
+    },
+    true
+  );
+
+  if (themeColorMeta) {
+    const updateThemeColor = function (isDark) {
+      themeColorMeta.setAttribute("content", isDark ? "#18181b" : "#ffffff");
+    };
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const handleChange = function (event) {
+      updateThemeColor(event.matches);
+    };
+
+    updateThemeColor(mediaQuery.matches);
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleChange);
+      return;
+    }
+
+    if (typeof mediaQuery.addListener === "function") {
+      mediaQuery.addListener(handleChange);
+    }
   }
 })();

--- a/public/theme-color.js
+++ b/public/theme-color.js
@@ -33,6 +33,7 @@
       window.sessionStorage.setItem(assetLoadRecoveryStorageKey, "pending");
       return true;
     } catch {
+      // Ignore storage access failures; recovery remains best-effort.
       return false;
     }
   }
@@ -53,7 +54,7 @@
 
     return (
       targetUrl.origin === window.location.origin &&
-      /\/assets\/.+\.js(?:\?.*)?$/.test(targetUrl.pathname)
+      /\/assets\/.+\.js$/.test(targetUrl.pathname)
     );
   }
 

--- a/src/main.test.tsx
+++ b/src/main.test.tsx
@@ -6,6 +6,8 @@ import {
   installSystemColorSchemeSync,
   syncSystemColorScheme,
 } from "./lib/systemColorScheme";
+import { AppWithI18n } from "./main";
+import { render, waitFor } from "@testing-library/react";
 
 function createMatchMediaStub(initialMatches: boolean) {
   let matches = initialMatches;
@@ -103,5 +105,19 @@ describe("system color scheme sync", () => {
     expect(document.documentElement).toHaveClass("dark");
     expect(document.documentElement.style.colorScheme).toBe("dark");
     expect(matchMediaStub.listenerCount()).toBe(0);
+  });
+
+  it("dispatches the bootstrap-ready event after the app renders", async () => {
+    const matchMediaStub = createMatchMediaStub(false);
+    vi.stubGlobal("matchMedia", matchMediaStub.matchMedia);
+    const dispatchEventSpy = vi.spyOn(window, "dispatchEvent");
+
+    render(<AppWithI18n />);
+
+    await waitFor(() => {
+      expect(dispatchEventSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "app-bootstrap-ready" })
+      );
+    });
   });
 });

--- a/src/main.test.tsx
+++ b/src/main.test.tsx
@@ -110,14 +110,15 @@ describe("system color scheme sync", () => {
   it("dispatches the bootstrap-ready event after the app renders", async () => {
     const matchMediaStub = createMatchMediaStub(false);
     vi.stubGlobal("matchMedia", matchMediaStub.matchMedia);
-    const dispatchEventSpy = vi.spyOn(window, "dispatchEvent");
+    const bootstrapReadyListener = vi.fn();
+    window.addEventListener("app-bootstrap-ready", bootstrapReadyListener, {
+      once: true,
+    });
 
     render(<AppWithI18n />);
 
     await waitFor(() => {
-      expect(dispatchEventSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ type: "app-bootstrap-ready" })
-      );
+      expect(bootstrapReadyListener).toHaveBeenCalledOnce();
     });
   });
 });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -30,6 +30,10 @@ export function AppWithI18n() {
 
   useEffect(() => installSystemColorSchemeSync(), []);
 
+  useEffect(() => {
+    window.dispatchEvent(new Event("app-bootstrap-ready"));
+  }, []);
+
   return (
     <I18nProvider i18n={i18n}>
       <RuntimeStyleCspSupport />

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -68,13 +68,21 @@ cleanupOutdatedCaches();
 // Precache all build assets (injected by Vite PWA plugin)
 precacheAndRoute(self.__WB_MANIFEST);
 
+function isCacheableStaticAssetRequest(request: Request): boolean {
+  const pathname = new URL(request.url).pathname;
+
+  return (
+    pathname !== "/theme-color.js" &&
+    (request.destination === "image" ||
+      request.destination === "style" ||
+      request.destination === "script" ||
+      request.destination === "font")
+  );
+}
+
 // Cache static assets with CacheFirst strategy
 registerRoute(
-  ({ request }) =>
-    request.destination === "image" ||
-    request.destination === "style" ||
-    request.destination === "script" ||
-    request.destination === "font",
+  ({ request }) => isCacheableStaticAssetRequest(request),
   new CacheFirst({
     cacheName: "static-assets",
   })

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -378,7 +378,9 @@ describe("Build Configuration and Source Verification", () => {
     expect(viteConfig).toContain(
       'globPatterns: ["**/*.{js,css,ico,png,svg,woff,woff2}"]'
     );
-    expect(viteConfig).toContain('globIgnores: ["**/*.html"]');
+    expect(viteConfig).toContain(
+      'globIgnores: ["**/*.html", "theme-color.js"]'
+    );
     expect(viteConfig).toContain("navigateFallback: null");
     expect(viteConfig).toContain("nonceBearingHtmlShellPattern");
     expect(viteConfig).toContain("manifestTransforms");
@@ -395,6 +397,15 @@ describe("Build Configuration and Source Verification", () => {
     expect(serviceWorker).not.toContain(
       'createHandlerBoundToURL("/index.html")'
     );
+  });
+
+  it("keeps the recovery bootstrap out of service-worker caches", () => {
+    const serviceWorker = readRepoFile("src/sw.ts");
+    const viteConfig = readRepoFile("vite.config.ts");
+
+    expect(viteConfig).toContain('"theme-color.js"');
+    expect(serviceWorker).toContain("isCacheableStaticAssetRequest");
+    expect(serviceWorker).toContain('pathname !== "/theme-color.js"');
   });
 
   it("uses an external theme-color bootstrap so CSP can block inline scripts", () => {

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -459,7 +459,9 @@ describe("Build Configuration and Source Verification", () => {
     expect(htaccess).toContain('Files "source-offer.json"');
     expect(htaccess).toContain('Cache-Control "no-cache, must-revalidate"');
     expect(htaccess).toContain('Files "theme-color.js"');
-    expect(htaccess).toContain('Cache-Control "no-cache, no-store, must-revalidate"');
+    expect(htaccess).toContain(
+      'Cache-Control "no-cache, no-store, must-revalidate"'
+    );
 
     expect(nginxConfig).toContain("location = /sw.js");
     expect(nginxConfig).toContain("Service-Worker-Allowed");

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -411,6 +411,18 @@ describe("Build Configuration and Source Verification", () => {
     expect(themeColorJs).not.toContain("<script");
   });
 
+  it("keeps stale hashed-entry recovery in the early bootstrap script", () => {
+    const themeColorJs = readRepoFile("public/theme-color.js");
+
+    expect(themeColorJs).toContain("window.addEventListener(");
+    expect(themeColorJs).toContain('"error"');
+    expect(themeColorJs).toContain("secpal.asset-load-recovery");
+    expect(themeColorJs).toContain("navigator.serviceWorker.getRegistrations");
+    expect(themeColorJs).toContain("window.caches.keys");
+    expect(themeColorJs).toContain("window.location.reload()");
+    expect(themeColorJs).toContain("app-bootstrap-ready");
+  });
+
   it("reads CSP nonces from emitted script/link tags instead of a custom meta carrier", () => {
     const nonceHelper = readRepoFile("src/lib/cspNonce.tsx");
 

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -421,6 +421,7 @@ describe("Build Configuration and Source Verification", () => {
     expect(themeColorJs).toContain("window.caches.keys");
     expect(themeColorJs).toContain("window.location.reload()");
     expect(themeColorJs).toContain("app-bootstrap-ready");
+    expect(themeColorJs).not.toContain("(?:\\?.*)?$");
   });
 
   it("reads CSP nonces from emitted script/link tags instead of a custom meta carrier", () => {
@@ -446,12 +447,15 @@ describe("Build Configuration and Source Verification", () => {
     );
     expect(htaccess).toContain('Files "source-offer.json"');
     expect(htaccess).toContain('Cache-Control "no-cache, must-revalidate"');
+    expect(htaccess).toContain('Files "theme-color.js"');
+    expect(htaccess).toContain('Cache-Control "no-cache, no-store, must-revalidate"');
 
     expect(nginxConfig).toContain("location = /sw.js");
     expect(nginxConfig).toContain("Service-Worker-Allowed");
     expect(nginxConfig).toContain("default_type application/manifest+json");
     expect(nginxConfig).toContain("location = /manifest.webmanifest");
     expect(nginxConfig).toContain("location = /source-offer.json");
+    expect(nginxConfig).toContain("location = /theme-color.js");
     expect(nginxConfig).toContain("default_type application/json");
   });
 

--- a/tests/theme-color-bootstrap.test.ts
+++ b/tests/theme-color-bootstrap.test.ts
@@ -29,30 +29,73 @@ interface ThemeColorTestWindow extends Window {
   };
 }
 
-describe("theme-color bootstrap stale asset recovery", () => {
-  it("skips reload when it cannot persist the one-shot recovery latch", async () => {
-    document.head.innerHTML = "";
-    document.body.innerHTML = "";
+function installRecoveryEnvironment() {
+  document.head.innerHTML = "";
+  document.body.innerHTML = "";
 
-    const testWindow = globalThis as ThemeColorTestWindow;
-    testWindow.__themeColorReload = vi.fn();
-    const getRegistrations = vi
-      .fn()
-      .mockResolvedValue([{ unregister: vi.fn().mockResolvedValue(true) }]);
-    Object.defineProperty(navigator, "serviceWorker", {
+  const testWindow = globalThis as ThemeColorTestWindow;
+  testWindow.__themeColorReload = vi.fn();
+  const unregister = vi.fn().mockResolvedValue(true);
+  const getRegistrations = vi.fn().mockResolvedValue([{ unregister }]);
+  Object.defineProperty(navigator, "serviceWorker", {
+    configurable: true,
+    value: {
+      getRegistrations,
+    },
+  });
+  const cacheDelete = vi.fn().mockResolvedValue(true);
+  const cacheKeys = vi.fn().mockResolvedValue(["html-shell"]);
+  Object.defineProperty(window, "caches", {
+    configurable: true,
+    value: {
+      keys: cacheKeys,
+      delete: cacheDelete,
+    },
+  });
+
+  return { cacheDelete, cacheKeys, getRegistrations, testWindow, unregister };
+}
+
+async function waitForRecoveryTasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => window.setTimeout(resolve, 0));
+}
+
+describe("theme-color bootstrap stale asset recovery", () => {
+  it("recovers when an early same-origin built asset preload fails", async () => {
+    const { cacheDelete, cacheKeys, getRegistrations, testWindow, unregister } =
+      installRecoveryEnvironment();
+    Object.defineProperty(window, "sessionStorage", {
       configurable: true,
       value: {
-        getRegistrations,
+        getItem: vi.fn().mockReturnValue(null),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+        clear: vi.fn(),
       },
     });
-    const cacheKeys = vi.fn().mockResolvedValue(["html-shell"]);
-    Object.defineProperty(window, "caches", {
-      configurable: true,
-      value: {
-        keys: cacheKeys,
-        delete: vi.fn().mockResolvedValue(true),
-      },
-    });
+    new Function(instrumentedThemeColorBootstrapSource)();
+
+    const preload = document.createElement("link");
+    preload.rel = "modulepreload";
+    preload.href = "/assets/index-stale.js";
+    document.head.append(preload);
+    preload.dispatchEvent(new Event("error"));
+
+    await waitForRecoveryTasks();
+
+    expect(getRegistrations).toHaveBeenCalledOnce();
+    expect(unregister).toHaveBeenCalledOnce();
+    expect(cacheKeys).toHaveBeenCalledOnce();
+    expect(cacheDelete).toHaveBeenCalledWith("html-shell");
+    expect(testWindow.__themeColorReload).toHaveBeenCalledOnce();
+  });
+
+  it("skips reload when it cannot persist the one-shot recovery latch", async () => {
+    const { cacheKeys, getRegistrations, testWindow } =
+      installRecoveryEnvironment();
     Object.defineProperty(window, "sessionStorage", {
       configurable: true,
       value: {
@@ -69,10 +112,7 @@ describe("theme-color bootstrap stale asset recovery", () => {
     expect(testWindow.__themeColorTestHooks).toBeDefined();
     testWindow.__themeColorTestHooks?.recoverFromStaleHashedAsset();
 
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
-    await new Promise((resolve) => window.setTimeout(resolve, 0));
+    await waitForRecoveryTasks();
 
     expect(getRegistrations).not.toHaveBeenCalled();
     expect(cacheKeys).not.toHaveBeenCalled();

--- a/tests/theme-color-bootstrap.test.ts
+++ b/tests/theme-color-bootstrap.test.ts
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+import path from "node:path";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const themeColorBootstrapSource = readFileSync(
+  path.join(repoRoot, "public/theme-color.js"),
+  "utf8"
+);
+const instrumentedThemeColorBootstrapSource = themeColorBootstrapSource
+  .replace("window.location.reload();", "globalThis.__themeColorReload();")
+  .replace(
+    "})();",
+    [
+      "globalThis.__themeColorTestHooks = { recoverFromStaleHashedAsset };",
+      "})();",
+    ].join("\n")
+  );
+
+interface ThemeColorTestWindow extends Window {
+  __themeColorReload: ReturnType<typeof vi.fn>;
+  __themeColorTestHooks?: {
+    recoverFromStaleHashedAsset: () => void;
+  };
+}
+
+describe("theme-color bootstrap stale asset recovery", () => {
+  it("skips reload when it cannot persist the one-shot recovery latch", async () => {
+    document.head.innerHTML = "";
+    document.body.innerHTML = "";
+
+    const testWindow = globalThis as ThemeColorTestWindow;
+    testWindow.__themeColorReload = vi.fn();
+    const getRegistrations = vi
+      .fn()
+      .mockResolvedValue([{ unregister: vi.fn().mockResolvedValue(true) }]);
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: {
+        getRegistrations,
+      },
+    });
+    const cacheKeys = vi.fn().mockResolvedValue(["html-shell"]);
+    Object.defineProperty(window, "caches", {
+      configurable: true,
+      value: {
+        keys: cacheKeys,
+        delete: vi.fn().mockResolvedValue(true),
+      },
+    });
+    Object.defineProperty(window, "sessionStorage", {
+      configurable: true,
+      value: {
+        getItem: vi.fn().mockReturnValue(null),
+        setItem: vi.fn(() => {
+          throw new Error("sessionStorage unavailable");
+        }),
+        removeItem: vi.fn(),
+        clear: vi.fn(),
+      },
+    });
+    new Function(instrumentedThemeColorBootstrapSource)();
+
+    expect(testWindow.__themeColorTestHooks).toBeDefined();
+    testWindow.__themeColorTestHooks?.recoverFromStaleHashedAsset();
+
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+    expect(getRegistrations).not.toHaveBeenCalled();
+    expect(cacheKeys).not.toHaveBeenCalled();
+    expect(testWindow.__themeColorReload).not.toHaveBeenCalled();
+  });
+});

--- a/tests/theme-color-bootstrap.test.ts
+++ b/tests/theme-color-bootstrap.test.ts
@@ -29,6 +29,15 @@ interface ThemeColorTestWindow extends Window {
   };
 }
 
+function createDeferredPromise() {
+  let resolve: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve: resolve! };
+}
+
 function installRecoveryEnvironment() {
   document.head.innerHTML = "";
   document.body.innerHTML = "";
@@ -117,5 +126,60 @@ describe("theme-color bootstrap stale asset recovery", () => {
     expect(getRegistrations).not.toHaveBeenCalled();
     expect(cacheKeys).not.toHaveBeenCalled();
     expect(testWindow.__themeColorReload).not.toHaveBeenCalled();
+  });
+
+  it("keeps the recovery latch until the next page boots", async () => {
+    document.head.innerHTML = "";
+    document.body.innerHTML = "";
+
+    const testWindow = globalThis as ThemeColorTestWindow;
+    testWindow.__themeColorReload = vi.fn();
+    const unregisterDeferred = createDeferredPromise();
+    const cacheDeferred = createDeferredPromise();
+    const unregister = vi.fn().mockReturnValue(unregisterDeferred.promise);
+    const getRegistrations = vi.fn().mockResolvedValue([{ unregister }]);
+    const removeItem = vi.fn();
+    const setItem = vi.fn();
+
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: {
+        getRegistrations,
+      },
+    });
+    Object.defineProperty(window, "caches", {
+      configurable: true,
+      value: {
+        keys: vi.fn().mockReturnValue(cacheDeferred.promise.then(() => [])),
+        delete: vi.fn().mockResolvedValue(true),
+      },
+    });
+    Object.defineProperty(window, "sessionStorage", {
+      configurable: true,
+      value: {
+        getItem: vi.fn().mockReturnValue(null),
+        setItem,
+        removeItem,
+        clear: vi.fn(),
+      },
+    });
+
+    new Function(instrumentedThemeColorBootstrapSource)();
+
+    testWindow.__themeColorTestHooks?.recoverFromStaleHashedAsset();
+    window.dispatchEvent(new Event("app-bootstrap-ready"));
+
+    expect(setItem).toHaveBeenCalledWith(
+      "secpal.asset-load-recovery",
+      "pending"
+    );
+    expect(removeItem).not.toHaveBeenCalled();
+    expect(testWindow.__themeColorReload).not.toHaveBeenCalled();
+
+    unregisterDeferred.resolve();
+    cacheDeferred.resolve();
+    await waitForRecoveryTasks();
+
+    expect(testWindow.__themeColorReload).toHaveBeenCalledOnce();
   });
 });

--- a/tests/theme-color-bootstrap.test.ts
+++ b/tests/theme-color-bootstrap.test.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
-import path from "node:path";
 import { readFileSync } from "node:fs";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -212,7 +212,7 @@ export default defineConfig(({ mode, command }) => {
         },
         injectManifest: {
           globPatterns: ["**/*.{js,css,ico,png,svg,woff,woff2}"],
-          globIgnores: ["**/*.html"],
+          globIgnores: ["**/*.html", "theme-color.js"],
           manifestTransforms: [
             async (entries) => ({
               manifest: entries.filter(
@@ -272,7 +272,7 @@ export default defineConfig(({ mode, command }) => {
         },
         workbox: {
           globPatterns: ["**/*.{js,css,ico,png,svg,woff,woff2}"],
-          globIgnores: ["**/*.html"],
+          globIgnores: ["**/*.html", "theme-color.js"],
           navigateFallback: null,
           cleanupOutdatedCaches: true,
           runtimeCaching: buildPwaRuntimeCaching(),


### PR DESCRIPTION
## Defect

Reproduced a blank dark screen after deploy where the browser requested a deleted hashed entry bundle (`/assets/index-*.js`) and returned `404`, leaving the app shell unloaded.

## Current change

- Add early bootstrap recovery in [public/theme-color.js](public/theme-color.js) so stale hashed entry failures clear the affected runtime caches, unregister stale service workers, and reload once instead of stranding the user on a blank page.
- Dispatch an `app-bootstrap-ready` signal from [src/main.tsx](src/main.tsx) so the bootstrap recovery latch resets only after the app has rendered successfully.
- Lock the regression down with source-level coverage in [tests/build.test.ts](tests/build.test.ts) and runtime coverage in [src/main.test.tsx](src/main.test.tsx).
- Document the user-visible fix in [CHANGELOG.md](CHANGELOG.md).

## Validation

- `npm test -- --run tests/build.test.ts src/main.test.tsx`
- `npm run build`
- `npm run typecheck`
- `npm run lint`

## Follow-up before ready

- Linked workspaces: none required for this frontend-only fix.
- Remaining checks before marking ready: review the deployed preview in the PR view, confirm the stale-cache recovery path behaves as expected in-browser, and complete the final self-review with zero findings.
