### PR TITLE
Require canonical runtime discovery schema 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,11 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Rejected Android runtime bootstrap responses whose schema version is not an
-  integer JSON number instead of coercing non-canonical values such as strings.
-- Android runtime discovery now accepts the canonical bootstrap schema `4`,
-  retains schema `3` only for the documented Android rollout window, and sends
-  the validated schema version in browser notification-installation payloads.
+- Android runtime discovery now accepts only strict JSON integer bootstrap
+  schema `4`, rejects every other or malformed schema value without coercion,
+  and sends the validated canonical schema in browser notification-installation
+  payloads.
 - Declared Chai as an explicit Vitest development dependency so clean
   installations can resolve Vitest's assertion package before the test suite
   starts.

--- a/src/services/runtimeDiscovery.test.ts
+++ b/src/services/runtimeDiscovery.test.ts
@@ -67,7 +67,7 @@ describe("runtime discovery", () => {
     ).resolves.toEqual(payload.data);
   });
 
-  it("temporarily accepts schema 3 for supported Android releases", async () => {
+  it("rejects the obsolete schema 3", async () => {
     const payload = createBootstrapPayload({
       compatibility: {
         bootstrap_version: "v1",
@@ -88,7 +88,7 @@ describe("runtime discovery", () => {
             new Response(JSON.stringify(payload), { status: 200 })
           ),
       })
-    ).resolves.toEqual(payload.data);
+    ).rejects.toMatchObject({ code: "BOOTSTRAP_INCOMPATIBLE" });
   });
 
   it.each(["4", null, true, [], {}, 4.5])(

--- a/src/services/runtimeDiscovery.ts
+++ b/src/services/runtimeDiscovery.ts
@@ -12,13 +12,6 @@ import type { SecPalRuntimeInfo } from "../native";
 const CURRENT_BOOTSTRAP_VERSION = "v1";
 const CURRENT_BOOTSTRAP_SCHEMA_VERSION = 4;
 
-// Keep schema 3 only while the API accepts schema-3 notification registrations
-// from supported Android releases. Remove it with that API compatibility path.
-const ACCEPTED_BOOTSTRAP_SCHEMA_VERSIONS = new Set([
-  3,
-  CURRENT_BOOTSTRAP_SCHEMA_VERSION,
-]);
-
 export type RuntimeDiscoveryErrorCode =
   | "INVALID_INSTANCE_URL"
   | "RUNTIME_INFO_UNAVAILABLE"
@@ -278,7 +271,7 @@ function validateBootstrapPayload(
     compatibility.bootstrap_version !== CURRENT_BOOTSTRAP_VERSION ||
     typeof schemaVersion !== "number" ||
     !Number.isInteger(schemaVersion) ||
-    !ACCEPTED_BOOTSTRAP_SCHEMA_VERSIONS.has(schemaVersion)
+    schemaVersion !== CURRENT_BOOTSTRAP_SCHEMA_VERSION
   ) {
     throw new RuntimeDiscoveryError(
       "BOOTSTRAP_INCOMPATIBLE",

--- a/tests/e2e/android-mock-instance.spec.ts
+++ b/tests/e2e/android-mock-instance.spec.ts
@@ -200,6 +200,14 @@ test.describe("Android mock instance switching", () => {
     await expect(page.getByText(/signed in to other tenant/i)).toBeVisible();
     await expect.poll(() => selectedHealthRequests.length).toBeGreaterThan(0);
 
+    await context.addCookies([
+      {
+        name: "XSRF-TOKEN",
+        value: "test-xsrf-token",
+        url: page.url(),
+      },
+    ]);
+
     await page.getByLabel(/email/i).fill("person@secpal.dev");
     await page.getByLabel(/password/i).fill("not-a-real-password");
     await page.getByRole("button", { name: /log in/i }).click();


### PR DESCRIPTION
## Summary

Runtime discovery accepted bootstrap schemas 3 and 4 even though SecPal has no
production population that requires the older compatibility path. The positive
schema-3 regression demonstrated that non-canonical discovery responses could
still enter runtime state.

This change:

- requires `compatibility.schema_version` to be the strict JSON integer `4`
- rejects schema 3, other integers, fractions, strings, nulls, booleans, arrays,
  and objects with `BOOTSTRAP_INCOMPATIBLE`
- removes the accepted-schema set and obsolete rollout comments
- keeps notification installation payloads forwarding the validated canonical
  schema value
- replaces the schema-3 acceptance regression with a rejection regression
- keeps native-facade, notification, and Android E2E fixtures on schema 4
- consolidates the unreleased changelog entry around the final schema-4-only
  behavior
- seeds the Android mock E2E CSRF state required to exercise the retargeted
  cross-origin login boundary

## Evidence

The new schema-3 rejection regression failed first because runtime discovery
resolved successfully with schema 3. It passes after replacing the compatibility
allowlist with the canonical schema comparison.

The repository audit finds no active schema-3 support, fallback, alias, rollout
comment, positive fixture, or documentation promise. Schema 3 remains only in
the regression that proves it is rejected.

## Validation

- `reuse lint`
- `npm test -- --run src/services/runtimeDiscovery.test.ts src/hooks/useNotifications.test.ts src/native/facades.test.ts` (53 tests)
- Android mock instance E2E boundary (3 tests)
- `npm run typecheck`
- `npm run lint`
- `npm run build:android`
- push preflight, including the complete Vitest suite (196 test files, 2,852 tests)
- `git diff --check`

## Dependencies and readiness

This is part of `SecPal/.github#590` and supersedes the compatibility direction
from #1509. There are no unresolved in-scope dependencies. GitHub checks are
still pending and prevent readiness. The PR remains draft for those checks and
the required final review in the PR view before it can be marked ready.

Closes #1510.
