### PR TITLE
test: stabilize AuthContext session-expiry cache isolation

### DIFF
--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -519,36 +519,54 @@ describe("AuthContext", () => {
     });
 
     it("clears the prefetch cache when session:expired tears down the session", async () => {
-      await seedStoredUser({
-        id: 1,
+      const storedUser = {
+        id: "1",
         name: "Test User",
         email: "test@secpal.dev",
+        emailVerified: false,
         permissions: ["employees.read"],
-      });
+      };
+      await seedStoredUser(storedUser);
 
-      render(
-        <AuthProvider>
-          <PermissionTestComponent permission="employees.read" />
-        </AuthProvider>
-      );
+      // This test verifies the session-expiry lifecycle, not encrypted-vault
+      // bootstrap timing. Resolve the stored session directly so the event
+      // handler is registered against a known authenticated state.
+      const getUserSpy = vi
+        .spyOn(authStorage, "getUser")
+        .mockResolvedValueOnce(storedUser);
 
-      await waitFor(() => {
-        expect(screen.getByTestId("hasPermission")).toHaveTextContent("true");
-      });
+      try {
+        render(
+          <AuthProvider>
+            <PermissionTestComponent permission="employees.read" />
+          </AuthProvider>
+        );
 
-      await waitFor(() => {
-        expect(sessionEventHandlers.get("session:expired")).toHaveLength(1);
-      });
+        await waitFor(() => {
+          expect(screen.getByTestId("hasPermission")).toHaveTextContent("true");
+        });
 
-      vi.mocked(resetPrefetchCache).mockClear();
+        await waitFor(() => {
+          expect(sessionEventHandlers.get("session:expired")).toHaveLength(1);
+        });
 
-      await act(async () => {
-        const handlers = sessionEventHandlers.get("session:expired") ?? [];
-        handlers.forEach((handler) => handler());
-        await new Promise((r) => setTimeout(r, 0));
-      });
+        vi.mocked(resetPrefetchCache).mockClear();
 
-      expect(resetPrefetchCache).toHaveBeenCalled();
+        await act(async () => {
+          const handlers = sessionEventHandlers.get("session:expired") ?? [];
+          handlers.forEach((handler) => handler());
+          await new Promise((r) => setTimeout(r, 0));
+        });
+
+        await waitFor(() => {
+          expect(screen.getByTestId("hasPermission")).toHaveTextContent(
+            "false"
+          );
+          expect(resetPrefetchCache).toHaveBeenCalled();
+        });
+      } finally {
+        getUserSpy.mockRestore();
+      }
     });
 
     it("tears down native logout events without service-worker client redirects", async () => {


### PR DESCRIPTION
Closes #1376

## Failing test

The CI run reported that `AuthContext > prefetch cache isolation across session teardown > clears the prefetch cache when session:expired tears down the session` timed out at `src/contexts/AuthContext.test.tsx:536`. The test waited for `hasPermission` to become `true`, but encrypted-vault bootstrap timing left the rendered value `false`.

## Change

- Resolve the stored user directly in this lifecycle test after seeding the approved auth storage path.
- Keep the `session:expired` handler under test and assert both observable session teardown and prefetch-cache reset.
- Restore the scoped storage spy in `finally`.

## Validation

- `npm test -- --run src/contexts/AuthContext.test.tsx` (21 passed)
- Focused session-expiry test repeated 10 times
- `npm run typecheck`
- `npm run lint -- --no-cache`
- Full suite: 188 files and 2,811 tests passed
- Push preflight: formatting, domain-policy, lint, and typecheck passed before the final test result needs confirmation

## Before marking ready

- Confirm the final pre-push test result or CI status.
- No linked workspace changes are required.
