### PR TITLE
Remove obsolete native enrollment facade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Removed the final obsolete native enrollment compatibility surface from the
+  public enterprise facade, which now exposes only the preserved OSS-license
+  bridge.
 - Removed the obsolete Android provisioning frontend route, navigation,
   enrollment-session transport, capabilities, runtime-bootstrap bridge field,
   and associated localization and E2E support.

--- a/src/native/SecPalEnterprise.ts
+++ b/src/native/SecPalEnterprise.ts
@@ -3,13 +3,7 @@
 
 import { Capacitor, registerPlugin } from "@capacitor/core";
 
-export interface SecPalEnterpriseEnrollment {
-  readonly tenantId: string;
-  readonly managedBy?: string;
-}
-
 export interface SecPalEnterpriseFacade {
-  getEnrollment(): Promise<SecPalEnterpriseEnrollment | null>;
   isOssLicensesAvailable(): boolean;
   openOssLicenses(): Promise<boolean>;
 }
@@ -44,9 +38,6 @@ function isOssLicensesAvailable(): boolean {
 }
 
 export const SecPalEnterprise: SecPalEnterpriseFacade = {
-  async getEnrollment(): Promise<SecPalEnterpriseEnrollment | null> {
-    return null;
-  },
   isOssLicensesAvailable(): boolean {
     return isOssLicensesAvailable();
   },

--- a/src/native/facades.test.ts
+++ b/src/native/facades.test.ts
@@ -43,11 +43,15 @@ describe("native facade surface", () => {
     expect(nativeFacades).not.toHaveProperty("executeNativeCommand");
   });
 
+  it("limits the enterprise facade to the OSS-license bridge", () => {
+    expect(Object.keys(nativeFacades.SecPalEnterprise).sort()).toEqual([
+      "isOssLicensesAvailable",
+      "openOssLicenses",
+    ]);
+  });
+
   it("keeps the prepared facades as inert stubs", async () => {
     await expect(nativeFacades.SecPalDeviceState.getSnapshot()).resolves.toBe(
-      null
-    );
-    await expect(nativeFacades.SecPalEnterprise.getEnrollment()).resolves.toBe(
       null
     );
     await expect(

--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -9,7 +9,6 @@ export {
 } from "./SecPalDeviceState";
 export {
   SecPalEnterprise,
-  type SecPalEnterpriseEnrollment,
   type SecPalEnterpriseFacade,
 } from "./SecPalEnterprise";
 export {


### PR DESCRIPTION
## Summary

Remove the final obsolete native enrollment compatibility surface while preserving the existing native OSS-license presentation bridge.

## Problem and evidence

The public `SecPalEnterprise` facade still declared an enrollment result type and a `getEnrollment()` method whose implementation always returned `null`. The type was also re-exported from the native barrel, and the only remaining caller was the facade test. There is no corresponding native plugin method or proven live consumer.

This leftover contract conflicts with the completed retirement of the enrollment-token flow.

## Changes

- remove the obsolete enrollment type, facade method, and null implementation
- remove the enrollment type re-export from the native barrel
- replace the obsolete null assertion with an exact public-surface regression guard
- preserve the OSS-license capability discovery, delegation, and fail-closed behavior
- record the final compatibility-surface removal in the changelog

## Validation

- demonstrated the regression guard failing first on the existing extra facade method
- `npm test -- --run src/native/facades.test.ts` — 8 tests passed
- `npm test` — 196 test files and 2,852 tests passed
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run i18n:check`
- `reuse lint`
- `git diff --check`
- commit and pre-push hooks
- repository and linked-organization caller scans found no active `SecPalEnterpriseEnrollment` or `getEnrollment()` references
- broader retired Android enrollment terminology remains limited to negative regression guards, removal migrations, cleanup code, and historical records

## Dependencies and readiness

There are no unresolved in-scope implementation checks or dependencies. The final self-review in the PR view found no issues. This PR remains draft pending required CI checks.

Closes #1500
