### PR TITLE
fix(deps): update brace-expansion to 5.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   starts.
 - Updated the transitive `fast-uri` dependency to 3.1.4 to remediate the
   literal-backslash authority delimiter host-confusion vulnerability.
+- Updated the transitive `brace-expansion` dependency to 5.0.8 to remediate
+  its unbounded-expansion memory denial-of-service vulnerability.
 - Aligned generated customer response types with the required
   caller-visible `customer_establishments` array.
 - Loaded every customer-establishment assignment page, resolved authorized

--- a/package-lock.json
+++ b/package-lock.json
@@ -8167,16 +8167,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "flatted": "3.4.2",
     "picomatch@^2": "2.3.2",
     "picomatch@^4": "4.0.4",
-    "brace-expansion": ">=5.0.7",
+    "brace-expansion": ">=5.0.8",
     "@isaacs/brace-expansion": ">=5.0.1",
     "minimatch": ">=10.2.4",
     "yauzl": "3.2.1",


### PR DESCRIPTION
## Summary

Closes #1513.

### Problem and evidence

The lockfile resolved the transitive `brace-expansion` package at 5.0.7, which is affected by an unbounded-expansion memory denial-of-service vulnerability. `npm ls brace-expansion --all` now resolves the only installed instance through `eslint` and `minimatch` at 5.0.8.

### Change

- Raised the package override floor to `brace-expansion` 5.0.8.
- Updated the resolved package, integrity hash, and supported-engine metadata in `package-lock.json`.
- Recorded the security remediation in `CHANGELOG.md`.

### Validation

- `npm ci`
- `npm run lint`
- `npm run typecheck`
- `npm test` — 196 files and 2,852 tests passed
- `npm run build`
- `reuse lint`
- Git pre-commit and pre-push checks

### Remaining checks and dependencies

There is no in-scope dependency preventing this update. `npm audit` still reports the separately tracked `js-yaml` and React Router findings in #1514 and #1515, respectively, under epic #1512. This PR remains a draft pending CI and the final PR-view self-review.
