### PR TITLE
Fix Vitest jsdom worker resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Switched Vitest's bounded worker pool from forks to threads so jsdom
+  environment startup no longer intermittently fails to resolve installed
+  modules during full-suite validation.
 - Hardened the real-container browser validation to compare exact API origins,
   observe and block unexpected API origins, allocate a dynamic host port, use
   fresh workspace-isolated images, and clean up only its uniquely named Docker

--- a/tests/vite.config.test.ts
+++ b/tests/vite.config.test.ts
@@ -167,19 +167,23 @@ describe("vite test workflow", () => {
   it.each([
     { ci: "", environment: "outside CI" },
     { ci: "true", environment: "in CI" },
-  ])("caps workers when the full suite runs $environment", async ({ ci }) => {
-    vi.stubEnv("CI", ci);
-    const { default: viteConfig } = await import("../vite.config");
-    const config =
-      typeof viteConfig === "function"
-        ? viteConfig({
-            command: "serve",
-            mode: "test",
-            isPreview: false,
-            isSsrBuild: false,
-          })
-        : viteConfig;
+  ])(
+    "uses a bounded thread pool when the full suite runs $environment",
+    async ({ ci }) => {
+      vi.stubEnv("CI", ci);
+      const { default: viteConfig } = await import("../vite.config");
+      const config =
+        typeof viteConfig === "function"
+          ? viteConfig({
+              command: "serve",
+              mode: "test",
+              isPreview: false,
+              isSsrBuild: false,
+            })
+          : viteConfig;
 
-    expect(config.test?.maxWorkers).toBe(2);
-  });
+      expect(config.test?.pool).toBe("threads");
+      expect(config.test?.maxWorkers).toBe(2);
+    }
+  );
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -337,6 +337,10 @@ export default defineConfig(({ mode, command }) => {
       unstubEnvs: true,
       testTimeout: 20000, // 20 seconds per test to keep full-suite UI tests stable under CI load
       hookTimeout: 20000, // 20 seconds for beforeEach/afterEach hooks
+      // Fork workers can intermittently fail to resolve jsdom during startup
+      // even when the dependency is present. Threads share this process's
+      // resolver while retaining isolated test workers.
+      pool: "threads",
       // Native validation and hosted runners can both expose constrained CPUs;
       // the default worker pool can thrash and stall heavyweight build checks.
       maxWorkers: 2,


### PR DESCRIPTION
## Summary

Closes #1569.

Vitest's default fork workers could intermittently fail to resolve `jsdom/index.js` during environment startup even though `jsdom@30.0.1` was installed. The failures occurred in unrelated test files and caused `npm run test:ci` to exit before later validation phases.

- Run the jsdom suite in Vitest's `threads` pool while retaining the two-worker limit.
- Add configuration coverage for local and CI execution.
- Document the fix in the changelog.

## Validation

- `npx vitest run tests/vite.config.test.ts --silent=passed-only`
- `npm run test:ci` — 200 test files and 2,924 tests passed.
- `npm run lint`
- `npm run typecheck`
- `reuse lint`
- Local commit and push preflight checks

## Readiness

No in-scope dependency or unresolved local validation prevents review. This remains a draft pending the final pull request self-review.