### PR TITLE
feat: add customer Legal Entity lookup client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added synchronized customer API type aliases for `legal_entity_id` and a
+  dedicated customer Legal Entity lookup client that only reads
+  `/v1/customers/legal-entities` and validates the minimal `id`/`name`
+  response shape.
+
 ### Fixed
 
 - Renamed the German `Legal Entity` label to `Rechtsträger` in the

--- a/src/pages/Customers/CustomerCreate.test.tsx
+++ b/src/pages/Customers/CustomerCreate.test.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -8,9 +8,11 @@ import { BrowserRouter } from "react-router-dom";
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
 import CustomerCreate from "./CustomerCreate";
+import * as customerLegalEntitiesApi from "../../services/customerLegalEntitiesApi";
 import * as customersApi from "../../services/customersApi";
 
 // Mock the API
+vi.mock("../../services/customerLegalEntitiesApi");
 vi.mock("../../services/customersApi");
 
 const SLOW_TEST_TIMEOUT = 20000;
@@ -55,9 +57,9 @@ async function chooseFirstLegalEntity() {
 describe("CustomerCreate", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(customersApi.listCustomerLegalEntities).mockResolvedValue(
-      legalEntities
-    );
+    vi.mocked(
+      customerLegalEntitiesApi.listCustomerLegalEntities
+    ).mockResolvedValue(legalEntities);
   });
 
   it("renders the form with all required fields", () => {

--- a/src/pages/Customers/CustomerCreate.tsx
+++ b/src/pages/Customers/CustomerCreate.tsx
@@ -15,10 +15,8 @@ import { Button } from "@/ui/button";
 import { Checkbox } from "@/ui/checkbox";
 import { Input } from "@/ui/input";
 import { Textarea } from "@/ui/textarea";
-import {
-  createCustomer,
-  listCustomerLegalEntities,
-} from "../../services/customersApi";
+import { createCustomer } from "../../services/customersApi";
+import { listCustomerLegalEntities } from "../../services/customerLegalEntitiesApi";
 import type {
   CreateCustomerRequest,
   Address,

--- a/src/services/customerLegalEntitiesApi.test.ts
+++ b/src/services/customerLegalEntitiesApi.test.ts
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { apiConfig } from "../config";
+import { listCustomerLegalEntities } from "./customerLegalEntitiesApi";
+import * as csrf from "./csrf";
+
+vi.mock("./csrf");
+
+describe("customerLegalEntitiesApi", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches only the customer legal entity lookup endpoint", async () => {
+    const mockResponse = {
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        data: [
+          {
+            id: "550e8400-e29b-41d4-a716-446655440001",
+            name: "SecPal GmbH",
+          },
+        ],
+      }),
+    };
+
+    vi.mocked(csrf.apiFetch).mockResolvedValue(mockResponse as any);
+
+    const result = await listCustomerLegalEntities();
+
+    expect(csrf.apiFetch).toHaveBeenCalledWith(
+      `${apiConfig.baseUrl}/v1/customers/legal-entities`
+    );
+    expect(result).toEqual([
+      {
+        id: "550e8400-e29b-41d4-a716-446655440001",
+        name: "SecPal GmbH",
+      },
+    ]);
+  });
+
+  it("rejects missing lookup fields", async () => {
+    const mockResponse = {
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        data: [{ id: "550e8400-e29b-41d4-a716-446655440001" }],
+      }),
+    };
+
+    vi.mocked(csrf.apiFetch).mockResolvedValue(mockResponse as any);
+
+    await expect(listCustomerLegalEntities()).rejects.toThrow(
+      /legal entity lookup response/i
+    );
+  });
+
+  it("rejects widened organizational unit responses", async () => {
+    const mockResponse = {
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        data: [
+          {
+            id: "550e8400-e29b-41d4-a716-446655440001",
+            name: "SecPal GmbH",
+            type: "company",
+            is_legal_entity: true,
+          },
+        ],
+      }),
+    };
+
+    vi.mocked(csrf.apiFetch).mockResolvedValue(mockResponse as any);
+
+    await expect(listCustomerLegalEntities()).rejects.toThrow(
+      /legal entity lookup response/i
+    );
+  });
+
+  it("surfaces API errors", async () => {
+    const mockResponse = {
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+      json: vi.fn().mockResolvedValue({ message: "Forbidden" }),
+    };
+
+    vi.mocked(csrf.apiFetch).mockResolvedValue(mockResponse as any);
+
+    await expect(listCustomerLegalEntities()).rejects.toThrow("Forbidden");
+  });
+});

