### PR TITLE
Reject non-numeric bootstrap schema versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Rejected Android runtime bootstrap responses whose schema version is not an
+  integer JSON number instead of coercing non-canonical values such as strings.
 - Android runtime discovery now accepts the canonical bootstrap schema `4`,
   retains schema `3` only for the documented Android rollout window, and sends
   the validated schema version in browser notification-installation payloads.

--- a/src/services/runtimeDiscovery.test.ts
+++ b/src/services/runtimeDiscovery.test.ts
@@ -91,6 +91,33 @@ describe("runtime discovery", () => {
     ).resolves.toEqual(payload.data);
   });
 
+  it.each(["4", null, true, [], {}, 4.5])(
+    "rejects malformed bootstrap schema version %j",
+    async (schemaVersion) => {
+      const payload = createBootstrapPayload({
+        compatibility: {
+          bootstrap_version: "v1",
+          schema_version: schemaVersion,
+          minimum_supported_app_version: "1.4.0",
+          minimum_supported_app_build: 10400,
+        },
+      });
+
+      await expect(
+        discoverAndroidRuntimeBootstrap({
+          instanceUrl: "https://api.secpal.dev",
+          locale: "en",
+          runtimeInfo,
+          fetchBootstrap: vi
+            .fn()
+            .mockResolvedValue(
+              new Response(JSON.stringify(payload), { status: 200 })
+            ),
+        })
+      ).rejects.toMatchObject({ code: "BOOTSTRAP_INCOMPATIBLE" });
+    }
+  );
+
   it("fetches canonical Android bootstrap metadata for a secure instance origin", async () => {
     const fetchBootstrap = vi.fn().mockResolvedValue(
       new Response(JSON.stringify(createBootstrapPayload()), {

--- a/src/services/runtimeDiscovery.ts
+++ b/src/services/runtimeDiscovery.ts
@@ -272,10 +272,12 @@ function validateBootstrapPayload(
   const minimumSupportedAppBuild = Number(
     compatibility.minimum_supported_app_build
   );
-  const schemaVersion = Number(compatibility.schema_version);
+  const schemaVersion = compatibility.schema_version;
 
   if (
     compatibility.bootstrap_version !== CURRENT_BOOTSTRAP_VERSION ||
+    typeof schemaVersion !== "number" ||
+    !Number.isInteger(schemaVersion) ||
     !ACCEPTED_BOOTSTRAP_SCHEMA_VERSIONS.has(schemaVersion)
   ) {
     throw new RuntimeDiscoveryError(


### PR DESCRIPTION
## Summary

- require `compatibility.schema_version` to be an integer JSON number
- reject malformed schema-version types before checking the supported rollout set
- preserve support for numeric schema versions 3 and 4
- document the stricter bootstrap validation

## Problem and evidence

Runtime discovery converted `compatibility.schema_version` with `Number(...)`.
That accepted non-canonical values such as the JSON string `"4"` and returned
them as the supported numeric schema version `4`.

The regression test reproduced the defect first: discovery resolved
successfully for `"4"` instead of returning `BOOTSTRAP_INCOMPATIBLE`.

## Change

The bootstrap parser now checks the raw value with a JSON-number type guard and
`Number.isInteger(...)` before consulting the supported rollout set. Regression
coverage exercises a numeric string, null, a boolean, an array, an object, and a
fractional number while retaining positive coverage for numeric schemas 3 and
4.

## Validation

- `npm run test:related -- src/services/runtimeDiscovery.ts` (5 files, 105 tests)
- `npm run typecheck`
- `npx eslint src/services/runtimeDiscovery.ts src/services/runtimeDiscovery.test.ts --report-unused-disable-directives --max-warnings 0`
- `npx prettier --check src/services/runtimeDiscovery.ts src/services/runtimeDiscovery.test.ts CHANGELOG.md`
- `reuse lint`
- `PREFLIGHT_RUN_TESTS=1 git push` (196 files, 2,851 tests, plus full lint, typecheck, formatting, Markdown, and domain-policy checks)
- commit hooks, including REUSE, Prettier, Markdownlint, conflict, whitespace, and line-ending checks

## Readiness

No known in-scope dependency or local check prevents readiness. This remains a
draft until GitHub checks complete and the final PR-view self-review confirms
that no issues remain.

Closes #1497.
