### PR TITLE
Fix sidebar default on tablet screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Kept the regular sidebar collapsed by default below the 1440 px breakpoint
+  so narrow landscape screens retain their available content space while
+  preserving each user's saved sidebar preference.
 - Stabilized the Android instance-switch cleanup regression test by awaiting the
   native runtime reset before checking asynchronous browser push cleanup, and
   reset auth-storage mock history after test setup so cleanup assertions cannot

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -216,7 +216,7 @@ describe("ApplicationLayout", () => {
     clearSidebarStateCookie();
     Object.defineProperty(window, "innerWidth", {
       configurable: true,
-      value: 1024,
+      value: 1440,
     });
     i18n.load("en", {});
     i18n.activate("en");

--- a/src/ui/sidebar.tsx
+++ b/src/ui/sidebar.tsx
@@ -36,6 +36,19 @@ const SIDEBAR_WIDTH = "16rem";
 const SIDEBAR_WIDTH_MOBILE = "18rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";
+const SIDEBAR_DEFAULT_OPEN_MEDIA_QUERY = "(min-width: 90rem)";
+
+function getDefaultSidebarOpen(): boolean {
+  if (typeof window === "undefined") {
+    return true;
+  }
+
+  if (typeof window.matchMedia === "function") {
+    return window.matchMedia(SIDEBAR_DEFAULT_OPEN_MEDIA_QUERY).matches;
+  }
+
+  return window.innerWidth >= 1440;
+}
 
 function getSidebarOpenFromCookie(defaultOpen: boolean): boolean {
   if (typeof document === "undefined") {
@@ -88,7 +101,7 @@ export function useSidebar() {
 }
 
 export function SidebarProvider({
-  defaultOpen = true,
+  defaultOpen: defaultOpenProp,
   open: openProp,
   onOpenChange: setOpenProp,
   className,
@@ -101,6 +114,7 @@ export function SidebarProvider({
   onOpenChange?: (open: boolean) => void;
 }) {
   const isMobile = useIsMobile();
+  const defaultOpen = defaultOpenProp ?? getDefaultSidebarOpen();
   const [openMobile, setOpenMobile] = React.useState(false);
   const [uncontrolledOpen, setUncontrolledOpen] = React.useState(() =>
     getSidebarOpenFromCookie(defaultOpen)

--- a/src/ui/ui.test.tsx
+++ b/src/ui/ui.test.tsx
@@ -129,6 +129,47 @@ describe("shared shadcn/radix UI basis", () => {
     expect(matchMedia).toHaveBeenCalledWith("(min-width: 90rem)");
   });
 
+  it("keeps the sidebar expanded by default at the desktop breakpoint", () => {
+    const matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query === "(min-width: 90rem)",
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }));
+    vi.stubGlobal("matchMedia", matchMedia);
+
+    const { container } = render(
+      <SidebarProvider>
+        <Sidebar>
+          <SidebarHeader>Navigation</SidebarHeader>
+        </Sidebar>
+      </SidebarProvider>
+    );
+
+    expect(container.querySelector('[data-slot="sidebar"]')).toHaveAttribute(
+      "data-state",
+      "expanded"
+    );
+    expect(matchMedia).toHaveBeenCalledWith("(min-width: 90rem)");
+  });
+
+  it("uses the viewport width when matchMedia is unavailable", () => {
+    vi.stubGlobal("matchMedia", undefined);
+    vi.stubGlobal("innerWidth", 1440);
+
+    const { container } = render(
+      <SidebarProvider>
+        <Sidebar>
+          <SidebarHeader>Navigation</SidebarHeader>
+        </Sidebar>
+      </SidebarProvider>
+    );
+
+    expect(container.querySelector('[data-slot="sidebar"]')).toHaveAttribute(
+      "data-state",
+      "expanded"
+    );
+  });
+
   it("uses canonical shadcn slots and theme-token classes across core primitives", () => {
     const { container } = render(
       <div>

--- a/src/ui/ui.test.tsx
+++ b/src/ui/ui.test.tsx
@@ -77,6 +77,58 @@ import {
 } from ".";
 
 describe("shared shadcn/radix UI basis", () => {
+  it("restores a saved open sidebar preference below the desktop default breakpoint", () => {
+    const matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    vi.stubGlobal("matchMedia", matchMedia);
+    document.cookie = "sidebar_state=true; path=/";
+
+    try {
+      const { container } = render(
+        <SidebarProvider>
+          <Sidebar>
+            <SidebarHeader>Navigation</SidebarHeader>
+          </Sidebar>
+        </SidebarProvider>
+      );
+
+      expect(container.querySelector('[data-slot="sidebar"]')).toHaveAttribute(
+        "data-state",
+        "expanded"
+      );
+      expect(matchMedia).toHaveBeenCalledWith("(min-width: 90rem)");
+    } finally {
+      document.cookie =
+        "sidebar_state=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/";
+    }
+  });
+
+  it("keeps the sidebar collapsed by default below the desktop breakpoint", () => {
+    const matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    vi.stubGlobal("matchMedia", matchMedia);
+
+    const { container } = render(
+      <SidebarProvider>
+        <Sidebar>
+          <SidebarHeader>Navigation</SidebarHeader>
+        </Sidebar>
+      </SidebarProvider>
+    );
+
+    expect(container.querySelector('[data-slot="sidebar"]')).toHaveAttribute(
+      "data-state",
+      "collapsed"
+    );
+    expect(matchMedia).toHaveBeenCalledWith("(min-width: 90rem)");
+  });
+
   it("uses canonical shadcn slots and theme-token classes across core primitives", () => {
     const { container } = render(
       <div>


### PR DESCRIPTION
## Evidence

The sidebar initialized as expanded at tablet landscape widths because the shared provider defaulted to open whenever no `sidebar_state` cookie was present. The focused regression test first failed when it required a collapsed initial state below the desktop breakpoint.

## Summary

- Default the sidebar to collapsed below 1440 px when no saved preference exists.
- Preserve a saved sidebar preference at every viewport width.
- Update the desktop layout test fixture and changelog entry for the new responsive default.

## Validation

- `npm test -- --run src/ui/ui.test.tsx src/components/application-layout.test.tsx` (74 tests passed)
- `npm run typecheck`
- `npm run lint`
- `npx prettier --check --cache '**/*.{md,yml,yaml,json,ts,tsx,js,jsx}'`
- Push preflight: formatting, Markdown lint, domain policy, lint, and typecheck

## Follow-up before ready

No linked workspaces or unresolved local checks. Keep this PR as a draft until CI and final PR-view self-review complete.
