### PR TITLE
Stabilize custom Vite build test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Stabilized the custom Vite output-directory release-build regression test by
+  giving its full typecheck, Vite/PWA build, and SBOM-generation path a
+  load-tolerant timeout.
 - Restored the mandatory Prettier pre-commit hook under npm 12 by running the
   repository's installed formatter as a local system hook and installing its
   locked dependencies during hook setup.

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -173,7 +173,10 @@ describe("Build Configuration and Source Verification", () => {
     } finally {
       rmSync(distRoot, { recursive: true, force: true });
     }
-  }, 30_000);
+    // This covers the full release build path (typecheck, Vite/PWA build, and
+    // SBOM generation). It took 26.8 seconds in isolation, so retain a
+    // load-tolerant timeout without changing the default for lightweight tests.
+  }, 60_000);
 
   it("keeps timeout-minutes only on runnable quality workflow jobs", () => {
     const qualityWorkflow = readRepoFile(".github/workflows/quality.yml");


### PR DESCRIPTION
## Reproduction

The custom Vite output-directory build regression test previously exceeded its
30-second Vitest timeout while running the complete release path. Its isolated
test body had taken 26.8 seconds, leaving insufficient headroom for normal
machine-load variance.

## Summary

- Give only the full custom-output release-build test a 60-second timeout.
- Document the release-path work covered by that timeout and record the fix in
  the changelog.

## Validation

- `npx vitest run tests/build.test.ts --reporter=verbose` — 39 passed; the
  custom-output test completed in 20.4 seconds.
- `npx prettier --check tests/build.test.ts CHANGELOG.md`
- `npx eslint tests/build.test.ts`
- Commit hooks, including `reuse lint`; push preflight, including repository
  lint and typecheck.

## Follow-up

No linked workspaces require follow-up. CI checks are in progress and must
pass before this draft can be marked ready for review.
