### PR TITLE
Auto-select sole legal entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dependency updates and local linting in sync without a duplicate version pin.
 - Customer creation now requires a tenant-authorized Legal Entity, automatically
   selects and disables the field when exactly one is available, and submits that
-  assignment. Customer list, detail, and edit views display only the API-provided
-  assignment and prevent updates to unmigrated customers until an authorized
-  Legal Entity is explicitly selected.
+  assignment. Selections that are no longer authorized are discarded after the
+  available options refresh. Customer list, detail, and edit views display only
+  the API-provided assignment and prevent updates to unmigrated customers until
+  an authorized Legal Entity is explicitly selected.
 - Added retry recovery for failed customer Legal Entity lookups in create and
   edit flows and normalized malformed lookup envelopes to the documented
   validation error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   locked dependencies during hook setup.
 - Derived the preflight Markdown linter version from `package.json`, keeping
   dependency updates and local linting in sync without a duplicate version pin.
-- Customer creation now requires an explicit tenant-authorized Legal Entity
-  selection. Customer list, detail, and edit views display only the API-provided
+- Customer creation now requires a tenant-authorized Legal Entity, automatically
+  selects and disables the field when exactly one is available, and submits that
+  assignment. Customer list, detail, and edit views display only the API-provided
   assignment and prevent updates to unmigrated customers until an authorized
   Legal Entity is explicitly selected.
 - Added retry recovery for failed customer Legal Entity lookups in create and

--- a/src/pages/Customers/CustomerCreate.test.tsx
+++ b/src/pages/Customers/CustomerCreate.test.tsx
@@ -375,7 +375,7 @@ describe("CustomerCreate", () => {
     });
   });
 
