### PR TITLE
Fix document language initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Updated the document language when the selected application locale changes,
-  preventing browsers from offering to translate German content as English.
+- Updated the document language during bootstrap and when the selected
+  application locale changes, preventing browsers from offering to translate
+  German content as English and ensuring locale bootstrap updates are not
+  served from stale server or service-worker caches.
 - Kept the regular sidebar collapsed by default below the 1440 px breakpoint
   so narrow landscape screens retain their available content space while
   preserving each user's saved sidebar preference.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Updated the document language when the selected application locale changes,
+  preventing browsers from offering to translate German content as English.
 - Kept the regular sidebar collapsed by default below the 1440 px breakpoint
   so narrow landscape screens retain their available content space while
   preserving each user's saved sidebar preference.

--- a/deploy/nginx/app.secpal.dev.conf
+++ b/deploy/nginx/app.secpal.dev.conf
@@ -169,6 +169,22 @@ server {
     try_files $uri =404;
   }
 
+  location = /document-language.js {
+    add_header Content-Security-Policy $secpal_csp always;
+    add_header Permissions-Policy $secpal_permissions_policy always;
+    add_header Strict-Transport-Security $secpal_hsts always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "0" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    add_header Cross-Origin-Resource-Policy "same-origin" always;
+    add_header Origin-Agent-Cluster "?1" always;
+    add_header X-Permitted-Cross-Domain-Policies "none" always;
+    add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+    try_files $uri =404;
+  }
+
   location / {
     try_files $uri $uri/ /index.html;
   }

--- a/docs/deployment-spa-routing.md
+++ b/docs/deployment-spa-routing.md
@@ -30,7 +30,7 @@ It also now carries the baseline browser hardening for the shipped PWA:
 - enforcing a production CSP without inline scripts
 - explicitly denying unused browser capabilities via `Permissions-Policy`
 - setting `COOP` / `CORP` and related response headers consistently
-- keeping `index.html`, `sw.js`, `manifest.webmanifest`, and `theme-color.js` on short cache rules so security and PWA updates land quickly
+- keeping `index.html`, `sw.js`, `manifest.webmanifest`, `theme-color.js`, and `document-language.js` on short cache rules so security, locale, and PWA updates land quickly
 
 **File:** `public/.htaccess`
 
@@ -95,7 +95,7 @@ The file already covers:
 - the production CSP and `Permissions-Policy`
 - `Strict-Transport-Security`, `Referrer-Policy`, and framing protection
 - explicit `404` handling for `/v1/*`, `/sanctum/*`, and `/health*`
-- exact-match delivery rules for `/`, `/index.html`, `/sw.js`, `/manifest.webmanifest`, and `/theme-color.js`
+- exact-match delivery rules for `/`, `/index.html`, `/sw.js`, `/manifest.webmanifest`, `/theme-color.js`, and `/document-language.js`
 - the manifest MIME fix (`application/manifest+json`) and update-safe cache headers
 
 Use this file as your site config or merge its contents into the live server block:
@@ -330,7 +330,7 @@ Before deploying to production:
 - ✅ `/source-offer.json` publishes immutable corresponding-source URLs for the deployed `frontend` / `contracts` set, with optional `android`
 - ✅ `GET /v1/release` publishes the immutable corresponding-source URL for the deployed `api`
 - ✅ CSP, permissions, and modern cross-origin headers enabled
-- ✅ `index.html`, `sw.js`, `manifest.webmanifest`, `/theme-color.js`, and `/source-offer.json` use short cache rules
+- ✅ `index.html`, `sw.js`, `manifest.webmanifest`, `/theme-color.js`, `/document-language.js`, and `/source-offer.json` use short cache rules
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -66,6 +66,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
       name="description"
       content="SecPal is workforce operations software for private security teams, with secure browser access, onboarding, staffing, and field operations workflows."
     />
+    <script src="/document-language.js"></script>
     <script src="/theme-color.js"></script>
     <title>SecPal</title>
   </head>

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -62,9 +62,9 @@
   Header always set Origin-Agent-Cluster "?1"
   Header always set X-Permitted-Cross-Domain-Policies "none"
 
