### PR TITLE
fix(deps): update brace-expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Updated the transitive `brace-expansion` dependency to 5.0.9 or newer to
+  remediate its denial-of-service vulnerability.
 - Kept passkey enrollment request payloads contract-derived end to end: both
   client calls now accept the generated OpenAPI request types directly, and
   type-level regression coverage prevents the client boundary from drifting

--- a/package-lock.json
+++ b/package-lock.json
@@ -5558,9 +5558,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "flatted": "3.4.2",
     "picomatch@^2": "2.3.2",
     "picomatch@^4": "4.0.4",
-    "brace-expansion": ">=5.0.8",
+    "brace-expansion": ">=5.0.9",
     "@isaacs/brace-expansion": ">=5.0.1",
     "minimatch": ">=10.2.4",
     "yauzl": "3.2.1",


### PR DESCRIPTION
## Summary

Updates the transitive `brace-expansion` dependency to the patched 5.0.9
release.

## Problem and evidence

`npm audit` reported a high-severity denial-of-service vulnerability in the
previously resolved `brace-expansion@5.0.8`. The dependency is installed through
`eslint` and `minimatch`, and the existing override allowed the affected
versions below 5.0.9.

## Change

- Raise the `brace-expansion` override in `package.json` to `>=5.0.9`.
- Regenerate the lockfile so it resolves `brace-expansion@5.0.9`.
- Record the security fix in `CHANGELOG.md`.

## Validation

- `npm ci --include=dev --ignore-scripts`
- `npm audit --json` (0 vulnerabilities)
- `npm ls brace-expansion` (resolves 5.0.9)
- `npm test` (203 files, 2,933 tests passed)
- `npm run typecheck`
- `npm run lint`
- `reuse lint`
- Local commit and push hooks

## Readiness

No in-scope checks are unresolved. A pre-existing Vite native-config-loader
compatibility warning from the full test run is tracked separately in #1583.