-  it("does not submit a stale legal entity after authorized options refresh", async () => {
+  it("requires selecting the lone replacement after an authorized options refresh", async () => {
     const user = userEvent.setup();
     const replacementLegalEntity = {
       id: "550e8400-e29b-41d4-a716-446655440003",
@@ -419,11 +419,17 @@ describe("CustomerCreate", () => {
         resolveRefresh([replacementLegalEntity]);
         await refreshPromise;
       });
-      await waitFor(() => {
-        expect(
-          screen.getByRole("combobox", { name: /legal entity/i })
-        ).toHaveTextContent("Select legal entity...");
+      const trigger = await screen.findByRole("combobox", {
+        name: /legal entity/i,
       });
+      await waitFor(() => {
+        expect(trigger).toBeEnabled();
+        expect(trigger).toHaveTextContent("Select legal entity...");
+      });
+      await user.click(trigger);
+      await user.click(
+        await screen.findByRole("option", { name: replacementLegalEntity.name })
+      );
 
       fireEvent.change(screen.getByLabelText(/customer name/i), {
         target: { value: "Refreshed Entity Customer" },
@@ -442,10 +448,13 @@ describe("CustomerCreate", () => {
         screen.getByRole("button", { name: /create customer/i })
       );
 
-      expect(
-        await screen.findByText(/legal entity is required/i)
-      ).toBeInTheDocument();
-      expect(customersApi.createCustomer).not.toHaveBeenCalled();
+      await waitFor(() => {
+        expect(customersApi.createCustomer).toHaveBeenCalledWith(
+          expect.objectContaining({
+            legal_entity_id: replacementLegalEntity.id,
+          })
+        );
+      });
     } finally {
       unmount();
       if (previousLocale) {

--- a/src/pages/Customers/CustomerCreate.test.tsx
+++ b/src/pages/Customers/CustomerCreate.test.tsx
@@ -3,6 +3,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -372,6 +373,87 @@ describe("CustomerCreate", () => {
         })
       );
     });
+  });
+
+  it("does not submit a stale legal entity after authorized options refresh", async () => {
+    const user = userEvent.setup();
+    const replacementLegalEntity = {
+      id: "550e8400-e29b-41d4-a716-446655440003",
+      name: "SecPal Services GmbH",
+    };
+    const previousLocale = i18n.locale;
+    const nextLocale = previousLocale === "de" ? "en" : "de";
+    let resolveRefresh: (
+      entities: Awaited<
+        ReturnType<typeof customerLegalEntitiesApi.listCustomerLegalEntities>
+      >
+    ) => void = () => {};
+    const refreshPromise = new Promise<
+      Awaited<
+        ReturnType<typeof customerLegalEntitiesApi.listCustomerLegalEntities>
+      >
+    >((resolve) => {
+      resolveRefresh = resolve;
+    });
+
+    vi.mocked(customerLegalEntitiesApi.listCustomerLegalEntities)
+      .mockResolvedValueOnce(legalEntities)
+      .mockReturnValueOnce(refreshPromise);
+
+    const { unmount } = renderWithRouter(<CustomerCreate />);
+
+    await chooseLegalEntity(secondLegalEntity.name);
+
+    try {
+      act(() => {
+        i18n.load(nextLocale, {});
+        i18n.activate(nextLocale);
+      });
+
+      await waitFor(() => {
+        expect(
+          customerLegalEntitiesApi.listCustomerLegalEntities
+        ).toHaveBeenCalledTimes(2);
+      });
+      await act(async () => {
+        resolveRefresh([firstLegalEntity, replacementLegalEntity]);
+        await refreshPromise;
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByRole("combobox", { name: /legal entity/i })
+        ).toHaveTextContent("Select legal entity...");
+      });
+
+      fireEvent.change(screen.getByLabelText(/customer name/i), {
+        target: { value: "Refreshed Entity Customer" },
+      });
+      fireEvent.change(screen.getByLabelText(/street/i), {
+        target: { value: "Street 1" },
+      });
+      fireEvent.change(screen.getByLabelText(/postal code/i), {
+        target: { value: "12345" },
+      });
+      fireEvent.change(screen.getByLabelText(/city/i), {
+        target: { value: "City" },
+      });
+
+      await user.click(
+        screen.getByRole("button", { name: /create customer/i })
+      );
+
+      expect(
+        await screen.findByText(/legal entity is required/i)
+      ).toBeInTheDocument();
+      expect(customersApi.createCustomer).not.toHaveBeenCalled();
+    } finally {
+      unmount();
+      if (previousLocale) {
+        act(() => {
+          i18n.activate(previousLocale);
+        });
+      }
+    }
   });
 
   it("selects, disables, and submits the only available legal entity", async () => {

--- a/src/pages/Customers/CustomerCreate.test.tsx
+++ b/src/pages/Customers/CustomerCreate.test.tsx
@@ -416,7 +416,7 @@ describe("CustomerCreate", () => {
         ).toHaveBeenCalledTimes(2);
       });
       await act(async () => {
-        resolveRefresh([firstLegalEntity, replacementLegalEntity]);
+        resolveRefresh([replacementLegalEntity]);
         await refreshPromise;
       });
       await waitFor(() => {

--- a/src/pages/Customers/CustomerCreate.test.tsx
+++ b/src/pages/Customers/CustomerCreate.test.tsx
@@ -374,7 +374,7 @@ describe("CustomerCreate", () => {
     });
   });
 
-  it("requires an explicit legal entity selection when exactly one entity is available", async () => {
+  it("selects, disables, and submits the only available legal entity", async () => {
     const user = userEvent.setup();
     const mockCustomer = {
       id: "customer-single-entity",
@@ -402,8 +402,10 @@ describe("CustomerCreate", () => {
     const trigger = await screen.findByRole("combobox", {
       name: /legal entity/i,
     });
-    expect(trigger).toBeEnabled();
-    expect(trigger).toHaveTextContent("Select legal entity...");
+    await waitFor(() => {
+      expect(trigger).toBeDisabled();
+      expect(trigger).toHaveTextContent(firstLegalEntity.name);
+    });
 
     fireEvent.change(screen.getByLabelText(/customer name/i), {
       target: { value: "Single Entity Customer" },
@@ -420,10 +422,13 @@ describe("CustomerCreate", () => {
 
     await user.click(screen.getByRole("button", { name: /create customer/i }));
 
-    expect(
-      await screen.findByText(/legal entity is required/i)
-    ).toBeInTheDocument();
-    expect(customersApi.createCustomer).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(customersApi.createCustomer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          legal_entity_id: firstLegalEntity.id,
+        })
+      );
+    });
   });
 
   it("shows an empty state and cannot post when no legal entity is available", async () => {

--- a/src/pages/Customers/CustomerCreate.tsx
+++ b/src/pages/Customers/CustomerCreate.tsx
@@ -184,9 +184,13 @@ export default function CustomerCreate() {
     }));
   }
 
+  const selectedLegalEntityId =
+    legalEntities.length === 1
+      ? legalEntities[0]!.id
+      : formData.legal_entity_id;
+
   function validateForm(): CustomerFormErrors {
     const validationErrors: CustomerFormErrors = {};
-    const selectedLegalEntityId = formData.legal_entity_id;
 
     if (formData.name.trim().length === 0) {
       validationErrors.name = _(msg`Customer name is required.`);
@@ -247,7 +251,7 @@ export default function CustomerCreate() {
     try {
       // Clean up the data before sending
       const dataToSend: CreateCustomerRequest = {
-        legal_entity_id: formData.legal_entity_id,
+        legal_entity_id: selectedLegalEntityId,
         name: formData.name,
         billing_address: formData.billing_address,
         is_active: formData.is_active,
@@ -285,10 +289,10 @@ export default function CustomerCreate() {
   }
 
   const hasLegalEntityOptions = legalEntities.length > 0;
-  const legalEntitySelectDisabled = loadingLegalEntities;
+  const legalEntitySelectDisabled =
+    loadingLegalEntities || legalEntities.length === 1;
   const cannotCreateCustomer =
     loading || loadingLegalEntities || !hasLegalEntityOptions || !!lookupError;
-  const selectedLegalEntityId = formData.legal_entity_id;
 
   return (
     <div className="max-w-3xl">

--- a/src/pages/Customers/CustomerCreate.tsx
+++ b/src/pages/Customers/CustomerCreate.tsx
@@ -187,7 +187,11 @@ export default function CustomerCreate() {
   const selectedLegalEntityId =
     legalEntities.length === 1
       ? legalEntities[0]!.id
-      : formData.legal_entity_id;
+      : legalEntities.some(
+            (legalEntity) => legalEntity.id === formData.legal_entity_id
+          )
+        ? formData.legal_entity_id
+        : "";
 
   function validateForm(): CustomerFormErrors {
     const validationErrors: CustomerFormErrors = {};

--- a/src/pages/Customers/CustomerCreate.tsx
+++ b/src/pages/Customers/CustomerCreate.tsx
@@ -184,14 +184,17 @@ export default function CustomerCreate() {
     }));
   }
 
-  const selectedLegalEntityId =
-    legalEntities.length === 1
+  const hasExplicitLegalEntitySelection =
+    formData.legal_entity_id.trim().length > 0;
+  const selectedLegalEntityId = hasExplicitLegalEntitySelection
+    ? legalEntities.some(
+        (legalEntity) => legalEntity.id === formData.legal_entity_id
+      )
+      ? formData.legal_entity_id
+      : ""
+    : legalEntities.length === 1
       ? legalEntities[0]!.id
-      : legalEntities.some(
-            (legalEntity) => legalEntity.id === formData.legal_entity_id
-          )
-        ? formData.legal_entity_id
-        : "";
+      : "";
 
   function validateForm(): CustomerFormErrors {
     const validationErrors: CustomerFormErrors = {};

--- a/src/pages/Customers/CustomerCreate.tsx
+++ b/src/pages/Customers/CustomerCreate.tsx
@@ -186,10 +186,14 @@ export default function CustomerCreate() {
 
   const hasExplicitLegalEntitySelection =
     formData.legal_entity_id.trim().length > 0;
+  const isExplicitLegalEntitySelectionAuthorized = legalEntities.some(
+    (legalEntity) => legalEntity.id === formData.legal_entity_id
+  );
+  const hasStaleExplicitLegalEntitySelection =
+    hasExplicitLegalEntitySelection &&
+    !isExplicitLegalEntitySelectionAuthorized;
   const selectedLegalEntityId = hasExplicitLegalEntitySelection
-    ? legalEntities.some(
-        (legalEntity) => legalEntity.id === formData.legal_entity_id
-      )
+    ? isExplicitLegalEntitySelectionAuthorized
       ? formData.legal_entity_id
       : ""
     : legalEntities.length === 1
@@ -297,7 +301,8 @@ export default function CustomerCreate() {
 
   const hasLegalEntityOptions = legalEntities.length > 0;
   const legalEntitySelectDisabled =
-    loadingLegalEntities || legalEntities.length === 1;
+    loadingLegalEntities ||
+    (legalEntities.length === 1 && !hasStaleExplicitLegalEntitySelection);
   const cannotCreateCustomer =
     loading || loadingLegalEntities || !hasLegalEntityOptions || !!lookupError;
 


### PR DESCRIPTION
## Evidence

The customer-create regression test reproduced that a tenant with exactly one authorized Legal Entity still showed an empty, editable selector and blocked submission until a redundant manual selection.

## Change

The customer-create form now derives the selected Legal Entity from the sole available authorized option, disables the selector when there is no alternative, and sends that identifier in the create request. The changelog and focused regression coverage were updated.

## Validation

- `npx vitest run src/pages/Customers/CustomerCreate.test.tsx` — 23 passed
- `npm run typecheck`
- `npx eslint src/pages/Customers/CustomerCreate.tsx src/pages/Customers/CustomerCreate.test.tsx --max-warnings 0`
- `npx prettier --check CHANGELOG.md src/pages/Customers/CustomerCreate.tsx src/pages/Customers/CustomerCreate.test.tsx`
- `reuse lint`
- Push preflight: 193 test files and 2,855 tests passed

## Follow-up before ready

No linked workspace changes are required. GitHub Actions checks have not completed yet; this PR remains a draft pending the final PR-view self-review and CI results.