-  # Keep the HTML shell, recovery bootstrap, service worker, and manifest fresh
-  # so security and PWA updates activate quickly instead of sitting behind
-  # intermediary caches.
+  # Keep the HTML shell, early bootstraps, service worker, and manifest fresh
+  # so security, locale, and PWA updates activate quickly instead of sitting
+  # behind intermediary caches.
   <Files "index.html">
     Header always set Cache-Control "no-cache, no-store, must-revalidate"
   </Files>
@@ -83,6 +83,10 @@
   </Files>
 
   <Files "theme-color.js">
+    Header always set Cache-Control "no-cache, no-store, must-revalidate"
+  </Files>
+
+  <Files "document-language.js">
     Header always set Cache-Control "no-cache, no-store, must-revalidate"
   </Files>
 </IfModule>

--- a/public/document-language.js
+++ b/public/document-language.js
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+(function () {
+  var locale = "en";
+
+  try {
+    var storedLocale = window.localStorage.getItem("secpal-locale");
+    if (storedLocale === "de" || storedLocale === "en") {
+      locale = storedLocale;
+    } else if (navigator.language.split("-")[0] === "de") {
+      locale = "de";
+    }
+  } catch {
+    if (navigator.language.split("-")[0] === "de") {
+      locale = "de";
+    }
+  }
+
+  document.documentElement.lang = locale;
+})();

