### PR TITLE
test: clarify DOM-node class assertions

### DIFF
--- a/src/components/MoveOrganizationalUnitDialog.test.tsx
+++ b/src/components/MoveOrganizationalUnitDialog.test.tsx
@@ -443,7 +443,15 @@ describe("MoveOrganizationalUnitDialog", () => {
       );
       const label = within(option).getByText(/Make root unit/i);
       const contentRow = label.parentElement;
-      const icon = contentRow?.querySelector("svg");
+
+      expect(contentRow).toBeInTheDocument();
+      if (!contentRow) {
+        throw new Error(
+          "Expected the root-unit option content row to be present."
+        );
+      }
+
+      const icon = contentRow.querySelector("svg");
 
       expect(contentRow).toHaveClass(
         "flex",

--- a/src/components/MoveOrganizationalUnitDialog.test.tsx
+++ b/src/components/MoveOrganizationalUnitDialog.test.tsx
@@ -443,6 +443,7 @@ describe("MoveOrganizationalUnitDialog", () => {
       );
       const label = within(option).getByText(/Make root unit/i);
       const contentRow = label.parentElement;
+      const icon = contentRow?.querySelector("svg");
 
       expect(contentRow).toHaveClass(
         "flex",
@@ -451,7 +452,8 @@ describe("MoveOrganizationalUnitDialog", () => {
         "items-center",
         "gap-2"
       );
-      expect(contentRow?.querySelector("svg")).toHaveClass("shrink-0");
+      expect(icon).toBeInTheDocument();
+      expect(icon).toHaveClass("shrink-0");
       expect(label).toHaveClass("min-w-0", "truncate");
     }, 15000);
 

--- a/src/components/RouteLoader.test.tsx
+++ b/src/components/RouteLoader.test.tsx
@@ -57,10 +57,10 @@ describe("RouteLoader", () => {
 
   it("keeps the loading header below the iOS top safe area", () => {
     const { container } = renderWithI18n(<RouteLoader />);
+    const header = container.querySelector("header");
 
-    expect(container.querySelector("header")).toHaveClass(
-      "pt-[var(--app-safe-area-inset-top)]"
-    );
+    expect(header).toBeInTheDocument();
+    expect(header).toHaveClass("pt-[var(--app-safe-area-inset-top)]");
   });
 
   it("renders skeleton placeholders instead of a spinner", () => {

--- a/src/components/mobile-sidebar-layout.test.tsx
+++ b/src/components/mobile-sidebar-layout.test.tsx
@@ -52,16 +52,22 @@ describe("mobile sidebar layouts", () => {
         </MemoryRouter>
       );
 
-      expect(document.querySelector("header")).toHaveClass(
-        "pt-[var(--app-safe-area-inset-top)]"
-      );
+      const header = document.querySelector("header");
+
+      expect(header).toBeInTheDocument();
+      expect(header).toHaveClass("pt-[var(--app-safe-area-inset-top)]");
 
       await user.click(screen.getByRole("button", { name: "Open navigation" }));
 
       expect(
         await screen.findByRole("dialog", { name: "Navigationsmenü" })
       ).toBeInTheDocument();
-      expect(document.querySelector('[data-slot="sheet-content"]')).toHaveClass(
+      const sheetContent = document.querySelector(
+        '[data-slot="sheet-content"]'
+      );
+
+      expect(sheetContent).toBeInTheDocument();
+      expect(sheetContent).toHaveClass(
         "pt-[calc(0.5rem+var(--app-safe-area-inset-top))]"
       );
       const mobilePanel = document.querySelector(
@@ -80,9 +86,12 @@ describe("mobile sidebar layouts", () => {
       expect(
         screen.getByRole("button", { name: "Navigation schließen" })
       ).toHaveClass("size-11");
-      expect(document.querySelector('[data-slot="sheet-overlay"]')).toHaveClass(
-        "lg:hidden"
+      const sheetOverlay = document.querySelector(
+        '[data-slot="sheet-overlay"]'
       );
+
+      expect(sheetOverlay).toBeInTheDocument();
+      expect(sheetOverlay).toHaveClass("lg:hidden");
     }
   );
 });

--- a/src/pages/Employees/EmployeeBwrPanel.test.tsx
+++ b/src/pages/Employees/EmployeeBwrPanel.test.tsx
@@ -273,13 +273,18 @@ describe("EmployeeBwrPanel", () => {
         /Sie können die BWR-Daten einsehen, aber zum Verwalten ist Schreibberechtigung erforderlich/i
       )
     ).toBeInTheDocument();
-    expect(
-      document.querySelector('[data-slot="employee-status-badge"]')
-    ).toHaveClass("bg-muted", "text-muted-foreground");
-    expect(document.querySelector('[data-slot="card"]')).toHaveClass(
-      "bg-card",
-      "text-card-foreground"
+    const employeeStatusBadge = document.querySelector(
+      '[data-slot="employee-status-badge"]'
     );
+    const card = document.querySelector('[data-slot="card"]');
+
+    expect(employeeStatusBadge).toBeInTheDocument();
+    expect(employeeStatusBadge).toHaveClass(
+      "bg-muted",
+      "text-muted-foreground"
+    );
+    expect(card).toBeInTheDocument();
+    expect(card).toHaveClass("bg-card", "text-card-foreground");
 
     i18n.activate("en");
   });

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -3599,7 +3599,9 @@ describe("Login", () => {
         "pt-3",
         "pb-[var(--app-footer-padding-bottom)]"
       );
-      expect(footer.querySelector("div")).toHaveClass("text-muted-foreground");
+      const footerContent = footer.querySelector("div");
+      expect(footerContent).toBeInTheDocument();
+      expect(footerContent).toHaveClass("text-muted-foreground");
       expect(
         screen.getByRole("link", {
           name: "Powered by SecPal – A guard's best friend",

--- a/src/ui/ui.test.tsx
+++ b/src/ui/ui.test.tsx
@@ -297,37 +297,39 @@ describe("shared shadcn/radix UI basis", () => {
       "select-trigger"
     );
     expect(screen.getByRole("alert")).toHaveAttribute("data-slot", "alert");
-    expect(container.querySelector('[data-slot="card"]')).toHaveClass(
+    const card = container.querySelector('[data-slot="card"]');
+    const progress = container.querySelector('[data-slot="progress"]');
+    const avatar = container.querySelector('[data-slot="avatar"]');
+    const avatarFallback = container.querySelector(
+      '[data-slot="avatar-fallback"]'
+    );
+    const skeleton = container.querySelector('[data-slot="skeleton"]');
+    const table = container.querySelector('[data-slot="table"]');
+    const tableHeader = container.querySelector('[data-slot="table-header"]');
+    const tableRow = container.querySelector('[data-slot="table-row"]');
+
+    expect(card).toBeInTheDocument();
+    expect(card).toHaveClass(
       "bg-card",
       "text-card-foreground",
       "border-border"
     );
     expect(screen.getByText("Active")).toHaveAttribute("data-slot", "badge");
-    expect(container.querySelector('[data-slot="progress"]')).toHaveClass(
-      "bg-primary/20"
-    );
-    expect(container.querySelector('[data-slot="avatar"]')).toHaveClass(
-      "rounded-full"
-    );
-    expect(container.querySelector('[data-slot="avatar"]')).toHaveAttribute(
-      "data-size",
-      "sm"
-    );
-    expect(
-      container.querySelector('[data-slot="avatar-fallback"]')
-    ).toHaveClass("bg-muted", "text-muted-foreground");
-    expect(container.querySelector('[data-slot="skeleton"]')).toHaveClass(
-      "bg-muted"
-    );
-    expect(container.querySelector('[data-slot="table"]')).toHaveClass(
-      "caption-bottom"
-    );
-    expect(container.querySelector('[data-slot="table-header"]')).toHaveClass(
-      "[&_tr]:border-border"
-    );
-    expect(
-      container.querySelectorAll('[data-slot="table-row"]')[0]
-    ).toHaveClass("border-border");
+    expect(progress).toBeInTheDocument();
+    expect(progress).toHaveClass("bg-primary/20");
+    expect(avatar).toBeInTheDocument();
+    expect(avatar).toHaveClass("rounded-full");
+    expect(avatar).toHaveAttribute("data-size", "sm");
+    expect(avatarFallback).toBeInTheDocument();
+    expect(avatarFallback).toHaveClass("bg-muted", "text-muted-foreground");
+    expect(skeleton).toBeInTheDocument();
+    expect(skeleton).toHaveClass("bg-muted");
+    expect(table).toBeInTheDocument();
+    expect(table).toHaveClass("caption-bottom");
+    expect(tableHeader).toBeInTheDocument();
+    expect(tableHeader).toHaveClass("[&_tr]:border-border");
+    expect(tableRow).toBeInTheDocument();
+    expect(tableRow).toHaveClass("border-border");
   });
 
   it("keeps native buttons on type=button by default", () => {


### PR DESCRIPTION
## Validation

- `npm test -- --run src/ui/ui.test.tsx src/components/MoveOrganizationalUnitDialog.test.tsx src/components/RouteLoader.test.tsx src/pages/Employees/EmployeeBwrPanel.test.tsx src/components/mobile-sidebar-layout.test.tsx src/pages/Login.test.tsx` — 156 tests passed across 6 files
- `npm run format:check -- …` — passed for all touched test files
- `npx eslint … --report-unused-disable-directives --max-warnings 0` — passed for all touched test files
- `npm run typecheck` — passed
- `reuse lint` and `git diff --check` — passed

## Summary

- Capture DOM nodes queried in the scoped tests before applying class or attribute matchers.
- Assert that each captured node is in the document first, so missing nodes produce explicit failures.

Closes #1379

## Follow-up before marking ready

- CI checks are in progress.
- The PR-view self-review found no issues; there are no linked workspace changes or unresolved local validation checks.
