### PR TITLE
Fix organizational unit filter encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   actions. Capability checks now expose an accurate, bounded loading state,
   malformed native responses use device-neutral guidance, and passkey-only
   incompatibility alerts use assertive announcements.
-- Serialized organizational-unit active and assignable list filters as
-  `true`/`false`, matching API validation and preventing filtered requests from
-  failing with HTTP 422.
+- Serialized organizational-unit active and assignable list filters as `1`/`0`,
+  matching API validation and preventing filtered requests from failing with
+  HTTP 422 when opening forms that load assignable organizational units.
 - Release artifacts now include a deterministic third-party dependency notice
   bundle generated from their actual JavaScript and copied-asset module graph.
   It preserves package-specific notices and license texts, including Inter's

--- a/src/services/organizationalUnitApi.test.ts
+++ b/src/services/organizationalUnitApi.test.ts
@@ -71,12 +71,12 @@ describe("Organizational Unit API", () => {
     });
 
     it.each([
-      ["is_active", true, "is_active=true"],
-      ["is_active", false, "is_active=false"],
-      ["is_assignable", true, "is_assignable=true"],
-      ["is_assignable", false, "is_assignable=false"],
+      ["is_active", true, "is_active=1"],
+      ["is_active", false, "is_active=0"],
+      ["is_assignable", true, "is_assignable=1"],
+      ["is_assignable", false, "is_assignable=0"],
     ] as const)(
-      "serializes %s=%s as a boolean query value",
+      "serializes %s=%s as an API-compatible boolean query value",
       async (filter, value, expectedQuery) => {
         mockFetchWithCsrf.mockResolvedValue({
           ok: true,

--- a/src/services/organizationalUnitApi.test.ts
+++ b/src/services/organizationalUnitApi.test.ts
@@ -91,20 +91,8 @@ describe("Organizational Unit API", () => {
         });
 
         expect(mockFetchWithCsrf).toHaveBeenCalledWith(
-          expect.stringContaining("type=branch"),
-          expect.any(Object)
-        );
-        expect(mockFetchWithCsrf).toHaveBeenCalledWith(
-          expect.stringContaining("parent_id=parent-1"),
-          expect.any(Object)
-        );
-        expect(mockFetchWithCsrf).toHaveBeenCalledWith(
-          expect.stringContaining("per_page=10"),
-          expect.any(Object)
-        );
-        expect(mockFetchWithCsrf).toHaveBeenCalledWith(
-          expect.stringContaining(expectedQuery),
-          expect.any(Object)
+          `${apiConfig.baseUrl}/v1/organizational-units?type=branch&parent_id=parent-1&${expectedQuery}&per_page=10`,
+          expect.objectContaining({ method: "GET" })
         );
       }
     );

--- a/src/services/organizationalUnitApi.ts
+++ b/src/services/organizationalUnitApi.ts
@@ -71,10 +71,10 @@ export async function listOrganizationalUnits(
     params.set("parent_id", filters.parent_id ?? "null");
   }
   if (filters?.is_active !== undefined) {
-    params.set("is_active", String(filters.is_active));
+    params.set("is_active", filters.is_active ? "1" : "0");
   }
   if (filters?.is_assignable !== undefined) {
-    params.set("is_assignable", String(filters.is_assignable));
+    params.set("is_assignable", filters.is_assignable ? "1" : "0");
   }
   if (filters?.per_page) {
     params.set("per_page", String(filters.per_page));


### PR DESCRIPTION
## Reproduced defect

`listOrganizationalUnits({ is_assignable: true })` encoded the filter as
`is_assignable=true`. The API rejects that query value, so forms that load
assignable organizational units fail with HTTP 422 before an object can be
created. The added regression cases in `src/services/organizationalUnitApi.test.ts:73`
initially failed against the `true`/`false` serialization.

## Change

- Encode active and assignable organizational-unit filters as `1` or `0` in
  `src/services/organizationalUnitApi.ts:73`.
- Cover both boolean values for both filters in
  `src/services/organizationalUnitApi.test.ts:73`.
- Correct the Unreleased changelog entry in `CHANGELOG.md:27`.

## Validation

- `npm test -- src/services/organizationalUnitApi.test.ts` (17 passed)
- `npm run typecheck`
- `npx eslint src/services/organizationalUnitApi.ts src/services/organizationalUnitApi.test.ts`
- Push hooks: Prettier, Markdownlint, domain-policy check, lint, and typecheck

## Follow-up before ready

- No linked-workspace changes are required.
- Await CI and complete the final self-review in this PR before marking it ready.
