### PR TITLE
feat: publish immutable frontend images

### DIFF
--- a/.github/workflows/frontend-container.yml
+++ b/.github/workflows/frontend-container.yml
@@ -31,7 +31,7 @@ jobs:
           cache: npm
 
       - name: Set up Docker Buildx
-        # v4.0.0
+        # v4.2.0
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
 
       - name: Install dependencies

--- a/.github/workflows/frontend-container.yml
+++ b/.github/workflows/frontend-container.yml
@@ -20,10 +20,12 @@ jobs:
     timeout-minutes: 35
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        # v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: "22.22.2"
           cache: npm

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -168,6 +168,9 @@ jobs:
     permissions:
       contents: read
       packages: read
+    outputs:
+      runtime_amd64_digest: ${{ steps.verify_image.outputs.amd64_digest }}
+      runtime_arm64_digest: ${{ steps.verify_image.outputs.arm64_digest }}
     env:
       IMAGE_DIGEST: ${{ needs.publish.outputs.image_digest }}
       IMAGE_CREATED: ${{ needs.publish.outputs.image_created }}
@@ -221,6 +224,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify workflow-built digest and BuildKit attestations
+        id: verify_image
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -279,6 +283,26 @@ jobs:
                 | select((.annotations["vnd.docker.reference.type"] // "") == "attestation-manifest")
                 | .annotations["vnd.docker.reference.digest"]] | sort)
           ' "$manifest_file"
