### PR TITLE
test: eliminate LoginLanguageSwitcher act warning

### DIFF
--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -3577,6 +3577,7 @@ describe("Login", () => {
       vi.mocked(i18nModule.activateLocale).mockRejectedValueOnce(
         new Error("Failed to fetch chunk /assets/de-abc123.js")
       );
+      const user = userEvent.setup();
 
       renderLogin();
 
@@ -3586,11 +3587,16 @@ describe("Login", () => {
         ).toBeInTheDocument();
       });
 
-      await selectLanguage("Deutsch");
-
-      expect(await screen.findByRole("alert")).toHaveTextContent(
-        /failed to change language/i
+      await user.click(
+        screen.getByRole("combobox", { name: /select language/i })
       );
+      await user.click(await screen.findByRole("option", { name: "Deutsch" }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toHaveTextContent(
+          /failed to change language/i
+        );
+      });
 
       expect(
         screen.queryByText(/failed to fetch chunk/i)


### PR DESCRIPTION
## Summary

- Await the language-selection interaction with `userEvent` in the locale-activation failure test.
- Wait for the localized alert content to settle before continuing assertions.

## Problem and evidence

Issue #1548 reported that `src/pages/Login.test.tsx` could emit a React `act(...)` warning in `language switcher > shows the localized fallback error message when locale activation fails`.

`LoginLanguageSwitcher` sets its error state after the rejected `activateLocale(locale)` promise settles. The previous synchronous `fireEvent` interaction could return before that update was covered by an awaited interaction or assertion boundary.

## Change

The affected test now uses awaited `userEvent` clicks for the combobox and German option, then waits for the visible localized alert in `src/pages/Login.test.tsx`.

It continues to verify that the raw chunk-loading error is not rendered.

## Validation

- `npx vitest run src/pages/Login.test.tsx` — 100 tests passed without an `act(...)` warning.
- `npx eslint src/pages/Login.test.tsx`
- `npm run typecheck`
- `reuse lint`
- Push preflight: 196 test files and 2,864 tests passed, with formatting, lint, typecheck, and domain-policy checks passing.

## Readiness

No in-scope dependencies or unresolved local validation checks block review. This remains a draft pending the final PR-view self-review.

Closes #1548
