### PR TITLE
fix(ci): restore Prettier pre-commit hook with npm 12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
       - id: prettier
         name: prettier
-        entry: npx --no-install prettier --write
+        entry: ./node_modules/.bin/prettier --write
         language: system
         types_or: [markdown, yaml, json]
         exclude: 'package-lock\.json|composer\.lock|yarn\.lock|pnpm-lock\.yaml'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,10 +15,12 @@ repos:
       - id: reuse
 
   # Code formatting
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: local
     hooks:
       - id: prettier
+        name: prettier
+        entry: npx --no-install prettier --write
+        language: system
         types_or: [markdown, yaml, json]
         exclude: 'package-lock\.json|composer\.lock|yarn\.lock|pnpm-lock\.yaml'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Restored the mandatory Prettier pre-commit hook under npm 12 by running the
+  repository's installed formatter as a local system hook.
 - Derived the preflight Markdown linter version from `package.json`, keeping
   dependency updates and local linting in sync without a duplicate version pin.
 - Added retry recovery for failed customer Legal Entity lookups and normalized

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Restored the mandatory Prettier pre-commit hook under npm 12 by running the
-  repository's installed formatter as a local system hook.
+  repository's installed formatter as a local system hook and installing its
+  locked dependencies during hook setup.
 - Derived the preflight Markdown linter version from `package.json`, keeping
   dependency updates and local linting in sync without a duplicate version pin.
 - Added retry recovery for failed customer Legal Entity lookups and normalized

--- a/scripts/setup-pre-commit.sh
+++ b/scripts/setup-pre-commit.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-FileCopyrightText: 2025 SecPal Contributors
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: MIT
 
 set -euo pipefail
@@ -23,6 +23,17 @@ if ! command -v pre-commit &>/dev/null; then
 	echo ""
 	exit 1
 fi
+
+if ! command -v npm &>/dev/null; then
+	echo "❌ npm is not installed."
+	echo ""
+	echo "Install the supported Node.js and npm toolchain, then run this script again."
+	exit 1
+fi
+
+# Install the locked project dependencies required by local system hooks.
+echo "📦 Installing project dependencies..."
+npm ci
 
 # Install pre-commit hooks
 echo "📦 Installing pre-commit hooks..."

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -331,6 +331,17 @@ describe("Build Configuration and Source Verification", () => {
     }
   });
 
+  it("runs Prettier as a local system hook compatible with npm 12", () => {
+    const preCommitConfig = readRepoFile(".pre-commit-config.yaml");
+
+    expect(preCommitConfig).not.toContain("pre-commit/mirrors-prettier");
+    expect(preCommitConfig).toContain("- id: prettier");
+    expect(preCommitConfig).toContain("language: system");
+    expect(preCommitConfig).toContain(
+      "entry: npx --no-install prettier --write"
+    );
+  });
+
   it("keeps SecPal attribution off Lukas-owned locale sidecars", () => {
     for (const relativePath of [
       "src/locales/de/messages.js.license",

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -343,6 +343,15 @@ describe("Build Configuration and Source Verification", () => {
     expect(preCommitConfig).not.toContain("npx --no-install prettier");
   });
 
+  it("installs Node dependencies before verifying local pre-commit hooks", () => {
+    const setupPreCommit = readRepoFile("scripts/setup-pre-commit.sh");
+
+    expect(setupPreCommit).toContain("npm ci");
+    expect(setupPreCommit.indexOf("npm ci")).toBeLessThan(
+      setupPreCommit.indexOf("pre-commit install --install-hooks")
+    );
+  });
+
   it("keeps SecPal attribution off Lukas-owned locale sidecars", () => {
     for (const relativePath of [
       "src/locales/de/messages.js.license",

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -338,8 +338,9 @@ describe("Build Configuration and Source Verification", () => {
     expect(preCommitConfig).toContain("- id: prettier");
     expect(preCommitConfig).toContain("language: system");
     expect(preCommitConfig).toContain(
-      "entry: npx --no-install prettier --write"
+      "entry: ./node_modules/.bin/prettier --write"
     );
+    expect(preCommitConfig).not.toContain("npx --no-install prettier");
   });
 
   it("keeps SecPal attribution off Lukas-owned locale sidecars", () => {


### PR DESCRIPTION
## Verification

- Regression coverage first failed while `.pre-commit-config.yaml` referenced
  `pre-commit/mirrors-prettier`, then passed after the local-hook migration.
- `npm exec vitest -- run tests/build.test.ts`
- `pre-commit validate-config`
- `pre-commit run prettier --all-files`
- `pre-commit run shellcheck --files scripts/setup-pre-commit.sh`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `reuse lint` for the changed files
- Push preflight, including formatting, Markdown linting, domain-policy, lint,
  and TypeScript checks

## Summary

- replace the npm 12-incompatible Prettier mirror hook with a local system hook
- require the repository-installed Prettier binary directly
- install locked Node dependencies before verifying local pre-commit hooks
- add regression coverage and document the fix in the changelog

Closes #1408.

## Follow-up before ready

- CI checks are pending.
- Full setup verification still depends on the separately tracked existing
  hook failures in #1410, #1411, and #1412.
- No linked workspace changes are required.
