### PR TITLE
Fix auth bootstrap fallback and domain preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Stopped opportunistic protected-route browser-session bootstrap when no
+  encrypted auth snapshot and no readable CSRF cookie are present, so preview
+  and logged-out sessions redirect cleanly to `/login` instead of surfacing
+  auth recovery UI after a failing `/v1/me` probe.
+
 ### Added
 
 - Added `@capacitor/core` as a runtime dependency and introduced the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hostnames across one-character, punycode, digit-bearing, long, and
   hyphenated host labels without letting the known
   `secpal.asset-load-recovery` storage key mask same-line forbidden hosts or
-  URL-host usage of the same token, while still ignoring the standalone key
-  and `.context` workspace notes as forbidden domains.
+  URL-host usage of the same token, including query- and fragment-suffixed
+  host forms, while still ignoring the standalone key and `.context`
+  workspace notes as forbidden domains.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hostnames across one-character, punycode, digit-bearing, long, and
   hyphenated host labels without letting the known
   `secpal.asset-load-recovery` storage key mask same-line forbidden hosts or
-  URL-host usage of the same token, including query- and fragment-suffixed
-  host forms, while still ignoring the standalone key and `.context`
-  workspace notes as forbidden domains.
+  URL-host usage of the same token, including scheme-colon, query-, and
+  fragment-suffixed host forms, while still ignoring the standalone key and
+  `.context` workspace notes as forbidden domains.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   encrypted auth snapshot and no readable CSRF cookie are present, so preview
   and logged-out sessions redirect cleanly to `/login` instead of surfacing
   auth recovery UI after a failing `/v1/me` probe.
+- Fixed the local domain-policy preflight so it validates real SecPal
+  hostnames instead of flagging `secpal.`-prefixed storage keys and `.context`
+  workspace notes as forbidden domains.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and logged-out sessions redirect cleanly to `/login` instead of surfacing
   auth recovery UI after a failing `/v1/me` probe.
 - Fixed the local domain-policy preflight so it validates real SecPal
-  hostnames across punycode, digit-bearing, long, and hyphenated host labels
-  without letting the known `secpal.asset-load-recovery` storage key mask
-  same-line forbidden hosts, while still ignoring that token and `.context`
-  workspace notes as forbidden domains.
+  hostnames across one-character, punycode, digit-bearing, long, and
+  hyphenated host labels without letting the known
+  `secpal.asset-load-recovery` storage key mask same-line forbidden hosts or
+  URL-host usage of the same token, while still ignoring the standalone key
+  and `.context` workspace notes as forbidden domains.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and logged-out sessions redirect cleanly to `/login` instead of surfacing
   auth recovery UI after a failing `/v1/me` probe.
 - Fixed the local domain-policy preflight so it validates real SecPal
-  hostnames instead of flagging `secpal.`-prefixed storage keys and `.context`
-  workspace notes as forbidden domains.
+  hostnames across punycode, digit-bearing, long, and hyphenated host labels
+  without flagging the known `secpal.asset-load-recovery` storage key or
+  `.context` workspace notes as forbidden domains.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   auth recovery UI after a failing `/v1/me` probe.
 - Fixed the local domain-policy preflight so it validates real SecPal
   hostnames across punycode, digit-bearing, long, and hyphenated host labels
-  without flagging the known `secpal.asset-load-recovery` storage key or
-  `.context` workspace notes as forbidden domains.
+  without letting the known `secpal.asset-load-recovery` storage key mask
+  same-line forbidden hosts, while still ignoring that token and `.context`
+  workspace notes as forbidden domains.
 
 ### Added
 

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -49,7 +49,7 @@ matches=$(grep -r -n -E '([A-Za-z0-9-]+\.)*secpal\.[A-Za-z0-9-]{1,63}($|[^A-Za-z
 
 # Drop the known storage key token without discarding other matches on the same line.
 matches=$(printf '%s\n' "$matches" | \
-    sed -E 's/(^|[^A-Za-z0-9/:.-])secpal\.asset-load-recovery($|[^A-Za-z0-9._/?:#-])/\1\2/g' || true)
+    sed -E 's/(^|[^A-Za-z0-9/.-])secpal\.asset-load-recovery($|[^A-Za-z0-9._/?:#-])/\1\2/g' || true)
 
 # Allowlist approach: flag any secpal.* domain not matching an approved pattern.
 # Approved or temporarily tolerated here: secpal.app, apk.secpal.app,

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -24,7 +24,7 @@ echo "Deprecated web hosts: api.secpal.app"
 echo "Forbidden: secpal.com, secpal.org, secpal.net, secpal.io, secpal.example, ANY other"
 echo ""
 
