### PR TITLE
test: synchronize disabled option Enter

### DIFF
--- a/src/ui/onboarding.test.tsx
+++ b/src/ui/onboarding.test.tsx
@@ -929,15 +929,32 @@ describe("onboarding shadcn primitives", () => {
       <TestCommandPopover
         label="Country"
         onValueChange={handleValueChange}
-        options={[{ value: "de", label: "Germany", disabled: true }]}
+        options={[
+          { value: "fr", label: "France" },
+          { value: "de", label: "Germany", disabled: true },
+        ]}
       />
     );
 
-    await user.click(screen.getByRole("combobox", { name: "Country" }));
+    const trigger = screen.getByRole("combobox", { name: "Country" });
+    await user.click(trigger);
+    const searchbox = await screen.findByPlaceholderText(/search/i);
+    const disabledOption = await screen.findByRole("option", {
+      name: "Germany",
+    });
+
+    await waitFor(() => expect(searchbox).toHaveFocus());
+    await user.keyboard("{ArrowDown}{ArrowDown}");
+    await waitFor(() =>
+      expect(disabledOption).toHaveAttribute("data-highlighted", "")
+    );
+
     await user.keyboard("{Enter}");
 
     expect(handleValueChange).not.toHaveBeenCalled();
-    expect(await screen.findByPlaceholderText(/search/i)).toBeInTheDocument();
+    expect(searchbox).toBeInTheDocument();
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(trigger).toHaveTextContent("Select option");
   });
 
   it("does not move the active index when ArrowDown is pressed on an empty result list", async () => {

--- a/src/ui/onboarding.test.tsx
+++ b/src/ui/onboarding.test.tsx
@@ -1022,9 +1022,10 @@ describe("onboarding shadcn primitives", () => {
 
     await waitFor(() => expect(searchbox).toHaveFocus());
     expect(options).toHaveLength(2);
-    options.forEach((option) =>
-      expect(option).toHaveAttribute("aria-disabled", "true")
-    );
+    options.forEach((option) => {
+      expect(option).toHaveAttribute("aria-disabled", "true");
+      expect(option).not.toHaveAttribute("data-highlighted");
+    });
 
     await user.keyboard("{Enter}");
 

--- a/src/ui/onboarding.test.tsx
+++ b/src/ui/onboarding.test.tsx
@@ -1000,6 +1000,38 @@ describe("onboarding shadcn primitives", () => {
     expect(handleValueChange).not.toHaveBeenCalled();
   });
 
+  it("does not select when Enter is pressed with only disabled options", async () => {
+    const user = userEvent.setup();
+    const handleValueChange = vi.fn();
+
+    render(
+      <TestCommandPopover
+        label="Country"
+        onValueChange={handleValueChange}
+        options={[
+          { value: "de", label: "Germany", disabled: true },
+          { value: "fr", label: "France", disabled: true },
+        ]}
+      />
+    );
+
+    const trigger = screen.getByRole("combobox", { name: "Country" });
+    await user.click(trigger);
+    const searchbox = await screen.findByPlaceholderText(/search/i);
+    const options = await screen.findAllByRole("option");
+
+    await waitFor(() => expect(searchbox).toHaveFocus());
+    expect(options).toHaveLength(2);
+    options.forEach((option) =>
+      expect(option).toHaveAttribute("aria-disabled", "true")
+    );
+
+    await user.keyboard("{Enter}");
+
+    expect(handleValueChange).not.toHaveBeenCalled();
+    expect(trigger).toHaveTextContent("Select option");
+  });
+
   it("exposes an accessible name for the searchbox derived from the localized search placeholder", async () => {
     const user = userEvent.setup();
 


### PR DESCRIPTION
## Problem and evidence

The disabled-option Enter regression test sent Enter immediately after clicking the command-popover trigger. Reproduction showed that the trigger could still own focus while `aria-expanded` was `false` and the popup input and options were not mounted. Enter then acted on the trigger instead of exercising the disabled option.

Base UI 1.6.0 also does not auto-highlight a result set containing only disabled options. The original fixture therefore did not establish the active-disabled-option precondition described by the test name.

## Change

- Wait for the command-popover search field to render and receive focus.
- Navigate to a disabled option and assert its highlighted state before pressing Enter.
- Verify that Enter keeps the popup open, preserves the empty selection, and does not call `onValueChange` when the disabled option is active.
- Cover the distinct all-disabled result-list case and verify that Enter cannot select a value even when no option is active.

This PR changes test synchronization and regression coverage only. Product code, dependencies, CSP configuration, and changelog entries are unchanged.

## Validation

- `npm ci`: passed; 0 vulnerabilities
- Both disabled-option Enter scenarios: passed in five separate repetitions
- `npx vitest run src/ui/onboarding.test.tsx --reporter=verbose`: 33 passed
- `npm run lint`: passed
- `npm run typecheck`: passed
- `npm run test:ui-csp`: passed
- `npm run test:ci`: 199 files and 2919 tests passed
- `reuse lint`: passed
- Local four-pass review: no remaining findings

## Readiness

There is no known in-scope dependency or unresolved check. The final pull request diff self-review found no remaining issues. The recurring outdated Browserslist-data warning is tracked separately in #1555 and does not affect this behavior. The repository's required container-check context was corrected separately to match the emitted `Container Contract` check, and all required hosted checks now pass. This pull request remains draft as requested.
