### PR TITLE
Fix fast-uri vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Updated the transitive `fast-uri` dependency to 3.1.4 to remediate the
+  literal-backslash authority delimiter host-confusion vulnerability.
 - Aligned generated customer response types with the required
   caller-visible `customer_establishments` array.
 - Loaded every customer-establishment assignment page, resolved authorized

--- a/package-lock.json
+++ b/package-lock.json
@@ -9393,9 +9393,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Problem and evidence

`package-lock.json` resolved the `vite-plugin-pwa` dependency path to
`fast-uri` 3.1.2. That version is affected by literal-backslash authority
delimiter host confusion, which can cause a host-policy parser and Node URL
consumer to disagree about the destination host.

## Change

- Updated the locked `fast-uri` package resolution to 3.1.4.
- Added an Unreleased changelog entry for the security remediation.

## Validation

- `npm ci --ignore-scripts` completed with zero audit vulnerabilities.
- `npm ls fast-uri` resolved the dependency path to `fast-uri@3.1.4`.
- `npm run build` passed.
- `npm run lint` passed.
- `reuse lint` passed.
- `npm audit --audit-level=high` reported zero vulnerabilities.
- The signed commit passed the configured pre-commit checks and standard
  pre-push formatting, lint, typecheck, and domain-policy checks.

## Readiness

The full Vitest suite cannot start after the clean install because
`@vitest/expect` cannot resolve `chai`; this is tracked in #1492 and prevents
this draft from being ready for review. An unrelated deprecated `source-map`
dependency is tracked in #1491. Neither finding changes the `fast-uri` update
in this pull request.
