### PR TITLE
Track Browserslist database updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Declared Chai as an explicit Vitest development dependency so clean
   installations can resolve Vitest's assertion package before the test suite
   starts.
+- Declared `caniuse-lite` as an explicit development dependency so daily
+  Dependabot updates keep the Browserslist browser database current and
+  production builds no longer emit stale-data warnings.
 - Updated the transitive `fast-uri` dependency to 3.1.4 to remediate the
   literal-backslash authority delimiter host-confusion vulnerability.
 - Updated the transitive `brace-expansion` dependency to 5.0.8 to remediate

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "@vitejs/plugin-react": "^6.0.4",
         "@vitest/coverage-v8": "^4.1.10",
         "@vitest/ui": "^4.1.10",
+        "caniuse-lite": "^1.0.30001806",
         "chai": "^6.2.2",
         "cross-env": "^10.1.0",
         "eslint": "^10.8.0",
@@ -5767,9 +5768,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001777",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz",
-      "integrity": "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "@vitejs/plugin-react": "^6.0.4",
     "@vitest/coverage-v8": "^4.1.10",
     "@vitest/ui": "^4.1.10",
+    "caniuse-lite": "^1.0.30001806",
     "chai": "^6.2.2",
     "cross-env": "^10.1.0",
     "eslint": "^10.8.0",

--- a/tests/dependabot.config.test.ts
+++ b/tests/dependabot.config.test.ts
@@ -31,8 +31,38 @@ function getIndentedSection(text: string, sectionName: string): string {
   return sectionLines.join("\n");
 }
 
+function getPackageEcosystemSection(text: string, ecosystem: string): string {
+  const lines = text.split("\n");
+  const marker = `- package-ecosystem: "${ecosystem}"`;
+  const startIndex = lines.findIndex((line) => line.trim() === marker);
+
+  if (startIndex === -1) {
+    return "";
+  }
+
+  const sectionIndent = lines[startIndex].match(/^ */)?.[0].length ?? 0;
+  const sectionLines = [lines[startIndex]];
+
+  for (const line of lines.slice(startIndex + 1)) {
+    const lineIndent = line.match(/^ */)?.[0].length ?? 0;
+
+    if (
+      line.trim().startsWith("- package-ecosystem:") &&
+      lineIndent === sectionIndent
+    ) {
+      break;
+    }
+
+    sectionLines.push(line);
+  }
+
+  return sectionLines.join("\n");
+}
+
 describe("Dependabot configuration", () => {
+  const changelogPath = join(process.cwd(), "CHANGELOG.md");
   const configPath = join(process.cwd(), ".github", "dependabot.yml");
+  const packageLockPath = join(process.cwd(), "package-lock.json");
   const packageJsonPath = join(process.cwd(), "package.json");
 
   function readConfigText(): string {
@@ -92,7 +122,38 @@ describe("Dependabot configuration", () => {
 
   it("tracks the Browserslist browser database as a direct development dependency", () => {
     const devDependencies = readDependencies("devDependencies");
+    const caniuseLiteRange = devDependencies["caniuse-lite"];
+    const npmUpdates = getPackageEcosystemSection(readConfigText(), "npm");
 
-    expect(devDependencies["caniuse-lite"]).toBeDefined();
+    expect(caniuseLiteRange).toMatch(/^\^1\.0\.\d+$/);
+    expect(npmUpdates).toContain('versioning-strategy: "increase"');
+
+    expect(existsSync(packageLockPath)).toBe(true);
+    const packageLock = JSON.parse(readFileSync(packageLockPath, "utf8")) as {
+      packages?: Record<
+        string,
+        {
+          devDependencies?: Record<string, string>;
+          version?: string;
+        }
+      >;
+    };
+
+    expect(packageLock.packages?.[""]?.devDependencies?.["caniuse-lite"]).toBe(
+      caniuseLiteRange
+    );
+    expect(packageLock.packages?.["node_modules/caniuse-lite"]?.version).toBe(
+      caniuseLiteRange?.slice(1)
+    );
+  });
+
+  it("documents Browserslist database update automation", () => {
+    expect(existsSync(changelogPath)).toBe(true);
+
+    const changelog = readFileSync(changelogPath, "utf8");
+
+    expect(changelog).toMatch(
+      /Declared `caniuse-lite` as an explicit development dependency so daily\s+Dependabot updates/
+    );
   });
 });

--- a/tests/dependabot.config.test.ts
+++ b/tests/dependabot.config.test.ts
@@ -41,15 +41,18 @@ describe("Dependabot configuration", () => {
     return readFileSync(configPath, "utf8");
   }
 
-  function readDependencies(): Record<string, string> {
+  function readDependencies(
+    dependencyType: "dependencies" | "devDependencies" = "dependencies"
+  ): Record<string, string> {
     expect(existsSync(packageJsonPath)).toBe(true);
 
     return (
       (
         JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
           dependencies?: Record<string, string>;
+          devDependencies?: Record<string, string>;
         }
-      ).dependencies ?? {}
+      )[dependencyType] ?? {}
     );
   }
 
@@ -85,5 +88,11 @@ describe("Dependabot configuration", () => {
     expect(dependencies.react).toBeDefined();
     expect(dependencies["react-dom"]).toBeDefined();
     expect(dependencies.react).toBe(dependencies["react-dom"]);
+  });
+
+  it("tracks the Browserslist browser database as a direct development dependency", () => {
+    const devDependencies = readDependencies("devDependencies");
+
+    expect(devDependencies["caniuse-lite"]).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

The production build reported that the Browserslist browser database was six months old. `caniuse-lite` was only transitive, so the existing daily Dependabot npm updates did not maintain it as a version dependency.

This change makes `caniuse-lite` an explicit development dependency and updates the lockfile to `1.0.30001806`. The existing daily Dependabot configuration can now raise regular dependency updates, and the existing patch-update auto-merge workflow can handle eligible updates.

`CHANGELOG.md` documents the dependency-maintenance automation, and `tests/dependabot.config.test.ts` verifies that the browser database remains a direct development dependency, uses the configured Dependabot update strategy, and stays synchronized with the lockfile.

## Validation

- `npm test -- tests/dependabot.config.test.ts`
- `npm run lint`
- `npm run typecheck`
- `reuse lint`
- `npm run build`
- `git diff --check`

All checks passed. The production build no longer emits the stale Browserslist database warning.

## Readiness

There are no in-scope dependency or unresolved local-check blockers. This remains a draft for review.

Separate finding: #1559 tracks transient Polyscope preview artifacts being included by ESLint while they are removed.
