### PR TITLE
test(build): stabilize custom Vite output timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Normalized generated locale catalogs and conflict-marker hook documentation
   so a first full pre-commit run completes without modifying tracked files.
 - Stabilized the custom Vite output-directory release-build regression test by
-  giving its full typecheck, Vite/PWA build, and SBOM-generation path a
-  load-tolerant timeout.
+  giving its full typecheck, Vite/PWA build, and SBOM-generation path enough
+  load-tolerant time to complete during full-suite runs.
 - Restored the mandatory Prettier pre-commit hook under npm 12 by running the
   repository's installed formatter as a local system hook and installing its
   locked dependencies during hook setup.

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -174,9 +174,9 @@ describe("Build Configuration and Source Verification", () => {
       rmSync(distRoot, { recursive: true, force: true });
     }
     // This covers the full release build path (typecheck, Vite/PWA build, and
-    // SBOM generation). It took 26.8 seconds in isolation, so retain a
-    // load-tolerant timeout without changing the default for lightweight tests.
-  }, 60_000);
+    // SBOM generation). It can exceed 60 seconds under full-suite load, so
+    // retain a load-tolerant timeout without changing lightweight test defaults.
+  }, 120_000);
 
   it("keeps timeout-minutes only on runnable quality workflow jobs", () => {
     const qualityWorkflow = readRepoFile(".github/workflows/quality.yml");


### PR DESCRIPTION
## Reproduced defect

The custom Vite output-directory regression runs the full release build path:
TypeScript checking, Vite/PWA build, and dependency SBOM generation. Under
full-suite load its 60-second test-local timeout could expire before the build
finished. A deliberately insufficient 10-second timeout reproduced the failure.

Closes #1419.

## Change

- Raise only this release-build regression's timeout to 120 seconds in
  `tests/build.test.ts`, preserving every custom-output and emitted-artifact
  assertion.
- Clarify the matching Unreleased changelog entry.

## Validation

- Focused build suite: 39 tests passed.
- Full suite: 192 test files and 2,848 tests passed.
- `npm run typecheck`
- `npm run lint`
- `reuse lint`
- Signed commit and repository pre-commit/pre-push checks passed.

## Follow-up before ready for review

No linked-workspace changes are required. Local validation is complete; wait
for required CI checks and the final PR self-review before marking this draft
ready.
