### PR TITLE
Fix Vitest Chai resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Declared Chai as an explicit Vitest development dependency so clean
+  installations can resolve Vitest's assertion package before the test suite
+  starts.
 - Updated the transitive `fast-uri` dependency to 3.1.4 to remediate the
   literal-backslash authority delimiter host-confusion vulnerability.
 - Aligned generated customer response types with the required

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "@vitejs/plugin-react": "^6.0.4",
         "@vitest/coverage-v8": "^4.1.10",
         "@vitest/ui": "^4.1.10",
+        "chai": "^6.2.2",
         "cross-env": "^10.1.0",
         "eslint": "^10.7.0",
         "eslint-plugin-react-hooks": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "@vitejs/plugin-react": "^6.0.4",
     "@vitest/coverage-v8": "^4.1.10",
     "@vitest/ui": "^4.1.10",
+    "chai": "^6.2.2",
     "cross-env": "^10.1.0",
     "eslint": "^10.7.0",
     "eslint-plugin-react-hooks": "^7.1.1",

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -242,11 +242,14 @@ describe("Build Configuration and Source Verification", () => {
       >;
     };
 
-    expect(packageJson.devDependencies?.chai).toBe("^6.2.2");
-    expect(packageLock.packages[""]?.devDependencies?.chai).toBe("^6.2.2");
-    expect(
-      packageLock.packages["node_modules/@vitest/expect"]?.dependencies?.chai
-    ).toBeDefined();
+    const expectedChaiRange =
+      packageLock.packages["node_modules/@vitest/expect"]?.dependencies?.chai;
+
+    expect(expectedChaiRange).toBeDefined();
+    expect(packageJson.devDependencies?.chai).toBe(expectedChaiRange);
+    expect(packageLock.packages[""]?.devDependencies?.chai).toBe(
+      expectedChaiRange
+    );
     expect(packageLock.packages["node_modules/chai"]).toBeDefined();
   });
 

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -228,6 +228,28 @@ describe("Build Configuration and Source Verification", () => {
     expect(packageLock.packages?.[""]?.license).toBe(packageJson.license);
   });
 
+  it("declares Chai for Vitest's assertion package", () => {
+    const packageJson = JSON.parse(readRepoFile("package.json")) as {
+      devDependencies?: Record<string, string>;
+    };
+    const packageLock = JSON.parse(readRepoFile("package-lock.json")) as {
+      packages: Record<
+        string,
+        {
+          dependencies?: Record<string, string>;
+          devDependencies?: Record<string, string>;
+        }
+      >;
+    };
+
+    expect(packageJson.devDependencies?.chai).toBe("^6.2.2");
+    expect(packageLock.packages[""]?.devDependencies?.chai).toBe("^6.2.2");
+    expect(
+      packageLock.packages["node_modules/@vitest/expect"]?.dependencies?.chai
+    ).toBeDefined();
+    expect(packageLock.packages["node_modules/chai"]).toBeDefined();
+  });
+
   it("keeps explicit dev and build scripts for every app surface", () => {
     const packageJson = JSON.parse(readRepoFile("package.json")) as {
       scripts?: Record<string, string>;


### PR DESCRIPTION
## Summary

Closes #1492.

`@vitest/expect` imports `chai` at runtime. After a clean installation, the
full Vitest suite could stop before running tests when that package was not
available from the project dependency graph.

This change declares `chai` as an explicit development dependency and updates
the lockfile root metadata, ensuring the assertion package is installed for
the Vitest suite. The Unreleased changelog records the fix.

## Validation

- `npm ci --dry-run`
- `npm exec -- vitest run src/lib/serviceWorkerAuthRedirect.test.ts --bail=1`
  (1 file, 6 tests passed)
- `npm run typecheck`
- `npm run lint`
- `reuse lint`
- Pre-commit and pre-push checks

## Remaining check

`npm run test:run` has not completed in a stable isolated installation and
remains required before this draft can be marked ready for review.