+          runtime_digest() {
+            local architecture=$1
+            jq -er --arg architecture "$architecture" '
+              [.manifests[]
+                | select((.annotations["vnd.docker.reference.type"] // "")
+                    != "attestation-manifest")
+                | select(.platform.os == "linux"
+                    and .platform.architecture == $architecture)
+                | .digest]
+                | if length == 1 then .[0] else empty end
+            ' "$manifest_file"
+          }
+          amd64_digest=$(runtime_digest amd64)
+          arm64_digest=$(runtime_digest arm64)
+          printf '%s\n' "$amd64_digest" | grep -Eq '^sha256:[0-9a-f]{64}$'
+          printf '%s\n' "$arm64_digest" | grep -Eq '^sha256:[0-9a-f]{64}$'
+          {
+            printf 'amd64_digest=%s\n' "$amd64_digest"
+            printf 'arm64_digest=%s\n' "$arm64_digest"
+          } >> "$GITHUB_OUTPUT"
           for platform in linux/amd64 linux/arm64; do
             image_config=$(docker buildx imagetools inspect "$DIGEST_REF" \
               --format "{{json (index .Image \"${platform}\")}}")
@@ -310,8 +334,11 @@ jobs:
                   == "https://github.com/moby/buildkit/blob/master/docs/attestations/slsa-definitions.md"
                 and .runDetails.metadata.buildkit_completeness.request == true
                 and .runDetails.metadata.buildkit_completeness.resolvedDependencies == true
-                and any(.buildDefinition.resolvedDependencies[];
-                  .uri == $source and .digest.sha1 == $revision)
+                and ([.buildDefinition.resolvedDependencies[]
+                  | select(.digest.sha1? != null)]
+                  | length == 1
+                    and .[0].uri == $source
+                    and .[0].digest.sha1 == $revision)
               '
           done
 
@@ -344,6 +371,8 @@ jobs:
     env:
       IMAGE_DIGEST: ${{ needs.publish.outputs.image_digest }}
       PUBLISHED_TAG: ${{ needs.publish.outputs.published_tag }}
+      RUNTIME_AMD64_DIGEST: ${{ needs.verify.outputs.runtime_amd64_digest }}
+      RUNTIME_ARM64_DIGEST: ${{ needs.verify.outputs.runtime_arm64_digest }}
     steps:
       - name: Checkout publishing commit
         id: checkout
@@ -441,12 +470,19 @@ jobs:
 
       - name: Record published image identity
         run: |
+          set -euo pipefail
+          printf '%s\n' "$RUNTIME_AMD64_DIGEST" | grep -Eq '^sha256:[0-9a-f]{64}$'
+          printf '%s\n' "$RUNTIME_ARM64_DIGEST" | grep -Eq '^sha256:[0-9a-f]{64}$'
           {
             printf '## Published SecPal frontend image\n\n'
             printf -- "- Source commit: \`%s\`\n" "$GITHUB_SHA"
             printf -- "- Discovery tag: \`%s:%s\`\n" "$CANONICAL_IMAGE" "$PUBLISHED_TAG"
             printf -- "- Canonical digest: \`%s@%s\`\n" "$CANONICAL_IMAGE" "$IMAGE_DIGEST"
             printf -- "- Platforms: \`linux/amd64\`, \`linux/arm64\`\n"
+            printf -- "- linux/amd64 runtime manifest digest (evidence only): \`%s\`\n" \
+              "$RUNTIME_AMD64_DIGEST"
+            printf -- "- linux/arm64 runtime manifest digest (evidence only): \`%s\`\n" \
+              "$RUNTIME_ARM64_DIGEST"
             printf -- '- BuildKit SBOM: verified for both platforms\n'
             printf -- '- BuildKit provenance: verified for both platforms\n'
             printf -- '- Runtime smoke: verified for both platforms\n'

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -158,7 +158,7 @@ jobs:
             org.opencontainers.image.version=${{ steps.metadata.outputs.version }}
           sbom: >-
             generator=docker.io/docker/buildkit-syft-scanner:stable-1@sha256:79e7b013cbec16bbb436f312819a49a4a57752b2270c1a9332ae1a10fcc82a68
-          provenance: mode=max
+          provenance: mode=max,version=v1
 
   verify:
     name: Verify Published Frontend Image

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -1,0 +1,456 @@
+---
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: CC0-1.0
+
+name: Publish Container
+on:
+  push:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: publish-container-${{ github.repository }}-${{ github.sha }}
+  cancel-in-progress: false
+
+env:
+  CANONICAL_IMAGE: ghcr.io/secpal/frontend
+
+jobs:
+  validate:
+    name: Validate Frontend Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout publishing commit
+        id: checkout
+        # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Set up Node.js
+        # v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "22.22.2"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --foreground-scripts
+
+      - name: Run container publishing and source policy tests
+        run: >-
+          npm exec -- vitest run
+          tests/container-publishing-workflow.test.ts
+          tests/container-contract.test.ts
+
+      - name: Lint Dockerfile
+        run: >-
+          docker run --rm -i
+          hadolint/hadolint:v2.14.0-debian@sha256:158cd0184dcaa18bd8ec20b61f4c1cabdf8b32a592d062f57bdcb8e4c1d312e2
+          < Dockerfile
+
+      - name: Lint container scripts
+        run: >-
+          docker run --rm -v "$PWD:/mnt:ro" -w /mnt
+          koalaman/shellcheck:v0.10.0@sha256:2097951f02e735b613f4a34de20c40f937a6c8f18ecb170612c88c34517221fb
+          scripts/container-smoke.sh
+          scripts/container-browser.sh
+          docker/secpal-entrypoint.sh
+
+  publish:
+    name: Publish Frontend Image
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image_digest: ${{ steps.build.outputs.digest }}
+      image_created: ${{ steps.metadata.outputs.created }}
+      image_version: ${{ steps.metadata.outputs.version }}
+      published_tag: ${{ steps.published_tag.outputs.tag }}
+    steps:
+      - name: Checkout publishing commit
+        id: checkout
+        # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Log in to GHCR
+        id: registry-login
+        # v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve deterministic image metadata
+        id: metadata
+        run: |
+          set -euo pipefail
+          created=$(git show -s --format=%cI "$GITHUB_SHA")
+          source_epoch=$(git show -s --format=%ct "$GITHUB_SHA")
+          package_version=$(jq -er '.version' package.json)
+          printf '%s\n' "$source_epoch" | grep -Eq '^[0-9]+$'
+          printf '%s\n' "$package_version" \
+            | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'
+          image_version="${package_version}+git.${GITHUB_SHA}"
+          {
+            printf 'created=%s\n' "$created"
+            printf 'source_epoch=%s\n' "$source_epoch"
+            printf 'version=%s\n' "$image_version"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Resolve unique published tag
+        id: published_tag
+        run: >-
+          printf 'tag=build-%s-%s-%s\n'
+          "$GITHUB_SHA" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT"
+          >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        # v4.2.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8
+        with:
+          image: >-
+            docker.io/tonistiigi/binfmt:latest@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        # v4.2.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
+        with:
+          version: v0.36.0
+          driver-opts: >-
+            image=docker.io/moby/buildkit:buildx-stable-1@sha256:2f5adac4ecd194d9f8c10b7b5d7bceb5186853db1b26e5abd3a657af0b7e26ec
+
+      - name: Build and push run-scoped image
+        id: build
+        # v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
+        with:
+          context: https://github.com/SecPal/frontend.git#${{ github.sha }}
+          push: true
+          pull: true
+          no-cache: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ env.CANONICAL_IMAGE }}:${{ steps.published_tag.outputs.tag }}
+          build-args: |
+            SECPAL_IMAGE_REVISION=${{ github.sha }}
+            SECPAL_IMAGE_VERSION=${{ steps.metadata.outputs.version }}
+            SOURCE_DATE_EPOCH=${{ steps.metadata.outputs.source_epoch }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/SecPal/frontend
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.title=SecPal Frontend
+            org.opencontainers.image.description=Unprivileged static reference server for the SecPal frontend
+            org.opencontainers.image.licenses=AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
+            org.opencontainers.image.version=${{ steps.metadata.outputs.version }}
+          sbom: >-
+            generator=docker.io/docker/buildkit-syft-scanner:stable-1@sha256:79e7b013cbec16bbb436f312819a49a4a57752b2270c1a9332ae1a10fcc82a68
+          provenance: mode=max
+
+  verify:
+    name: Verify Published Frontend Image
+    needs: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: read
+    env:
+      IMAGE_DIGEST: ${{ needs.publish.outputs.image_digest }}
+      IMAGE_CREATED: ${{ needs.publish.outputs.image_created }}
+      IMAGE_VERSION: ${{ needs.publish.outputs.image_version }}
+      PUBLISHED_TAG: ${{ needs.publish.outputs.published_tag }}
+    steps:
+      - name: Checkout publishing commit
+        id: checkout
+        # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Set up Node.js
+        # v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "22.22.2"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --foreground-scripts
+
+      - name: Install Chromium
+        run: npm exec -- playwright install --with-deps chromium
+
+      - name: Set up QEMU for runtime verification
+        # v4.2.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8
+        with:
+          image: >-
+            docker.io/tonistiigi/binfmt:latest@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        # v4.2.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
+        with:
+          version: v0.36.0
+          driver-opts: >-
+            image=docker.io/moby/buildkit:buildx-stable-1@sha256:2f5adac4ecd194d9f8c10b7b5d7bceb5186853db1b26e5abd3a657af0b7e26ec
+
+      - name: Log in to GHCR
+        id: registry-login
+        # v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify workflow-built digest and BuildKit attestations
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          printf '%s\n' "$PUBLISHED_TAG" \
+            | grep -Eq "^build-${GITHUB_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}$"
+          printf '%s\n' "$IMAGE_DIGEST" | grep -Eq '^sha256:[0-9a-f]{64}$'
+          TAG_REF="${CANONICAL_IMAGE}:${PUBLISHED_TAG}"
+          DIGEST_REF="${CANONICAL_IMAGE}@${IMAGE_DIGEST}"
+          manifest_file=$(mktemp)
+          headers_file=$(mktemp)
+          trap 'rm -f "$manifest_file" "$headers_file"' EXIT
+          registry_token=$(curl --fail --silent --show-error \
+            --user "${GITHUB_ACTOR}:${GHCR_TOKEN}" \
+            --get \
+            --data-urlencode 'scope=repository:secpal/frontend:pull' \
+            --data-urlencode 'service=ghcr.io' \
+            'https://ghcr.io/token' | jq -er '.token')
+          status=$(curl --silent --show-error \
+            --output "$manifest_file" \
+            --dump-header "$headers_file" \
+            --write-out '%{http_code}' \
+            --header "Authorization: Bearer ${registry_token}" \
+            --header 'Accept: application/vnd.oci.image.index.v1+json' \
+            "https://ghcr.io/v2/secpal/frontend/manifests/${PUBLISHED_TAG}")
+          test "$status" = 200
+          jq -e '.mediaType == "application/vnd.oci.image.index.v1+json"' "$manifest_file"
+          byte_digest="sha256:$(sha256sum "$manifest_file" | awk '{print $1}')"
+          registry_digest=$(awk '
+            index(tolower($0), "docker-content-digest:") == 1 {
+              sub("^[^:]+:[[:space:]]*", "")
+              sub("\\r$", "")
+              value = $0
+            }
+            END { print value }
+          ' "$headers_file")
+          test "$byte_digest" = "$IMAGE_DIGEST"
+          test "$registry_digest" = "$IMAGE_DIGEST"
+          printf 'Verified discovery snapshot %s at %s\n' "$TAG_REF" "$DIGEST_REF"
+          jq -e '
+            .mediaType == "application/vnd.oci.image.index.v1+json"
+            and ([.manifests[]
+              | select((.annotations["vnd.docker.reference.type"] // "") != "attestation-manifest")
+              | "\(.platform.os)/\(.platform.architecture)"] | sort)
+              == ["linux/amd64", "linux/arm64"]
+            and ([.manifests[]
+              | select((.annotations["vnd.docker.reference.type"] // "") == "attestation-manifest")]
+              | length) == 2
+            and all(.manifests[]
+              | select((.annotations["vnd.docker.reference.type"] // "") == "attestation-manifest");
+              .platform.os == "unknown" and .platform.architecture == "unknown")
+            and ([.manifests[]
+              | select((.annotations["vnd.docker.reference.type"] // "") != "attestation-manifest")
+              | .digest] | sort)
+              == ([.manifests[]
+                | select((.annotations["vnd.docker.reference.type"] // "") == "attestation-manifest")
+                | .annotations["vnd.docker.reference.digest"]] | sort)
+          ' "$manifest_file"
+          for platform in linux/amd64 linux/arm64; do
+            image_config=$(docker buildx imagetools inspect "$DIGEST_REF" \
+              --format "{{json (index .Image \"${platform}\")}}")
+            printf '%s\n' "$image_config" | jq -e \
+              --arg source 'https://github.com/SecPal/frontend' \
+              --arg revision "$GITHUB_SHA" \
+              --arg title 'SecPal Frontend' \
+              --arg description 'Unprivileged static reference server for the SecPal frontend' \
+              --arg licenses 'AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution' \
+              --arg created "$IMAGE_CREATED" \
+              --arg version "$IMAGE_VERSION" '
+                .config.Labels["org.opencontainers.image.source"] == $source
+                and .config.Labels["org.opencontainers.image.revision"] == $revision
+                and .config.Labels["org.opencontainers.image.title"] == $title
+                and .config.Labels["org.opencontainers.image.description"] == $description
+                and .config.Labels["org.opencontainers.image.licenses"] == $licenses
+                and .config.Labels["org.opencontainers.image.created"] == $created
+                and .config.Labels["org.opencontainers.image.version"] == $version
+              '
+            docker buildx imagetools inspect "$DIGEST_REF" \
+              --format "{{json (index .SBOM \"${platform}\").SPDX}}" \
+              | jq -e '.SPDXID == "SPDXRef-DOCUMENT" and (.packages | length) > 0'
+            docker buildx imagetools inspect "$DIGEST_REF" \
+              --format "{{json (index .Provenance \"${platform}\").SLSA}}" \
+              | jq -e \
+                --arg source "https://github.com/SecPal/frontend.git#${GITHUB_SHA}" \
+                --arg revision "$GITHUB_SHA" '
+                .buildDefinition.buildType
+                  == "https://github.com/moby/buildkit/blob/master/docs/attestations/slsa-definitions.md"
+                and .runDetails.metadata.buildkit_completeness.request == true
+                and .runDetails.metadata.buildkit_completeness.resolvedDependencies == true
+                and any(.buildDefinition.resolvedDependencies[];
+                  .uri == $source and .digest.sha1 == $revision)
+              '
+          done
+
+      - name: Exercise both published runtime platforms
+        run: |
+          set -euo pipefail
+          DIGEST_REF="${CANONICAL_IMAGE}@${IMAGE_DIGEST}"
+          for platform in linux/amd64 linux/arm64; do
+            docker pull --platform "$platform" "$DIGEST_REF"
+            SECPAL_CONTAINER_PLATFORM="$platform" \
+              SECPAL_CONTAINER_SKIP_BUILD=1 \
+              SECPAL_CONTAINER_IMAGE="$DIGEST_REF" \
+              npm run test:container
+            SECPAL_CONTAINER_PLATFORM="$platform" \
+              SECPAL_CONTAINER_SKIP_BUILD=1 \
+              SECPAL_CONTAINER_IMAGE="$DIGEST_REF" \
+              npm run test:e2e:container
+          done
+
+  attest:
+    name: Attest Verified Frontend Image
+    needs: [publish, verify]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    env:
+      IMAGE_DIGEST: ${{ needs.publish.outputs.image_digest }}
+      PUBLISHED_TAG: ${{ needs.publish.outputs.published_tag }}
+    steps:
+      - name: Checkout publishing commit
+        id: checkout
+        # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Log in to GHCR
+        id: registry-login
+        # v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate GitHub artifact attestation
+        id: attest
+        # v4.2.1
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d
+        with:
+          subject-name: ${{ env.CANONICAL_IMAGE }}
+          subject-digest: ${{ needs.publish.outputs.image_digest }}
+          push-to-registry: true
+          create-storage-record: false
+
+      - name: Verify selected GitHub artifact attestation
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          DIGEST_REF="${CANONICAL_IMAGE}@${IMAGE_DIGEST}"
+          gh attestation verify "oci://${DIGEST_REF}" \
+            --bundle-from-oci \
+            --repo SecPal/frontend \
+            --signer-workflow SecPal/frontend/.github/workflows/publish-container.yml \
+            --signer-digest "$GITHUB_SHA" \
+            --source-ref refs/heads/main \
+            --source-digest "$GITHUB_SHA" \
+            --deny-self-hosted-runners
+
+      - name: Verify final discovery snapshot and artifact attestation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          printf '%s\n' "$PUBLISHED_TAG" \
+            | grep -Eq "^build-${GITHUB_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}$"
+          TAG_REF="${CANONICAL_IMAGE}:${PUBLISHED_TAG}"
+          DIGEST_REF="${CANONICAL_IMAGE}@${IMAGE_DIGEST}"
+          manifest_file=$(mktemp)
+          headers_file=$(mktemp)
+          trap 'rm -f "$manifest_file" "$headers_file"' EXIT
+          registry_token=$(curl --fail --silent --show-error \
+            --user "${GITHUB_ACTOR}:${GHCR_TOKEN}" \
+            --get \
+            --data-urlencode 'scope=repository:secpal/frontend:pull' \
+            --data-urlencode 'service=ghcr.io' \
+            'https://ghcr.io/token' | jq -er '.token')
+          status=$(curl --silent --show-error \
+            --output "$manifest_file" \
+            --dump-header "$headers_file" \
+            --write-out '%{http_code}' \
+            --header "Authorization: Bearer ${registry_token}" \
+            --header 'Accept: application/vnd.oci.image.index.v1+json' \
+            "https://ghcr.io/v2/secpal/frontend/manifests/${PUBLISHED_TAG}")
+          test "$status" = 200
+          jq -e '.mediaType == "application/vnd.oci.image.index.v1+json"' "$manifest_file"
+          byte_digest="sha256:$(sha256sum "$manifest_file" | awk '{print $1}')"
+          registry_digest=$(awk '
+            index(tolower($0), "docker-content-digest:") == 1 {
+              sub("^[^:]+:[[:space:]]*", "")
+              sub("\\r$", "")
+              value = $0
+            }
+            END { print value }
+          ' "$headers_file")
+          test "$byte_digest" = "$IMAGE_DIGEST"
+          test "$registry_digest" = "$IMAGE_DIGEST"
+          gh attestation verify "oci://${DIGEST_REF}" \
+            --bundle-from-oci \
+            --repo SecPal/frontend \
+            --signer-workflow SecPal/frontend/.github/workflows/publish-container.yml \
+            --signer-digest "$GITHUB_SHA" \
+            --source-ref refs/heads/main \
+            --source-digest "$GITHUB_SHA" \
+            --deny-self-hosted-runners
+          printf 'Verified discovery snapshot %s at canonical digest %s\n' \
+            "$TAG_REF" "$DIGEST_REF"
+          printf '%s\n' \
+            'The recorded digest remains canonical even if a registry tag later changes.'
+
+      - name: Record published image identity
+        run: |
+          {
+            printf '## Published SecPal frontend image\n\n'
+            printf -- "- Source commit: \`%s\`\n" "$GITHUB_SHA"
+            printf -- "- Discovery tag: \`%s:%s\`\n" "$CANONICAL_IMAGE" "$PUBLISHED_TAG"
+            printf -- "- Canonical digest: \`%s@%s\`\n" "$CANONICAL_IMAGE" "$IMAGE_DIGEST"
+            printf -- "- Platforms: \`linux/amd64\`, \`linux/arm64\`\n"
+            printf -- '- BuildKit SBOM: verified for both platforms\n'
+            printf -- '- BuildKit provenance: verified for both platforms\n'
+            printf -- '- Runtime smoke: verified for both platforms\n'
+            printf -- '- Chromium smoke: verified for both platforms\n'
+            printf -- '- GitHub Artifact Attestation: verified\n\n'
+            printf 'The discovery tag is not a deployment or trust reference.\n'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -382,6 +382,56 @@ jobs:
           ref: ${{ github.sha }}
           persist-credentials: false
 
+      - name: Install pinned GitHub CLI
+        env:
+          GH_VERSION: "2.97.0"
+          GH_LINUX_AMD64_SHA256: "a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112"
+        run: |
+          set -euo pipefail
+
+          archive="$RUNNER_TEMP/gh_${GH_VERSION}_linux_amd64.tar.gz"
+          extracted="$RUNNER_TEMP/gh_${GH_VERSION}_linux_amd64"
+          install_dir="$RUNNER_TEMP/gh-bin"
+
+          curl --proto '=https' \
+            --tlsv1.2 \
+            --fail \
+            --location \
+            --silent \
+            --show-error \
+            "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+            --output "$archive"
+
+          printf '%s  %s\n' "$GH_LINUX_AMD64_SHA256" "$archive" |
+            sha256sum --check --strict
+
+          tar \
+            --extract \
+            --gzip \
+            --file "$archive" \
+            --directory "$RUNNER_TEMP" \
+            --no-same-owner
+
+          install -d -m 0700 "$install_dir"
+          install -m 0755 "$extracted/bin/gh" "$install_dir/gh"
+
+          PINNED_GH="$install_dir/gh"
+          printf '%s\n' "$install_dir" >> "$GITHUB_PATH"
+
+          actual_version=$("$PINNED_GH" version | head -n 1)
+          expected_version="gh version ${GH_VERSION}"
+          printf 'GitHub CLI version: %s\n' "$actual_version"
+          case "$actual_version" in
+            "$expected_version" | "$expected_version "*) ;;
+            *)
+              printf 'Unexpected GitHub CLI version: %s\n' "$actual_version" >&2
+              exit 1
+              ;;
+          esac
+
+          "$PINNED_GH" attestation verify --help >/dev/null
+          printf 'PINNED_GH=%s\n' "$PINNED_GH" >> "$GITHUB_ENV"
+
       - name: Log in to GHCR
         id: registry-login
         # v4.6.0
@@ -407,7 +457,7 @@ jobs:
         run: |
           set -euo pipefail
           DIGEST_REF="${CANONICAL_IMAGE}@${IMAGE_DIGEST}"
-          gh attestation verify "oci://${DIGEST_REF}" \
+          "$PINNED_GH" attestation verify "oci://${DIGEST_REF}" \
             --bundle-from-oci \
             --repo SecPal/frontend \
             --signer-workflow SecPal/frontend/.github/workflows/publish-container.yml \
@@ -455,7 +505,7 @@ jobs:
           ' "$headers_file")
           test "$byte_digest" = "$IMAGE_DIGEST"
           test "$registry_digest" = "$IMAGE_DIGEST"
-          gh attestation verify "oci://${DIGEST_REF}" \
+          "$PINNED_GH" attestation verify "oci://${DIGEST_REF}" \
             --bundle-from-oci \
             --repo SecPal/frontend \
             --signer-workflow SecPal/frontend/.github/workflows/publish-container.yml \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ghcr.io/secpal/frontend` Web/PWA image with run-specific discovery tags,
   canonical OCI index digests, exact index-byte verification, deterministic
   OCI metadata, `linux/amd64` and `linux/arm64` runtime and Chromium checks,
-  per-platform BuildKit SPDX SBOM and `mode=max` provenance verification, and
-  digest-bound GitHub Artifact Attestations. Pull-request CI remains registry
-  read-only, deployment consumption remains pending, and Phase C remains in
-  progress. Frontend image publication is implemented but not yet
-  operationally verified.
+  per-platform BuildKit SPDX SBOM and SLSA v1 `mode=max` provenance
+  verification, and digest-bound GitHub Artifact Attestations. Pull-request CI
+  remains registry read-only, deployment consumption remains pending, and
+  Phase C remains in progress. Frontend image publication is implemented but
+  not yet operationally verified.
 - Added a production-ready unprivileged frontend container image that serves
   the existing Web/PWA artifact through static Nginx on port 8080, configures
   the API origin at startup through strict `SECPAL_API_URL` validation, and
@@ -91,6 +91,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   version 2.97.0 and verified the official release archive checksum before use.
 - Extended the frontend publisher policy tests to reject any additional
   attestation verification that bypasses the pinned GitHub CLI.
+- Requested SLSA v1 provenance to match the publisher's verification schema,
+  treated an empty Docker `SOURCE_DATE_EPOCH` build argument as unset, and made
+  unsupported container-platform diagnostics identify the rejected value
+  without leaking temporary smoke-test resources.
 - Normalized static artifact, license, Nginx configuration, and entrypoint
   modes inside the image so inherited workspace ACLs cannot make unprivileged
   runtime files unreadable or non-executable despite Dockerfile `COPY --chmod`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added push-to-`main` publication for the official
+  `ghcr.io/secpal/frontend` Web/PWA image with run-specific discovery tags,
+  canonical OCI index digests, exact index-byte verification, deterministic
+  OCI metadata, `linux/amd64` and `linux/arm64` runtime and Chromium checks,
+  per-platform BuildKit SPDX SBOM and `mode=max` provenance verification, and
+  digest-bound GitHub Artifact Attestations. Pull-request CI remains registry
+  read-only, deployment consumption remains pending, and Phase C remains in
+  progress. Frontend image publication is implemented but not yet
+  operationally verified.
 - Added a production-ready unprivileged frontend container image that serves
   the existing Web/PWA artifact through static Nginx on port 8080, configures
   the API origin at startup through strict `SECPAL_API_URL` validation, and
@@ -68,6 +77,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Bound the embedded dependency SPDX document timestamp and namespace to the
+  publishing commit through `SOURCE_DATE_EPOCH`, making repeated builds of the
+  same source produce identical application SBOM bytes.
+- Normalized static artifact, license, Nginx configuration, and entrypoint
+  modes inside the image so inherited workspace ACLs cannot make unprivileged
+  runtime files unreadable or non-executable despite Dockerfile `COPY --chmod`
+  declarations.
 - Updated the transitive `brace-expansion` dependency to 5.0.9 or newer to
   remediate its denial-of-service vulnerability.
 - Kept passkey enrollment request payloads contract-derived end to end: both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,9 +77,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Bound the embedded dependency SPDX document timestamp and namespace to the
-  publishing commit through `SOURCE_DATE_EPOCH`, making repeated builds of the
-  same source produce identical application SBOM bytes.
+- Bound the embedded dependency SPDX document timestamp to the publishing
+  commit through `SOURCE_DATE_EPOCH` and its namespace to the document content,
+  making repeated builds of the same source produce identical application SBOM
+  bytes without namespace collisions between different documents.
 - Required the verified BuildKit provenance to contain exactly one Git source
   revision, rejected additional tag and registry-write paths in publisher
   policy coverage, and recorded both runtime-platform manifest digests as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   revision, rejected additional tag and registry-write paths in publisher
   policy coverage, and recorded both runtime-platform manifest digests as
   non-canonical post-merge evidence.
+- Made the provenance policy regression helper fail immediately with an
+  actionable error when its required `jq` executable is unavailable.
 - Normalized static artifact, license, Nginx configuration, and entrypoint
   modes inside the image so inherited workspace ACLs cannot make unprivileged
   runtime files unreadable or non-executable despite Dockerfile `COPY --chmod`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   actionable error when its required `jq` executable is unavailable.
 - Pinned the GitHub CLI used for frontend artifact-attestation verification to
   version 2.97.0 and verified the official release archive checksum before use.
+- Extended the frontend publisher policy tests to reject any additional
+  attestation verification that bypasses the pinned GitHub CLI.
 - Normalized static artifact, license, Nginx configuration, and entrypoint
   modes inside the image so inherited workspace ACLs cannot make unprivileged
   runtime files unreadable or non-executable despite Dockerfile `COPY --chmod`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bound the embedded dependency SPDX document timestamp and namespace to the
   publishing commit through `SOURCE_DATE_EPOCH`, making repeated builds of the
   same source produce identical application SBOM bytes.
+- Required the verified BuildKit provenance to contain exactly one Git source
+  revision, rejected additional tag and registry-write paths in publisher
+  policy coverage, and recorded both runtime-platform manifest digests as
+  non-canonical post-merge evidence.
 - Normalized static artifact, license, Nginx configuration, and entrypoint
   modes inside the image so inherited workspace ACLs cannot make unprivileged
   runtime files unreadable or non-executable despite Dockerfile `COPY --chmod`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-canonical post-merge evidence.
 - Made the provenance policy regression helper fail immediately with an
   actionable error when its required `jq` executable is unavailable.
+- Pinned the GitHub CLI used for frontend artifact-attestation verification to
+  version 2.97.0 and verified the official release archive checksum before use.
 - Normalized static artifact, license, Nginx configuration, and entrypoint
   modes inside the image so inherited workspace ACLs cannot make unprivileged
   runtime files unreadable or non-executable despite Dockerfile `COPY --chmod`

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ COPY package.json package-lock.json .npmrc ./
 RUN npm ci
 
 COPY . .
+ARG SOURCE_DATE_EPOCH
 RUN npm run build:web
 
 FROM nginxinc/nginx-unprivileged:1.30.4-trixie@sha256:679387908ea95d6d8de12952cd15d6b351258054a992d2106d3b6aa12659d87d AS runtime
@@ -34,6 +35,15 @@ COPY --chmod=0444 docker/nginx.conf /etc/nginx/nginx.conf
 COPY --chmod=0444 docker/default.conf /etc/nginx/conf.d/default.conf
 COPY --chmod=0444 docker/security-headers.conf /etc/nginx/snippets/secpal-security-headers.conf
 COPY --chmod=0555 docker/secpal-entrypoint.sh /usr/local/bin/secpal-entrypoint
+RUN find /usr/share/nginx/html /usr/share/licenses/secpal-frontend \
+      -type d -exec chmod 0555 {} + \
+    && find /usr/share/nginx/html /usr/share/licenses/secpal-frontend \
+      -type f -exec chmod 0444 {} + \
+    && chmod 0444 \
+      /etc/nginx/nginx.conf \
+      /etc/nginx/conf.d/default.conf \
+      /etc/nginx/snippets/secpal-security-headers.conf \
+    && chmod 0555 /usr/local/bin/secpal-entrypoint
 
 USER 101:101
 

--- a/README.md
+++ b/README.md
@@ -116,8 +116,29 @@ and configure its API origin only when the container starts. The complete
 non-root, read-only example and cache/health contracts are documented in the
 [frontend container guide](docs/deployment/frontend-container.md).
 
-The frontend container is a static reference server, not the public deployment
-edge.
+The published Web/PWA image identity is `ghcr.io/secpal/frontend`. Deployments
+and rollbacks must use only the canonical OCI index digest reference:
+
+```text
+ghcr.io/secpal/frontend@sha256:<oci-index-digest>
+```
+
+Publisher runs create one discovery tag with the format
+`build-<source-sha>-<run-id>-<run-attempt>`. That tag is not a deployment
+contract, rollback contract, or trust anchor and is not technically immutable
+against another authorized registry writer. The digest is the trust boundary.
+
+The multi-architecture image supports only `linux/amd64` and `linux/arm64`.
+Publishing generates and verifies a BuildKit SPDX SBOM, `mode=max` provenance,
+both runtime-platform contracts, both Chromium contracts, and a GitHub Artifact
+Attestation bound to the OCI index digest. The runtime remains a static,
+unprivileged `101:101` reference server without Node.js; `SECPAL_API_URL` is
+supplied only at startup. It does not publish Android or iOS artifacts and does
+not provide TLS or public-edge behavior.
+
+Frontend image publication is implemented but not yet operationally verified.
+Digest consumption in `SecPal/deployment` remains pending in a separate change,
+so Phase C remains in progress.
 
 ### Customer-Owned Browser Web Push Rollout
 

--- a/README.md
+++ b/README.md
@@ -124,17 +124,18 @@ ghcr.io/secpal/frontend@sha256:<oci-index-digest>
 ```
 
 Publisher runs create one discovery tag with the format
-`build-<source-sha>-<run-id>-<run-attempt>`. That tag is not a deployment
-contract, rollback contract, or trust anchor and is not technically immutable
-against another authorized registry writer. The digest is the trust boundary.
+`build-<40-character-source-sha>-<run-id>-<run-attempt>`. That tag is not a
+deployment contract, rollback contract, or trust anchor and is not technically
+immutable against another authorized registry writer. The digest is the trust
+boundary.
 
 The multi-architecture image supports only `linux/amd64` and `linux/arm64`.
-Publishing generates and verifies a BuildKit SPDX SBOM, `mode=max` provenance,
-both runtime-platform contracts, both Chromium contracts, and a GitHub Artifact
-Attestation bound to the OCI index digest. The runtime remains a static,
-unprivileged `101:101` reference server without Node.js; `SECPAL_API_URL` is
-supplied only at startup. It does not publish Android or iOS artifacts and does
-not provide TLS or public-edge behavior.
+Publishing generates and verifies a BuildKit SPDX SBOM, SLSA v1 provenance in
+`mode=max`, both runtime-platform contracts, both Chromium contracts, and a
+GitHub Artifact Attestation bound to the OCI index digest. The runtime remains
+a static, unprivileged `101:101` reference server without Node.js;
+`SECPAL_API_URL` is supplied only at startup. It does not publish Android or
+iOS artifacts and does not provide TLS or public-edge behavior.
 
 Frontend image publication is implemented but not yet operationally verified.
 Digest consumption in `SecPal/deployment` remains pending in a separate change,

--- a/docs/deployment/frontend-container.md
+++ b/docs/deployment/frontend-container.md
@@ -44,7 +44,7 @@ ghcr.io/secpal/frontend@sha256:<oci-index-digest>
 Each successful publisher run creates exactly one discovery tag:
 
 ```text
-build-<source-sha>-<run-id>-<run-attempt>
+build-<40-character-source-sha>-<run-id>-<run-attempt>
 ```
 
 The discovery tag locates the output of one workflow attempt. It is not a
@@ -56,11 +56,11 @@ The publisher runs only after a push to `main`, always rebuilds the selected
 source commit, and publishes exactly `linux/amd64` and `linux/arm64`. The build
 uses the commit timestamp for `org.opencontainers.image.created` and combines
 the package version with the full source commit as
-`<package-version>+git.<source-sha>`.
+`<package-version>+git.<full-source-sha>`.
 
 For both platforms the workflow verifies all OCI labels, a non-empty BuildKit
-SPDX SBOM, and `mode=max` provenance bound to the exact source commit and
-repository build context. It hashes the exact OCI index response bytes,
+SPDX SBOM, and SLSA v1 provenance in `mode=max` bound to the exact source commit
+and repository build context. It hashes the exact OCI index response bytes,
 compares the result and the registry `Docker-Content-Digest` header with the
 Buildx digest, runs the complete container and Chromium contracts against the
 digest reference, and creates a GitHub Artifact Attestation for that digest.

--- a/docs/deployment/frontend-container.md
+++ b/docs/deployment/frontend-container.md
@@ -26,6 +26,60 @@ including TypeScript, Vite's PWA `injectManifest` build, dependency SBOM, third-
 party notices, and license artifacts. It does not introduce a second
 container-specific application build.
 
+## Published Image Identity
+
+The only official image is:
+
+```text
+ghcr.io/secpal/frontend
+```
+
+The only canonical trust, deployment, update, and rollback identity is the OCI
+index digest:
+
+```text
+ghcr.io/secpal/frontend@sha256:<oci-index-digest>
+```
+
+Each successful publisher run creates exactly one discovery tag:
+
+```text
+build-<source-sha>-<run-id>-<run-attempt>
+```
+
+The discovery tag locates the output of one workflow attempt. It is not a
+deployment contract, rollback contract, or trust anchor. It is also not
+technically immutable against another registry writer with sufficient
+permissions. Consumers must record and use the verified OCI index digest.
+
+The publisher runs only after a push to `main`, always rebuilds the selected
+source commit, and publishes exactly `linux/amd64` and `linux/arm64`. The build
+uses the commit timestamp for `org.opencontainers.image.created` and combines
+the package version with the full source commit as
+`<package-version>+git.<source-sha>`.
+
+For both platforms the workflow verifies all OCI labels, a non-empty BuildKit
+SPDX SBOM, and `mode=max` provenance bound to the exact source commit and
+repository build context. It hashes the exact OCI index response bytes,
+compares the result and the registry `Docker-Content-Digest` header with the
+Buildx digest, runs the complete container and Chromium contracts against the
+digest reference, and creates a GitHub Artifact Attestation for that digest.
+The attestation verification binds the repository, publisher workflow,
+`refs/heads/main`, source commit, signer commit, and GitHub-hosted runner.
+
+This image contains only the browser Web/PWA artifact. It does not publish
+Android or iOS artifacts. Its Nginx runtime remains an unprivileged `101:101`
+static reference server without Node.js; deployments supply `SECPAL_API_URL`
+only when the container starts. TLS termination and public-edge controls remain
+deployment responsibilities.
+
+Frontend image publication is implemented but not yet operationally verified.
+After merge, operators must record the successful publisher run and complete
+the package linkage, public-visibility, anonymous digest-pull, final discovery
+snapshot, and final attestation checks. Digest consumption in
+`SecPal/deployment` remains a separate follow-up, so Phase C remains in
+progress.
+
 ## Run
 
 `SECPAL_API_URL` is required and must be one exact ASCII HTTPS origin. Paths,
@@ -135,5 +189,6 @@ manifest digest. To update a pin:
 4. update the tag and digest together;
 5. run `npm run test:container` and `npm run test:e2e:container`.
 
-The image is built and validated locally and in CI. This repository does not
-publish it to a registry yet.
+Pull-request CI continues to build and validate the image locally without
+registry credentials or write effects. Registry publication occurs only in the
+push-triggered publisher after merge to `main`.

--- a/scripts/container-browser.sh
+++ b/scripts/container-browser.sh
@@ -10,6 +10,18 @@ IMAGE_TAG=${SECPAL_CONTAINER_IMAGE:-$DEFAULT_IMAGE_TAG}
 CONTAINER_LABEL="secpal.dev/test-role=frontend-container-browser"
 RUN_ID=$(node -e 'process.stdout.write(require("node:crypto").randomUUID())')
 CONTAINER_NAME="secpal-frontend-browser-${RUN_ID}"
+PLATFORM_ARGS=()
+
+case ${SECPAL_CONTAINER_PLATFORM:-} in
+  "") ;;
+  linux/amd64 | linux/arm64)
+    PLATFORM_ARGS+=(--platform "$SECPAL_CONTAINER_PLATFORM")
+    ;;
+  *)
+    echo "ERROR: unsupported container platform" >&2
+    exit 1
+    ;;
+esac
 
 cleanup_container() {
   docker rm --force "$CONTAINER_NAME" >/dev/null 2>&1 || true
@@ -27,13 +39,13 @@ trap 'handle_signal 130' INT
 trap 'handle_signal 143' TERM
 
 if [ "${SECPAL_CONTAINER_SKIP_BUILD:-0}" != "1" ]; then
-  docker build --tag "$IMAGE_TAG" "$ROOT_DIR"
+  docker build "${PLATFORM_ARGS[@]}" --tag "$IMAGE_TAG" "$ROOT_DIR"
 elif ! docker image inspect "$IMAGE_TAG" >/dev/null 2>&1; then
   echo "ERROR: frontend container image is missing while builds are disabled" >&2
   exit 1
 fi
 
-docker run \
+docker run "${PLATFORM_ARGS[@]}" \
   --detach \
   --name "$CONTAINER_NAME" \
   --label "$CONTAINER_LABEL" \

--- a/scripts/container-browser.sh
+++ b/scripts/container-browser.sh
@@ -18,7 +18,8 @@ case ${SECPAL_CONTAINER_PLATFORM:-} in
     PLATFORM_ARGS+=(--platform "$SECPAL_CONTAINER_PLATFORM")
     ;;
   *)
-    echo "ERROR: unsupported container platform" >&2
+    printf 'ERROR: unsupported container platform: %s\n' \
+      "$SECPAL_CONTAINER_PLATFORM" >&2
     exit 1
     ;;
 esac

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -12,6 +12,18 @@ CONTAINER_A="${CONTAINER_PREFIX}-a"
 CONTAINER_B="${CONTAINER_PREFIX}-b"
 TEMP_DIR=$(mktemp -d)
 CONTAINERS=()
+PLATFORM_ARGS=()
+
+case ${SECPAL_CONTAINER_PLATFORM:-} in
+  "") ;;
+  linux/amd64 | linux/arm64)
+    PLATFORM_ARGS+=(--platform "$SECPAL_CONTAINER_PLATFORM")
+    ;;
+  *)
+    echo "ERROR: unsupported container platform" >&2
+    exit 1
+    ;;
+esac
 
 cleanup() {
   for container in "${CONTAINERS[@]}"; do
@@ -27,7 +39,7 @@ fail() {
 }
 
 if [ "${SECPAL_CONTAINER_SKIP_BUILD:-0}" != "1" ]; then
-  docker build \
+  docker build "${PLATFORM_ARGS[@]}" \
     --pull \
     --build-arg SECPAL_IMAGE_REVISION="${GITHUB_SHA:-local-test}" \
     --build-arg SECPAL_IMAGE_VERSION="${SECPAL_IMAGE_VERSION:-0.0.1-local}" \
@@ -42,7 +54,7 @@ start_container() {
   local name=$1
   local api_origin=$2
 
-  docker run \
+  docker run "${PLATFORM_ARGS[@]}" \
     --detach \
     --name "$name" \
     --read-only \
@@ -209,7 +221,7 @@ assert_header "$PORT_A" "/THIRD-PARTY-NOTICES.md" '^Content-Type: text/markdown'
 assert_header "$PORT_A" "/" '^X-Content-Type-Options: nosniff$'
 assert_header "$PORT_A" "/runtime-config.js" '^X-Frame-Options: DENY$'
 
-docker run --rm --entrypoint /bin/sh "$IMAGE_TAG" -c '
+docker run "${PLATFORM_ARGS[@]}" --rm --entrypoint /bin/sh "$IMAGE_TAG" -c '
   ! command -v node >/dev/null 2>&1
   ! command -v npm >/dev/null 2>&1
   for path in /src /tests /node_modules /.git /package-lock.json /vite.config.ts /coverage /playwright-report; do
@@ -232,7 +244,8 @@ valid_origins=(
   "https://xn--bcher-kva.example"
 )
 for origin in "${valid_origins[@]}"; do
-  docker run --rm --env "SECPAL_API_URL=$origin" "$IMAGE_TAG" true >/dev/null 2>&1 ||
+  docker run "${PLATFORM_ARGS[@]}" --rm \
+    --env "SECPAL_API_URL=$origin" "$IMAGE_TAG" true >/dev/null 2>&1 ||
     fail "valid origin was rejected"
 done
 
@@ -272,14 +285,16 @@ invalid_origins=(
   "https://api.example.com:"
 )
 
-if docker run --rm "$IMAGE_TAG" true >"$TEMP_DIR/invalid.log" 2>&1; then
+if docker run "${PLATFORM_ARGS[@]}" --rm \
+  "$IMAGE_TAG" true >"$TEMP_DIR/invalid.log" 2>&1; then
   fail "container started without SECPAL_API_URL"
 fi
 grep -Fq 'SECPAL_API_URL must be an exact ASCII HTTPS origin' "$TEMP_DIR/invalid.log" ||
   fail "missing-value error did not describe the origin contract"
 
 for origin in "${invalid_origins[@]}"; do
-  if docker run --rm --env "SECPAL_API_URL=$origin" "$IMAGE_TAG" true \
+  if docker run "${PLATFORM_ARGS[@]}" --rm \
+    --env "SECPAL_API_URL=$origin" "$IMAGE_TAG" true \
     >"$TEMP_DIR/invalid.log" 2>&1; then
     fail "container accepted an invalid origin"
   fi

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -10,7 +10,6 @@ IMAGE_TAG=${SECPAL_CONTAINER_IMAGE:-$DEFAULT_IMAGE_TAG}
 CONTAINER_PREFIX="secpal-frontend-contract-$$"
 CONTAINER_A="${CONTAINER_PREFIX}-a"
 CONTAINER_B="${CONTAINER_PREFIX}-b"
-TEMP_DIR=$(mktemp -d)
 CONTAINERS=()
 PLATFORM_ARGS=()
 
@@ -20,10 +19,13 @@ case ${SECPAL_CONTAINER_PLATFORM:-} in
     PLATFORM_ARGS+=(--platform "$SECPAL_CONTAINER_PLATFORM")
     ;;
   *)
-    echo "ERROR: unsupported container platform" >&2
+    printf 'ERROR: unsupported container platform: %s\n' \
+      "$SECPAL_CONTAINER_PLATFORM" >&2
     exit 1
     ;;
 esac
+
+TEMP_DIR=$(mktemp -d)
 
 cleanup() {
   for container in "${CONTAINERS[@]}"; do

--- a/scripts/generate-dependency-sbom.mjs
+++ b/scripts/generate-dependency-sbom.mjs
@@ -47,6 +47,32 @@ function normalizedLicense(license) {
     : "NOASSERTION";
 }
 
+function resolveCreationDate() {
+  const sourceDateEpoch = process.env.SOURCE_DATE_EPOCH;
+
+  if (sourceDateEpoch === undefined) {
+    return new Date();
+  }
+
+  if (!/^(0|[1-9][0-9]*)$/u.test(sourceDateEpoch)) {
+    throw new Error("SOURCE_DATE_EPOCH must be a non-negative integer");
+  }
+
+  const epochSeconds = Number(sourceDateEpoch);
+  const epochMilliseconds = epochSeconds * 1000;
+  const creationDate = new Date(epochMilliseconds);
+
+  if (
+    !Number.isSafeInteger(epochSeconds) ||
+    !Number.isSafeInteger(epochMilliseconds) ||
+    Number.isNaN(creationDate.getTime())
+  ) {
+    throw new Error("SOURCE_DATE_EPOCH is outside the supported date range");
+  }
+
+  return creationDate;
+}
+
 const packages = Object.entries(packageLock.packages ?? {})
   .filter(([, packageData]) => packageData.version)
   .map(([packagePath, packageData], index) => {
@@ -65,14 +91,16 @@ const packages = Object.entries(packageLock.packages ?? {})
     };
   });
 
+const creationDate = resolveCreationDate();
+
 const sbom = {
   SPDXID: "SPDXRef-DOCUMENT",
   creationInfo: {
-    created: new Date().toISOString(),
+    created: creationDate.toISOString(),
     creators: ["Tool: SecPal lockfile SPDX generator"],
   },
   dataLicense: "CC0-1.0",
-  documentNamespace: `https://spdx.org/spdxdocs/${toSpdxIdPart(packageLock.name ?? "application")}-${Date.now()}`,
+  documentNamespace: `https://spdx.org/spdxdocs/${toSpdxIdPart(packageLock.name ?? "application")}-${creationDate.getTime()}`,
   name: `${packageLock.name ?? "application"} dependency inventory`,
   packages,
   relationships: packages.map(({ SPDXID }) => ({

--- a/scripts/generate-dependency-sbom.mjs
+++ b/scripts/generate-dependency-sbom.mjs
@@ -51,7 +51,7 @@ function normalizedLicense(license) {
 function resolveCreationDate() {
   const sourceDateEpoch = process.env.SOURCE_DATE_EPOCH;
 
-  if (sourceDateEpoch === undefined) {
+  if (sourceDateEpoch === undefined || sourceDateEpoch === "") {
     return new Date();
   }
 

--- a/scripts/generate-dependency-sbom.mjs
+++ b/scripts/generate-dependency-sbom.mjs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: MIT
 
+import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
@@ -100,7 +101,7 @@ const sbom = {
     creators: ["Tool: SecPal lockfile SPDX generator"],
   },
   dataLicense: "CC0-1.0",
-  documentNamespace: `https://spdx.org/spdxdocs/${toSpdxIdPart(packageLock.name ?? "application")}-${creationDate.getTime()}`,
+  documentNamespace: "",
   name: `${packageLock.name ?? "application"} dependency inventory`,
   packages,
   relationships: packages.map(({ SPDXID }) => ({
@@ -110,6 +111,11 @@ const sbom = {
   })),
   spdxVersion: "SPDX-2.3",
 };
+
+const documentDigest = createHash("sha256")
+  .update(JSON.stringify(sbom))
+  .digest("hex");
+sbom.documentNamespace = `https://spdx.org/spdxdocs/${toSpdxIdPart(packageLock.name ?? "application")}-${documentDigest}`;
 
 mkdirSync(outputDirectory, { recursive: true });
 writeFileSync(

--- a/tests/container-contract.test.ts
+++ b/tests/container-contract.test.ts
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -139,5 +141,49 @@ describe("frontend container source contract", () => {
     expect(workflow).not.toMatch(
       /packages:\s*write|id-token:\s*write|docker\s+push|buildx\s+--push/iu
     );
+  });
+
+  it.each(["scripts/container-smoke.sh", "scripts/container-browser.sh"])(
+    "%s reports the rejected container platform",
+    (script) => {
+      const unsupportedPlatform = "linux/riscv64";
+      const result = spawnSync("bash", [script], {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          SECPAL_CONTAINER_PLATFORM: unsupportedPlatform,
+        },
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        `ERROR: unsupported container platform: ${unsupportedPlatform}`
+      );
+    }
+  );
+
+  it("validates the smoke platform before allocating temporary resources", () => {
+    const temporaryRoot = mkdtempSync(
+      path.join(tmpdir(), "secpal-invalid-platform-")
+    );
+
+    try {
+      const result = spawnSync("bash", ["scripts/container-smoke.sh"], {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          SECPAL_CONTAINER_PLATFORM: "linux/riscv64",
+          TMPDIR: temporaryRoot,
+        },
+      });
+
+      expect(result.status).toBe(1);
+      expect(readdirSync(temporaryRoot)).toEqual([]);
+    } finally {
+      rmSync(temporaryRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/container-contract.test.ts
+++ b/tests/container-contract.test.ts
@@ -29,6 +29,9 @@ describe("frontend container source contract", () => {
       "COPY package.json package-lock.json .npmrc ./"
     );
     expect(dockerfile).toContain("RUN npm run build:web");
+    expect(dockerfile).toMatch(
+      /RUN find \/usr\/share\/nginx\/html \/usr\/share\/licenses\/secpal-frontend[^]*-type f -exec chmod 0444[^]*&& chmod 0444[^]*&& chmod 0555 \/usr\/local\/bin\/secpal-entrypoint/u
+    );
     expect(dockerfile).toContain("USER 101:101");
     expect(dockerfile).toContain("EXPOSE 8080");
     expect(dockerfile).not.toContain(

--- a/tests/container-publishing-workflow.test.ts
+++ b/tests/container-publishing-workflow.test.ts
@@ -170,10 +170,6 @@ function assertPinnedGitHubCliPolicy(workflow: string): void {
     "Verify final discovery snapshot and artifact attestation"
   );
   const installCommands = shellScript(install);
-  const verificationCommands = [
-    shellScript(selectedVerification),
-    shellScript(finalVerification),
-  ].join("\n");
   const officialArchiveUrl =
     "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz";
 
@@ -254,14 +250,13 @@ function assertPinnedGitHubCliPolicy(workflow: string): void {
 
   expect(
     countMatches(
-      verificationCommands,
+      attest,
       /"\$PINNED_GH" attestation verify "oci:\/\/\$\{DIGEST_REF\}"/gu
     )
   ).toBe(2);
-  expect(verificationCommands).not.toMatch(
-    /(?:^|\n)\s*gh attestation verify/gu
-  );
-  expect(`${installCommands}\n${verificationCommands}`).not.toMatch(
+  expect(countMatches(attest, /"\$PINNED_GH" attestation verify/gu)).toBe(3);
+  expect(countMatches(attest, /attestation verify/gu)).toBe(3);
+  expect(attest).not.toMatch(
     /command -v gh|\/usr\/bin\/gh|gh\s+\|\||\|\|\s*"\$PINNED_GH"|releases\/latest|apt.*install.*gh|brew.*install.*gh|snap.*install.*gh/iu
   );
 
@@ -992,6 +987,20 @@ describe("frontend container publishing workflow", () => {
           value,
           '"$PINNED_GH" attestation verify "oci://${DIGEST_REF}"',
           'gh attestation verify "oci://${DIGEST_REF}"'
+        ),
+    ],
+    [
+      "additional runner GitHub CLI verification",
+      (value) =>
+        replaceRequired(
+          value,
+          "      - name: Verify selected GitHub artifact attestation",
+          [
+            "      - name: Verify with runner GitHub CLI",
+            '        run: gh attestation verify "oci://${CANONICAL_IMAGE}@${IMAGE_DIGEST}"',
+            "",
+            "      - name: Verify selected GitHub artifact attestation",
+          ].join("\n")
         ),
     ],
     [

--- a/tests/container-publishing-workflow.test.ts
+++ b/tests/container-publishing-workflow.test.ts
@@ -34,6 +34,31 @@ function jobBlock(workflow: string, jobName: string): string {
   return lines.slice(start, nextJob === -1 ? undefined : nextJob).join("\n");
 }
 
+function stepBlock(job: string, stepName: string): string {
+  const lines = job.split("\n");
+  const start = lines.findIndex((line) => line === `      - name: ${stepName}`);
+
+  expect(start, `missing ${stepName} step`).toBeGreaterThanOrEqual(0);
+
+  const nextStep = lines.findIndex(
+    (line, index) => index > start && /^ {6}- name: /u.test(line)
+  );
+
+  return lines.slice(start, nextStep === -1 ? undefined : nextStep).join("\n");
+}
+
+function shellScript(step: string): string {
+  const lines = step.split("\n");
+  const run = lines.findIndex((line) => line === "        run: |");
+
+  expect(run, "missing shell run block").toBeGreaterThanOrEqual(0);
+
+  return lines
+    .slice(run + 1)
+    .map((line) => (line.startsWith("          ") ? line.slice(10) : line))
+    .join("\n");
+}
+
 function actionReferences(workflow: string): string[] {
   return [...workflow.matchAll(/^\s*uses:\s*([^\s#]+)(?:\s*#.*)?$/gmu)].map(
     ([, reference]) => reference
@@ -47,6 +72,36 @@ function replaceRequired(
 ): string {
   expect(value).toContain(searchValue);
   return value.replace(searchValue, replacement);
+}
+
+function removeRequiredStep(
+  workflow: string,
+  jobName: string,
+  stepName: string
+): string {
+  return replaceRequired(
+    workflow,
+    stepBlock(jobBlock(workflow, jobName), stepName),
+    ""
+  );
+}
+
+function moveRequiredStepBefore(
+  workflow: string,
+  jobName: string,
+  movedStepName: string,
+  beforeStepName: string
+): string {
+  const job = jobBlock(workflow, jobName);
+  const movedStep = stepBlock(job, movedStepName);
+  const beforeStep = stepBlock(job, beforeStepName);
+  const withoutMovedStep = replaceRequired(workflow, movedStep, "");
+
+  return replaceRequired(
+    withoutMovedStep,
+    beforeStep,
+    `${movedStep}${beforeStep}`
+  );
 }
 
 function provenanceVerificationPolicy(workflow: string): string {
@@ -103,7 +158,123 @@ function evaluateProvenancePolicy(
   return result;
 }
 
+function assertPinnedGitHubCliPolicy(workflow: string): void {
+  const attest = jobBlock(workflow, "attest");
+  const install = stepBlock(attest, "Install pinned GitHub CLI");
+  const selectedVerification = stepBlock(
+    attest,
+    "Verify selected GitHub artifact attestation"
+  );
+  const finalVerification = stepBlock(
+    attest,
+    "Verify final discovery snapshot and artifact attestation"
+  );
+  const installCommands = shellScript(install);
+  const verificationCommands = [
+    shellScript(selectedVerification),
+    shellScript(finalVerification),
+  ].join("\n");
+  const officialArchiveUrl =
+    "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz";
+
+  expect(install).toMatch(/^ {10}GH_VERSION: "2\.97\.0"$/mu);
+  expect(install).toMatch(
+    /^ {10}GH_LINUX_AMD64_SHA256: "a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112"$/mu
+  );
+  expect(countMatches(attest, /^ {10}GH_VERSION:/gmu)).toBe(1);
+  expect(countMatches(attest, /^ {10}GH_LINUX_AMD64_SHA256:/gmu)).toBe(1);
+  expect(installCommands).toMatch(
+    /^archive="\$RUNNER_TEMP\/gh_\$\{GH_VERSION\}_linux_amd64\.tar\.gz"$/mu
+  );
+  expect(installCommands).toMatch(
+    /^extracted="\$RUNNER_TEMP\/gh_\$\{GH_VERSION\}_linux_amd64"$/mu
+  );
+  expect(installCommands).toMatch(/^install_dir="\$RUNNER_TEMP\/gh-bin"$/mu);
+  expect(installCommands).toContain(
+    [
+      "curl --proto '=https' \\",
+      "  --tlsv1.2 \\",
+      "  --fail \\",
+      "  --location \\",
+      "  --silent \\",
+      "  --show-error \\",
+      `  "${officialArchiveUrl}" \\`,
+      '  --output "$archive"',
+    ].join("\n")
+  );
+  expect(
+    countMatches(
+      installCommands,
+      /https:\/\/github\.com\/cli\/cli\/releases\/download\//gu
+    )
+  ).toBe(1);
+  expect(installCommands).not.toMatch(/http:\/\//u);
+  expect(installCommands).toMatch(
+    /^printf '%s {2}%s\\n' "\$GH_LINUX_AMD64_SHA256" "\$archive" \|$/mu
+  );
+  expect(installCommands).toMatch(/^ {2}sha256sum --check --strict$/mu);
+  expect(countMatches(installCommands, /sha256sum --check --strict/gu)).toBe(1);
+  expect(installCommands).toMatch(/^ {2}--file "\$archive" \\$/mu);
+  expect(installCommands).toMatch(/^ {2}--directory "\$RUNNER_TEMP" \\$/mu);
+  expect(installCommands).toMatch(/^ {2}--no-same-owner$/mu);
+  expect(installCommands).toMatch(/^install -d -m 0700 "\$install_dir"$/mu);
+  expect(installCommands).toMatch(
+    /^install -m 0755 "\$extracted\/bin\/gh" "\$install_dir\/gh"$/mu
+  );
+  expect(installCommands).toMatch(/^PINNED_GH="\$install_dir\/gh"$/mu);
+  expect(installCommands).toMatch(
+    /^printf '%s\\n' "\$install_dir" >> "\$GITHUB_PATH"$/mu
+  );
+  expect(installCommands).toMatch(
+    /^printf 'PINNED_GH=%s\\n' "\$PINNED_GH" >> "\$GITHUB_ENV"$/mu
+  );
+  expect(installCommands).toMatch(
+    /^actual_version=\$\("\$PINNED_GH" version \| head -n 1\)$/mu
+  );
+  expect(installCommands).toMatch(
+    /^expected_version="gh version \$\{GH_VERSION\}"$/mu
+  );
+  expect(installCommands).toMatch(
+    /^printf 'GitHub CLI version: %s\\n' "\$actual_version"$/mu
+  );
+  expect(installCommands).toMatch(/^case "\$actual_version" in$/mu);
+  expect(installCommands).toMatch(
+    /^ {2}"\$expected_version" \| "\$expected_version "\*\) ;;$/mu
+  );
+  expect(installCommands).toMatch(/^ {4}exit 1$/mu);
+  expect(installCommands).toMatch(
+    /^"\$PINNED_GH" attestation verify --help >\/dev\/null$/mu
+  );
+
+  for (const verification of [selectedVerification, finalVerification]) {
+    expect(shellScript(verification)).toMatch(
+      /^"\$PINNED_GH" attestation verify "oci:\/\/\$\{DIGEST_REF\}" \\$/mu
+    );
+  }
+
+  expect(
+    countMatches(
+      verificationCommands,
+      /"\$PINNED_GH" attestation verify "oci:\/\/\$\{DIGEST_REF\}"/gu
+    )
+  ).toBe(2);
+  expect(verificationCommands).not.toMatch(
+    /(?:^|\n)\s*gh attestation verify/gu
+  );
+  expect(`${installCommands}\n${verificationCommands}`).not.toMatch(
+    /command -v gh|\/usr\/bin\/gh|gh\s+\|\||\|\|\s*"\$PINNED_GH"|releases\/latest|apt.*install.*gh|brew.*install.*gh|snap.*install.*gh/iu
+  );
+
+  const installIndex = attest.indexOf(install);
+  expect(installIndex).toBeGreaterThan(
+    attest.indexOf("Checkout publishing commit")
+  );
+  expect(attest.indexOf(selectedVerification)).toBeGreaterThan(installIndex);
+  expect(attest.indexOf(finalVerification)).toBeGreaterThan(installIndex);
+}
+
 function assertSecurityCriticalPolicy(workflow: string): void {
+  assertPinnedGitHubCliPolicy(workflow);
   expect(workflow).toMatch(/on:\n {2}push:\n {4}branches: \[main\](?:\n|$)/u);
   expect(workflow).not.toMatch(/pull_request:|workflow_dispatch:|schedule:/u);
   expect(workflow).toContain("permissions: {}");
@@ -312,6 +483,10 @@ describe("frontend container publishing workflow", () => {
     expect(workflow).toMatch(
       /docker\/buildkit-syft-scanner:[^@\s]+@sha256:[0-9a-f]{64}/u
     );
+  });
+
+  it("installs and exclusively uses the reviewed GitHub CLI release", () => {
+    assertPinnedGitHubCliPolicy(workflow);
   });
 
   it("verifies exact index bytes, platform metadata, SBOM, and provenance", () => {
@@ -563,7 +738,12 @@ describe("frontend container publishing workflow", () => {
     expect(initialVerificationIndex).toBeGreaterThan(generateIndex);
     expect(finalSnapshotIndex).toBeGreaterThan(initialVerificationIndex);
     expect(summaryIndex).toBeGreaterThan(finalSnapshotIndex);
-    expect(countMatches(attest, /gh attestation verify/gu)).toBe(2);
+    expect(
+      countMatches(
+        attest,
+        /"\$PINNED_GH" attestation verify "oci:\/\/\$\{DIGEST_REF\}"/gu
+      )
+    ).toBe(2);
     expect(attest).toContain('test "$byte_digest" = "$IMAGE_DIGEST"');
     expect(attest).toContain('test "$registry_digest" = "$IMAGE_DIGEST"');
   });
@@ -725,4 +905,112 @@ describe("frontend container publishing workflow", () => {
     const mutatedWorkflow = replaceRequired(workflow, searchValue, replacement);
     expect(() => assertSecurityCriticalPolicy(mutatedWorkflow)).toThrow();
   });
+
+  const githubCliMutations: Array<[string, (value: string) => string]> = [
+    [
+      "missing GitHub CLI installation",
+      (value) =>
+        removeRequiredStep(value, "attest", "Install pinned GitHub CLI"),
+    ],
+    [
+      "wrong GitHub CLI version",
+      (value) =>
+        replaceRequired(value, 'GH_VERSION: "2.97.0"', 'GH_VERSION: "2.96.0"'),
+    ],
+    [
+      "wrong GitHub CLI checksum",
+      (value) =>
+        replaceRequired(
+          value,
+          "a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112",
+          "b".repeat(64)
+        ),
+    ],
+    [
+      "missing checksum verification",
+      (value) =>
+        replaceRequired(value, "sha256sum --check --strict", "cat >/dev/null"),
+    ],
+    [
+      "non-strict checksum verification",
+      (value) =>
+        replaceRequired(
+          value,
+          "sha256sum --check --strict",
+          "sha256sum --check"
+        ),
+    ],
+    [
+      "non-official GitHub CLI host",
+      (value) =>
+        replaceRequired(
+          value,
+          "https://github.com/cli/cli/releases/download/",
+          "https://downloads.example.com/cli/cli/releases/download/"
+        ),
+    ],
+    [
+      "insecure GitHub CLI download",
+      (value) =>
+        replaceRequired(
+          value,
+          "https://github.com/cli/cli/releases/download/",
+          "http://github.com/cli/cli/releases/download/"
+        ),
+    ],
+    [
+      "divergent archive version",
+      (value) =>
+        replaceRequired(
+          value,
+          'gh_${GH_VERSION}_linux_amd64.tar.gz" \\',
+          'gh_2.96.0_linux_amd64.tar.gz" \\'
+        ),
+    ],
+    [
+      "missing GITHUB_PATH update",
+      (value) =>
+        replaceRequired(
+          value,
+          'printf \'%s\\n\' "$install_dir" >> "$GITHUB_PATH"',
+          "true # GITHUB_PATH update removed"
+        ),
+    ],
+    [
+      "missing version enforcement",
+      (value) =>
+        replaceRequired(
+          value,
+          'case "$actual_version" in',
+          'case "$expected_version" in'
+        ),
+    ],
+    [
+      "runner GitHub CLI fallback",
+      (value) =>
+        replaceRequired(
+          value,
+          '"$PINNED_GH" attestation verify "oci://${DIGEST_REF}"',
+          'gh attestation verify "oci://${DIGEST_REF}"'
+        ),
+    ],
+    [
+      "attestation verification before CLI installation",
+      (value) =>
+        moveRequiredStepBefore(
+          value,
+          "attest",
+          "Verify selected GitHub artifact attestation",
+          "Install pinned GitHub CLI"
+        ),
+    ],
+  ];
+
+  it.each(githubCliMutations)(
+    "rejects the %s mutation",
+    (_name, mutateWorkflow) => {
+      const mutatedWorkflow = mutateWorkflow(workflow);
+      expect(() => assertPinnedGitHubCliPolicy(mutatedWorkflow)).toThrow();
+    }
+  );
 });

--- a/tests/container-publishing-workflow.test.ts
+++ b/tests/container-publishing-workflow.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -427,10 +427,69 @@ describe("frontend container publishing workflow", () => {
 
       expect(firstSbom).toBe(secondSbom);
       expect(parsedSbom.creationInfo.created).toBe("2023-11-14T22:13:20.000Z");
-      expect(parsedSbom.documentNamespace).toMatch(/-1700000000000$/u);
+      expect(parsedSbom.documentNamespace).toMatch(/-[0-9a-f]{64}$/u);
     } finally {
       rmSync(firstOutput, { recursive: true, force: true });
       rmSync(secondOutput, { recursive: true, force: true });
+    }
+  });
+
+  it("uses different SPDX namespaces for different documents with the same creation time", () => {
+    const firstProject = mkdtempSync(
+      path.join(tmpdir(), "secpal-sbom-namespace-first-")
+    );
+    const secondProject = mkdtempSync(
+      path.join(tmpdir(), "secpal-sbom-namespace-second-")
+    );
+    const sourceDateEpoch = "1700000000";
+    const env = { ...process.env, SOURCE_DATE_EPOCH: sourceDateEpoch };
+    const generator = path.join(
+      repoRoot,
+      "scripts",
+      "generate-dependency-sbom.mjs"
+    );
+    const firstPackageLock = JSON.parse(readRepoFile("package-lock.json")) as {
+      packages: Record<string, { version?: string }>;
+    };
+    const secondPackageLock = structuredClone(firstPackageLock);
+
+    secondPackageLock.packages[""].version = "0.0.0-namespace-collision-test";
+
+    try {
+      for (const [project, packageLock] of [
+        [firstProject, firstPackageLock],
+        [secondProject, secondPackageLock],
+      ] as const) {
+        writeFileSync(
+          path.join(project, "package-lock.json"),
+          `${JSON.stringify(packageLock)}\n`
+        );
+        execFileSync(process.execPath, [generator], {
+          cwd: project,
+          env,
+          stdio: "pipe",
+        });
+      }
+
+      const firstSbom = JSON.parse(
+        readFileSync(
+          path.join(firstProject, "dist", "dependencies.spdx.json"),
+          "utf8"
+        )
+      ) as { documentNamespace: string };
+      const secondSbom = JSON.parse(
+        readFileSync(
+          path.join(secondProject, "dist", "dependencies.spdx.json"),
+          "utf8"
+        )
+      ) as { documentNamespace: string };
+
+      expect(firstSbom.documentNamespace).not.toBe(
+        secondSbom.documentNamespace
+      );
+    } finally {
+      rmSync(firstProject, { recursive: true, force: true });
+      rmSync(secondProject, { recursive: true, force: true });
     }
   });
 

--- a/tests/container-publishing-workflow.test.ts
+++ b/tests/container-publishing-workflow.test.ts
@@ -60,7 +60,8 @@ function provenanceVerificationPolicy(workflow: string): string {
 
 function evaluateProvenancePolicy(
   policy: string,
-  resolvedDependencies: unknown[]
+  resolvedDependencies: unknown[],
+  jqExecutable = "jq"
 ): ReturnType<typeof spawnSync> {
   const revision = "0123456789012345678901234567890123456789";
   const source = `https://github.com/SecPal/frontend.git#${revision}`;
@@ -80,14 +81,26 @@ function evaluateProvenancePolicy(
     },
   };
 
-  return spawnSync(
-    "jq",
+  const result = spawnSync(
+    jqExecutable,
     ["-e", "--arg", "source", source, "--arg", "revision", revision, policy],
     {
       encoding: "utf8",
       input: JSON.stringify(provenance),
     }
   );
+
+  if (result.error) {
+    if ((result.error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error("jq is required to evaluate the provenance policy", {
+        cause: result.error,
+      });
+    }
+
+    throw result.error;
+  }
+
+  return result;
 }
 
 function assertSecurityCriticalPolicy(workflow: string): void {
@@ -349,6 +362,24 @@ describe("frontend container publishing workflow", () => {
     expect(valid.status).toBe(0);
     expect(additionalRevision.status).not.toBe(0);
     expect(wrongRevisionOnly.status).not.toBe(0);
+  });
+
+  it("reports a clear error when jq is unavailable", () => {
+    const temporaryDirectory = mkdtempSync(
+      path.join(tmpdir(), "secpal-missing-jq-")
+    );
+
+    try {
+      expect(() =>
+        evaluateProvenancePolicy(
+          "true",
+          [],
+          path.join(temporaryDirectory, "jq")
+        )
+      ).toThrowError("jq is required to evaluate the provenance policy");
+    } finally {
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
   });
 
   it("runs both runtime and Chromium contracts against the digest on exactly two platforms", () => {

--- a/tests/container-publishing-workflow.test.ts
+++ b/tests/container-publishing-workflow.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -49,6 +49,47 @@ function replaceRequired(
   return value.replace(searchValue, replacement);
 }
 
+function provenanceVerificationPolicy(workflow: string): string {
+  const match = workflow.match(
+    /--arg revision "\$GITHUB_SHA" '\n(?<policy>[^]*?)\n {14}'\n {10}done/u
+  );
+
+  expect(match?.groups?.policy).toBeDefined();
+  return match!.groups!.policy!;
+}
+
+function evaluateProvenancePolicy(
+  policy: string,
+  resolvedDependencies: unknown[]
+): ReturnType<typeof spawnSync> {
+  const revision = "0123456789012345678901234567890123456789";
+  const source = `https://github.com/SecPal/frontend.git#${revision}`;
+  const provenance = {
+    buildDefinition: {
+      buildType:
+        "https://github.com/moby/buildkit/blob/master/docs/attestations/slsa-definitions.md",
+      resolvedDependencies,
+    },
+    runDetails: {
+      metadata: {
+        buildkit_completeness: {
+          request: true,
+          resolvedDependencies: true,
+        },
+      },
+    },
+  };
+
+  return spawnSync(
+    "jq",
+    ["-e", "--arg", "source", source, "--arg", "revision", revision, policy],
+    {
+      encoding: "utf8",
+      input: JSON.stringify(provenance),
+    }
+  );
+}
+
 function assertSecurityCriticalPolicy(workflow: string): void {
   expect(workflow).toMatch(/on:\n {2}push:\n {4}branches: \[main\](?:\n|$)/u);
   expect(workflow).not.toMatch(/pull_request:|workflow_dispatch:|schedule:/u);
@@ -77,6 +118,10 @@ function assertSecurityCriticalPolicy(workflow: string): void {
     1
   );
   expect(countMatches(workflow, /^\s*push:\s*true\s*$/gmu)).toBe(1);
+  expect(countMatches(workflow, /^\s*tags:/gmu)).toBe(1);
+  expect(workflow).toMatch(
+    /^\s*tags: \$\{\{ env\.CANONICAL_IMAGE \}\}:\$\{\{ steps\.published_tag\.outputs\.tag \}\}\s*$/mu
+  );
   expect(workflow).toContain("platforms: linux/amd64,linux/arm64");
   expect(workflow).toContain(
     "context: https://github.com/SecPal/frontend.git#${{ github.sha }}"
@@ -133,6 +178,9 @@ function assertSecurityCriticalPolicy(workflow: string): void {
   expect(countMatches(workflow, /--deny-self-hosted-runners/gu)).toBe(2);
   expect(workflow).not.toMatch(
     /curl[^\n]*(?:--request|-X)\s+(?:PUT|DELETE)|docker\s+manifest\s+push|docker\s+buildx\s+imagetools\s+create|promotion|promote|package\s+delete|manifest\s+delete/iu
+  );
+  expect(workflow).not.toMatch(
+    /docker\s+(?:push|buildx\s+build)|podman\s+push|oras\s+push|crane\s+push|skopeo\s+copy|regctl\s+(?:image\s+copy|manifest\s+put)/iu
   );
 }
 
@@ -268,6 +316,41 @@ describe("frontend container publishing workflow", () => {
     expect(verify).not.toMatch(/\|\|\s*true|continue-on-error:\s*true/u);
   });
 
+  it("rejects provenance containing any additional source revision", () => {
+    const revision = "0123456789012345678901234567890123456789";
+    const policy = provenanceVerificationPolicy(workflow);
+    const expectedSource = {
+      digest: { sha1: revision },
+      uri: `https://github.com/SecPal/frontend.git#${revision}`,
+    };
+    const unrelatedBaseImage = {
+      digest: { sha256: "a".repeat(64) },
+      uri: "pkg:docker/nginxinc/nginx-unprivileged@1.30.4",
+    };
+    const unexpectedSource = {
+      digest: { sha1: "f".repeat(40) },
+      uri: `https://github.com/SecPal/frontend.git#${"f".repeat(40)}`,
+    };
+
+    const valid = evaluateProvenancePolicy(policy, [
+      expectedSource,
+      unrelatedBaseImage,
+    ]);
+    const additionalRevision = evaluateProvenancePolicy(policy, [
+      expectedSource,
+      unexpectedSource,
+    ]);
+    const wrongRevisionOnly = evaluateProvenancePolicy(policy, [
+      unexpectedSource,
+      unrelatedBaseImage,
+    ]);
+
+    expect(valid.error).toBeUndefined();
+    expect(valid.status).toBe(0);
+    expect(additionalRevision.status).not.toBe(0);
+    expect(wrongRevisionOnly.status).not.toBe(0);
+  });
+
   it("runs both runtime and Chromium contracts against the digest on exactly two platforms", () => {
     const verify = jobBlock(workflow, "verify");
 
@@ -395,6 +478,30 @@ describe("frontend container publishing workflow", () => {
     expect(attest).toContain('test "$registry_digest" = "$IMAGE_DIGEST"');
   });
 
+  it("records both runtime manifest digests as non-canonical evidence", () => {
+    const verify = jobBlock(workflow, "verify");
+    const attest = jobBlock(workflow, "attest");
+
+    expect(verify).toContain(
+      "runtime_amd64_digest: ${{ steps.verify_image.outputs.amd64_digest }}"
+    );
+    expect(verify).toContain(
+      "runtime_arm64_digest: ${{ steps.verify_image.outputs.arm64_digest }}"
+    );
+    expect(attest).toContain(
+      "RUNTIME_AMD64_DIGEST: ${{ needs.verify.outputs.runtime_amd64_digest }}"
+    );
+    expect(attest).toContain(
+      "RUNTIME_ARM64_DIGEST: ${{ needs.verify.outputs.runtime_arm64_digest }}"
+    );
+    expect(attest).toContain(
+      "linux/amd64 runtime manifest digest (evidence only)"
+    );
+    expect(attest).toContain(
+      "linux/arm64 runtime manifest digest (evidence only)"
+    );
+  });
+
   it("keeps registry writes structurally limited", () => {
     expect(countMatches(workflow, /^\s*push:\s*true\s*$/gmu)).toBe(1);
     expect(countMatches(workflow, /^\s*push-to-registry:\s*true\s*$/gmu)).toBe(
@@ -488,6 +595,41 @@ describe("frontend container publishing workflow", () => {
       "raw manifest write",
       "set -euo pipefail",
       "curl -X PUT manifest\n          set -euo pipefail",
+    ],
+    [
+      "additional branch tag",
+      "tags: ${{ env.CANONICAL_IMAGE }}:${{ steps.published_tag.outputs.tag }}",
+      "tags: ${{ env.CANONICAL_IMAGE }}:${{ steps.published_tag.outputs.tag }},${{ env.CANONICAL_IMAGE }}:main",
+    ],
+    [
+      "additional release tag",
+      "tags: ${{ env.CANONICAL_IMAGE }}:${{ steps.published_tag.outputs.tag }}",
+      "tags: ${{ env.CANONICAL_IMAGE }}:${{ steps.published_tag.outputs.tag }},${{ env.CANONICAL_IMAGE }}:v0.0.1",
+    ],
+    [
+      "additional stable source SHA tag",
+      "tags: ${{ env.CANONICAL_IMAGE }}:${{ steps.published_tag.outputs.tag }}",
+      "tags: ${{ env.CANONICAL_IMAGE }}:${{ steps.published_tag.outputs.tag }},${{ env.CANONICAL_IMAGE }}:${{ github.sha }}",
+    ],
+    [
+      "shell docker push",
+      "set -euo pipefail",
+      'docker push "${CANONICAL_IMAGE}:${PUBLISHED_TAG}"\n          set -euo pipefail',
+    ],
+    [
+      "ORAS registry push",
+      "set -euo pipefail",
+      'oras push "${CANONICAL_IMAGE}:${PUBLISHED_TAG}" artifact\n          set -euo pipefail',
+    ],
+    [
+      "Skopeo registry copy",
+      "set -euo pipefail",
+      'skopeo copy source "docker://${CANONICAL_IMAGE}:${PUBLISHED_TAG}"\n          set -euo pipefail',
+    ],
+    [
+      "custom Buildx push",
+      "set -euo pipefail",
+      "docker buildx build --push .\n          set -euo pipefail",
     ],
   ])("rejects the %s mutation", (_name, searchValue, replacement) => {
     const mutatedWorkflow = replaceRequired(workflow, searchValue, replacement);

--- a/tests/container-publishing-workflow.test.ts
+++ b/tests/container-publishing-workflow.test.ts
@@ -270,6 +270,11 @@ function assertPinnedGitHubCliPolicy(workflow: string): void {
 
 function assertSecurityCriticalPolicy(workflow: string): void {
   assertPinnedGitHubCliPolicy(workflow);
+  const buildStep = stepBlock(
+    jobBlock(workflow, "publish"),
+    "Build and push run-scoped image"
+  );
+
   expect(workflow).toMatch(/on:\n {2}push:\n {4}branches: \[main\](?:\n|$)/u);
   expect(workflow).not.toMatch(/pull_request:|workflow_dispatch:|schedule:/u);
   expect(workflow).toContain("permissions: {}");
@@ -314,8 +319,12 @@ function assertSecurityCriticalPolicy(workflow: string): void {
   expect(workflow).toMatch(
     /image_version=.*\$\{package_version\}\+git\.\$\{GITHUB_SHA\}/u
   );
-  expect(workflow).toMatch(/sbom:\s*>-[^]*buildkit-syft-scanner[^@]*@sha256:/u);
-  expect(workflow).toContain("provenance: mode=max");
+  expect(countMatches(workflow, /^ {10}sbom:/gmu)).toBe(1);
+  expect(buildStep).toMatch(
+    /^ {10}sbom: >-\n {12}generator=docker\.io\/docker\/buildkit-syft-scanner:[^@\s]+@sha256:[0-9a-f]{64}$/mu
+  );
+  expect(countMatches(workflow, /^ {10}provenance:/gmu)).toBe(1);
+  expect(buildStep).toMatch(/^ {10}provenance: mode=max,version=v1$/mu);
   expect(workflow).toContain("pull: true");
   expect(workflow).toContain("no-cache: true");
   expect(workflow).not.toMatch(
@@ -635,6 +644,39 @@ describe("frontend container publishing workflow", () => {
     }
   });
 
+  it("treats an empty SOURCE_DATE_EPOCH build argument as unset", () => {
+    const outputDirectory = mkdtempSync(
+      path.join(tmpdir(), "secpal-sbom-empty-epoch-")
+    );
+    const earliestCreationTime = Date.now();
+
+    try {
+      execFileSync(
+        process.execPath,
+        ["scripts/generate-dependency-sbom.mjs", outputDirectory],
+        {
+          cwd: repoRoot,
+          env: { ...process.env, SOURCE_DATE_EPOCH: "" },
+          stdio: "pipe",
+        }
+      );
+
+      const parsedSbom = JSON.parse(
+        readFileSync(
+          path.join(outputDirectory, "dependencies.spdx.json"),
+          "utf8"
+        )
+      ) as { creationInfo: { created: string } };
+      const latestCreationTime = Date.now();
+      const creationTime = Date.parse(parsedSbom.creationInfo.created);
+
+      expect(creationTime).toBeGreaterThanOrEqual(earliestCreationTime);
+      expect(creationTime).toBeLessThanOrEqual(latestCreationTime);
+    } finally {
+      rmSync(outputDirectory, { recursive: true, force: true });
+    }
+  });
+
   it("uses different SPDX namespaces for different documents with the same creation time", () => {
     const firstProject = mkdtempSync(
       path.join(tmpdir(), "secpal-sbom-namespace-first-")
@@ -798,9 +840,14 @@ describe("frontend container publishing workflow", () => {
     expect(documentation).toContain(
       "ghcr.io/secpal/frontend@sha256:<oci-index-digest>"
     );
-    expect(documentation).toContain(
-      "build-<source-sha>-<run-id>-<run-attempt>"
-    );
+    for (const document of [readme, containerGuide]) {
+      expect(document).toContain(
+        "build-<40-character-source-sha>-<run-id>-<run-attempt>"
+      );
+      expect(document).not.toContain(
+        "build-<source-sha>-<run-id>-<run-attempt>"
+      );
+    }
     expect(documentation).toContain(
       "Frontend image publication is implemented but not yet operationally verified."
     );
@@ -840,7 +887,29 @@ describe("frontend container publishing workflow", () => {
       ".",
     ],
     ["disabled SBOM", "sbom: >-", "sbom: false #"],
-    ["weak provenance", "provenance: mode=max", "provenance: mode=min"],
+    [
+      "weak provenance",
+      "provenance: mode=max,version=v1",
+      "provenance: mode=min,version=v1",
+    ],
+    [
+      "legacy provenance schema",
+      "provenance: mode=max,version=v1",
+      "provenance: mode=max,version=v0.2",
+    ],
+    [
+      "duplicate overriding provenance",
+      "provenance: mode=max,version=v1",
+      [
+        "provenance: mode=max,version=v1",
+        "          provenance: mode=min,version=v0.2",
+      ].join("\n"),
+    ],
+    [
+      "duplicate overriding SBOM",
+      "provenance: mode=max,version=v1",
+      ["sbom: false", "          provenance: mode=max,version=v1"].join("\n"),
+    ],
     [
       "missing index byte check",
       'test "$byte_digest" = "$IMAGE_DIGEST"',
@@ -941,7 +1010,7 @@ describe("frontend container publishing workflow", () => {
         replaceRequired(
           value,
           "https://github.com/cli/cli/releases/download/",
-          "https://downloads.example.com/cli/cli/releases/download/"
+          "https://downloads.secpal.dev/cli/cli/releases/download/"
         ),
     ],
     [

--- a/tests/container-publishing-workflow.test.ts
+++ b/tests/container-publishing-workflow.test.ts
@@ -1,0 +1,496 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  ".."
+);
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function countMatches(value: string, pattern: RegExp): number {
+  return [...value.matchAll(pattern)].length;
+}
+
+function jobBlock(workflow: string, jobName: string): string {
+  const lines = workflow.split("\n");
+  const start = lines.findIndex((line) => line === `  ${jobName}:`);
+
+  expect(start, `missing ${jobName} job`).toBeGreaterThanOrEqual(0);
+
+  const nextJob = lines.findIndex(
+    (line, index) => index > start && /^ {2}[a-z][a-z0-9_-]*:$/u.test(line)
+  );
+
+  return lines.slice(start, nextJob === -1 ? undefined : nextJob).join("\n");
+}
+
+function actionReferences(workflow: string): string[] {
+  return [...workflow.matchAll(/^\s*uses:\s*([^\s#]+)(?:\s*#.*)?$/gmu)].map(
+    ([, reference]) => reference
+  );
+}
+
+function replaceRequired(
+  value: string,
+  searchValue: string,
+  replacement: string
+): string {
+  expect(value).toContain(searchValue);
+  return value.replace(searchValue, replacement);
+}
+
+function assertSecurityCriticalPolicy(workflow: string): void {
+  expect(workflow).toMatch(/on:\n {2}push:\n {4}branches: \[main\](?:\n|$)/u);
+  expect(workflow).not.toMatch(/pull_request:|workflow_dispatch:|schedule:/u);
+  expect(workflow).toContain("permissions: {}");
+  expect(workflow).toContain("CANONICAL_IMAGE: ghcr.io/secpal/frontend");
+  expect(workflow).not.toMatch(
+    /(?:inputs|vars)\.[A-Z0-9_]*(?:REGISTRY|IMAGE|REPOSITORY)|GHCR_HOST:|GHCR_REPOSITORY_PATH:/u
+  );
+  expect(workflow).not.toMatch(
+    /docker\.io\/secpal\/frontend|CANONICAL_IMAGE:\s*secpal\/frontend|ghcr\.io\/secpal\/(?:web|pwa)/u
+  );
+  expect(
+    countMatches(
+      workflow,
+      /build-\$\{GITHUB_SHA\}-\$\{GITHUB_RUN_ID\}-\$\{GITHUB_RUN_ATTEMPT\}/gu
+    )
+  ).toBe(2);
+  expect(workflow).toContain("printf 'tag=build-%s-%s-%s\\n'");
+  expect(workflow).toContain(
+    'grep -Eq "^build-${GITHUB_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}$"'
+  );
+  expect(workflow).not.toMatch(
+    /(?:^|[-_:/])latest(?:$|[-_:/])|refs\/heads\/\$\{\{|refs\/tags\/\$\{\{|sha-\$\{\{\s*github\.sha/u
+  );
+  expect(countMatches(workflow, /uses:\s+docker\/build-push-action@/gu)).toBe(
+    1
+  );
+  expect(countMatches(workflow, /^\s*push:\s*true\s*$/gmu)).toBe(1);
+  expect(workflow).toContain("platforms: linux/amd64,linux/arm64");
+  expect(workflow).toContain(
+    "context: https://github.com/SecPal/frontend.git#${{ github.sha }}"
+  );
+  expect(workflow).toContain("SECPAL_IMAGE_REVISION=${{ github.sha }}");
+  expect(workflow).toContain("SECPAL_IMAGE_VERSION=${{");
+  expect(workflow).toContain("SOURCE_DATE_EPOCH=${{");
+  expect(workflow).toContain(
+    'source_epoch=$(git show -s --format=%ct "$GITHUB_SHA")'
+  );
+  expect(workflow).toMatch(
+    /image_version=.*\$\{package_version\}\+git\.\$\{GITHUB_SHA\}/u
+  );
+  expect(workflow).toMatch(/sbom:\s*>-[^]*buildkit-syft-scanner[^@]*@sha256:/u);
+  expect(workflow).toContain("provenance: mode=max");
+  expect(workflow).toContain("pull: true");
+  expect(workflow).toContain("no-cache: true");
+  expect(workflow).not.toMatch(
+    /cache-from:|imagetools\s+create|restore-cache/iu
+  );
+  expect(workflow).toContain(
+    'byte_digest="sha256:$(sha256sum "$manifest_file" | awk \'{print $1}\')"'
+  );
+  expect(workflow).toContain("docker-content-digest:");
+  expect(
+    countMatches(workflow, /test "\$byte_digest" = "\$IMAGE_DIGEST"/gu)
+  ).toBe(2);
+  expect(workflow).toContain('test "$registry_digest" = "$IMAGE_DIGEST"');
+  expect(workflow).toContain(
+    '.mediaType == "application/vnd.oci.image.index.v1+json"'
+  );
+  expect(workflow).toContain('== ["linux/amd64", "linux/arm64"]');
+  expect(workflow).toMatch(/attestation-manifest[^]*length\) == 2/u);
+  expect(workflow).toContain("for platform in linux/amd64 linux/arm64; do");
+  expect(workflow).toContain(
+    '--arg source "https://github.com/SecPal/frontend.git#${GITHUB_SHA}"'
+  );
+  expect(workflow).toContain('.SPDXID == "SPDXRef-DOCUMENT"');
+  expect(workflow).toContain("(.packages | length) > 0");
+  expect(workflow).toContain("buildkit_completeness.request == true");
+  expect(workflow).toContain(
+    "buildkit_completeness.resolvedDependencies == true"
+  );
+  expect(workflow).toContain("subject-name: ${{ env.CANONICAL_IMAGE }}");
+  expect(workflow).toContain(
+    "subject-digest: ${{ needs.publish.outputs.image_digest }}"
+  );
+  expect(workflow).toContain(
+    "--signer-workflow SecPal/frontend/.github/workflows/publish-container.yml"
+  );
+  expect(workflow).toContain('--signer-digest "$GITHUB_SHA"');
+  expect(workflow).toContain("--source-ref refs/heads/main");
+  expect(workflow).toContain('--source-digest "$GITHUB_SHA"');
+  expect(countMatches(workflow, /--deny-self-hosted-runners/gu)).toBe(2);
+  expect(workflow).not.toMatch(
+    /curl[^\n]*(?:--request|-X)\s+(?:PUT|DELETE)|docker\s+manifest\s+push|docker\s+buildx\s+imagetools\s+create|promotion|promote|package\s+delete|manifest\s+delete/iu
+  );
+}
+
+describe("frontend container publishing workflow", () => {
+  const workflow = readRepoFile(".github/workflows/publish-container.yml");
+  const pullRequestWorkflow = readRepoFile(
+    ".github/workflows/frontend-container.yml"
+  );
+  const dockerfile = readRepoFile("Dockerfile");
+  const packageJson = readRepoFile("package.json");
+  const smokeScript = readRepoFile("scripts/container-smoke.sh");
+  const browserScript = readRepoFile("scripts/container-browser.sh");
+  const readme = readRepoFile("README.md");
+  const containerGuide = readRepoFile("docs/deployment/frontend-container.md");
+  const changelog = readRepoFile("CHANGELOG.md");
+
+  it("publishes only fresh run-scoped multi-architecture images from main", () => {
+    assertSecurityCriticalPolicy(workflow);
+
+    expect(workflow).toContain("name: Publish Container");
+    expect(workflow).toContain(
+      "group: publish-container-${{ github.repository }}-${{ github.sha }}"
+    );
+    expect(workflow).toContain("cancel-in-progress: false");
+    expect(workflow).toContain("runs-on: ubuntu-latest");
+    expect(workflow).not.toMatch(
+      /restore-cache|cache-from:|imagetools create/iu
+    );
+
+    const buildStep = workflow.match(
+      /- name: Build and push run-scoped image[^]*?(?=\n\s{6}- name:|\n {2}[a-z])/u
+    )?.[0];
+    expect(buildStep).toBeDefined();
+    expect(buildStep).toContain("push: true");
+    expect(buildStep).toContain("pull: true");
+    expect(buildStep).toContain("no-cache: true");
+    expect(buildStep).toContain(
+      "tags: ${{ env.CANONICAL_IMAGE }}:${{ steps.published_tag.outputs.tag }}"
+    );
+    expect(buildStep).not.toMatch(/cache-from:|load:\s*true/u);
+  });
+
+  it("uses empty top-level permissions and explicit least-privilege jobs", () => {
+    expect(workflow).toMatch(/^permissions: \{\}$/mu);
+
+    const validate = jobBlock(workflow, "validate");
+    const publish = jobBlock(workflow, "publish");
+    const verify = jobBlock(workflow, "verify");
+    const attest = jobBlock(workflow, "attest");
+
+    expect(validate).toMatch(/permissions:\n {6}contents: read/u);
+    expect(validate).not.toMatch(/packages:|id-token:|attestations:/u);
+    expect(publish).toMatch(
+      /permissions:\n {6}contents: read\n {6}packages: write/u
+    );
+    expect(publish).not.toMatch(/id-token:|attestations:/u);
+    expect(verify).toMatch(
+      /permissions:\n {6}contents: read\n {6}packages: read/u
+    );
+    expect(verify).not.toMatch(/packages: write|id-token:|attestations:/u);
+    expect(attest).toMatch(/contents: read/u);
+    expect(attest).toMatch(/packages: write/u);
+    expect(attest).toMatch(/id-token: write/u);
+    expect(attest).toMatch(/attestations: write/u);
+
+    for (const job of [validate, publish, verify, attest]) {
+      expect(job).toMatch(/timeout-minutes: [1-9][0-9]*/u);
+    }
+  });
+
+  it("validates before publishing, verifies before attesting, and exports canonical metadata", () => {
+    expect(jobBlock(workflow, "publish")).toContain("needs: validate");
+    expect(jobBlock(workflow, "verify")).toContain("needs: publish");
+    expect(jobBlock(workflow, "attest")).toContain("needs: [publish, verify]");
+    expect(workflow).toContain("name: Validate Frontend Image");
+    expect(workflow).toContain("name: Publish Frontend Image");
+    expect(workflow).toContain("name: Verify Published Frontend Image");
+    expect(workflow).toContain("name: Attest Verified Frontend Image");
+
+    for (const output of [
+      "image_digest",
+      "image_created",
+      "image_version",
+      "published_tag",
+    ]) {
+      expect(jobBlock(workflow, "publish")).toMatch(
+        new RegExp(`^      ${output}:`, "mu")
+      );
+    }
+  });
+
+  it("checks out and validates the exact publishing commit without registry credentials", () => {
+    const validate = jobBlock(workflow, "validate");
+
+    expect(validate).toContain("ref: ${{ github.sha }}");
+    expect(validate).toContain("persist-credentials: false");
+    expect(validate).toContain('node-version: "22.22.2"');
+    expect(validate).toContain("npm ci --foreground-scripts");
+    expect(validate).toContain("tests/container-publishing-workflow.test.ts");
+    expect(validate).toContain("tests/container-contract.test.ts");
+    expect(validate).toMatch(/hadolint\/hadolint:[^@\s]+@sha256:/u);
+    expect(validate).toMatch(/koalaman\/shellcheck:[^@\s]+@sha256:/u);
+    expect(validate).not.toMatch(
+      /docker\/login-action|GITHUB_TOKEN|packages:|services:/u
+    );
+  });
+
+  it("pins every action and supply-chain tool to an immutable identity", () => {
+    for (const reference of actionReferences(workflow)) {
+      expect(reference).toMatch(/@[0-9a-f]{40}$/u);
+    }
+
+    expect(workflow).toContain("version: v0.36.0");
+    expect(workflow).toMatch(/moby\/buildkit:[^@\s]+@sha256:[0-9a-f]{64}/u);
+    expect(workflow).toMatch(/tonistiigi\/binfmt:[^@\s]+@sha256:[0-9a-f]{64}/u);
+    expect(workflow).toMatch(
+      /docker\/buildkit-syft-scanner:[^@\s]+@sha256:[0-9a-f]{64}/u
+    );
+  });
+
+  it("verifies exact index bytes, platform metadata, SBOM, and provenance", () => {
+    const verify = jobBlock(workflow, "verify");
+
+    expect(verify).toContain("Accept: application/vnd.oci.image.index.v1+json");
+    expect(verify).toContain("%{http_code}");
+    expect(verify).toContain('test "$status" = 200');
+    expect(
+      countMatches(verify, /\.config\.Labels\["org\.opencontainers\.image\./gu)
+    ).toBe(7);
+    expect(verify).toContain('org.opencontainers.image.created"] == $created');
+    expect(verify).toContain('org.opencontainers.image.version"] == $version');
+    expect(verify).toContain(".digest.sha1 == $revision");
+    expect(verify).not.toMatch(/\|\|\s*true|continue-on-error:\s*true/u);
+  });
+
+  it("runs both runtime and Chromium contracts against the digest on exactly two platforms", () => {
+    const verify = jobBlock(workflow, "verify");
+
+    expect(verify).toContain('DIGEST_REF="${CANONICAL_IMAGE}@${IMAGE_DIGEST}"');
+    expect(verify).toContain(
+      'docker pull --platform "$platform" "$DIGEST_REF"'
+    );
+    expect(verify).toContain('SECPAL_CONTAINER_PLATFORM="$platform"');
+    expect(verify).toContain("SECPAL_CONTAINER_SKIP_BUILD=1");
+    expect(verify).toContain('SECPAL_CONTAINER_IMAGE="$DIGEST_REF"');
+    expect(verify).toContain("npm run test:container");
+    expect(verify).toContain("npm run test:e2e:container");
+
+    for (const script of [smokeScript, browserScript]) {
+      expect(script).toContain("SECPAL_CONTAINER_PLATFORM");
+      expect(script).toContain(
+        'PLATFORM_ARGS+=(--platform "$SECPAL_CONTAINER_PLATFORM")'
+      );
+      expect(script).not.toMatch(/docker\s+(?:rmi|image rm)/u);
+    }
+  });
+
+  it("preserves the hardened static Web/PWA runtime contract", () => {
+    expect(dockerfile).toContain("RUN npm run build:web");
+    expect(dockerfile).toContain("USER 101:101");
+    expect(dockerfile).toContain("ARG SECPAL_IMAGE_REVISION");
+    expect(dockerfile).toContain("ARG SECPAL_IMAGE_VERSION");
+    expect(dockerfile).toContain("ARG SOURCE_DATE_EPOCH");
+    expect(countMatches(dockerfile, /^FROM node/gmu)).toBe(1);
+    expect(dockerfile).toMatch(
+      /^FROM nginxinc\/nginx-unprivileged:[^\n]+ AS runtime$/mu
+    );
+    expect(packageJson).toContain('"test:container"');
+    expect(packageJson).toContain('"test:e2e:container"');
+    expect(smokeScript).toContain("--read-only");
+    expect(smokeScript).toContain("--cap-drop=ALL");
+    expect(smokeScript).toContain("SECPAL_API_URL");
+    expect(smokeScript).toContain("/health/live");
+    expect(smokeScript).toContain("source maps");
+    expect(smokeScript).toContain("command -v node");
+    expect(smokeScript).toContain("command -v npm");
+    expect(smokeScript).toContain("docker stop --time 10");
+  });
+
+  it("makes the embedded dependency SBOM reproducible from SOURCE_DATE_EPOCH", () => {
+    const firstOutput = mkdtempSync(path.join(tmpdir(), "secpal-sbom-first-"));
+    const secondOutput = mkdtempSync(
+      path.join(tmpdir(), "secpal-sbom-second-")
+    );
+    const sourceDateEpoch = "1700000000";
+    const env = { ...process.env, SOURCE_DATE_EPOCH: sourceDateEpoch };
+
+    try {
+      for (const outputDirectory of [firstOutput, secondOutput]) {
+        execFileSync(
+          process.execPath,
+          ["scripts/generate-dependency-sbom.mjs", outputDirectory],
+          { cwd: repoRoot, env, stdio: "pipe" }
+        );
+      }
+
+      const firstSbom = readFileSync(
+        path.join(firstOutput, "dependencies.spdx.json"),
+        "utf8"
+      );
+      const secondSbom = readFileSync(
+        path.join(secondOutput, "dependencies.spdx.json"),
+        "utf8"
+      );
+      const parsedSbom = JSON.parse(firstSbom) as {
+        creationInfo: { created: string };
+        documentNamespace: string;
+      };
+
+      expect(firstSbom).toBe(secondSbom);
+      expect(parsedSbom.creationInfo.created).toBe("2023-11-14T22:13:20.000Z");
+      expect(parsedSbom.documentNamespace).toMatch(/-1700000000000$/u);
+    } finally {
+      rmSync(firstOutput, { recursive: true, force: true });
+      rmSync(secondOutput, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an invalid SOURCE_DATE_EPOCH instead of emitting misleading metadata", () => {
+    const outputDirectory = mkdtempSync(
+      path.join(tmpdir(), "secpal-sbom-invalid-")
+    );
+
+    try {
+      expect(() =>
+        execFileSync(
+          process.execPath,
+          ["scripts/generate-dependency-sbom.mjs", outputDirectory],
+          {
+            cwd: repoRoot,
+            env: { ...process.env, SOURCE_DATE_EPOCH: "not-an-epoch" },
+            stdio: "pipe",
+          }
+        )
+      ).toThrow();
+    } finally {
+      rmSync(outputDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("attests the exact digest with the required source and hosted-runner binding, then rechecks it", () => {
+    const attest = jobBlock(workflow, "attest");
+    const generateIndex = attest.indexOf(
+      "Generate GitHub artifact attestation"
+    );
+    const initialVerificationIndex = attest.indexOf(
+      "Verify selected GitHub artifact attestation"
+    );
+    const finalSnapshotIndex = attest.indexOf(
+      "Verify final discovery snapshot and artifact attestation"
+    );
+    const summaryIndex = attest.indexOf("Record published image identity");
+
+    expect(generateIndex).toBeGreaterThanOrEqual(0);
+    expect(initialVerificationIndex).toBeGreaterThan(generateIndex);
+    expect(finalSnapshotIndex).toBeGreaterThan(initialVerificationIndex);
+    expect(summaryIndex).toBeGreaterThan(finalSnapshotIndex);
+    expect(countMatches(attest, /gh attestation verify/gu)).toBe(2);
+    expect(attest).toContain('test "$byte_digest" = "$IMAGE_DIGEST"');
+    expect(attest).toContain('test "$registry_digest" = "$IMAGE_DIGEST"');
+  });
+
+  it("keeps registry writes structurally limited", () => {
+    expect(countMatches(workflow, /^\s*push:\s*true\s*$/gmu)).toBe(1);
+    expect(countMatches(workflow, /^\s*push-to-registry:\s*true\s*$/gmu)).toBe(
+      1
+    );
+    expect(workflow).not.toMatch(
+      /curl[^\n]*(?:--request|-X)\s+(?:PUT|DELETE)|docker\s+manifest\s+push|docker\s+buildx\s+imagetools\s+create|promotion|promote|delete-package-version/iu
+    );
+  });
+
+  it("keeps pull-request container CI read-only and pins every changed action", () => {
+    expect(pullRequestWorkflow).toMatch(
+      /permissions:\n {2}contents: read(?:\n|$)/u
+    );
+    expect(pullRequestWorkflow).not.toMatch(
+      /packages:\s*write|id-token:\s*write|attestations:\s*write|docker\/login-action|docker\s+push|registry.*secret/iu
+    );
+    for (const reference of actionReferences(pullRequestWorkflow)) {
+      expect(reference).toMatch(/@[0-9a-f]{40}$/u);
+    }
+    expect(pullRequestWorkflow).toContain("npm run test:container");
+    expect(pullRequestWorkflow).toContain("npm run test:e2e:container");
+  });
+
+  it("documents digest-only trust without claiming Phase C completion", () => {
+    const documentation = `${readme}\n${containerGuide}\n${changelog}`;
+
+    expect(documentation).toContain("ghcr.io/secpal/frontend");
+    expect(documentation).toContain(
+      "ghcr.io/secpal/frontend@sha256:<oci-index-digest>"
+    );
+    expect(documentation).toContain(
+      "build-<source-sha>-<run-id>-<run-attempt>"
+    );
+    expect(documentation).toContain(
+      "Frontend image publication is implemented but not yet operationally verified."
+    );
+    expect(documentation).toContain("Phase C remains in progress");
+    expect(documentation).not.toMatch(
+      /Phase C is complete|The frontend is deployed|SecPal is production-ready|Phase D is complete/u
+    );
+  });
+
+  it.each([
+    ["pull-request publishing", "on:\n  push:\n", "on:\n  pull_request:\n"],
+    [
+      "moving image tag",
+      "build-${GITHUB_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}",
+      "latest",
+    ],
+    ["wrong image identity", "ghcr.io/secpal/frontend", "ghcr.io/secpal/web"],
+    [
+      "registry host variable",
+      "CANONICAL_IMAGE:",
+      "GHCR_HOST: ghcr.io\n  CANONICAL_IMAGE:",
+    ],
+    [
+      "registry reuse",
+      "pull: true",
+      "cache-from: type=registry\n          pull: true",
+    ],
+    ["build cache enabled", "no-cache: true", "no-cache: false"],
+    [
+      "single architecture",
+      "platforms: linux/amd64,linux/arm64",
+      "platforms: linux/amd64",
+    ],
+    [
+      "unbound context",
+      "https://github.com/SecPal/frontend.git#${{ github.sha }}",
+      ".",
+    ],
+    ["disabled SBOM", "sbom: >-", "sbom: false #"],
+    ["weak provenance", "provenance: mode=max", "provenance: mode=min"],
+    [
+      "missing index byte check",
+      'test "$byte_digest" = "$IMAGE_DIGEST"',
+      "true",
+    ],
+    [
+      "wrong attestation subject",
+      "subject-name: ${{ env.CANONICAL_IMAGE }}",
+      "subject-name: secpal/frontend",
+    ],
+    [
+      "self-hosted signer allowed",
+      "--deny-self-hosted-runners",
+      "--format json",
+    ],
+    [
+      "raw manifest write",
+      "set -euo pipefail",
+      "curl -X PUT manifest\n          set -euo pipefail",
+    ],
+  ])("rejects the %s mutation", (_name, searchValue, replacement) => {
+    const mutatedWorkflow = replaceRequired(workflow, searchValue, replacement);
+    expect(() => assertSecurityCriticalPolicy(mutatedWorkflow)).toThrow();
+  });
+});


### PR DESCRIPTION
## Problem and evidence

`SecPal/frontend` does not yet publish its Web/PWA runtime image from `main`.
At the starting commit, `0af002c0aa9452488e300431c6b7d03d1a373034`,
the repository had a hardened local container contract but no publisher for the
official `ghcr.io/secpal/frontend` image. Deployment still builds the frontend
from a pinned source revision, so publishing and deployment consumption must
remain separate changes.

Policy-first review demonstrated three verification gaps before this branch was
finalized:

- provenance accepted the expected source revision even when another
  conflicting source revision was present;
- policy coverage did not reject every additional tag or common registry write
  client; and
- the verification summary did not retain the two platform runtime digests as
  non-canonical evidence.

The attestation job also invoked the GitHub CLI supplied by the mutable hosted
runner image. That allowed the CLI version, supported flags, or verification
semantics to change without a repository change. A focused policy test failed
against the previous head because the pinned installation step was absent, and
the missing-installation mutation reproduced the same violation before the
workflow was changed.

## Change

- add the push-to-`main` `Publish Container` workflow;
- publish only `ghcr.io/secpal/frontend` with one run-specific discovery tag;
- make the OCI index digest the sole trust, deployment, update, and rollback
  identity;
- build exactly `linux/amd64` and `linux/arm64` in one fresh multi-architecture
  build;
- verify exact index bytes, registry digest headers, platform manifests, OCI
  metadata, BuildKit SBOM and provenance, runtime behavior, and Chromium
  behavior;
- require one exact provenance source dependency bound to the source commit;
- retain the amd64 and arm64 runtime digests as evidence while keeping the OCI
  index digest canonical;
- create and verify a GitHub Artifact Attestation for the exact OCI index
  digest;
- install GitHub CLI 2.97.0 from its official release archive, verify the
  reviewed SHA-256 checksum, enforce the effective version, and invoke that
  absolute binary for both attestation verification passes; and
- keep pull-request container CI registry-read-only.

## Governance

- Epic: #1590
- Closes #1591
- Deployment consumption follow-up: SecPal/deployment#3
- Remaining moving workflow references: #1592
- Existing Vite native-loader warning: #1583, with remediation in #1587

This pull request closes only the publishing sub-issue. It does not close the
epic, modify `SecPal/deployment`, deploy the frontend, or complete Phase C.

## Publication contract

- Official image: `ghcr.io/secpal/frontend`
- Discovery tag: `build-<40-character-source-sha>-<run-id>-<run-attempt>`
- Canonical reference:
  `ghcr.io/secpal/frontend@sha256:<oci-index-digest>`
- Platforms: exactly `linux/amd64` and `linux/arm64`
- Build context and revision: exact `github.sha`
- Image version: `<package-version>+git.<full-source-sha>`
- Created timestamp and embedded dependency SBOM timestamp: source commit time
- Build behavior: fresh pull, no cache, one multi-architecture build/push
- BuildKit attestations: non-empty SPDX SBOM and `mode=max` provenance for both
  runtime platforms

The discovery tag is not a deployment contract, rollback contract, or trust
anchor, and another authorized registry writer could technically move it.

The verify job compares the SHA-256 of the exact OCI index response bytes and
the `Docker-Content-Digest` response header with the build digest. It rejects
unexpected runtime platforms or BuildKit attestation manifests and verifies
all required OCI labels. Both platforms run the container and Chromium
contracts from the digest reference. The final job attests the exact OCI index
digest, verifies its repository, workflow, branch, source, signer, and runner
bindings, and then repeats the discovery snapshot and attestation checks.

Registry write effects are structurally limited to the single image build/push
and the Artifact Attestation step. There are no raw OCI manifest writes,
promotion scripts, moving SHA/release/branch/latest tags, registry reuse paths,
or delete operations. No package or registry mutation occurred during pull
request preparation.

## Validation

Initial implementation and remediation validation included:

- `npm ci --foreground-scripts`
- focused Vitest matrices, container contracts, migration boundaries, and
  UI/CSP architecture tests
- local container and Chromium contracts, including an explicit
  `linux/amd64` run against the prebuilt image
- Web and Android production builds
- shell syntax and ShellCheck validation
- nine policy mutations observed failing before their corresponding fixes

Current-head hardening validation:

- focused publishing and container contract matrix: 56 tests passed
- publishing policy suite: 52 tests passed
- full preflight: 204 test files and 2,985 tests passed
- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `yamllint` for both container workflows
- `actionlint` for both container workflows
- `reuse lint`
- `git diff --check`
- pinned GitHub CLI 2.97.0 archive checksum verification
- policy mutations for missing or altered GitHub CLI pinning: twelve cases
  passed

The reviewed archive is
`https://github.com/cli/cli/releases/download/v2.97.0/gh_2.97.0_linux_amd64.tar.gz`
with SHA-256
`a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112`.
All commits are signed locally and GitHub reports every PR commit as verified.

## Readiness

Current head: `92ccd1911af31f98a0cb82f0d759e684d3d771d2`

The single current-head check snapshot taken after the push contained no
failures. PR Size Check and CLA had completed successfully; Quality Checks,
Frontend Container, both CodeQL workflows, UI and CSP Architecture, Lighthouse
CI, and the conflict-marker check were still in progress. The checks were not
polled or retried.

The publisher uses the official GitHub CLI 2.97.0 release archive, verifies its
reviewed SHA-256 checksum, and invokes that exact binary for both artifact
attestation verification passes.

All review threads are resolved, the pull request is not a draft, and GitHub
reports no merge conflict. This pull request is ready for merge only after the
remaining current-head checks complete successfully and every commit remains
verified in the GitHub UI.

Frontend image publication is implemented but not yet operationally verified.
The publisher must first run successfully after merge. Package linkage,
visibility, anonymous digest pull, and final post-merge attestation checks remain
required before Phase C.4 can begin. Phase C remains in progress.
