### PR TITLE
fix: keep mobile sidebar user actions above system navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Kept the mobile sidebar's user footer above Android system navigation bars
+  by applying the bottom safe-area inset, so the user menu and sign-out action
+  remain reachable in portrait mode.
 - Android passkey sign-in and registration now honor the native capability
   bridge: Android 6 through 13 show a safe Android 14 compatibility message,
   retain permitted password sign-in, and report an incompatibility error for

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -535,6 +535,11 @@ describe("ApplicationLayout", () => {
         expect(mobileSidebar).toHaveClass(
           "pt-[var(--app-safe-area-inset-top)]"
         );
+        expect(
+          mobileSidebar?.querySelector('[data-slot="sidebar-footer"]')
+        ).toHaveClass(
+          "pb-[calc(0.5rem+env(safe-area-inset-bottom,0px))]"
+        );
         expect(mobileSidebar?.className).not.toContain("[&>button]:hidden");
         const mobileSidebarRail = mobileSidebar?.querySelector(
           '[data-slot="sidebar-rail"]'

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -537,9 +537,7 @@ describe("ApplicationLayout", () => {
         );
         expect(
           mobileSidebar?.querySelector('[data-slot="sidebar-footer"]')
-        ).toHaveClass(
-          "pb-[calc(0.5rem+env(safe-area-inset-bottom,0px))]"
-        );
+        ).toHaveClass("pb-[calc(0.5rem+env(safe-area-inset-bottom,0px))]");
         expect(mobileSidebar?.className).not.toContain("[&>button]:hidden");
         const mobileSidebarRail = mobileSidebar?.querySelector(
           '[data-slot="sidebar-rail"]'

--- a/src/components/application-layout.test.tsx
+++ b/src/components/application-layout.test.tsx
@@ -535,17 +535,21 @@ describe("ApplicationLayout", () => {
         expect(mobileSidebar).toHaveClass(
           "pt-[var(--app-safe-area-inset-top)]"
         );
-        expect(
-          mobileSidebar?.querySelector('[data-slot="sidebar-footer"]')
-        ).toHaveClass("pb-[calc(0.5rem+env(safe-area-inset-bottom,0px))]");
-        expect(mobileSidebar?.className).not.toContain("[&>button]:hidden");
-        const mobileSidebarRail = mobileSidebar?.querySelector(
+        const mobileSidebarFooter = mobileSidebar!.querySelector<HTMLElement>(
+          '[data-slot="sidebar-footer"]'
+        );
+        expect(mobileSidebarFooter).toBeInTheDocument();
+        expect(mobileSidebarFooter).toHaveClass(
+          "pb-[calc(0.5rem+env(safe-area-inset-bottom,0px))]"
+        );
+        expect(mobileSidebar!.className).not.toContain("[&>button]:hidden");
+        const mobileSidebarRail = mobileSidebar!.querySelector(
           '[data-slot="sidebar-rail"]'
         );
         expect(mobileSidebarRail).toBeInTheDocument();
         expect(mobileSidebarRail).toHaveClass("hidden");
         expect(mobileSidebarRail).toHaveClass("md:flex");
-        expect(mobileSidebarRail?.className).not.toContain("sm:flex");
+        expect(mobileSidebarRail!.className).not.toContain("sm:flex");
 
         await user.click(screen.getByRole("button", { name: /close/i }));
 

--- a/src/ui/sidebar.tsx
+++ b/src/ui/sidebar.tsx
@@ -428,7 +428,7 @@ export function SidebarFooter({
       data-slot="sidebar-footer"
       data-sidebar="footer"
       className={cn(
-        "flex flex-col gap-2 p-2 pb-[calc(0.5rem+env(safe-area-inset-bottom,0px))]",
+        "flex flex-col gap-2 px-2 pt-2 pb-[calc(0.5rem+env(safe-area-inset-bottom,0px))]",
         className
       )}
       {...props}

--- a/src/ui/sidebar.tsx
+++ b/src/ui/sidebar.tsx
@@ -427,7 +427,10 @@ export function SidebarFooter({
     <div
       data-slot="sidebar-footer"
       data-sidebar="footer"
-      className={cn("flex flex-col gap-2 p-2", className)}
+      className={cn(
+        "flex flex-col gap-2 p-2 pb-[calc(0.5rem+env(safe-area-inset-bottom,0px))]",
+        className
+      )}
       {...props}
     />
   );

--- a/src/ui/ui.test.tsx
+++ b/src/ui/ui.test.tsx
@@ -62,6 +62,7 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarFooter,
   SidebarProvider,
   SectionSkeleton,
   Skeleton,
@@ -127,6 +128,20 @@ describe("shared shadcn/radix UI basis", () => {
       "collapsed"
     );
     expect(matchMedia).toHaveBeenCalledWith("(min-width: 90rem)");
+  });
+
+  it("keeps the sidebar footer above the system navigation area", () => {
+    const { container } = render(
+      <SidebarProvider>
+        <Sidebar collapsible="none">
+          <SidebarFooter>User actions</SidebarFooter>
+        </Sidebar>
+      </SidebarProvider>
+    );
+
+    expect(container.querySelector('[data-slot="sidebar-footer"]')).toHaveClass(
+      "pb-[calc(0.5rem+env(safe-area-inset-bottom,0px))]"
+    );
   });
 
   it("keeps the sidebar expanded by default at the desktop breakpoint", () => {

--- a/src/ui/ui.test.tsx
+++ b/src/ui/ui.test.tsx
@@ -139,7 +139,14 @@ describe("shared shadcn/radix UI basis", () => {
       </SidebarProvider>
     );
 
-    expect(container.querySelector('[data-slot="sidebar-footer"]')).toHaveClass(
+    const sidebarFooter = container.querySelector<HTMLElement>(
+      '[data-slot="sidebar-footer"]'
+    );
+
+    expect(sidebarFooter).toBeInTheDocument();
+    expect(sidebarFooter).toHaveClass(
+      "px-2",
+      "pt-2",
       "pb-[calc(0.5rem+env(safe-area-inset-bottom,0px))]"
     );
   });


### PR DESCRIPTION
## Summary

- Add bottom safe-area padding to the shared sidebar footer.
- Keep the mobile user menu and sign-out action reachable above Android system navigation bars.
- Add a regression test and document the fix in the changelog.

## Root cause

The mobile sidebar drawer uses the full viewport height, while the sidebar footer only had a fixed `p-2` padding. On Android edge-to-edge layouts, the user-menu trigger could extend into the system navigation area and become untappable.

## Validation

- TDD regression test initially failed before the implementation.
- 30 focused frontend tests passed.
- TypeScript typecheck passed.
- ESLint passed.
- Android debug APK rebuilt successfully and installed on the connected Samsung XCover 7.
- No Android source changes are included; the UI/UX fix remains in the frontend repository.