### PR TITLE
Stabilize Android runtime cleanup test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Stabilized the Android instance-switch cleanup regression test by awaiting the
+  native runtime reset before checking asynchronous browser push cleanup, and
+  reset auth-storage mock history after test setup so cleanup assertions cannot
+  be satisfied by setup calls.
 - Clarified the `/source` description as the AGPL source offer for the SecPal
   components made available through the service.
 - Removed the redundant `AGPL v3+` link from every `Legal` menu; the `/source`

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -342,6 +342,7 @@ describe("App", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     await authStorage.clear();
+    mockAuthStorage.clear.mockClear();
     localStorage.clear();
     sessionStorage.clear();
     delete (globalThis as { SecPalNativeAuthBridge?: unknown })

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -824,10 +824,12 @@ describe("App", () => {
       );
 
       await waitFor(() => {
-        expect(unsubscribe).toHaveBeenCalled();
+        expect(bridge.clearRuntimeBootstrap).toHaveBeenCalledTimes(1);
       });
-      expect(bridge.clearRuntimeBootstrap).toHaveBeenCalledTimes(1);
-      expect(mockAuthStorage.clear).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(unsubscribe).toHaveBeenCalled();
+        expect(mockAuthStorage.clear).toHaveBeenCalled();
+      });
       expect(
         await screen.findByRole("heading", {
           name: /enter your instance url/i,

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -721,7 +721,7 @@ describe("App", () => {
     );
 
     await waitFor(() => {
-      expect(bridge.clearRuntimeBootstrap).toHaveBeenCalledTimes(1);
+      expect(bridge.clearRuntimeBootstrap).toHaveBeenCalled();
     });
     expect(mockAuthStorage.clear).toHaveBeenCalled();
     expect(localStorage.getItem("auth_token")).toBeNull();
@@ -730,6 +730,7 @@ describe("App", () => {
     expect(
       await screen.findByRole("heading", { name: /enter your instance url/i })
     ).toBeInTheDocument();
+    expect(bridge.clearRuntimeBootstrap).toHaveBeenCalledTimes(1);
   });
 
   it("best-effort revokes the native session before switching Android instances", async () => {
@@ -781,7 +782,7 @@ describe("App", () => {
     );
 
     await waitFor(() => {
-      expect(bridge.clearRuntimeBootstrap).toHaveBeenCalledTimes(1);
+      expect(bridge.clearRuntimeBootstrap).toHaveBeenCalled();
     });
     expect(mockAuthStorage.clear).toHaveBeenCalled();
     expect(localStorage.getItem("auth_token")).toBeNull();
@@ -791,6 +792,7 @@ describe("App", () => {
         name: /enter your instance url/i,
       })
     ).toBeInTheDocument();
+    expect(bridge.clearRuntimeBootstrap).toHaveBeenCalledTimes(1);
   });
 
   it("clears configured Android runtime even when push cleanup observes a registration conflict", async () => {
@@ -825,7 +827,7 @@ describe("App", () => {
       );
 
       await waitFor(() => {
-        expect(bridge.clearRuntimeBootstrap).toHaveBeenCalledTimes(1);
+        expect(bridge.clearRuntimeBootstrap).toHaveBeenCalled();
       });
       await waitFor(() => {
         expect(unsubscribe).toHaveBeenCalled();
@@ -836,6 +838,7 @@ describe("App", () => {
           name: /enter your instance url/i,
         })
       ).toBeInTheDocument();
+      expect(bridge.clearRuntimeBootstrap).toHaveBeenCalledTimes(1);
     } finally {
       if (serviceWorkerDescriptor) {
         Object.defineProperty(


### PR DESCRIPTION
## Reproduced failure

`npm run test:ci` intermittently failed `src/App.test.tsx > clears configured Android runtime even when push cleanup observes a registration conflict`, while the isolated test passed.

## Change

- Wait for the Android runtime bootstrap clear triggered by the instance switch before asserting the best-effort push cleanup.
- Keep the push cleanup assertion tolerant of delayed cleanup started by earlier test cases.

Closes #1358.

## Validation

- `npx vitest run src/App.test.tsx -t "clears configured Android runtime even when push cleanup observes a registration conflict" --bail=1`
- `npx vitest run src/App.test.tsx --bail=1`
- `npm run test:ci`
- `npm run typecheck`
- `npm run lint -- --no-cache`
- Push preflight: formatting, lint, domain-policy checks, and affected Vitest tests

## Follow-up before ready

- No linked workspace changes or unresolved code checks.
- Complete CI and the final self-review in the PR view before marking this draft ready.