--- a/src/services/customerLegalEntitiesApi.ts
+++ b/src/services/customerLegalEntitiesApi.ts
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+import { apiConfig } from "../config";
+import type { CustomerLegalEntityLookup } from "../types/customers";
+import { apiFetch } from "./csrf";
+
+const LEGAL_ENTITY_LOOKUP_KEYS = new Set(["id", "name"]);
+
+function parseCustomerLegalEntityLookup(
+  value: unknown
+): CustomerLegalEntityLookup {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Invalid legal entity lookup response");
+  }
+
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record);
+
+  if (
+    keys.some((key) => !LEGAL_ENTITY_LOOKUP_KEYS.has(key)) ||
+    typeof record.id !== "string" ||
+    typeof record.name !== "string"
+  ) {
+    throw new Error("Invalid legal entity lookup response");
+  }
+
+  return {
+    id: record.id,
+    name: record.name,
+  };
+}
+
+export async function listCustomerLegalEntities(): Promise<
+  CustomerLegalEntityLookup[]
+> {
+  const response = await apiFetch(
+    `${apiConfig.baseUrl}/v1/customers/legal-entities`
+  );
+
+  if (!response.ok) {
+    const error = await response
+      .json()
+      .catch(() => ({ message: response.statusText }));
+    throw new Error(error.message || "Failed to list legal entities");
+  }
+
+  const data = (await response.json()) as { data?: unknown };
+  if (!Array.isArray(data.data)) {
+    throw new Error("Invalid legal entity lookup response");
+  }
+
+  return data.data.map(parseCustomerLegalEntityLookup);
+}

--- a/src/services/customersApi.test.ts
+++ b/src/services/customersApi.test.ts
@@ -8,7 +8,6 @@ import {
   listCustomers,
   getCustomer,
   createCustomer,
-  listCustomerLegalEntities,
   updateCustomer,
   listSites,
   getSite,
@@ -269,58 +268,6 @@ describe("customersApi", () => {
             "Content-Type": "application/json",
           }),
         })
-      );
-    });
-  });
-
-  describe("listCustomerLegalEntities", () => {
-    it("fetches the narrow customer legal entity lookup", async () => {
-      const mockResponse = {
-        ok: true,
-        json: vi.fn().mockResolvedValue({
-          data: [
-            {
-              id: "550e8400-e29b-41d4-a716-446655440001",
-              name: "SecPal GmbH",
-            },
-          ],
-        }),
-      };
-
-      vi.mocked(csrf.apiFetch).mockResolvedValue(mockResponse as any);
-
-      const result = await listCustomerLegalEntities();
-
-      expect(csrf.apiFetch).toHaveBeenCalledWith(
-        `${apiConfig.baseUrl}/v1/customers/legal-entities`
-      );
-      expect(result).toEqual([
-        {
-          id: "550e8400-e29b-41d4-a716-446655440001",
-          name: "SecPal GmbH",
-        },
-      ]);
-    });
-
-    it("rejects legal entity lookup responses that include general organizational data", async () => {
-      const mockResponse = {
-        ok: true,
-        json: vi.fn().mockResolvedValue({
-          data: [
-            {
-              id: "550e8400-e29b-41d4-a716-446655440001",
-              name: "SecPal GmbH",
-              type: "company",
-              parent_id: "550e8400-e29b-41d4-a716-446655440000",
-            },
-          ],
-        }),
-      };
-
-      vi.mocked(csrf.apiFetch).mockResolvedValue(mockResponse as any);
-
-      await expect(listCustomerLegalEntities()).rejects.toThrow(
-        /legal entity lookup response/i
       );
     });
   });

