### PR TITLE
Preserve bundled dependency license notices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Release artifacts now include a deterministic third-party dependency notice
+  bundle generated from their actual JavaScript and copied-asset module graph.
+  It preserves package-specific notices and license texts, including Inter's
+  OFL-1.1 notice, while retaining the existing shadcn MIT notice files.
 - Audited third-party licensing and REUSE metadata: removed stale CC0 Lingui
   generated-output annotations that conflicted with the checked-in catalog
   sidecars, documented the verified shadcn provenance and dependency inventory

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -147,6 +147,7 @@ describe("Build Configuration and Source Verification", () => {
         "utf8"
       );
       expect(dependencyNotices).toContain("@fontsource/inter");
+      expect(dependencyNotices).toContain("## tailwindcss@");
       expect(dependencyNotices).toContain("SIL Open Font License");
       expect(dependencyNotices).toContain(
         "Copyright 2016 The Inter Project Authors"

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -139,6 +139,33 @@ describe("Build Configuration and Source Verification", () => {
       expect(existsSync(path.join(distRoot, "dependencies.spdx.json"))).toBe(
         true
       );
+      expect(
+        existsSync(path.join(distRoot, "THIRD-PARTY-DEPENDENCY-NOTICES.md"))
+      ).toBe(true);
+      const dependencyNotices = readFileSync(
+        path.join(distRoot, "THIRD-PARTY-DEPENDENCY-NOTICES.md"),
+        "utf8"
+      );
+      expect(dependencyNotices).toContain("@fontsource/inter");
+      expect(dependencyNotices).toContain("SIL Open Font License");
+      expect(dependencyNotices).toContain(
+        "Copyright 2016 The Inter Project Authors"
+      );
+      for (const workboxPackage of [
+        "workbox-core",
+        "workbox-precaching",
+        "workbox-routing",
+        "workbox-strategies",
+      ]) {
+        expect(dependencyNotices).toContain(`## ${workboxPackage}@`);
+      }
+      expect(readFileSync(path.join(distRoot, "sw.js"), "utf8")).toContain(
+        "THIRD-PARTY-DEPENDENCY-NOTICES.md"
+      );
+      expect(existsSync(path.join(distRoot, "THIRD-PARTY-NOTICES.md"))).toBe(
+        true
+      );
+      expect(existsSync(path.join(distRoot, "LICENSES/MIT.txt"))).toBe(true);
       expect(readFileSync(path.join(distRoot, "index.html"), "utf8")).toContain(
         'src="/custom/'
       );
@@ -505,7 +532,7 @@ describe("Build Configuration and Source Verification", () => {
       "<!--#echo var='csp_nonce' encoding='none' -->"
     );
     expect(viteConfig).toContain(
-      'globPatterns: ["**/*.{js,css,ico,png,svg,woff,woff2}"]'
+      'globPatterns: ["**/*.{js,css,ico,png,svg,woff,woff2,md}"]'
     );
     expect(viteConfig).toContain(
       'globIgnores: ["**/*.html", "theme-color.js", "document-language.js"]'

--- a/thirdPartyDependencyNotices.test.ts
+++ b/thirdPartyDependencyNotices.test.ts
@@ -101,6 +101,25 @@ describe("createThirdPartyDependencyNotice", () => {
       createThirdPartyDependencyNotice([`${packageDirectory}/index.js`])
     ).toThrow("lacks a name or version");
   });
+
+  it("uses a longer fence when a license notice contains backticks", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "dependency-notices-"));
+    temporaryDirectories.push(root);
+    const packageDirectory = createPackage(
+      root,
+      "fenced-license-package",
+      "1.0.0",
+      "```\nLicense text inside an upstream fence.\n```"
+    );
+
+    const notice = createThirdPartyDependencyNotice([
+      `${packageDirectory}/index.js`,
+    ]);
+
+    expect(notice).toContain(
+      "````text\n```\nLicense text inside an upstream fence.\n```\n````"
+    );
+  });
 });
 
 describe("mergeThirdPartyDependencyNotices", () => {
@@ -120,6 +139,15 @@ describe("mergeThirdPartyDependencyNotices", () => {
     expect(mergedNotice.indexOf("## example-license@1.0.0")).toBeLessThan(
       mergedNotice.indexOf("## workbox-core@7.4.0")
     );
+  });
+
+  it("keeps nested upstream fences inside the generated outer fence", () => {
+    const existingNotice = `${header}## fenced-license@1.0.0\n\n### LICENSE\n\n\`\`\`\`text\n\`\`\`\n## License heading\n\`\`\`\n\`\`\`\`\n`;
+    const generatedNotice = `${header}## workbox-core@7.4.0\n\n### LICENSE\n\n\`\`\`text\nWorkbox terms.\n\`\`\`\n`;
+
+    expect(() =>
+      mergeThirdPartyDependencyNotices(existingNotice, generatedNotice)
+    ).not.toThrow();
   });
 
   it("rejects malformed or truncated generated artifacts", () => {

--- a/thirdPartyDependencyNotices.test.ts
+++ b/thirdPartyDependencyNotices.test.ts
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createThirdPartyDependencyNotice,
+  mergeThirdPartyDependencyNotices,
+} from "./thirdPartyDependencyNotices";
+
+const header =
+  "# Third-Party Dependency Notices\n\nThis file is generated from the modules included in this release build. It preserves the license and notice files distributed with each bundled npm package.\n\n";
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+function createPackage(
+  root: string,
+  name: string,
+  version: string,
+  licenseText?: string,
+  author?: unknown
+): string {
+  const directory = path.join(root, "node_modules", ...name.split("/"));
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(
+    path.join(directory, "package.json"),
+    JSON.stringify({ author, license: "MIT", name, version })
+  );
+  if (licenseText) {
+    writeFileSync(path.join(directory, "LICENSE.md"), licenseText);
+  }
+  return directory;
+}
+
+describe("createThirdPartyDependencyNotice", () => {
+  it("deduplicates and sorts scoped and unscoped packages deterministically", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "dependency-notices-"));
+    temporaryDirectories.push(root);
+    const zebraDirectory = createPackage(root, "zebra", "2.0.0", "Zebra terms");
+    const alphaDirectory = createPackage(
+      root,
+      "@example/alpha",
+      "1.0.0",
+      "Alpha terms"
+    );
+
+    const notice = createThirdPartyDependencyNotice([
+      `${zebraDirectory}/index.js`,
+      `${alphaDirectory}/index.js?commonjs-proxy`,
+      `${zebraDirectory}/other.js`,
+    ]);
+
+    expect(notice.match(/^## /gm)).toHaveLength(2);
+    expect(notice.indexOf("## @example/alpha@1.0.0")).toBeLessThan(
+      notice.indexOf("## zebra@2.0.0")
+    );
+    expect(notice).toContain("Alpha terms");
+    expect(notice).toContain("Zebra terms");
+  });
+
+  it("normalizes Windows module paths and does not stringify object metadata", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "dependency-notices-"));
+    temporaryDirectories.push(root);
+    const packageDirectory = createPackage(
+      root,
+      "metadata-package",
+      "1.0.0",
+      undefined,
+      { name: "Example Author" }
+    );
+
+    const notice = createThirdPartyDependencyNotice([
+      `${packageDirectory.replaceAll("/", "\\")}\\index.js`,
+    ]);
+
+    expect(notice).toContain("## metadata-package@1.0.0");
+    expect(notice).not.toContain("[object Object]");
+  });
+
+  it("rejects packages whose non-string metadata cannot provide a license", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "dependency-notices-"));
+    temporaryDirectories.push(root);
+    const packageDirectory = createPackage(
+      root,
+      "invalid-metadata-package",
+      "1.0.0"
+    );
+    writeFileSync(
+      path.join(packageDirectory, "package.json"),
+      JSON.stringify({ license: { type: "MIT" }, name: [], version: {} })
+    );
+
+    expect(() =>
+      createThirdPartyDependencyNotice([`${packageDirectory}/index.js`])
+    ).toThrow("lacks a name or version");
+  });
+});
+
+describe("mergeThirdPartyDependencyNotices", () => {
+  it("preserves level-two headings embedded in fenced license text", () => {
+    const existingNotice = `${header}## example-license@1.0.0\n\n### LICENSE\n\n\`\`\`text\nTerms before heading.\n\n## This is license text, not a package\n\nTerms after heading.\n\`\`\`\n`;
+    const generatedNotice = `${header}## workbox-core@7.4.0\n\n### LICENSE\n\n\`\`\`text\nWorkbox terms.\n\`\`\`\n`;
+
+    const mergedNotice = mergeThirdPartyDependencyNotices(
+      existingNotice,
+      generatedNotice
+    );
+
+    expect(mergedNotice).toContain(
+      "## This is license text, not a package\n\nTerms after heading."
+    );
+    expect(mergedNotice.match(/^## /gm)).toHaveLength(3);
+    expect(mergedNotice.indexOf("## example-license@1.0.0")).toBeLessThan(
+      mergedNotice.indexOf("## workbox-core@7.4.0")
+    );
+  });
+
+  it("rejects malformed or truncated generated artifacts", () => {
+    expect(() =>
+      mergeThirdPartyDependencyNotices("unexpected", `${header}`)
+    ).toThrow("unexpected header");
+    expect(() =>
+      mergeThirdPartyDependencyNotices(
+        `${header}## package@1.0.0\n\n\`\`\`text\nunclosed\n`,
+        `${header}`
+      )
+    ).toThrow("unclosed fenced block");
+  });
+});

--- a/thirdPartyDependencyNotices.ts
+++ b/thirdPartyDependencyNotices.ts
@@ -20,7 +20,7 @@ interface InstalledPackage {
 }
 
 function packageDirectoryForModule(moduleId: string): string | null {
-  const normalizedModuleId = moduleId.split("?")[0].replaceAll("\\\\", "/");
+  const normalizedModuleId = moduleId.split("?")[0].replaceAll("\\", "/");
   const marker = "/node_modules/";
   const markerIndex = normalizedModuleId.lastIndexOf(marker);
 
@@ -52,25 +52,28 @@ function installedPackageForModule(moduleId: string): InstalledPackage | null {
 
   const packageJson = JSON.parse(
     readFileSync(path.join(directory, "package.json"), "utf8")
-  ) as {
-    author?: string;
-    copyright?: string;
-    license?: string;
-    name?: string;
-    version?: string;
-  };
+  ) as Record<string, unknown>;
 
-  if (!packageJson.name || !packageJson.version) {
+  const name = optionalString(packageJson.name);
+  const version = optionalString(packageJson.version);
+
+  if (!name || !version) {
     throw new Error(`Bundled package at ${directory} lacks a name or version.`);
   }
 
   return {
-    copyright: packageJson.copyright ?? packageJson.author,
+    copyright:
+      optionalString(packageJson.copyright) ??
+      optionalString(packageJson.author),
     directory,
-    license: packageJson.license,
-    name: packageJson.name,
-    version: packageJson.version,
+    license: optionalString(packageJson.license),
+    name,
+    version,
   };
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 function readPackageNoticeFiles(packageData: InstalledPackage): string {
@@ -142,25 +145,67 @@ export function createThirdPartyDependencyNotice(
   return `${noticeHeader}${entries.join("\n\n")}\n`;
 }
 
-function mergeThirdPartyDependencyNotices(
+function noticeSections(notice: string): readonly [string, string][] {
+  if (!notice.startsWith(noticeHeader)) {
+    throw new Error("Dependency notice has an unexpected header.");
+  }
+
+  const sections: Array<[string, string]> = [];
+  let currentHeading: string | null = null;
+  let currentLines: string[] = [];
+  let fenceMarker: "```" | "~~~" | null = null;
+
+  const finishSection = () => {
+    if (currentHeading) {
+      sections.push([currentHeading, currentLines.join("\n").trimEnd()]);
+    }
+  };
+
+  for (const line of notice.slice(noticeHeader.length).trim().split("\n")) {
+    const trimmedLine = line.trimStart();
+    const nextFenceMarker = trimmedLine.startsWith("```")
+      ? "```"
+      : trimmedLine.startsWith("~~~")
+        ? "~~~"
+        : null;
+
+    if (!fenceMarker && line.startsWith("## ")) {
+      finishSection();
+      currentHeading = line;
+      currentLines = [line];
+      continue;
+    }
+
+    if (currentHeading) {
+      currentLines.push(line);
+    } else if (line.trim()) {
+      throw new Error("Dependency notice contains content before a package.");
+    }
+
+    if (nextFenceMarker === fenceMarker) {
+      fenceMarker = null;
+    } else if (!fenceMarker && nextFenceMarker) {
+      fenceMarker = nextFenceMarker;
+    }
+  }
+
+  if (fenceMarker) {
+    throw new Error("Dependency notice contains an unclosed fenced block.");
+  }
+
+  finishSection();
+  return sections;
+}
+
+export function mergeThirdPartyDependencyNotices(
   existingNotice: string,
   generatedNotice: string
 ): string {
   const sections = new Map<string, string>();
 
   for (const notice of [existingNotice, generatedNotice]) {
-    for (const section of notice
-      .slice(noticeHeader.length)
-      .trim()
-      .split("\n\n## ")) {
-      const normalizedSection = section.startsWith("## ")
-        ? section
-        : `## ${section}`;
-      const heading = normalizedSection.split("\n", 1)[0];
-
-      if (heading !== "##") {
-        sections.set(heading, normalizedSection);
-      }
+    for (const [heading, section] of noticeSections(notice)) {
+      sections.set(heading, section);
     }
   }
 
@@ -178,7 +223,7 @@ export function thirdPartyDependencyNotices({
     path.join(process.cwd(), "package.json")
   );
   const addResolvedPackage = (source: string) => {
-    if (!source.startsWith("@") && !source.match(/^[A-Za-z0-9_-]+\//)) {
+    if (source.startsWith(".") || source.startsWith("/")) {
       return;
     }
 

--- a/thirdPartyDependencyNotices.ts
+++ b/thirdPartyDependencyNotices.ts
@@ -76,6 +76,16 @@ function optionalString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
+function fencedNoticeText(text: string): string {
+  const longestBacktickRun = Math.max(
+    2,
+    ...Array.from(text.matchAll(/`+/g), ([match]) => match.length)
+  );
+  const fence = "`".repeat(longestBacktickRun + 1);
+
+  return `${fence}text\n${text.trimEnd()}\n${fence}`;
+}
+
 function readPackageNoticeFiles(packageData: InstalledPackage): string {
   const noticeFiles = readdirSync(packageData.directory)
     .filter((fileName) => noticeFilePattern.test(fileName))
@@ -95,7 +105,7 @@ function readPackageNoticeFiles(packageData: InstalledPackage): string {
     );
 
     try {
-      return `The npm package does not include a standalone notice file. Its package metadata declares ${packageData.license}.${packageData.copyright ? `\n\nCopyright/author metadata: ${packageData.copyright}` : ""}\n\n### ${packageData.license}\n\n\`\`\`text\n${readFileSync(fallbackLicensePath, "utf8").trimEnd()}\n\`\`\``;
+      return `The npm package does not include a standalone notice file. Its package metadata declares ${packageData.license}.${packageData.copyright ? `\n\nCopyright/author metadata: ${packageData.copyright}` : ""}\n\n### ${packageData.license}\n\n${fencedNoticeText(readFileSync(fallbackLicensePath, "utf8"))}`;
     } catch {
       throw new Error(
         `Bundled package ${packageData.name}@${packageData.version} declares ${packageData.license} but its canonical license text is unavailable at ${fallbackLicensePath}.`
@@ -106,10 +116,9 @@ function readPackageNoticeFiles(packageData: InstalledPackage): string {
   return noticeFiles
     .map(
       (fileName) =>
-        `### ${fileName}\n\n\`\`\`text\n${readFileSync(
-          path.join(packageData.directory, fileName),
-          "utf8"
-        ).trimEnd()}\n\`\`\``
+        `### ${fileName}\n\n${fencedNoticeText(
+          readFileSync(path.join(packageData.directory, fileName), "utf8")
+        )}`
     )
     .join("\n\n");
 }
@@ -163,11 +172,7 @@ function noticeSections(notice: string): readonly [string, string][] {
 
   for (const line of notice.slice(noticeHeader.length).trim().split("\n")) {
     const trimmedLine = line.trimStart();
-    const nextFenceMarker = trimmedLine.startsWith("```")
-      ? "```"
-      : trimmedLine.startsWith("~~~")
-        ? "~~~"
-        : null;
+    const nextFenceMarker = trimmedLine.match(/^(`{3,}|~{3,})/)?.[1] ?? null;
 
     if (!fenceMarker && line.startsWith("## ")) {
       finishSection();

--- a/thirdPartyDependencyNotices.ts
+++ b/thirdPartyDependencyNotices.ts
@@ -1,0 +1,246 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: MIT
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import type { Plugin } from "vite";
+
+const noticeFilePattern = /^(copying|copyright|licen[cs]e|notice)([._-].*)?$/i;
+const artifactName = "THIRD-PARTY-DEPENDENCY-NOTICES.md";
+const noticeHeader =
+  "# Third-Party Dependency Notices\n\nThis file is generated from the modules included in this release build. It preserves the license and notice files distributed with each bundled npm package.\n\n";
+
+interface InstalledPackage {
+  copyright?: string;
+  directory: string;
+  license?: string;
+  name: string;
+  version: string;
+}
+
+function packageDirectoryForModule(moduleId: string): string | null {
+  const normalizedModuleId = moduleId.split("?")[0].replaceAll("\\\\", "/");
+  const marker = "/node_modules/";
+  const markerIndex = normalizedModuleId.lastIndexOf(marker);
+
+  if (markerIndex === -1) {
+    return null;
+  }
+
+  const packagePathParts = normalizedModuleId
+    .slice(markerIndex + marker.length)
+    .split("/");
+  const packagePartCount = packagePathParts[0].startsWith("@") ? 2 : 1;
+
+  if (packagePathParts.length < packagePartCount) {
+    return null;
+  }
+
+  return path.join(
+    normalizedModuleId.slice(0, markerIndex + marker.length),
+    ...packagePathParts.slice(0, packagePartCount)
+  );
+}
+
+function installedPackageForModule(moduleId: string): InstalledPackage | null {
+  const directory = packageDirectoryForModule(moduleId);
+
+  if (!directory) {
+    return null;
+  }
+
+  const packageJson = JSON.parse(
+    readFileSync(path.join(directory, "package.json"), "utf8")
+  ) as {
+    author?: string;
+    copyright?: string;
+    license?: string;
+    name?: string;
+    version?: string;
+  };
+
+  if (!packageJson.name || !packageJson.version) {
+    throw new Error(`Bundled package at ${directory} lacks a name or version.`);
+  }
+
+  return {
+    copyright: packageJson.copyright ?? packageJson.author,
+    directory,
+    license: packageJson.license,
+    name: packageJson.name,
+    version: packageJson.version,
+  };
+}
+
+function readPackageNoticeFiles(packageData: InstalledPackage): string {
+  const noticeFiles = readdirSync(packageData.directory)
+    .filter((fileName) => noticeFilePattern.test(fileName))
+    .sort();
+
+  if (noticeFiles.length === 0 && !packageData.license) {
+    throw new Error(
+      `Bundled package ${packageData.name}@${packageData.version} does not include a license declaration or notice file.`
+    );
+  }
+
+  if (noticeFiles.length === 0) {
+    const fallbackLicensePath = path.join(
+      process.cwd(),
+      "LICENSES",
+      `${packageData.license}.txt`
+    );
+
+    try {
+      return `The npm package does not include a standalone notice file. Its package metadata declares ${packageData.license}.${packageData.copyright ? `\n\nCopyright/author metadata: ${packageData.copyright}` : ""}\n\n### ${packageData.license}\n\n\`\`\`text\n${readFileSync(fallbackLicensePath, "utf8").trimEnd()}\n\`\`\``;
+    } catch {
+      throw new Error(
+        `Bundled package ${packageData.name}@${packageData.version} declares ${packageData.license} but its canonical license text is unavailable at ${fallbackLicensePath}.`
+      );
+    }
+  }
+
+  return noticeFiles
+    .map(
+      (fileName) =>
+        `### ${fileName}\n\n\`\`\`text\n${readFileSync(
+          path.join(packageData.directory, fileName),
+          "utf8"
+        ).trimEnd()}\n\`\`\``
+    )
+    .join("\n\n");
+}
+
+export function createThirdPartyDependencyNotice(
+  moduleIds: Iterable<string>
+): string {
+  const bundledPackages = new Map<string, InstalledPackage>();
+
+  for (const moduleId of moduleIds) {
+    const packageData = installedPackageForModule(moduleId);
+
+    if (packageData) {
+      bundledPackages.set(packageData.directory, packageData);
+    }
+  }
+
+  const entries = [...bundledPackages.values()]
+    .sort((left, right) => {
+      const leftIdentifier = `${left.name}@${left.version}`;
+      const rightIdentifier = `${right.name}@${right.version}`;
+      return leftIdentifier < rightIdentifier
+        ? -1
+        : leftIdentifier > rightIdentifier
+          ? 1
+          : 0;
+    })
+    .map(
+      (packageData) =>
+        `## ${packageData.name}@${packageData.version}\n\n${readPackageNoticeFiles(packageData)}`
+    );
+
+  return `${noticeHeader}${entries.join("\n\n")}\n`;
+}
+
+function mergeThirdPartyDependencyNotices(
+  existingNotice: string,
+  generatedNotice: string
+): string {
+  const sections = new Map<string, string>();
+
+  for (const notice of [existingNotice, generatedNotice]) {
+    for (const section of notice
+      .slice(noticeHeader.length)
+      .trim()
+      .split("\n\n## ")) {
+      const normalizedSection = section.startsWith("## ")
+        ? section
+        : `## ${section}`;
+      const heading = normalizedSection.split("\n", 1)[0];
+
+      if (heading !== "##") {
+        sections.set(heading, normalizedSection);
+      }
+    }
+  }
+
+  return `${noticeHeader}${[...sections.entries()]
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+    .map(([, section]) => section)
+    .join("\n\n")}\n`;
+}
+
+export function thirdPartyDependencyNotices({
+  mergeExistingArtifact = false,
+}: { mergeExistingArtifact?: boolean } = {}): Plugin {
+  const bundledModuleIds = new Set<string>();
+  const requireFromProject = createRequire(
+    path.join(process.cwd(), "package.json")
+  );
+  const addResolvedPackage = (source: string) => {
+    if (!source.startsWith("@") && !source.match(/^[A-Za-z0-9_-]+\//)) {
+      return;
+    }
+
+    try {
+      bundledModuleIds.add(requireFromProject.resolve(source));
+    } catch {
+      // Vite resolves aliases and virtual modules that are not npm packages.
+    }
+  };
+
+  return {
+    name: "secpal-third-party-dependency-notices",
+    buildStart() {
+      for (const relativePath of readdirSync(path.join(process.cwd(), "src"), {
+        recursive: true,
+      })) {
+        if (!relativePath.endsWith(".css")) {
+          continue;
+        }
+
+        const stylesheet = readFileSync(
+          path.join(process.cwd(), "src", relativePath),
+          "utf8"
+        );
+
+        for (const match of stylesheet.matchAll(
+          /@import\s+(?:url\(\s*)?["']([^"']+)["']/g
+        )) {
+          addResolvedPackage(match[1]);
+        }
+      }
+    },
+    generateBundle(outputOptions, bundle) {
+      for (const moduleId of this.getModuleIds()) {
+        bundledModuleIds.add(moduleId);
+      }
+
+      for (const output of Object.values(bundle)) {
+        if (output.type === "chunk") {
+          for (const moduleId of Object.keys(output.modules)) {
+            bundledModuleIds.add(moduleId);
+          }
+        }
+      }
+      const artifactPath = path.join(
+        outputOptions.dir ?? process.cwd(),
+        artifactName
+      );
+      const generatedNotice =
+        createThirdPartyDependencyNotice(bundledModuleIds);
+
+      this.emitFile({
+        fileName: artifactName,
+        source:
+          mergeExistingArtifact && existsSync(artifactPath)
+            ? mergeThirdPartyDependencyNotices(
+                readFileSync(artifactPath, "utf8"),
+                generatedNotice
+              )
+            : generatedNotice,
+        type: "asset",
+      });
+    },
+  };
+}

--- a/thirdPartyDependencyNotices.ts.license
+++ b/thirdPartyDependencyNotices.ts.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: MIT

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,7 @@ import { resolveLinguiVitePluginExports } from "./linguiVitePluginInterop";
 import { applyInjectManifestCodeSplittingFix } from "./src/lib/pwaInjectManifestBuildConfig";
 import { buildPwaRuntimeCaching } from "./src/lib/pwaRuntimeCaching";
 import { resolveAppSurface } from "./src/platform/appSurfaceContract";
+import { thirdPartyDependencyNotices } from "./thirdPartyDependencyNotices";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const { lingui } = resolveLinguiVitePluginExports(linguiVitePlugin);
@@ -217,14 +218,21 @@ export default defineConfig(({ mode, command }) => {
           },
         ],
       }),
+      thirdPartyDependencyNotices(),
       VitePWA({
         registerType: "prompt",
         strategies: "injectManifest",
         integration: {
-          configureCustomSWViteBuild: applyInjectManifestCodeSplittingFix,
+          configureCustomSWViteBuild: (inlineConfig) => {
+            applyInjectManifestCodeSplittingFix(inlineConfig);
+            inlineConfig.plugins = [
+              ...(inlineConfig.plugins ?? []),
+              thirdPartyDependencyNotices({ mergeExistingArtifact: true }),
+            ];
+          },
         },
         injectManifest: {
-          globPatterns: ["**/*.{js,css,ico,png,svg,woff,woff2}"],
+          globPatterns: ["**/*.{js,css,ico,png,svg,woff,woff2,md}"],
           globIgnores: ["**/*.html", "theme-color.js", "document-language.js"],
           manifestTransforms: [
             async (entries) => ({
@@ -284,7 +292,7 @@ export default defineConfig(({ mode, command }) => {
           ],
         },
         workbox: {
-          globPatterns: ["**/*.{js,css,ico,png,svg,woff,woff2}"],
+          globPatterns: ["**/*.{js,css,ico,png,svg,woff,woff2,md}"],
           globIgnores: ["**/*.html", "theme-color.js", "document-language.js"],
           navigateFallback: null,
           cleanupOutdatedCaches: true,


### PR DESCRIPTION
## Reproduced defect

The production build distributed Inter webfonts but did not include Inter's
copyright notice or the OFL-1.1 text. The initial regression assertion also
showed that the separate service-worker build omitted notices for its bundled
Workbox packages.

## Change summary

- Generate a deterministic dependency-notice artifact from the client and
  service-worker module graphs.
- Preserve package-provided copyright, license, and notice files; fail the
  build when a package has neither usable metadata nor notice text.
- Include Inter's OFL-1.1 notice and merge notices for the Workbox packages
  bundled by the service worker.
- Precache the generated artifact while retaining the existing shadcn MIT
  notice files.
- Add build assertions for Inter, Workbox, copied shadcn notices, and service
  worker precaching.

Closes #1367

## Validation

- `npm run test -- tests/build.test.ts`
- `npm run typecheck`
- `npm run lint`
- `reuse lint`
- Web, Android, iOS, preview, and analysis build artifact checks

## Follow-up before ready for review

- No linked workspace changes or unresolved implementation checks.
- Keep this PR in draft until the final PR-view self-review and CI checks are
  complete.
