### PR TITLE
test(customers): cover legal entity reassignment

### DIFF
--- a/src/services/customersApi.test.ts
+++ b/src/services/customersApi.test.ts
@@ -273,6 +273,40 @@ describe("customersApi", () => {
   });
 
   describe("updateCustomer", () => {
+    it("sends a legal entity reassignment payload", async () => {
+      const updateData = {
+        legal_entity_id: "550e8400-e29b-41d4-a716-446655440002",
+      };
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          data: {
+            id: "customer-123",
+            legal_entity_id: updateData.legal_entity_id,
+            name: "Existing Customer",
+            billing_address: {
+              street: "Street",
+              city: "City",
+              postal_code: "12345",
+              country: "DE",
+            },
+          },
+        }),
+      };
+
+      vi.mocked(csrf.apiFetch).mockResolvedValue(mockResponse as any);
+
+      await updateCustomer("customer-123", updateData);
+
+      expect(csrf.apiFetch).toHaveBeenCalledWith(
+        `${apiConfig.baseUrl}/v1/customers/customer-123`,
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify(updateData),
+        })
+      );
+    });
+
     it("updates customer successfully", async () => {
       const updateData = {
         name: "Updated Customer",


### PR DESCRIPTION
## Evidence

The earlier customer update request type excluded `legal_entity_id`, so a
contract-valid Legal Entity reassignment payload could not be passed to
`updateCustomer`. The generated schema alias now exposes the optional field;
this change adds the missing client-level regression coverage.

## Changes

- Verify that `updateCustomer` accepts and PATCH-serializes a reassignment
  payload containing `legal_entity_id`.

## Validation

- `npm test -- src/services/customersApi.test.ts src/types/api/customers.test.ts`
- `npm run typecheck`
- `npm run lint -- src/services/customersApi.test.ts`
- `git diff --check`

## Follow-up

- Linked workspaces: none.
- Unresolved checks: remote CI is pending. Keep this PR as a draft until CI
  completes and the final PR-view self-review is complete.

Closes #1400