--- a/src/services/customersApi.ts
+++ b/src/services/customersApi.ts
@@ -52,7 +52,6 @@ function handleApiValidationError(error: {
 
 import type {
   Customer,
-  CustomerLegalEntityLookup,
   CreateCustomerRequest,
   UpdateCustomerRequest,
   CustomerFilters,
@@ -111,53 +110,6 @@ export async function listCustomers(
 
   const data = (await response.json()) as PaginatedResponse<Customer>;
   return data;
-}
-
-function parseCustomerLegalEntityLookup(
-  value: unknown
-): CustomerLegalEntityLookup {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new Error("Invalid legal entity lookup response");
-  }
-
-  const record = value as Record<string, unknown>;
-  const keys = Object.keys(record);
-  const allowedKeys = new Set(["id", "name"]);
-
-  if (
-    keys.some((key) => !allowedKeys.has(key)) ||
-    typeof record.id !== "string" ||
-    typeof record.name !== "string"
-  ) {
-    throw new Error("Invalid legal entity lookup response");
-  }
-
-  return {
-    id: record.id,
-    name: record.name,
-  };
-}
-
-export async function listCustomerLegalEntities(): Promise<
-  CustomerLegalEntityLookup[]
-> {
-  const response = await apiFetch(
-    `${apiConfig.baseUrl}/v1/customers/legal-entities`
-  );
-
-  if (!response.ok) {
-    const error = await response
-      .json()
-      .catch(() => ({ message: response.statusText }));
-    throw new Error(error.message || "Failed to list legal entities");
-  }
-
-  const data = (await response.json()) as { data?: unknown };
-  if (!Array.isArray(data.data)) {
-    throw new Error("Invalid legal entity lookup response");
-  }
-
-  return data.data.map(parseCustomerLegalEntityLookup);
 }
 
 /**

--- a/src/types/api/customers.test.ts
+++ b/src/types/api/customers.test.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+import { describe, expect, it } from "vitest";
+import type { CreateCustomerRequest, Customer } from "./customers";
+
+describe("generated customer API types", () => {
+  it("syncs required legal entity ids onto customer reads and creates", () => {
+    const customerLegalEntityId: Customer["legal_entity_id"] =
+      "550e8400-e29b-41d4-a716-446655440001";
+    const createLegalEntityId: CreateCustomerRequest["legal_entity_id"] =
+      customerLegalEntityId;
+
+    expect(createLegalEntityId).toBe(customerLegalEntityId);
+  });
+});

--- a/src/types/api/customers.ts
+++ b/src/types/api/customers.ts
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+import type { components } from "./openapi.generated";
+
+type Schemas = components["schemas"];
+
+export type Customer = Schemas["Customer"];
+export type CreateCustomerRequest = Schemas["CustomerCreateRequest"];
+export type CustomerLegalEntityLookup = Schemas["CustomerLegalEntityLookup"];

--- a/src/types/api/openapi.generated.ts
+++ b/src/types/api/openapi.generated.ts
@@ -129,5 +129,47 @@ export interface components {
       data: components["schemas"]["OrganizationalUnit"][];
       meta: components["schemas"]["OrganizationalUnitPaginationMeta"];
     };
+    Address: {
+      street: string;
+      city: string;
+      postal_code: string;
+      country: string;
+      latitude?: number | null;
+      longitude?: number | null;
+    };
+    Contact: {
+      name: string;
+      email?: string | null;
+      phone?: string | null;
+      position?: string | null;
+    };
+    Customer: {
+      id: string;
+      customer_number: string;
+      legal_entity_id: string;
+      name: string;
+      billing_address: components["schemas"]["Address"];
+      contact?: components["schemas"]["Contact"] | null;
+      is_active: boolean;
+      notes?: string | null;
+      metadata?: Record<string, unknown> | null;
+      sites_count?: number;
+      created_at: string;
+      updated_at: string;
+      deleted_at?: string | null;
+    };
+    CustomerLegalEntityLookup: {
+      id: string;
+      name: string;
+    };
+    CustomerCreateRequest: {
+      legal_entity_id: string;
+      name: string;
+      billing_address: components["schemas"]["Address"];
+      contact?: components["schemas"]["Contact"] | null;
+      is_active?: boolean;
+      notes?: string | null;
+      metadata?: Record<string, unknown> | null;
+    };
   };
 }


### PR DESCRIPTION
## Summary

- Add generated Legal Entity API aliases and a dedicated minimal lookup client.

## Validation

- Focused Vitest coverage, TypeScript, and linting.


## Related draft PRs

- Contract Legal Entity: https://github.com/SecPal/contracts/pull/354
- API Legal Entity persistence: https://github.com/SecPal/api/pull/1282
- API creation authorization: https://github.com/SecPal/api/pull/1285
- API lookup endpoint: https://github.com/SecPal/api/pull/1284
- Frontend migration decision: https://github.com/SecPal/frontend/pull/1395
- Frontend contract integration: https://github.com/SecPal/frontend/pull/1398
- Frontend lookup client: https://github.com/SecPal/frontend/pull/1396
- Frontend selector: https://github.com/SecPal/frontend/pull/1397
- Contract VAT ID: https://github.com/SecPal/contracts/pull/353
- API VAT ID: https://github.com/SecPal/api/pull/1283
- Frontend VAT ID: https://github.com/SecPal/frontend/pull/1399
