### PR TITLE
Fix Vitest worker contention in native validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Capped the Vitest worker pool for every full-suite run, preventing concurrent
+  release-build validation tests from timing out in native workflow validation.
 - Kept the hooks diagnostic script's clean-shell command literal while making
   the full pre-commit setup verification ShellCheck-clean.
 - Normalized generated locale catalogs and conflict-marker hook documentation

--- a/tests/vite.config.test.ts
+++ b/tests/vite.config.test.ts
@@ -116,3 +116,29 @@ describe("vite config surface validation", () => {
     ).not.toThrow();
   });
 });
+
+describe("vite test workflow", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it.each([
+    { ci: "", environment: "outside CI" },
+    { ci: "true", environment: "in CI" },
+  ])("caps workers when the full suite runs $environment", async ({ ci }) => {
+    vi.stubEnv("CI", ci);
+    const { default: viteConfig } = await import("../vite.config");
+    const config =
+      typeof viteConfig === "function"
+        ? viteConfig({
+            command: "serve",
+            mode: "test",
+            isPreview: false,
+            isSsrBuild: false,
+          })
+        : viteConfig;
+
+    expect(config.test?.maxWorkers).toBe(2);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -339,9 +339,9 @@ export default defineConfig(({ mode, command }) => {
       unstubEnvs: true,
       testTimeout: 20000, // 20 seconds per test to keep full-suite UI tests stable under CI load
       hookTimeout: 20000, // 20 seconds for beforeEach/afterEach hooks
-      // Hosted runners expose 2 vCPUs; under parallel workflow load, the default
-      // worker pool can thrash and stall the suite tail (frontend#1233).
-      ...(isCi ? { maxWorkers: 2 } : {}),
+      // Native validation and hosted runners can both expose constrained CPUs;
+      // the default worker pool can thrash and stall heavyweight build checks.
+      maxWorkers: 2,
       // Exclude Playwright E2E tests (run separately via npm run test:e2e)
       exclude: ["**/node_modules/**", "**/dist/**", "**/tests/e2e/**"],
       coverage: {


### PR DESCRIPTION
## Reproduced defect

`npm run test` could time out in native workflow validation because the Vitest
worker cap in `vite.config.ts` applied only when `CI` was set. The affected
full-suite runs timed out in the release-build verification at
`tests/build.test.ts:122` and in `tests/shadcn-provenance.test.ts:212`, while
their isolated suites passed.

The regression test failed before this change: with `CI` unset, the resolved
Vitest configuration had no `maxWorkers` value.

Closes #1420

## Changes

- Cap the Vitest worker pool at two workers for both native and hosted runs.
- Cover the CI and non-CI configurations, while restoring stubbed environment
  state after each test.
- Record the workflow stabilization in the changelog.

## Validation

- `npm run test:run -- tests/vite.config.test.ts` (8 tests passed)
- `npm run test` (193 files and 2,855 tests passed)
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `reuse lint`
- Pre-commit and pre-push checks

## Follow-up

No linked workspace changes are required; contracts, API, and Android remain
unchanged. No unresolved local checks remain. Keep this PR as a draft until CI
finishes and the final PR-view self-review finds no issues.
