### PR TITLE
Remove retired changelog integration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,7 +50,6 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
   explicitly requires documenting AI tooling behavior.
 - Keep `SPDX-FileCopyrightText` years current in edited files or companion `.license` sidecars.
 - Domain policy is strict: `secpal.app` for the public homepage and real email addresses,
-  `changelog.secpal.app` for the public changelog site,
   `apk.secpal.app` for the canonical Android artifact and release-metadata host,
   `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev,
   staging, testing, and examples, and `app.secpal` only as the Android application identifier.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,6 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
   explicitly requires documenting AI tooling behavior.
 - Keep `SPDX-FileCopyrightText` years current in edited files or companion `.license` sidecars.
 - Domain policy is strict: `secpal.app` for the public homepage and real email addresses,
-  `changelog.secpal.app` for the public changelog site,
   `apk.secpal.app` for the canonical Android artifact and release-metadata host,
   `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev,
   staging, testing, and examples, and `app.secpal` only as the Android application identifier.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Removed the retired standalone changelog host from domain policy and
+  Polyscope preview-host parsing.
 - Changed local and hosted pull-request size reporting to treat 600 changed
   lines as an advisory reviewability threshold, with no override file, approval
   label, or size-triggered push failure; the focused policy regression now runs

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -16,10 +16,9 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 echo -e "${BLUE}=== Domain Policy Check ===${NC}"
-echo "Allowed: secpal.app, changelog.secpal.app, apk.secpal.app, secpal.dev"
+echo "Allowed: secpal.app, apk.secpal.app, secpal.dev"
 echo "Active web hosts: api.secpal.dev, app.secpal.dev"
 echo "Android artifact host: apk.secpal.app"
-echo "Changelog site: changelog.secpal.app"
 echo "Deprecated web hosts: api.secpal.app"
 echo "Forbidden: secpal.com, secpal.org, secpal.net, secpal.io, secpal.example, ANY other"
 echo ""
@@ -59,7 +58,7 @@ matches=$(printf '%s\n' "$matches" | \
 # api.secpal.app (reported separately below).
 # This catches unknown domains (e.g. secpal.xyz) that a denylist-only check would miss.
 violations=$(printf '%s\n' "$matches" | \
-    grep -Ev '(^|[^A-Za-z0-9.-])secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])changelog\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])apk\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])(\*\.|\.)?([A-Za-z0-9-]+\.)*secpal\.dev(\.[A-Za-z0-9_-]+)*($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])api\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' | \
+    grep -Ev '(^|[^A-Za-z0-9.-])secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])apk\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])(\*\.|\.)?([A-Za-z0-9-]+\.)*secpal\.dev(\.[A-Za-z0-9_-]+)*($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])api\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' | \
     grep -E 'secpal\.' || true)
 
 deprecated_web_hosts=$(printf '%s\n' "$matches" | \
@@ -109,7 +108,6 @@ else
     fi
     echo -e "${YELLOW}Policy:${NC}"
     echo "  - secpal.app: public homepage and real email addresses"
-    echo "  - changelog.secpal.app: public changelog site"
     echo "  - apk.secpal.app: canonical Android artifact and release-metadata host"
     echo "  - api.secpal.dev: live API host"
     echo "  - app.secpal.dev: live PWA/frontend host"

--- a/scripts/polyscope-workspace.mjs
+++ b/scripts/polyscope-workspace.mjs
@@ -12,7 +12,7 @@ const POLYSCOPE_CLONE_PATH_PATTERN =
 // `tests/e2e/target-urls.ts`. Accept canonical preview hosts as well as
 // `frontend-<workspace>` ones, but reject other repo previews such as `api-*`.
 const WORKSPACE_PREVIEW_HOSTNAME_PATTERN =
-  /^(?:(api|frontend|secpal-app|changelog)-)?([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)\.preview\.secpal\.dev$/i;
+  /^(?:(api|frontend|secpal-app)-)?([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)\.preview\.secpal\.dev$/i;
 
 export function detectPolyscopeWorkspaceName(
   env = process.env,

--- a/scripts/polyscope-workspace.test.mjs
+++ b/scripts/polyscope-workspace.test.mjs
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+import { describe, expect, it } from "vitest";
+
+import { getResolvableWorkspacePreviewName } from "./polyscope-workspace.mjs";
+
+describe("getResolvableWorkspacePreviewName", () => {
+  it("accepts the retired changelog prefix as part of a generic workspace name", () => {
+    expect(
+      getResolvableWorkspacePreviewName(
+        "https://changelog-grumpy-lynx.preview.secpal.dev"
+      )
+    ).toBe("changelog-grumpy-lynx");
+  });
+});

--- a/src/previewHostname.test.ts
+++ b/src/previewHostname.test.ts
@@ -14,4 +14,13 @@ describe("parsePreviewHostname", () => {
       workspace: "grumpy-lynx",
     });
   });
+
+  it("treats the retired changelog prefix as part of a generic workspace name", () => {
+    expect(
+      parsePreviewHostname("changelog-grumpy-lynx.preview.secpal.dev")
+    ).toEqual({
+      repo: null,
+      workspace: "changelog-grumpy-lynx",
+    });
+  });
 });

--- a/src/previewHostname.ts
+++ b/src/previewHostname.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 export const WORKSPACE_PREVIEW_HOSTNAME_PATTERN =
-  /^(?:(api|frontend|secpal-app|changelog)-)?([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)\.preview\.secpal\.dev$/i;
+  /^(?:(api|frontend|secpal-app)-)?([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)\.preview\.secpal\.dev$/i;
 
 export type PreviewHostname = {
   repo: string | null;

--- a/tests/unit/scripts/check-domains.test.ts
+++ b/tests/unit/scripts/check-domains.test.ts
@@ -48,6 +48,23 @@ function runDomainCheck(
 }
 
 describe("check-domains", () => {
+  it("rejects the retired standalone changelog host", () => {
+    const retiredHostname = ["changelog", "secpal", "app"].join(".");
+    const result = runDomainCheck([
+      {
+        path: "README.md",
+        contents: `The retired host is https://${retiredHostname}.\n`,
+      },
+    ]);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stdout + result.stderr).toContain(retiredHostname);
+    expect(result.stdout + result.stderr).toContain(
+      "Domain Policy Check FAILED"
+    );
+  });
+
   it("keeps tracked storage-key documentation and fixtures in browser-storage contexts", () => {
     const changelog = readFileSync(path.join(repoRoot, "CHANGELOG.md"), "utf8");
     const themeColorBootstrapTests = readFileSync(


### PR DESCRIPTION
## Summary

- remove the retired standalone changelog host from frontend domain policy and AI guidance
- stop treating changelog as a reserved Polyscope preview workspace prefix
- document the cleanup in the unreleased changelog

## Why

The retired project no longer needs a domain exception or dedicated preview-host parsing behavior.

## Validation

- `bash scripts/check-domains.sh`
- `npx vitest run src/previewHostname.test.ts`
- `reuse lint`
- repository pre-commit hooks
- repository pre-push preflight, including ESLint and TypeScript checks
