### PR TITLE
test: remove retired tool name from audit result

### DIFF
--- a/tests/native-api-development-guidance.test.ts
+++ b/tests/native-api-development-guidance.test.ts
@@ -73,7 +73,7 @@ describe("native API development guidance", () => {
     const retiredEnvironmentPattern = new RegExp(
       ["\\bD", "DEV\\b|\\bd", "dev\\b|\\.d", "dev"].join("")
     );
-    const activeDdevReferences = listActiveGuidanceFiles()
+    const retiredEnvironmentReferences = listActiveGuidanceFiles()
       .filter((file) => file !== "CHANGELOG.md")
       .flatMap((file) =>
         readRepoFile(file)
@@ -82,6 +82,6 @@ describe("native API development guidance", () => {
       )
       .filter(({ line }) => retiredEnvironmentPattern.test(line));
 
-    expect(activeDdevReferences).toEqual([]);
+    expect(retiredEnvironmentReferences).toEqual([]);
   });
 });


### PR DESCRIPTION
## Reproduced defect

The native workflow audit from SecPal/api#1324 failed against this checkout because `tests/native-api-development-guidance.test.ts` used the retired environment name in a camel-case local result variable.

## Change

- Rename the local result variable and its assertion to `retiredEnvironmentReferences`.
- Preserve the existing guidance-content scan and empty-result assertion.

## Validation

- `npm exec vitest run tests/native-api-development-guidance.test.ts`
- `npm run typecheck`
- `npm run lint`
- `reuse lint`
- Native workflow artifact audit from SecPal/api#1324 against this frontend checkout

## Follow-up before ready for review

- Linked work: SecPal/api#1324 provides the cross-repository audit. Its workspace currently tracks `main`, so the audit was run directly from that pull request's `remove-ddev` branch.
- No local validation remains unresolved. Complete the final PR-view self-review and confirm the linked API work before marking this draft ready.

Closes #1426
