### PR TITLE
Fix organizational unit boolean filter serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Serialized organizational-unit active and assignable list filters as
+  `true`/`false`, matching API validation and preventing filtered requests from
+  failing with HTTP 422.
 - Release artifacts now include a deterministic third-party dependency notice
   bundle generated from their actual JavaScript and copied-asset module graph.
   It preserves package-specific notices and license texts, including Inter's

--- a/src/services/organizationalUnitApi.test.ts
+++ b/src/services/organizationalUnitApi.test.ts
@@ -70,41 +70,44 @@ describe("Organizational Unit API", () => {
       );
     });
 
-    it("should apply filters correctly", async () => {
-      mockFetchWithCsrf.mockResolvedValue({
-        ok: true,
-        json: async () => ({ data: [], meta: {} }),
-      });
+    it.each([
+      ["is_active", true, "is_active=true"],
+      ["is_active", false, "is_active=false"],
+      ["is_assignable", true, "is_assignable=true"],
+      ["is_assignable", false, "is_assignable=false"],
+    ] as const)(
+      "serializes %s=%s as a boolean query value",
+      async (filter, value, expectedQuery) => {
+        mockFetchWithCsrf.mockResolvedValue({
+          ok: true,
+          json: async () => ({ data: [], meta: {} }),
+        });
 
-      await listOrganizationalUnits({
-        type: "branch",
-        parent_id: "parent-1",
-        is_active: false,
-        is_assignable: true,
-        per_page: 10,
-      });
+        await listOrganizationalUnits({
+          type: "branch",
+          parent_id: "parent-1",
+          [filter]: value,
+          per_page: 10,
+        });
 
-      expect(mockFetchWithCsrf).toHaveBeenCalledWith(
-        expect.stringContaining("type=branch"),
-        expect.any(Object)
-      );
-      expect(mockFetchWithCsrf).toHaveBeenCalledWith(
-        expect.stringContaining("parent_id=parent-1"),
-        expect.any(Object)
-      );
-      expect(mockFetchWithCsrf).toHaveBeenCalledWith(
-        expect.stringContaining("per_page=10"),
-        expect.any(Object)
-      );
-      expect(mockFetchWithCsrf).toHaveBeenCalledWith(
-        expect.stringContaining("is_active=0"),
-        expect.any(Object)
-      );
-      expect(mockFetchWithCsrf).toHaveBeenCalledWith(
-        expect.stringContaining("is_assignable=1"),
-        expect.any(Object)
-      );
-    });
+        expect(mockFetchWithCsrf).toHaveBeenCalledWith(
+          expect.stringContaining("type=branch"),
+          expect.any(Object)
+        );
+        expect(mockFetchWithCsrf).toHaveBeenCalledWith(
+          expect.stringContaining("parent_id=parent-1"),
+          expect.any(Object)
+        );
+        expect(mockFetchWithCsrf).toHaveBeenCalledWith(
+          expect.stringContaining("per_page=10"),
+          expect.any(Object)
+        );
+        expect(mockFetchWithCsrf).toHaveBeenCalledWith(
+          expect.stringContaining(expectedQuery),
+          expect.any(Object)
+        );
+      }
+    );
 
     it("should throw ApiError on failure", async () => {
       mockFetchWithCsrf.mockResolvedValue({

--- a/src/services/organizationalUnitApi.ts
+++ b/src/services/organizationalUnitApi.ts
@@ -71,10 +71,10 @@ export async function listOrganizationalUnits(
     params.set("parent_id", filters.parent_id ?? "null");
   }
   if (filters?.is_active !== undefined) {
-    params.set("is_active", filters.is_active ? "1" : "0");
+    params.set("is_active", String(filters.is_active));
   }
   if (filters?.is_assignable !== undefined) {
-    params.set("is_assignable", filters.is_assignable ? "1" : "0");
+    params.set("is_assignable", String(filters.is_assignable));
   }
   if (filters?.per_page) {
     params.set("per_page", String(filters.per_page));


### PR DESCRIPTION
The focused regression test first failed for all four boolean cases because the
client sent `is_active` and `is_assignable` as `0` or `1` rather than the
OpenAPI boolean literals.

## Summary

- serialize organizational-unit list filters as `true` or `false`
- cover both values for both filters in `src/services/organizationalUnitApi.test.ts`
- document the HTTP 422 fix in `CHANGELOG.md`

## Validation

- `npm test -- src/services/organizationalUnitApi.test.ts`
- `npm run typecheck`
- `npm run lint`
- `reuse lint`
- `PREFLIGHT_RUN_TESTS=1 git push` preflight, including the full test suite

## Follow-up before marking ready

- No linked-workspace changes are required.
- CI checks are in progress. Keep this PR as a draft until they complete and
  the final PR-view self-review remains clear.

Closes #1372
