### PR TITLE
Fix missing browser notification fallback icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Used the shipped canonical PNG icon for regular browser notification
+  fallbacks and verified every referenced notification icon is emitted by
+  production builds.
 - Resolved the deprecated `source-map@0.8.0-beta.0` transitive dependency from
   `workbox-build` to its supported 0.8.0 release.
 - Android runtime discovery now accepts only strict JSON integer bootstrap

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -421,7 +421,7 @@ describe("useNotifications", () => {
       });
     });
 
-    it("should fallback to browser notification if service worker unavailable", async () => {
+    it("uses the shipped canonical icon for the browser notification fallback", async () => {
       // Mock service worker without showNotification
       Object.defineProperty(navigator, "serviceWorker", {
         value: {
@@ -446,7 +446,7 @@ describe("useNotifications", () => {
 
       expect(mockNotification).toHaveBeenCalledWith("Fallback Notification", {
         body: "Using browser API",
-        icon: "/pwa-192x192.svg",
+        icon: "/pwa-192x192.png",
         tag: undefined,
         requireInteraction: undefined,
         data: undefined,

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -582,7 +582,7 @@ export function useNotifications(
           // Fallback to regular notification
           new Notification(options.title, {
             body: options.body,
-            icon: options.icon || "/pwa-192x192.svg",
+            icon: options.icon || "/pwa-192x192.png",
             tag: options.tag,
             requireInteraction: options.requireInteraction,
             data: options.data,

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -204,6 +204,23 @@ describe("Build Configuration and Source Verification", () => {
       expect(readFileSync(path.join(distRoot, "index.html"), "utf8")).toContain(
         'src="/custom/'
       );
+
+      const referencedNotificationIcons = [
+        "src/hooks/useNotifications.ts",
+        "src/sw.ts",
+      ].flatMap((sourcePath) =>
+        Array.from(
+          readRepoFile(sourcePath).matchAll(
+            /["'](\/pwa-[^"']+\.(?:png|svg))["']/gu
+          ),
+          (match) => match[1]
+        )
+      );
+
+      expect(referencedNotificationIcons.length).toBeGreaterThan(0);
+      for (const iconPath of new Set(referencedNotificationIcons)) {
+        expect(existsSync(path.join(distRoot, iconPath.slice(1)))).toBe(true);
+      }
     } finally {
       rmSync(distRoot, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- use the shipped `/pwa-192x192.png` asset for the regular browser `Notification` fallback
- cover the fallback with a focused regression test
- verify that production builds emit every static PWA icon referenced by the notification implementations

## Problem and evidence

The regular browser fallback in `src/hooks/useNotifications.ts` referenced
`/pwa-192x192.svg`, but `public/` ships only the canonical PNG variants. The
fallback therefore requested a missing runtime asset, and the stricter signed
Android artifact dependency verification in SecPal/android#495 detected the
same missing packaged dependency.

The focused fallback test and production-build asset verification both failed
against the previous SVG reference before the implementation changed.

## Change

The browser fallback now uses `/pwa-192x192.png`, matching the service-worker
notification paths. The fallback test asserts that exact constructor option,
and the release-build test discovers static PWA icon references in
`src/hooks/useNotifications.ts` and `src/sw.ts` and checks that each referenced
file exists in the emitted output.

`CHANGELOG.md` records the correction.

## Validation

- focused browser-fallback regression test
- focused production-build notification asset verification
- complete `src/hooks/useNotifications.test.ts` suite: 31 tests passed
- web production build
- Android production build with the PNG present in the artifact and referenced
  by both the application bundle and `sw.js`
- `npm run typecheck`
- `npm run lint`
- Prettier check for all changed files
- REUSE compliance
- signed-commit hooks and pre-push validation

## Readiness

No unresolved local checks or in-scope dependencies remain. This pull request
must land before the next signed Android artifact is produced with the stricter
dependency verifier from SecPal/android#495. It remains a draft as requested;
the final self-review in the pull request view found no issues.

Closes #1543
