### PR TITLE
Ignore local preview staging files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ storybook-static/
 !/.ddev/config.yaml
 
 .context
+.polyscope-preview-stage/


### PR DESCRIPTION
## Validation

The focused ignore check initially failed because `.polyscope-preview-stage/build.lock` was not ignored. It now passes and identifies `.gitignore:83` as the matching rule.

Completed checks:

- `git check-ignore -v .polyscope-preview-stage/build.lock`
- `git diff --check`
- `npm run lint`
- `npm run typecheck`
- Pre-push formatting, domain-policy, lint, and typecheck checks
- Commit hooks, including REUSE validation

## Summary

- Ignore the generated `.polyscope-preview-stage/` directory.
- Keep local preview lock files out of the working-tree change set.

## Follow-up before ready

Review CI results and complete the final self-review in the PR view. Related SecPal/api and SecPal/android workspaces were not changed by this frontend-only update.