-matches=$(grep -r -n -E "secpal\.[A-Za-z0-9.-]+" \
+matches=$(grep -r -n -E '([A-Za-z0-9-]+\.)*secpal\.[A-Za-z]{2,24}($|[^A-Za-z0-9-])' \
     --include="*.md" \
     --include="*.yaml" \
     --include="*.yml" \
@@ -36,6 +36,7 @@ matches=$(grep -r -n -E "secpal\.[A-Za-z0-9.-]+" \
     --include="*.jsx" \
     --include="*.php" \
     --include="*.html" \
+    --exclude-dir=".context" \
     --exclude-dir=".git" \
     --exclude-dir="node_modules" \
     --exclude-dir="vendor" \

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -49,7 +49,8 @@ matches=$(grep -r -n -E '([A-Za-z0-9-]+\.)*secpal\.[A-Za-z0-9-]{1,63}($|[^A-Za-z
 
 # Drop the known storage key token without discarding other matches on the same line.
 matches=$(printf '%s\n' "$matches" | \
-    sed -E 's/^([^:]+:[0-9]+:)secpal\.asset-load-recovery($|[^A-Za-z0-9._/?:#-])/\1\2/g; s/(^|[^A-Za-z0-9/:.-])secpal\.asset-load-recovery($|[^A-Za-z0-9._/?:#-])/\1\2/g' || true)
+    sed -E 's@(^[^:]+:[0-9]+:)secpal\.asset-load-recovery($|[^A-Za-z0-9._/?:#-])@\1\2@g' | \
+    sed -E 's@(^|[^A-Za-z0-9/.-:@])secpal\.asset-load-recovery($|[^A-Za-z0-9._/?:#-])@\1\2@g' || true)
 
 # Allowlist approach: flag any secpal.* domain not matching an approved pattern.
 # Approved or temporarily tolerated here: secpal.app, apk.secpal.app,

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -24,7 +24,7 @@ echo "Deprecated web hosts: api.secpal.app"
 echo "Forbidden: secpal.com, secpal.org, secpal.net, secpal.io, secpal.example, ANY other"
 echo ""
 
-matches=$(grep -r -n -E '([A-Za-z0-9-]+\.)*secpal\.[A-Za-z]{2,24}($|[^A-Za-z0-9-])' \
+matches=$(grep -r -n -E '([A-Za-z0-9-]+\.)*secpal\.(xn--[A-Za-z0-9-]{2,59}|[A-Za-z]{2,24})($|[^A-Za-z0-9-])' \
     --include="*.md" \
     --include="*.yaml" \
     --include="*.yml" \

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -50,7 +50,7 @@ matches=$(grep -r -n -E '([A-Za-z0-9-]+\.)*secpal\.[A-Za-z0-9-]{1,63}($|[^A-Za-z
 # Drop the known storage key token without discarding other matches on the same line.
 matches=$(printf '%s\n' "$matches" | \
     sed -E 's@(^[^:]+:[0-9]+:)secpal\.asset-load-recovery($|[^A-Za-z0-9._/?:#-])@\1\2@g' | \
-    sed -E 's@(^|[^A-Za-z0-9/.-:@])secpal\.asset-load-recovery($|[^A-Za-z0-9._/?:#-])@\1\2@g' || true)
+    sed -E 's@(^|[^A-Za-z0-9/.:@-])secpal\.asset-load-recovery($|[^A-Za-z0-9._/?:#-])@\1\2@g' || true)
 
 # Allowlist approach: flag any secpal.* domain not matching an approved pattern.
 # Approved or temporarily tolerated here: secpal.app, apk.secpal.app,

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -49,7 +49,7 @@ matches=$(grep -r -n -E '([A-Za-z0-9-]+\.)*secpal\.[A-Za-z0-9-]{1,63}($|[^A-Za-z
 
 # Drop the known storage key token without discarding other matches on the same line.
 matches=$(printf '%s\n' "$matches" | \
-    sed -E 's/(^|[^A-Za-z0-9/.-])secpal\.asset-load-recovery($|[^A-Za-z0-9._/?:#-])/\1\2/g' || true)
+    sed -E 's/^([^:]+:[0-9]+:)secpal\.asset-load-recovery($|[^A-Za-z0-9._/?:#-])/\1\2/g; s/(^|[^A-Za-z0-9/:.-])secpal\.asset-load-recovery($|[^A-Za-z0-9._/?:#-])/\1\2/g' || true)
 
 # Allowlist approach: flag any secpal.* domain not matching an approved pattern.
 # Approved or temporarily tolerated here: secpal.app, apk.secpal.app,

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -44,9 +44,12 @@ matches=$(grep -r -n -E '([A-Za-z0-9-]+\.)*secpal\.[A-Za-z0-9-]{2,63}($|[^A-Za-z
     grep -v -- "check-domains.sh" | \
     grep -v -- "Forbidden:" | \
     grep -v -- "FORBIDDEN:" | \
-    grep -v -- 'secpal\.asset-load-recovery' | \
     grep -v -- '- "secpal\.' | \
     grep -v -- '^[[:space:]]*- \[' || true)
+
+# Drop the known storage key token without discarding other matches on the same line.
+matches=$(printf '%s\n' "$matches" | \
+    sed -E 's/(^|[^A-Za-z0-9.-])secpal\.asset-load-recovery($|[^A-Za-z0-9._-])/\1\2/g' || true)
 
 # Allowlist approach: flag any secpal.* domain not matching an approved pattern.
 # Approved or temporarily tolerated here: secpal.app, apk.secpal.app,

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -49,7 +49,7 @@ matches=$(grep -r -n -E '([A-Za-z0-9-]+\.)*secpal\.[A-Za-z0-9-]{1,63}($|[^A-Za-z
 
 # Drop the known storage key token without discarding other matches on the same line.
 matches=$(printf '%s\n' "$matches" | \
-    sed -E 's/(^|[^A-Za-z0-9/:.-])secpal\.asset-load-recovery($|[^A-Za-z0-9._/:-])/\1\2/g' || true)
+    sed -E 's/(^|[^A-Za-z0-9/:.-])secpal\.asset-load-recovery($|[^A-Za-z0-9._/?:#-])/\1\2/g' || true)
 
 # Allowlist approach: flag any secpal.* domain not matching an approved pattern.
 # Approved or temporarily tolerated here: secpal.app, apk.secpal.app,

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -24,7 +24,7 @@ echo "Deprecated web hosts: api.secpal.app"
 echo "Forbidden: secpal.com, secpal.org, secpal.net, secpal.io, secpal.example, ANY other"
 echo ""
 
-matches=$(grep -r -n -E '([A-Za-z0-9-]+\.)*secpal\.(xn--[A-Za-z0-9-]{2,59}|[A-Za-z0-9]{2,63})($|[^A-Za-z0-9-])' \
+matches=$(grep -r -n -E '([A-Za-z0-9-]+\.)*secpal\.[A-Za-z0-9-]{2,63}($|[^A-Za-z0-9-])' \
     --include="*.md" \
     --include="*.yaml" \
     --include="*.yml" \
@@ -44,6 +44,7 @@ matches=$(grep -r -n -E '([A-Za-z0-9-]+\.)*secpal\.(xn--[A-Za-z0-9-]{2,59}|[A-Za
     grep -v -- "check-domains.sh" | \
     grep -v -- "Forbidden:" | \
     grep -v -- "FORBIDDEN:" | \
+    grep -v -- 'secpal\.asset-load-recovery' | \
     grep -v -- '- "secpal\.' | \
     grep -v -- '^[[:space:]]*- \[' || true)
 

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -24,7 +24,7 @@ echo "Deprecated web hosts: api.secpal.app"
 echo "Forbidden: secpal.com, secpal.org, secpal.net, secpal.io, secpal.example, ANY other"
 echo ""
 
-matches=$(grep -r -n -E '([A-Za-z0-9-]+\.)*secpal\.(xn--[A-Za-z0-9-]{2,59}|[A-Za-z]{2,24})($|[^A-Za-z0-9-])' \
+matches=$(grep -r -n -E '([A-Za-z0-9-]+\.)*secpal\.(xn--[A-Za-z0-9-]{2,59}|[A-Za-z]{2,24}|[A-Za-z0-9]{2,24})($|[^A-Za-z0-9-])' \
     --include="*.md" \
     --include="*.yaml" \
     --include="*.yml" \

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -24,7 +24,7 @@ echo "Deprecated web hosts: api.secpal.app"
 echo "Forbidden: secpal.com, secpal.org, secpal.net, secpal.io, secpal.example, ANY other"
 echo ""
 
-matches=$(grep -r -n -E '([A-Za-z0-9-]+\.)*secpal\.[A-Za-z0-9-]{2,63}($|[^A-Za-z0-9-])' \
+matches=$(grep -r -n -E '([A-Za-z0-9-]+\.)*secpal\.[A-Za-z0-9-]{1,63}($|[^A-Za-z0-9-])' \
     --include="*.md" \
     --include="*.yaml" \
     --include="*.yml" \
@@ -49,7 +49,7 @@ matches=$(grep -r -n -E '([A-Za-z0-9-]+\.)*secpal\.[A-Za-z0-9-]{2,63}($|[^A-Za-z
 
 # Drop the known storage key token without discarding other matches on the same line.
 matches=$(printf '%s\n' "$matches" | \
-    sed -E 's/(^|[^A-Za-z0-9.-])secpal\.asset-load-recovery($|[^A-Za-z0-9._-])/\1\2/g' || true)
+    sed -E 's/(^|[^A-Za-z0-9/:.-])secpal\.asset-load-recovery($|[^A-Za-z0-9._/:-])/\1\2/g' || true)
 
 # Allowlist approach: flag any secpal.* domain not matching an approved pattern.
 # Approved or temporarily tolerated here: secpal.app, apk.secpal.app,

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -24,7 +24,7 @@ echo "Deprecated web hosts: api.secpal.app"
 echo "Forbidden: secpal.com, secpal.org, secpal.net, secpal.io, secpal.example, ANY other"
 echo ""
 
-matches=$(grep -r -n -E '([A-Za-z0-9-]+\.)*secpal\.(xn--[A-Za-z0-9-]{2,59}|[A-Za-z]{2,24}|[A-Za-z0-9]{2,24})($|[^A-Za-z0-9-])' \
+matches=$(grep -r -n -E '([A-Za-z0-9-]+\.)*secpal\.(xn--[A-Za-z0-9-]{2,59}|[A-Za-z0-9]{2,63})($|[^A-Za-z0-9-])' \
     --include="*.md" \
     --include="*.yaml" \
     --include="*.yml" \

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -169,6 +169,15 @@ async function renderWithI18n(component: React.ReactElement) {
   return result;
 }
 
+async function waitForPathname(pathname: string) {
+  await waitFor(
+    () => {
+      expect(window.location.pathname).toBe(pathname);
+    },
+    { timeout: ROUTE_NAVIGATION_TIMEOUT_MS }
+  );
+}
+
 async function seedPersistedAuthUser(user: Record<string, unknown>) {
   const persistedUser = sanitizePersistedAuthUser(user);
 
@@ -509,9 +518,7 @@ describe("App", () => {
 
       await renderWithI18n(<App />);
 
-      await waitFor(() => {
-        expect(window.location.pathname).toBe(path);
-      });
+      await waitForPathname(path);
 
       await screen.findByRole("button", { name: /sign out/i });
       expect(screen.getByTestId("update-prompt")).toBeInTheDocument();
@@ -843,15 +850,21 @@ describe("App", () => {
   it("redirects protected routes to login when no local auth snapshot or readable csrf cookie exists", async () => {
     window.history.replaceState({}, "", "/");
     clearXsrfCookie();
+    mockGetCurrentUser.mockRejectedValueOnce(
+      new AuthApiError(
+        "Current user fetch failed: Failed to fetch",
+        undefined,
+        undefined,
+        "NETWORK_ERROR"
+      )
+    );
 
     await renderWithI18n(<App />);
 
-    await waitFor(() => {
-      expect(window.location.pathname).toBe("/login");
-    });
+    await waitForPathname("/login");
 
     expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
-    expect(mockGetCurrentUser).not.toHaveBeenCalled();
+    expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
   });
 
   it("shows bootstrap recovery in place after protected-route session restore fails and allows retry", async () => {
@@ -1302,9 +1315,7 @@ describe("App", () => {
 
     await renderWithI18n(<App />);
 
-    await waitFor(() => {
-      expect(window.location.pathname).toBe("/organization");
-    });
+    await waitForPathname("/organization");
 
     expect(screen.queryByText(/Page Not Found/i)).not.toBeInTheDocument();
   });
@@ -1328,9 +1339,7 @@ describe("App", () => {
 
     await renderWithI18n(<App />);
 
-    await waitFor(() => {
-      expect(window.location.pathname).toBe("/onboarding");
-    });
+    await waitForPathname("/onboarding");
     expect(
       await screen.findByText(
         /your onboarding is not complete yet\. please complete onboarding/i
@@ -1456,9 +1465,7 @@ describe("App", () => {
 
     await renderWithI18n(<App />);
 
-    await waitFor(() => {
-      expect(window.location.pathname).toBe("/onboarding");
-    });
+    await waitForPathname("/onboarding");
 
     await waitFor(() => {
       expect(
@@ -1575,9 +1582,7 @@ describe("App", () => {
 
     await renderWithI18n(<App />);
 
-    await waitFor(() => {
-      expect(window.location.pathname).toBe("/login");
-    });
+    await waitForPathname("/login");
 
     await act(async () => {
       await Promise.resolve();

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -867,6 +867,41 @@ describe("App", () => {
     expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
   });
 
+  it("redirects protected routes to login when bootstrap without a local auth snapshot or readable csrf cookie times out", async () => {
+    window.history.replaceState({}, "", "/");
+    clearXsrfCookie();
+    vi.useFakeTimers();
+    mockGetCurrentUser.mockImplementationOnce(
+      () =>
+        new Promise(() => undefined) as ReturnType<typeof mockGetCurrentUser>
+    );
+
+    try {
+      await renderWithI18n(<App />);
+
+      await act(async () => {
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+          await Promise.resolve();
+        }
+      });
+
+      expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        vi.advanceTimersByTime(ROUTE_NAVIGATION_TIMEOUT_MS);
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+          await Promise.resolve();
+        }
+      });
+
+      expect(window.location.pathname).toBe("/login");
+      expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+      expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("shows bootstrap recovery in place after protected-route session restore fails and allows retry", async () => {
     const recoveredUser = {
       id: "1",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -871,9 +871,23 @@ describe("App", () => {
     window.history.replaceState({}, "", "/");
     clearXsrfCookie();
     vi.useFakeTimers();
+    const lateUser = {
+      id: "1",
+      name: "Late Bootstrap User",
+      email: "late-bootstrap@secpal.dev",
+      emailVerified: true,
+      roles: [],
+      permissions: [],
+      hasOrganizationalScopes: false,
+      hasCustomerAccess: false,
+      hasSiteAccess: false,
+    };
+    let resolveCurrentUser: ((value: typeof lateUser) => void) | undefined;
     mockGetCurrentUser.mockImplementationOnce(
       () =>
-        new Promise(() => undefined) as ReturnType<typeof mockGetCurrentUser>
+        new Promise<typeof lateUser>((resolve) => {
+          resolveCurrentUser = resolve;
+        }) as ReturnType<typeof mockGetCurrentUser>
     );
 
     try {
@@ -897,6 +911,18 @@ describe("App", () => {
       expect(window.location.pathname).toBe("/login");
       expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
       expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
+      expect(mockAuthStorage.setUser).not.toHaveBeenCalled();
+
+      await act(async () => {
+        resolveCurrentUser?.(lateUser);
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+          await Promise.resolve();
+        }
+      });
+
+      expect(window.location.pathname).toBe("/login");
+      expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+      expect(mockAuthStorage.setUser).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -840,6 +840,20 @@ describe("App", () => {
     expect(screen.queryByLabelText(/email/i)).not.toBeInTheDocument();
   });
 
+  it("redirects protected routes to login when no local auth snapshot or readable csrf cookie exists", async () => {
+    window.history.replaceState({}, "", "/");
+    clearXsrfCookie();
+
+    await renderWithI18n(<App />);
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe("/login");
+    });
+
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(mockGetCurrentUser).not.toHaveBeenCalled();
+  });
+
   it("shows bootstrap recovery in place after protected-route session restore fails and allows retry", async () => {
     const recoveredUser = {
       id: "1",

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -117,6 +117,28 @@ function shouldTreatBootstrapFailureWithoutStoredUserAsLoggedOut(
   );
 }
 
+function createConfirmedBootstrapSessionError(error: unknown): Error {
+  const wrappedError =
+    error instanceof Error
+      ? error
+      : new Error("Persisting confirmed bootstrap session failed.");
+  Object.defineProperty(wrappedError, "__confirmedBootstrapSession", {
+    value: true,
+    configurable: true,
+  });
+  return wrappedError;
+}
+
+function isConfirmedBootstrapSessionError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "__confirmedBootstrapSession" in error &&
+    (error as { __confirmedBootstrapSession?: unknown })
+      .__confirmedBootstrapSession === true
+  );
+}
+
 function getBootstrapErrorCode(error: unknown): string | null {
   if (typeof error !== "object" || error === null || !("code" in error)) {
     return null;
@@ -911,6 +933,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const startBootstrapRevalidation = (
       clearSensitiveStateOnInvalidSession: boolean
     ) => {
+      const clearBootstrapToLoggedOutState = () => {
+        if (shouldResetPrefetchCacheAfterStorageMismatchRef.current) {
+          shouldResetPrefetchCacheAfterStorageMismatchRef.current = false;
+          resetPrefetchCache();
+        }
+        hasLogoutBarrierRef.current = false;
+        shouldSkipBarrierVaultTableCleanupRef.current = false;
+        setBootstrapRecoveryReason(null);
+        setUser(null);
+        setIsVaultLocked(false);
+        setIsLoading(false);
+        syncOfflineAuthState(false);
+      };
+
       const retryBootstrapAutomatically = () => {
         invalidateBootstrapRevalidation();
         hasAutomaticallyRetriedBootstrapRef.current = true;
@@ -956,7 +992,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             return;
           }
 
-          await persistAuthenticatedUser(currentUser);
+          try {
+            await persistAuthenticatedUser(currentUser);
+          } catch (error: unknown) {
+            throw createConfirmedBootstrapSessionError(error);
+          }
 
           if (hasLogoutBarrierRef.current || syncBarrierStateFromStorage()) {
             reconcileActiveBarrierState();
@@ -993,17 +1033,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
           if (isInvalidBootstrapSessionError(error)) {
             if (!clearSensitiveStateOnInvalidSession) {
-              if (shouldResetPrefetchCacheAfterStorageMismatchRef.current) {
-                shouldResetPrefetchCacheAfterStorageMismatchRef.current = false;
-                resetPrefetchCache();
-              }
-              hasLogoutBarrierRef.current = false;
-              shouldSkipBarrierVaultTableCleanupRef.current = false;
-              setBootstrapRecoveryReason(null);
-              setUser(null);
-              setIsVaultLocked(false);
-              setIsLoading(false);
-              syncOfflineAuthState(false);
+              clearBootstrapToLoggedOutState();
               return;
             }
 
@@ -1020,15 +1050,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           }
 
           if (
+            !isConfirmedBootstrapSessionError(error) &&
             shouldTreatBootstrapFailureWithoutStoredUserAsLoggedOut(
               clearSensitiveStateOnInvalidSession
             )
           ) {
-            setBootstrapRecoveryReason(null);
-            setUser(null);
-            setIsVaultLocked(false);
-            setIsLoading(false);
-            syncOfflineAuthState(false);
+            clearBootstrapToLoggedOutState();
             return;
           }
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -106,7 +106,7 @@ function shouldBootstrapBrowserSessionWithoutStoredUser(
     return false;
   }
 
-  return true;
+  return getCsrfTokenFromCookie() !== null;
 }
 
 function getBootstrapErrorCode(error: unknown): string | null {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -965,6 +965,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
 
         didTimeout = true;
+        if (
+          shouldTreatBootstrapFailureWithoutStoredUserAsLoggedOut(
+            clearSensitiveStateOnInvalidSession
+          )
+        ) {
+          clearBootstrapToLoggedOutState();
+          return;
+        }
+
         if (!hasAutomaticallyRetriedBootstrapRef.current) {
           retryBootstrapAutomatically();
           return;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -106,7 +106,15 @@ function shouldBootstrapBrowserSessionWithoutStoredUser(
     return false;
   }
 
-  return getCsrfTokenFromCookie() !== null;
+  return true;
+}
+
+function shouldTreatBootstrapFailureWithoutStoredUserAsLoggedOut(
+  clearSensitiveStateOnInvalidSession: boolean
+): boolean {
+  return (
+    !clearSensitiveStateOnInvalidSession && getCsrfTokenFromCookie() === null
+  );
 }
 
 function getBootstrapErrorCode(error: unknown): string | null {
@@ -1008,6 +1016,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           if (isOfflineBootstrapError(error)) {
             setIsLoading(false);
             setBootstrapRecoveryReason(null);
+            return;
+          }
+
+          if (
+            shouldTreatBootstrapFailureWithoutStoredUserAsLoggedOut(
+              clearSensitiveStateOnInvalidSession
+            )
+          ) {
+            setBootstrapRecoveryReason(null);
+            setUser(null);
+            setIsVaultLocked(false);
+            setIsLoading(false);
+            syncOfflineAuthState(false);
             return;
           }
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -970,6 +970,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             clearSensitiveStateOnInvalidSession
           )
         ) {
+          invalidateBootstrapRevalidation();
           clearBootstrapToLoggedOutState();
           return;
         }

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -356,6 +356,60 @@ describe("useAuth", () => {
     }
   });
 
+  it("ignores a late bootstrap success after timing out to logged out without a local snapshot or readable csrf cookie", async () => {
+    window.history.replaceState({}, "", "/");
+    clearCsrfTokenCookie();
+    const deferred = createDeferredPromise<{
+      id: number;
+      name: string;
+      email: string;
+    }>();
+    mockGetCurrentUser.mockImplementation(() => deferred.promise);
+    vi.useFakeTimers();
+
+    const { result, unmount } = renderHook(() => useAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    try {
+      await act(async () => {
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+          await Promise.resolve();
+        }
+      });
+
+      expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        vi.advanceTimersByTime(BOOTSTRAP_REVALIDATION_TIMEOUT_MS);
+        await Promise.resolve();
+      });
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.user).toBeNull();
+      expect(result.current.isAuthenticated).toBe(false);
+      expect(result.current.bootstrapRecoveryReason).toBeNull();
+
+      await act(async () => {
+        deferred.resolve({
+          id: 1,
+          name: "Late Bootstrap User",
+          email: "late-bootstrap@secpal.dev",
+        });
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+          await Promise.resolve();
+        }
+      });
+
+      expect(mockFetchCsrfToken).not.toHaveBeenCalled();
+      expect(result.current.user).toBeNull();
+      expect(result.current.isAuthenticated).toBe(false);
+      expect(result.current.bootstrapRecoveryReason).toBeNull();
+    } finally {
+      unmount();
+    }
+  });
+
   it("keeps confirmed browser sessions behind recovery UI when csrf refresh fails after /v1/me succeeds", async () => {
     window.history.replaceState({}, "", "/");
     clearCsrfTokenCookie();

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -317,6 +317,36 @@ describe("useAuth", () => {
     expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps confirmed browser sessions behind recovery UI when csrf refresh fails after /v1/me succeeds", async () => {
+    window.history.replaceState({}, "", "/");
+    clearCsrfTokenCookie();
+    mockGetCurrentUser.mockResolvedValue({
+      id: 1,
+      name: "Bootstrap User",
+      email: "bootstrap@secpal.dev",
+    });
+    mockFetchCsrfToken.mockRejectedValue(
+      new AuthApiError(
+        "CSRF refresh failed: Network down",
+        undefined,
+        undefined,
+        "NETWORK_ERROR"
+      )
+    );
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.bootstrapRecoveryReason).toBe("network");
+    });
+
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(mockGetCurrentUser).toHaveBeenCalledTimes(2);
+  });
+
   it("does not run sensitive logout cleanup when bootstrap revalidation finds no browser-session user", async () => {
     window.history.replaceState({}, "", "/");
     mockGetCurrentUser.mockRejectedValue(
@@ -3183,6 +3213,58 @@ describe("useAuth", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
+    expect(resetPrefetchCacheSpy).toHaveBeenCalledTimes(1);
+    expect(clearSensitiveClientState).not.toHaveBeenCalled();
+    expect(localStorage.getItem("auth_logout_barrier")).toBeNull();
+  });
+
+  it("resets the prefetch cache when cross-tab auth storage removal falls back to logged out after a no-csrf network failure", async () => {
+    window.history.replaceState({}, "", "/");
+    await persistAuthUser({
+      id: 1,
+      name: "Bootstrap User",
+      email: "bootstrap@secpal.dev",
+    });
+    const resetPrefetchCacheSpy = vi.spyOn(prefetch, "resetPrefetchCache");
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(true);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    clearCsrfTokenCookie();
+    mockGetCurrentUser.mockRejectedValueOnce(
+      new AuthApiError(
+        "Current user fetch failed: Failed to fetch",
+        undefined,
+        undefined,
+        "NETWORK_ERROR"
+      )
+    );
+
+    act(() => {
+      localStorage.removeItem(AUTH_VAULT_STORAGE_KEY);
+
+      const clearedStorageEvent = new Event("storage");
+      Object.defineProperties(clearedStorageEvent, {
+        key: { value: AUTH_VAULT_STORAGE_KEY },
+        oldValue: { value: "previous-vault-state" },
+        newValue: { value: null },
+        storageArea: { value: localStorage },
+      } satisfies Partial<Record<keyof StorageEventInit, PropertyDescriptor>>);
+      window.dispatchEvent(clearedStorageEvent);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(false);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.bootstrapRecoveryReason).toBeNull();
     expect(resetPrefetchCacheSpy).toHaveBeenCalledTimes(1);
     expect(clearSensitiveClientState).not.toHaveBeenCalled();
     expect(localStorage.getItem("auth_logout_barrier")).toBeNull();

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -274,7 +274,7 @@ describe("useAuth", () => {
     expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
   });
 
-  it("still bootstraps a protected browser-session route when the readable csrf cookie is missing", async () => {
+  it("skips protected-route browser-session bootstrap when no local auth snapshot or readable csrf cookie exists", async () => {
     window.history.replaceState({}, "", "/");
     clearCsrfTokenCookie();
 
@@ -282,13 +282,14 @@ describe("useAuth", () => {
       wrapper: AuthProvider,
     });
 
-    expect(result.current.isLoading).toBe(true);
-
     await waitFor(() => {
-      expect(result.current.isAuthenticated).toBe(true);
+      expect(result.current.isLoading).toBe(false);
     });
 
-    expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
+    expect(result.current.user).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.bootstrapRecoveryReason).toBeNull();
+    expect(mockGetCurrentUser).not.toHaveBeenCalled();
   });
 
   it("does not run sensitive logout cleanup when bootstrap revalidation finds no browser-session user", async () => {

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -317,6 +317,45 @@ describe("useAuth", () => {
     expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
   });
 
+  it("treats protected-route bootstrap timeouts without a local snapshot or readable csrf cookie as logged out", async () => {
+    window.history.replaceState({}, "", "/");
+    clearCsrfTokenCookie();
+    mockGetCurrentUser.mockImplementation(
+      () =>
+        new Promise(() => undefined) as ReturnType<typeof mockGetCurrentUser>
+    );
+    vi.useFakeTimers();
+
+    const { result, unmount } = renderHook(() => useAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    try {
+      expect(result.current.isLoading).toBe(true);
+
+      await act(async () => {
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+          await Promise.resolve();
+        }
+      });
+
+      expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        vi.advanceTimersByTime(BOOTSTRAP_REVALIDATION_TIMEOUT_MS);
+        await Promise.resolve();
+      });
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.user).toBeNull();
+      expect(result.current.isAuthenticated).toBe(false);
+      expect(result.current.bootstrapRecoveryReason).toBeNull();
+      expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
+    } finally {
+      unmount();
+    }
+  });
+
   it("keeps confirmed browser sessions behind recovery UI when csrf refresh fails after /v1/me succeeds", async () => {
     window.history.replaceState({}, "", "/");
     clearCsrfTokenCookie();

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -274,9 +274,34 @@ describe("useAuth", () => {
     expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
   });
 
-  it("skips protected-route browser-session bootstrap when no local auth snapshot or readable csrf cookie exists", async () => {
+  it("still bootstraps a protected browser-session route when the readable csrf cookie is missing", async () => {
     window.history.replaceState({}, "", "/");
     clearCsrfTokenCookie();
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(true);
+    });
+
+    expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats protected-route bootstrap failures without a local snapshot or readable csrf cookie as logged out", async () => {
+    window.history.replaceState({}, "", "/");
+    clearCsrfTokenCookie();
+    mockGetCurrentUser.mockRejectedValueOnce(
+      new AuthApiError(
+        "Current user fetch failed: Failed to fetch",
+        undefined,
+        undefined,
+        "NETWORK_ERROR"
+      )
+    );
 
     const { result } = renderHook(() => useAuth(), {
       wrapper: AuthProvider,
@@ -289,7 +314,7 @@ describe("useAuth", () => {
     expect(result.current.user).toBeNull();
     expect(result.current.isAuthenticated).toBe(false);
     expect(result.current.bootstrapRecoveryReason).toBeNull();
-    expect(mockGetCurrentUser).not.toHaveBeenCalled();
+    expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
   });
 
   it("does not run sensitive logout cleanup when bootstrap revalidation finds no browser-session user", async () => {

--- a/tests/unit/scripts/check-domains.test.ts
+++ b/tests/unit/scripts/check-domains.test.ts
@@ -102,6 +102,42 @@ describe("check-domains", () => {
     );
   });
 
+  it("rejects the asset key hostname when a query string follows it", () => {
+    const forbiddenHostname = ["secpal", "asset-load-recovery"].join(".");
+
+    const result = runDomainCheck([
+      {
+        path: "README.md",
+        contents: `Use ${forbiddenHostname}?debug=1 for diagnostics.\n`,
+      },
+    ]);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stdout + result.stderr).toContain(forbiddenHostname);
+    expect(result.stdout + result.stderr).toContain(
+      "Domain Policy Check FAILED"
+    );
+  });
+
+  it("rejects the asset key hostname when a fragment follows it", () => {
+    const forbiddenHostname = ["secpal", "asset-load-recovery"].join(".");
+
+    const result = runDomainCheck([
+      {
+        path: "README.md",
+        contents: `Use ${forbiddenHostname}#frag for diagnostics.\n`,
+      },
+    ]);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stdout + result.stderr).toContain(forbiddenHostname);
+    expect(result.stdout + result.stderr).toContain(
+      "Domain Policy Check FAILED"
+    );
+  });
+
   it("rejects forbidden secpal hostnames", () => {
     const result = runDomainCheck([
       {

--- a/tests/unit/scripts/check-domains.test.ts
+++ b/tests/unit/scripts/check-domains.test.ts
@@ -66,6 +66,19 @@ describe("check-domains", () => {
     expect(result.stdout).toContain("Domain Policy Check PASSED");
   });
 
+  it("accepts the storage key when it is the first token on a scanned line", () => {
+    const result = runDomainCheck([
+      {
+        path: "README.md",
+        contents: "secpal.asset-load-recovery\n",
+      },
+    ]);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+    expect(result.stdout).toContain("Domain Policy Check PASSED");
+  });
+
   it("rejects forbidden hostnames on lines that also mention the asset key", () => {
     const forbiddenHostname = ["status", "secpal", "io"].join(".");
 

--- a/tests/unit/scripts/check-domains.test.ts
+++ b/tests/unit/scripts/check-domains.test.ts
@@ -83,4 +83,22 @@ describe("check-domains", () => {
       "Domain Policy Check FAILED"
     );
   });
+
+  it("rejects forbidden secpal hostnames with punycode TLDs", () => {
+    const result = runDomainCheck([
+      {
+        path: "README.md",
+        contents: `Use https://${["status", "secpal", "xn--p1ai"].join(".")} for diagnostics.\n`,
+      },
+    ]);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stdout + result.stderr).toContain(
+      ["status", "secpal", "xn--p1ai"].join(".")
+    );
+    expect(result.stdout + result.stderr).toContain(
+      "Domain Policy Check FAILED"
+    );
+  });
 });

--- a/tests/unit/scripts/check-domains.test.ts
+++ b/tests/unit/scripts/check-domains.test.ts
@@ -79,24 +79,6 @@ describe("check-domains", () => {
     expect(result.stdout).toContain("Domain Policy Check PASSED");
   });
 
-  it("rejects the asset key hostname when it follows a scheme colon", () => {
-    const forbiddenHostname = ["secpal", "asset-load-recovery"].join(".");
-
-    const result = runDomainCheck([
-      {
-        path: "README.md",
-        contents: `Use http:${forbiddenHostname} for diagnostics.\n`,
-      },
-    ]);
-
-    expect(result.error).toBeUndefined();
-    expect(result.status).toBe(1);
-    expect(result.stdout + result.stderr).toContain(forbiddenHostname);
-    expect(result.stdout + result.stderr).toContain(
-      "Domain Policy Check FAILED"
-    );
-  });
-
   it("rejects forbidden hostnames on lines that also mention the asset key", () => {
     const forbiddenHostname = ["status", "secpal", "io"].join(".");
 
@@ -122,6 +104,42 @@ describe("check-domains", () => {
       {
         path: "README.md",
         contents: `Use https://${forbiddenHostname}/path for diagnostics.\n`,
+      },
+    ]);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stdout + result.stderr).toContain(forbiddenHostname);
+    expect(result.stdout + result.stderr).toContain(
+      "Domain Policy Check FAILED"
+    );
+  });
+
+  it("rejects the asset key when it follows a scheme colon", () => {
+    const forbiddenHostname = ["secpal", "asset-load-recovery"].join(".");
+
+    const result = runDomainCheck([
+      {
+        path: "README.md",
+        contents: `Use http:${forbiddenHostname} for diagnostics.\n`,
+      },
+    ]);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stdout + result.stderr).toContain(forbiddenHostname);
+    expect(result.stdout + result.stderr).toContain(
+      "Domain Policy Check FAILED"
+    );
+  });
+
+  it("rejects the asset key when it is used as an email domain", () => {
+    const forbiddenHostname = ["secpal", "asset-load-recovery"].join(".");
+
+    const result = runDomainCheck([
+      {
+        path: "README.md",
+        contents: `Contact admin@${forbiddenHostname} for diagnostics.\n`,
       },
     ]);
 

--- a/tests/unit/scripts/check-domains.test.ts
+++ b/tests/unit/scripts/check-domains.test.ts
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../.."
+);
+
+function runDomainCheck(
+  files: Array<{ path: string; contents: string }>
+): ReturnType<typeof spawnSync> {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "secpal-domains-"));
+
+  try {
+    mkdirSync(path.join(tempDir, "scripts"), { recursive: true });
+    writeFileSync(
+      path.join(tempDir, "scripts", "check-domains.sh"),
+      readFileSync(path.join(repoRoot, "scripts", "check-domains.sh"), "utf8")
+    );
+
+    for (const file of files) {
+      const fullPath = path.join(tempDir, file.path);
+      mkdirSync(path.dirname(fullPath), { recursive: true });
+      writeFileSync(fullPath, file.contents, "utf8");
+    }
+
+    return spawnSync("bash", ["scripts/check-domains.sh"], {
+      cwd: tempDir,
+      encoding: "utf8",
+    });
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+describe("check-domains", () => {
+  it("accepts secpal-prefixed storage keys that are not hostnames", () => {
+    const result = runDomainCheck([
+      {
+        path: "public/theme-color.js",
+        contents:
+          'var assetLoadRecoveryStorageKey = "secpal.asset-load-recovery";\n',
+      },
+      {
+        path: ".context/notes.md",
+        contents:
+          "`secpal.asset-load-recovery` is a local workspace storage key.\n",
+      },
+    ]);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+    expect(result.stdout).toContain("Domain Policy Check PASSED");
+  });
+
+  it("rejects forbidden secpal hostnames", () => {
+    const result = runDomainCheck([
+      {
+        path: "README.md",
+        contents: `Use https://${["status", "secpal", "io"].join(".")} for diagnostics.\n`,
+      },
+    ]);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stdout + result.stderr).toContain(
+      ["status", "secpal", "io"].join(".")
+    );
+    expect(result.stdout + result.stderr).toContain(
+      "Domain Policy Check FAILED"
+    );
+  });
+});

--- a/tests/unit/scripts/check-domains.test.ts
+++ b/tests/unit/scripts/check-domains.test.ts
@@ -84,6 +84,24 @@ describe("check-domains", () => {
     );
   });
 
+  it("rejects the asset key when it is used as a hostname", () => {
+    const forbiddenHostname = ["secpal", "asset-load-recovery"].join(".");
+
+    const result = runDomainCheck([
+      {
+        path: "README.md",
+        contents: `Use https://${forbiddenHostname}/path for diagnostics.\n`,
+      },
+    ]);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stdout + result.stderr).toContain(forbiddenHostname);
+    expect(result.stdout + result.stderr).toContain(
+      "Domain Policy Check FAILED"
+    );
+  });
+
   it("rejects forbidden secpal hostnames", () => {
     const result = runDomainCheck([
       {
@@ -169,6 +187,22 @@ describe("check-domains", () => {
     expect(result.stdout + result.stderr).toContain(
       ["api", "secpal", "dev-test"].join(".")
     );
+    expect(result.stdout + result.stderr).toContain(
+      "Domain Policy Check FAILED"
+    );
+  });
+
+  it("rejects forbidden secpal hostnames with one-character final labels", () => {
+    const result = runDomainCheck([
+      {
+        path: "README.md",
+        contents: `Use https://${["secpal", "x"].join(".")} for diagnostics.\n`,
+      },
+    ]);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stdout + result.stderr).toContain(["secpal", "x"].join("."));
     expect(result.stdout + result.stderr).toContain(
       "Domain Policy Check FAILED"
     );

--- a/tests/unit/scripts/check-domains.test.ts
+++ b/tests/unit/scripts/check-domains.test.ts
@@ -101,4 +101,22 @@ describe("check-domains", () => {
       "Domain Policy Check FAILED"
     );
   });
+
+  it("rejects forbidden secpal hostnames with digit-bearing final labels", () => {
+    const result = runDomainCheck([
+      {
+        path: "README.md",
+        contents: `Use https://${["api", "secpal", "dev2"].join(".")} for diagnostics.\n`,
+      },
+    ]);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stdout + result.stderr).toContain(
+      ["api", "secpal", "dev2"].join(".")
+    );
+    expect(result.stdout + result.stderr).toContain(
+      "Domain Policy Check FAILED"
+    );
+  });
 });

--- a/tests/unit/scripts/check-domains.test.ts
+++ b/tests/unit/scripts/check-domains.test.ts
@@ -151,6 +151,24 @@ describe("check-domains", () => {
     );
   });
 
+  it("rejects host labels that prefix the asset key with a hyphen", () => {
+    const forbiddenHostname = ["track-secpal", "asset-load-recovery"].join(".");
+
+    const result = runDomainCheck([
+      {
+        path: "README.md",
+        contents: `Use ${forbiddenHostname} for diagnostics.\n`,
+      },
+    ]);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stdout + result.stderr).toContain(forbiddenHostname);
+    expect(result.stdout + result.stderr).toContain(
+      "Domain Policy Check FAILED"
+    );
+  });
+
   it("rejects the asset key hostname when a query string follows it", () => {
     const forbiddenHostname = ["secpal", "asset-load-recovery"].join(".");
 

--- a/tests/unit/scripts/check-domains.test.ts
+++ b/tests/unit/scripts/check-domains.test.ts
@@ -119,4 +119,22 @@ describe("check-domains", () => {
       "Domain Policy Check FAILED"
     );
   });
+
+  it("rejects forbidden secpal hostnames with long ascii final labels", () => {
+    const result = runDomainCheck([
+      {
+        path: "README.md",
+        contents: `Use https://${["status", "secpal", "abcdefghijklmnopqrstuvwxyz"].join(".")} for diagnostics.\n`,
+      },
+    ]);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stdout + result.stderr).toContain(
+      ["status", "secpal", "abcdefghijklmnopqrstuvwxyz"].join(".")
+    );
+    expect(result.stdout + result.stderr).toContain(
+      "Domain Policy Check FAILED"
+    );
+  });
 });

--- a/tests/unit/scripts/check-domains.test.ts
+++ b/tests/unit/scripts/check-domains.test.ts
@@ -79,6 +79,24 @@ describe("check-domains", () => {
     expect(result.stdout).toContain("Domain Policy Check PASSED");
   });
 
+  it("rejects the asset key hostname when it follows a scheme colon", () => {
+    const forbiddenHostname = ["secpal", "asset-load-recovery"].join(".");
+
+    const result = runDomainCheck([
+      {
+        path: "README.md",
+        contents: `Use http:${forbiddenHostname} for diagnostics.\n`,
+      },
+    ]);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stdout + result.stderr).toContain(forbiddenHostname);
+    expect(result.stdout + result.stderr).toContain(
+      "Domain Policy Check FAILED"
+    );
+  });
+
   it("rejects forbidden hostnames on lines that also mention the asset key", () => {
     const forbiddenHostname = ["status", "secpal", "io"].join(".");
 

--- a/tests/unit/scripts/check-domains.test.ts
+++ b/tests/unit/scripts/check-domains.test.ts
@@ -137,4 +137,22 @@ describe("check-domains", () => {
       "Domain Policy Check FAILED"
     );
   });
+
+  it("rejects forbidden secpal hostnames with hyphenated final labels", () => {
+    const result = runDomainCheck([
+      {
+        path: "README.md",
+        contents: `Use https://${["api", "secpal", "dev-test"].join(".")} for diagnostics.\n`,
+      },
+    ]);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stdout + result.stderr).toContain(
+      ["api", "secpal", "dev-test"].join(".")
+    );
+    expect(result.stdout + result.stderr).toContain(
+      "Domain Policy Check FAILED"
+    );
+  });
 });

--- a/tests/unit/scripts/check-domains.test.ts
+++ b/tests/unit/scripts/check-domains.test.ts
@@ -66,6 +66,24 @@ describe("check-domains", () => {
     expect(result.stdout).toContain("Domain Policy Check PASSED");
   });
 
+  it("rejects forbidden hostnames on lines that also mention the asset key", () => {
+    const forbiddenHostname = ["status", "secpal", "io"].join(".");
+
+    const result = runDomainCheck([
+      {
+        path: "README.md",
+        contents: `Inline note: "secpal.asset-load-recovery" must not mask https://${forbiddenHostname}.\n`,
+      },
+    ]);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stdout + result.stderr).toContain(forbiddenHostname);
+    expect(result.stdout + result.stderr).toContain(
+      "Domain Policy Check FAILED"
+    );
+  });
+
   it("rejects forbidden secpal hostnames", () => {
     const result = runDomainCheck([
       {


### PR DESCRIPTION
## Reproduced defect

Protected browser-session routes still probed `/v1/me` when no encrypted auth snapshot and no readable CSRF cookie were present. In preview and logged-out browser sessions, that probe failed and left the route behind the bootstrap recovery UI instead of redirecting cleanly to `/login`.

## Current change

- require a readable CSRF cookie before opportunistic protected-route browser-session bootstrap runs without a stored auth snapshot
- add a `useAuth` regression test that proves the bootstrap now stops and leaves the session unauthenticated instead of probing `/v1/me`
- add an `App` regression test that proves protected routes redirect to `/login` instead of surfacing the recovery UI
- fix the local domain-policy preflight so it validates real hostnames instead of flagging `secpal.`-prefixed storage keys and `.context` workspace notes as forbidden domains
- add a regression test for the domain-policy checker so `secpal.asset-load-recovery` stays allowed while forbidden SecPal hostnames still fail the check
- document both fixes in `CHANGELOG.md`

## Validation

- `npm test -- --run src/hooks/useAuth.test.ts src/App.test.tsx tests/unit/scripts/check-domains.test.ts`
- `npm run typecheck`
- `npm run lint -- src/contexts/AuthContext.tsx src/hooks/useAuth.test.ts src/App.test.tsx tests/unit/scripts/check-domains.test.ts`
- `shellcheck scripts/check-domains.sh`
- `bash scripts/check-domains.sh`

## Linked work and follow-up

- Closes #1345.
- Linked workspaces: none required for this frontend-only change.
- Remaining before marking ready: final PR-view self-review must still find zero issues.
