### PR TITLE
test: eliminate OnboardingWizard act warnings

### DIFF
--- a/src/pages/Onboarding/OnboardingWizard.test.tsx
+++ b/src/pages/Onboarding/OnboardingWizard.test.tsx
@@ -3,6 +3,7 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -122,7 +123,7 @@ async function renderWithAuthenticatedProviders(options?: {
     },
   } as Awaited<ReturnType<typeof authApi.getCurrentUser>>);
 
-  return render(
+  const providers = (
     <MemoryRouter initialEntries={["/onboarding"]}>
       <I18nProvider i18n={i18n}>
         <AuthContext.Provider
@@ -165,6 +166,10 @@ async function renderWithAuthenticatedProviders(options?: {
       </I18nProvider>
     </MemoryRouter>
   );
+
+  await act(async () => {
+    render(providers);
+  });
 }
 
 async function selectNationality(
@@ -801,8 +806,7 @@ describe("OnboardingWizard", () => {
     const expiryInput = screen.getByLabelText(/residence title valid until/i);
     // 2026-06-01 is after auth date (2026-05-01) so validation must pass,
     // meaning employment-permitted question appears.
-    fireEvent.change(expiryInput, { target: { value: "2026-06-01" } });
-    fireEvent.blur(expiryInput);
+    await user.type(expiryInput, "2026-06-01");
 
     expect(
       await screen.findByLabelText(/employment permitted/i)
@@ -4598,7 +4602,7 @@ describe("OnboardingWizard initial loading and error states", () => {
     i18n.activate("en");
   });
 
-  it("renders the initial onboarding skeleton inside the wizard frame", () => {
+  it("renders the initial onboarding skeleton inside the wizard frame", async () => {
     let resolveSteps: (value: unknown[]) => void = () => {};
     onboardingApiMocks.fetchOnboardingSteps.mockImplementation(
       () =>
@@ -4623,6 +4627,10 @@ describe("OnboardingWizard initial loading and error states", () => {
     expect(loadingRegion.tagName.toLowerCase()).toBe("div");
 
     resolveSteps([]);
+
+    expect(
+      await screen.findByText(/no onboarding steps are available right now/i)
+    ).toBeInTheDocument();
   });
 
   it("keeps the wizard frame mounted while a step transition loads the next template", async () => {

--- a/src/pages/Onboarding/OnboardingWizard.test.tsx
+++ b/src/pages/Onboarding/OnboardingWizard.test.tsx
@@ -90,6 +90,15 @@ function setCsrfTokenCookie(value: string) {
   document.cookie = `XSRF-TOKEN=${encodeURIComponent(value)};path=/`;
 }
 
+function findReactActWarnings(calls: unknown[][]) {
+  return calls.filter((call) =>
+    call.some(
+      (value) =>
+        typeof value === "string" && value.includes("not wrapped in act")
+    )
+  );
+}
+
 async function renderWithAuthenticatedProviders(options?: {
   contractStartDate?: string | null;
   employeeId?: string;
@@ -785,9 +794,16 @@ describe("OnboardingWizard", () => {
       can_be_edited: false,
     });
 
+    const consoleError = vi.spyOn(console, "error");
     await renderWithAuthenticatedProviders({
       contractStartDate: "2026-05-01",
     });
+    const initialRenderActWarnings = findReactActWarnings(
+      consoleError.mock.calls
+    );
+    consoleError.mockRestore();
+
+    expect(initialRenderActWarnings).toHaveLength(0);
 
     expect(
       await screen.findByRole("heading", { name: /personal information form/i })
@@ -807,6 +823,8 @@ describe("OnboardingWizard", () => {
     // 2026-06-01 is after auth date (2026-05-01) so validation must pass,
     // meaning employment-permitted question appears.
     await user.type(expiryInput, "2026-06-01");
+    await user.tab();
+    expect(expiryInput).not.toHaveFocus();
 
     expect(
       await screen.findByLabelText(/employment permitted/i)
@@ -4603,6 +4621,7 @@ describe("OnboardingWizard initial loading and error states", () => {
   });
 
   it("renders the initial onboarding skeleton inside the wizard frame", async () => {
+    const consoleError = vi.spyOn(console, "error");
     let resolveSteps: (value: unknown[]) => void = () => {};
     onboardingApiMocks.fetchOnboardingSteps.mockImplementation(
       () =>
@@ -4631,6 +4650,13 @@ describe("OnboardingWizard initial loading and error states", () => {
     expect(
       await screen.findByText(/no onboarding steps are available right now/i)
     ).toBeInTheDocument();
+
+    const loadingTransitionActWarnings = findReactActWarnings(
+      consoleError.mock.calls
+    );
+    consoleError.mockRestore();
+
+    expect(loadingTransitionActWarnings).toHaveLength(0);
   });
 
   it("keeps the wizard frame mounted while a step transition loads the next template", async () => {

--- a/tests/e2e/onboarding-wizard-validation.spec.ts
+++ b/tests/e2e/onboarding-wizard-validation.spec.ts
@@ -80,17 +80,75 @@ const onboardingEmployee = {
   contract_start_date: "2026-05-01",
   status: "pre_contract",
 };
-const onboardingNationalities = [{ code: "DE", name: "German" }];
+const onboardingNationalities = [
+  { code: "DE", name: "German" },
+  { code: "TR", name: "Turkish" },
+];
+
+const personalInformationTemplate = {
+  id: "template-personal-information",
+  name: "Personal Information",
+  title: "Personal Information",
+  description: "Personal information required for registration.",
+  form_schema: {
+    type: "object",
+    required: ["gender", "nationalities"],
+    properties: {
+      gender: {
+        type: "string",
+        title: "Gender",
+        enum: ["male", "female", "diverse"],
+      },
+      nationalities: {
+        type: "array",
+        title: "Nationalities",
+        items: {
+          type: "string",
+          enum: ["DE", "TR"],
+        },
+      },
+    },
+  },
+  is_required: true,
+  is_system_template: true,
+  sort_order: 1,
+  can_be_deleted: false,
+  can_be_edited: false,
+};
+
+const personalInformationSubmission = {
+  id: "submission-personal-information",
+  employee_id: onboardingEmployee.id,
+  form_template_id: personalInformationTemplate.id,
+  form_data: {
+    gender: "female",
+    nationalities: ["TR"],
+  },
+  status: "draft",
+  created_at: "2026-05-01T00:00:00Z",
+  updated_at: "2026-05-01T00:00:00Z",
+};
+
+interface WizardRouteScenario {
+  templates: ReadonlyArray<{ id: string }>;
+  submissions: ReadonlyArray<{ form_template_id: string }>;
+}
+
+const patternValidationScenario: WizardRouteScenario = {
+  templates: [countryTemplate, finalTemplate],
+  submissions: [countrySubmission, finalSubmission],
+};
 
 async function installWizardValidationRoutes(
-  context: import("@playwright/test").BrowserContext
+  context: import("@playwright/test").BrowserContext,
+  scenario: WizardRouteScenario = patternValidationScenario
 ) {
   await context.route("**/v1/onboarding/templates", async (route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
       body: JSON.stringify({
-        data: [countryTemplate, finalTemplate],
+        data: scenario.templates,
       }),
     });
   });
@@ -99,11 +157,7 @@ async function installWizardValidationRoutes(
     const templateId = route.request().url().split("/").at(-1);
 
     const template =
-      templateId === countryTemplate.id
-        ? countryTemplate
-        : templateId === finalTemplate.id
-          ? finalTemplate
-          : null;
+      scenario.templates.find((entry) => entry.id === templateId) ?? null;
 
     if (!template) {
       await route.fulfill({
@@ -126,7 +180,7 @@ async function installWizardValidationRoutes(
       status: 200,
       contentType: "application/json",
       body: JSON.stringify({
-        data: [countrySubmission, finalSubmission],
+        data: scenario.submissions,
       }),
     });
   });
@@ -199,7 +253,7 @@ async function installWizardValidationRoutes(
   });
 }
 
-test.describe("Onboarding wizard validation fallback", () => {
+test.describe("Onboarding wizard validation", () => {
   test("uses the failed step schema when formatting cross-step pattern validation errors", async ({
     authenticatedPage: page,
   }) => {
@@ -238,5 +292,52 @@ test.describe("Onboarding wizard validation fallback", () => {
     await expect(
       page.getByText("The string should match pattern: ^[A-Z]{2}$")
     ).toHaveCount(0);
+  });
+
+  test("validates a residence-title date through the native browser control", async ({
+    authenticatedPage: page,
+  }) => {
+    test.skip(
+      isRemoteE2ETarget(),
+      "Deterministic residence-title coverage relies on local route mocks."
+    );
+
+    await installWizardValidationRoutes(page.context(), {
+      templates: [personalInformationTemplate],
+      submissions: [personalInformationSubmission],
+    });
+
+    await page.goto("/onboarding");
+    await page.waitForLoadState("networkidle");
+
+    await expect(
+      page.getByRole("heading", { name: /^Personal Information$/i })
+    ).toBeVisible();
+
+    const identityUploadGroup = page.getByRole("radiogroup", {
+      name: /would you like to upload your identity document now/i,
+    });
+    await identityUploadGroup
+      .getByRole("radio", { name: /^(no|nein)$/i })
+      .click();
+
+    await page.getByLabel(/residence title type/i).click();
+    await page
+      .getByRole("option", { name: /temporary residence permit/i })
+      .click();
+
+    const expiryInput = page.getByLabel(/residence title valid until/i);
+    await expect(expiryInput).toHaveAttribute("type", "date");
+    await expiryInput.fill("2030-06-01");
+    await expiryInput.press("Tab");
+
+    await expect(expiryInput).toHaveValue("2030-06-01");
+    await expect(
+      page.getByText(/must remain valid after your contract start date/i)
+    ).toHaveCount(0);
+
+    await expect(
+      page.getByRole("radiogroup", { name: /employment permitted/i })
+    ).toBeVisible();
   });
 });

--- a/tests/e2e/onboarding-wizard-validation.spec.ts
+++ b/tests/e2e/onboarding-wizard-validation.spec.ts
@@ -129,9 +129,18 @@ const personalInformationSubmission = {
   updated_at: "2026-05-01T00:00:00Z",
 };
 
+type WizardTemplate =
+  | typeof countryTemplate
+  | typeof finalTemplate
+  | typeof personalInformationTemplate;
+type WizardSubmission =
+  | typeof countrySubmission
+  | typeof finalSubmission
+  | typeof personalInformationSubmission;
+
 interface WizardRouteScenario {
-  templates: ReadonlyArray<{ id: string }>;
-  submissions: ReadonlyArray<{ form_template_id: string }>;
+  templates: ReadonlyArray<WizardTemplate>;
+  submissions: ReadonlyArray<WizardSubmission>;
 }
 
 const patternValidationScenario: WizardRouteScenario = {
@@ -216,11 +225,23 @@ async function installWizardValidationRoutes(
     }
 
     const requestBody = route.request().postDataJSON() as
-      { status?: string } | undefined;
+      { status?: string; form_data?: Record<string, unknown> } | undefined;
     const submissionId = route.request().url().split("/").at(-1);
+    const submission = scenario.submissions.find(
+      (entry) => entry.id === submissionId
+    );
+
+    if (!submission) {
+      await route.fulfill({
+        status: 404,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "Submission not found" }),
+      });
+      return;
+    }
 
     if (
-      submissionId === countrySubmission.id &&
+      submission.id === countrySubmission.id &&
       requestBody?.status === "draft"
     ) {
       await route.fulfill({
@@ -232,7 +253,7 @@ async function installWizardValidationRoutes(
     }
 
     if (
-      submissionId === countrySubmission.id &&
+      submission.id === countrySubmission.id &&
       requestBody?.status === "submitted"
     ) {
       await route.fulfill({
@@ -248,7 +269,13 @@ async function installWizardValidationRoutes(
     await route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({ data: finalSubmission }),
+      body: JSON.stringify({
+        data: {
+          ...submission,
+          status: requestBody?.status ?? submission.status,
+          form_data: requestBody?.form_data ?? submission.form_data,
+        },
+      }),
     });
   });
 }
@@ -306,6 +333,7 @@ test.describe("Onboarding wizard validation", () => {
       templates: [personalInformationTemplate],
       submissions: [personalInformationSubmission],
     });
+    await page.clock.install({ time: new Date("2026-05-15T12:00:00Z") });
 
     await page.goto("/onboarding");
     await page.waitForLoadState("networkidle");


### PR DESCRIPTION
## Summary

Fixes #1546.

- Await authenticated wizard rendering and user-visible settled states in the affected unit tests.
- Use awaited user input for date interactions so follow-up state updates remain inside Testing Library boundaries.
- Add deterministic E2E coverage for the native residence-title expiry control, with scenario-specific mock routes.

## Problem and evidence

`OnboardingWizard` tests passed while asynchronous state updates continued beyond their interaction or assertion boundaries, producing repeated React `act(...)` warnings in the focused Vitest run.

## Validation

- `CI=true npx vitest run src/ui/onboarding.test.tsx src/pages/Onboarding/OnboardingWizard.test.tsx --maxWorkers=1 --no-file-parallelism`
- `npm run test:migration-boundary`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci`
- `npm run build`
- `reuse lint`

## Readiness

No in-scope dependency is unresolved. The deterministic Playwright coverage was not executed locally because the repository requires separate authorization for environment-connected validation.