--- a/public/document-language.js
+++ b/public/document-language.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 (function () {
-  var locale = "en";
+  var locale;
 
   function getBrowserLocale() {
     try {

--- a/public/document-language.js
+++ b/public/document-language.js
@@ -4,17 +4,23 @@
 (function () {
   var locale = "en";
 
+  function getBrowserLocale() {
+    try {
+      return navigator.language.split("-")[0] === "de" ? "de" : "en";
+    } catch {
+      return "en";
+    }
+  }
+
   try {
     var storedLocale = window.localStorage.getItem("secpal-locale");
     if (storedLocale === "de" || storedLocale === "en") {
       locale = storedLocale;
-    } else if (navigator.language.split("-")[0] === "de") {
-      locale = "de";
+    } else {
+      locale = getBrowserLocale();
     }
   } catch {
-    if (navigator.language.split("-")[0] === "de") {
-      locale = "de";
-    }
+    locale = getBrowserLocale();
   }
 
   document.documentElement.lang = locale;

--- a/src/i18n.test.ts
+++ b/src/i18n.test.ts
@@ -3,9 +3,13 @@
 
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { i18n } from "@lingui/core";
-import { activateLocale, defaultLocale } from "./i18n";
+import { activateLocale, defaultLocale, initializeLocale } from "./i18n";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("i18n catalog loading", () => {
   it("keeps locale catalog loading on a single static path", async () => {
@@ -31,5 +35,22 @@ describe("i18n catalog loading", () => {
 
     await activateLocale("unsupported");
     expect(document.documentElement).toHaveAttribute("lang", defaultLocale);
+  });
+
+  it("reports locale activation failures during initialization", () => {
+    const error = new Error("catalog activation failed");
+    vi.spyOn(i18n, "load").mockImplementationOnce(() => {
+      throw error;
+    });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    initializeLocale();
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to initialize i18n locale:",
+      error
+    );
   });
 });

--- a/src/i18n.test.ts
+++ b/src/i18n.test.ts
@@ -24,4 +24,12 @@ describe("i18n catalog loading", () => {
     await activateLocale("unsupported");
     expect(i18n.locale).toBe(defaultLocale);
   });
+
+  it("keeps the document language in sync with the active locale", async () => {
+    await activateLocale("de");
+    expect(document.documentElement).toHaveAttribute("lang", "de");
+
+    await activateLocale("unsupported");
+    expect(document.documentElement).toHaveAttribute("lang", defaultLocale);
+  });
 });

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 import { i18n } from "@lingui/core";
@@ -27,6 +27,10 @@ export async function activateLocale(locale: string) {
     locale in locales ? (locale as Locale) : defaultLocale;
   i18n.load(selectedLocale, localeMessages[selectedLocale]);
   i18n.activate(selectedLocale);
+
+  if (typeof document !== "undefined") {
+    document.documentElement.lang = selectedLocale;
+  }
 }
 
 // Detect locale from browser or localStorage
@@ -58,6 +62,14 @@ export function detectLocale(): string {
   }
 
   return defaultLocale;
+}
+
+export function initializeLocale(): void {
+  try {
+    void activateLocale(detectLocale());
+  } catch (error) {
+    console.error("Failed to initialize i18n locale:", error);
+  }
 }
 
 // Save locale preference

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -22,7 +22,7 @@ const localeMessages = {
 i18n.load(defaultLocale, localeMessages[defaultLocale]);
 i18n.activate(defaultLocale);
 
-export async function activateLocale(locale: string) {
+export function activateLocale(locale: string): void {
   const selectedLocale: Locale =
     locale in locales ? (locale as Locale) : defaultLocale;
   i18n.load(selectedLocale, localeMessages[selectedLocale]);

--- a/src/main.test.tsx
+++ b/src/main.test.tsx
@@ -124,20 +124,32 @@ describe("system color scheme sync", () => {
   });
 
   it("sets the document language from the detected browser locale before rendering", () => {
-    const originalLanguage = navigator.language;
+    const originalLanguageDescriptor = Object.getOwnPropertyDescriptor(
+      navigator,
+      "language"
+    );
+    const originalDocumentLanguage = document.documentElement.lang;
     Object.defineProperty(navigator, "language", {
       configurable: true,
       value: "de-DE",
     });
     localStorage.removeItem("secpal-locale");
 
-    initializeLocale();
+    try {
+      initializeLocale();
 
-    expect(document.documentElement).toHaveAttribute("lang", "de");
-
-    Object.defineProperty(navigator, "language", {
-      configurable: true,
-      value: originalLanguage,
-    });
+      expect(document.documentElement).toHaveAttribute("lang", "de");
+    } finally {
+      if (originalLanguageDescriptor) {
+        Object.defineProperty(
+          navigator,
+          "language",
+          originalLanguageDescriptor
+        );
+      } else {
+        Reflect.deleteProperty(navigator, "language");
+      }
+      document.documentElement.lang = originalDocumentLanguage;
+    }
   });
 });

--- a/src/main.test.tsx
+++ b/src/main.test.tsx
@@ -7,6 +7,7 @@ import {
   syncSystemColorScheme,
 } from "./lib/systemColorScheme";
 import { AppWithI18n } from "./main";
+import { initializeLocale } from "./i18n";
 import { render, waitFor } from "@testing-library/react";
 
 function createMatchMediaStub(initialMatches: boolean) {
@@ -119,6 +120,24 @@ describe("system color scheme sync", () => {
 
     await waitFor(() => {
       expect(bootstrapReadyListener).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("sets the document language from the detected browser locale before rendering", () => {
+    const originalLanguage = navigator.language;
+    Object.defineProperty(navigator, "language", {
+      configurable: true,
+      value: "de-DE",
+    });
+    localStorage.removeItem("secpal-locale");
+
+    initializeLocale();
+
+    expect(document.documentElement).toHaveAttribute("lang", "de");
+
+    Object.defineProperty(navigator, "language", {
+      configurable: true,
+      value: originalLanguage,
     });
   });
 });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,7 @@ import { createRoot } from "react-dom/client";
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
 import App from "./App";
-import { activateLocale, detectLocale } from "./i18n";
+import { initializeLocale } from "./i18n";
 import { RuntimeStyleCspSupport } from "./lib/RuntimeStyleCspSupport";
 import {
   installSystemColorSchemeSync,
@@ -16,18 +16,6 @@ import { initWebVitals } from "./lib/webVitals";
 import "./index.css";
 
 export function AppWithI18n() {
-  useEffect(() => {
-    const initLocale = async () => {
-      try {
-        const locale = detectLocale();
-        await activateLocale(locale);
-      } catch (err) {
-        console.error("Failed to initialize i18n locale:", err);
-      }
-    };
-    initLocale();
-  }, []);
-
   useEffect(() => installSystemColorSchemeSync(), []);
 
   useEffect(() => {
@@ -50,6 +38,7 @@ if (typeof window !== "undefined" && !isTest) {
     throw new Error("Root element not found");
   }
 
+  initializeLocale();
   syncSystemColorScheme();
 
   // Cache root instance to avoid HMR warning

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -73,6 +73,7 @@ function isCacheableStaticAssetRequest(request: Request): boolean {
 
   return (
     pathname !== "/theme-color.js" &&
+    pathname !== "/document-language.js" &&
     (request.destination === "image" ||
       request.destination === "style" ||
       request.destination === "script" ||

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -508,7 +508,7 @@ describe("Build Configuration and Source Verification", () => {
       'globPatterns: ["**/*.{js,css,ico,png,svg,woff,woff2}"]'
     );
     expect(viteConfig).toContain(
-      'globIgnores: ["**/*.html", "theme-color.js"]'
+      'globIgnores: ["**/*.html", "theme-color.js", "document-language.js"]'
     );
     expect(viteConfig).toContain("navigateFallback: null");
     expect(viteConfig).toContain("nonceBearingHtmlShellPattern");
@@ -528,13 +528,15 @@ describe("Build Configuration and Source Verification", () => {
     );
   });
 
-  it("keeps the recovery bootstrap out of service-worker caches", () => {
+  it("keeps early bootstrap scripts out of service-worker caches", () => {
     const serviceWorker = readRepoFile("src/sw.ts");
     const viteConfig = readRepoFile("vite.config.ts");
 
     expect(viteConfig).toContain('"theme-color.js"');
+    expect(viteConfig).toContain('"document-language.js"');
     expect(serviceWorker).toContain("isCacheableStaticAssetRequest");
     expect(serviceWorker).toContain('pathname !== "/theme-color.js"');
+    expect(serviceWorker).toContain('pathname !== "/document-language.js"');
   });
 
   it("uses an external theme-color bootstrap so CSP can block inline scripts", () => {
@@ -588,6 +590,7 @@ describe("Build Configuration and Source Verification", () => {
     expect(htaccess).toContain('Files "source-offer.json"');
     expect(htaccess).toContain('Cache-Control "no-cache, must-revalidate"');
     expect(htaccess).toContain('Files "theme-color.js"');
+    expect(htaccess).toContain('Files "document-language.js"');
     expect(htaccess).toContain(
       'Cache-Control "no-cache, no-store, must-revalidate"'
     );
@@ -598,6 +601,7 @@ describe("Build Configuration and Source Verification", () => {
     expect(nginxConfig).toContain("location = /manifest.webmanifest");
     expect(nginxConfig).toContain("location = /source-offer.json");
     expect(nginxConfig).toContain("location = /theme-color.js");
+    expect(nginxConfig).toContain("location = /document-language.js");
     expect(nginxConfig).toContain("default_type application/json");
   });
 

--- a/tests/document-language-bootstrap.test.ts
+++ b/tests/document-language-bootstrap.test.ts
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { defaultLocale, locales } from "../src/i18n";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const bootstrapSource = readFileSync(
+  path.join(repoRoot, "public/document-language.js"),
+  "utf8"
+);
+const runBootstrap = new Function(
+  "window",
+  "navigator",
+  "document",
+  bootstrapSource
+);
+
+function executeBootstrap({
+  browserLanguage = "en-US",
+  storedLocale = null,
+  storageError,
+  languageError,
+}: {
+  browserLanguage?: string;
+  storedLocale?: string | null;
+  storageError?: Error;
+  languageError?: Error;
+} = {}) {
+  const documentElement = { lang: "" };
+  const localStorage = {
+    getItem() {
+      if (storageError) {
+        throw storageError;
+      }
+      return storedLocale;
+    },
+  };
+  const navigator = {
+    get language() {
+      if (languageError) {
+        throw languageError;
+      }
+      return browserLanguage;
+    },
+  };
+
+  runBootstrap({ localStorage }, navigator, { documentElement });
+
+  return documentElement.lang;
+}
+
+describe("document language bootstrap", () => {
+  it("supports every application locale and uses the shared default", () => {
+    for (const locale of Object.keys(locales)) {
+      expect(executeBootstrap({ storedLocale: locale })).toBe(locale);
+    }
+
+    expect(executeBootstrap({ browserLanguage: "unsupported" })).toBe(
+      defaultLocale
+    );
+  });
+
+  it("prefers a supported saved locale over the browser locale", () => {
+    expect(
+      executeBootstrap({ storedLocale: "de", browserLanguage: "en-US" })
+    ).toBe("de");
+  });
+
+  it("uses the supported browser locale when no valid preference exists", () => {
+    expect(
+      executeBootstrap({
+        storedLocale: "unsupported",
+        browserLanguage: "de-DE",
+      })
+    ).toBe("de");
+  });
+
+  it("uses the browser locale when storage is unavailable", () => {
+    expect(
+      executeBootstrap({
+        browserLanguage: "de-DE",
+        storageError: new Error("storage unavailable"),
+      })
+    ).toBe("de");
+  });
+
+  it("keeps the default locale when browser detection is unavailable", () => {
+    expect(() =>
+      executeBootstrap({
+        storageError: new Error("storage unavailable"),
+        languageError: new Error("language unavailable"),
+      })
+    ).not.toThrow();
+    expect(
+      executeBootstrap({ languageError: new Error("language unavailable") })
+    ).toBe("en");
+  });
+
+  it("loads before the application bootstrap", () => {
+    const indexHtml = readFileSync(path.join(repoRoot, "index.html"), "utf8");
+
+    expect(indexHtml.indexOf("/document-language.js")).toBeGreaterThan(-1);
+    expect(indexHtml.indexOf("/document-language.js")).toBeLessThan(
+      indexHtml.indexOf("/src/main.tsx")
+    );
+  });
+});

--- a/tests/document-language-bootstrap.test.ts
+++ b/tests/document-language-bootstrap.test.ts
@@ -96,7 +96,7 @@ describe("document language bootstrap", () => {
     ).not.toThrow();
     expect(
       executeBootstrap({ languageError: new Error("language unavailable") })
-    ).toBe("en");
+    ).toBe(defaultLocale);
   });
 
   it("loads before the application bootstrap", () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -225,7 +225,7 @@ export default defineConfig(({ mode, command }) => {
         },
         injectManifest: {
           globPatterns: ["**/*.{js,css,ico,png,svg,woff,woff2}"],
-          globIgnores: ["**/*.html", "theme-color.js"],
+          globIgnores: ["**/*.html", "theme-color.js", "document-language.js"],
           manifestTransforms: [
             async (entries) => ({
               manifest: entries.filter(
@@ -285,7 +285,7 @@ export default defineConfig(({ mode, command }) => {
         },
         workbox: {
           globPatterns: ["**/*.{js,css,ico,png,svg,woff,woff2}"],
-          globIgnores: ["**/*.html", "theme-color.js"],
+          globIgnores: ["**/*.html", "theme-color.js", "document-language.js"],
           navigateFallback: null,
           cleanupOutdatedCaches: true,
           runtimeCaching: buildPwaRuntimeCaching(),


### PR DESCRIPTION
## Defect reproduced

The regression test in `src/i18n.test.ts` first failed because activating German left the document root without `lang="de"`. Initial locale detection also ran from a React effect after the first render, leaving the static `lang="en"` value visible during bootstrap.

## Summary

- Set the document language in the shared locale activation path so manual language changes update it immediately.
- Load a small external head script before the application module to apply the stored or detected browser locale before React renders.
- Move locale initialization ahead of `root.render` and add coverage for browser-language detection.
- Record the user-visible fix in `CHANGELOG.md`.

## Validation

- `npm test -- --run src/i18n.test.ts src/main.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `reuse lint`
- `npm run build`
- `git diff --check`

## Follow-up before ready

- The full Vitest pre-push check is still running. Confirm its result and complete the final PR-view self-review before marking this draft ready.
- No linked workspaces were used. No additional follow-up items were identified.
