### PR TITLE
fix: harden published frontend runtime verification

### DIFF
--- a/.github/workflows/frontend-container.yml
+++ b/.github/workflows/frontend-container.yml
@@ -42,7 +42,8 @@ jobs:
 
       - name: Verify source container contracts
         run: >-
-          npm exec -- vitest run tests/container-contract.test.ts
+          npm exec -- vitest run tests/container-runtime-lifecycle.test.ts
+          tests/container-contract.test.ts
           src/config.test.ts src/lib/pwaRuntimeCaching.test.ts
 
       - name: Build and exercise hardened frontend image

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Run container publishing and source policy tests
         run: >-
           npm exec -- vitest run
+          tests/container-runtime-lifecycle.test.ts
           tests/container-publishing-workflow.test.ts
           tests/container-contract.test.ts
 
@@ -58,6 +59,7 @@ jobs:
         run: >-
           docker run --rm -v "$PWD:/mnt:ro" -w /mnt
           koalaman/shellcheck:v0.10.0@sha256:2097951f02e735b613f4a34de20c40f937a6c8f18ecb170612c88c34517221fb
+          scripts/container-runtime.sh
           scripts/container-smoke.sh
           scripts/container-browser.sh
           docker/secpal-entrypoint.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed published frontend startup by explicitly setting the Nginx snippets
+  directory to mode `0555`, and hardened runtime verification with bounded
+  loopback port and readiness waits that report container state, exit status,
+  Docker errors, and startup logs before cleanup.
 - Bound the embedded dependency SPDX document timestamp to the publishing
   commit through `SOURCE_DATE_EPOCH` and its namespace to the document content,
   making repeated builds of the same source produce identical application SBOM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   directory to mode `0555`, and hardened runtime verification with
   ownership-safe container creation plus bounded loopback port and readiness
   waits that report container state, exit status, Docker errors, and startup
-  logs before cleanup.
+  logs before cleanup while keeping the Chromium API-origin contract aligned
+  with the canonical SecPal API host.
 - Bound the embedded dependency SPDX document timestamp to the publishing
   commit through `SOURCE_DATE_EPOCH` and its namespace to the document content,
   making repeated builds of the same source produce identical application SBOM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,9 +78,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed published frontend startup by explicitly setting the Nginx snippets
-  directory to mode `0555`, and hardened runtime verification with bounded
-  loopback port and readiness waits that report container state, exit status,
-  Docker errors, and startup logs before cleanup.
+  directory to mode `0555`, and hardened runtime verification with
+  ownership-safe container creation plus bounded loopback port and readiness
+  waits that report container state, exit status, Docker errors, and startup
+  logs before cleanup.
 - Bound the embedded dependency SPDX document timestamp to the publishing
   commit through `SOURCE_DATE_EPOCH` and its namespace to the document content,
   making repeated builds of the same source produce identical application SBOM

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN find /usr/share/nginx/html /usr/share/licenses/secpal-frontend \
       /etc/nginx/nginx.conf \
       /etc/nginx/conf.d/default.conf \
       /etc/nginx/snippets/secpal-security-headers.conf \
-    && chmod 0555 /usr/local/bin/secpal-entrypoint
+    && chmod 0555 /etc/nginx/snippets /usr/local/bin/secpal-entrypoint
 
 USER 101:101
 

--- a/scripts/container-browser.sh
+++ b/scripts/container-browser.sh
@@ -60,7 +60,7 @@ if ! CONTAINER_ID=$(docker create "${PLATFORM_ARGS[@]}" \
   --tmpfs /tmp:rw,noexec,nosuid,nodev,size=16m \
   --cap-drop=ALL \
   --security-opt=no-new-privileges:true \
-  --env SECPAL_API_URL=https://api.container.example \
+  --env SECPAL_API_URL=https://api.secpal.dev \
   --publish 127.0.0.1::8080 \
   "$IMAGE_TAG"); then
   printf 'ERROR: could not create frontend browser container %s\n' \

--- a/scripts/container-browser.sh
+++ b/scripts/container-browser.sh
@@ -5,6 +5,8 @@
 set -euo pipefail
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
+# shellcheck source=scripts/container-runtime.sh
+source "$ROOT_DIR/scripts/container-runtime.sh"
 DEFAULT_IMAGE_TAG=$(node "$ROOT_DIR/scripts/container-test-image-tag.mjs" "$ROOT_DIR")
 IMAGE_TAG=${SECPAL_CONTAINER_IMAGE:-$DEFAULT_IMAGE_TAG}
 CONTAINER_LABEL="secpal.dev/test-role=frontend-container-browser"
@@ -46,7 +48,7 @@ elif ! docker image inspect "$IMAGE_TAG" >/dev/null 2>&1; then
   exit 1
 fi
 
-docker run "${PLATFORM_ARGS[@]}" \
+if ! docker run "${PLATFORM_ARGS[@]}" \
   --detach \
   --name "$CONTAINER_NAME" \
   --label "$CONTAINER_LABEL" \
@@ -57,36 +59,23 @@ docker run "${PLATFORM_ARGS[@]}" \
   --security-opt=no-new-privileges:true \
   --env SECPAL_API_URL=https://api.container.example \
   --publish 127.0.0.1::8080 \
-  "$IMAGE_TAG" >/dev/null
-
-CONTAINER_PORT=$(
-  docker inspect \
-    --format '{{(index (index .NetworkSettings.Ports "8080/tcp") 0).HostPort}}' \
-    "$CONTAINER_NAME"
-)
-
-if ! [[ "$CONTAINER_PORT" =~ ^[0-9]+$ ]]; then
-  echo "ERROR: frontend container did not receive a host port" >&2
+  "$IMAGE_TAG" >/dev/null; then
+  fail_with_container_diagnostics \
+    "$CONTAINER_NAME" \
+    "could not start frontend browser container"
   exit 1
 fi
+
+CONTAINER_PORT=$(wait_for_container_port "$CONTAINER_NAME" 8080)
 
 SECPAL_CONTAINER_BASE_URL="http://127.0.0.1:${CONTAINER_PORT}"
 export SECPAL_CONTAINER_BASE_URL
 
-container_ready=0
-for _attempt in $(seq 1 100); do
-  if curl --fail --silent \
-    "${SECPAL_CONTAINER_BASE_URL}/health/live" >/dev/null 2>&1; then
-    container_ready=1
-    break
-  fi
-  sleep 0.1
-done
+wait_for_container_live "$CONTAINER_NAME" "$CONTAINER_PORT"
 
-if [ "$container_ready" != "1" ]; then
-  docker logs "$CONTAINER_NAME" >&2 || true
-  echo "ERROR: frontend container did not become ready" >&2
+if ! npm exec -- playwright test --config=playwright.container.config.ts; then
+  fail_with_container_diagnostics \
+    "$CONTAINER_NAME" \
+    "frontend container browser contract failed"
   exit 1
 fi
-
-npm exec -- playwright test --config=playwright.container.config.ts

--- a/scripts/container-browser.sh
+++ b/scripts/container-browser.sh
@@ -6,12 +6,14 @@ set -euo pipefail
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
 # shellcheck source=scripts/container-runtime.sh
+# shellcheck disable=SC1091
 source "$ROOT_DIR/scripts/container-runtime.sh"
 DEFAULT_IMAGE_TAG=$(node "$ROOT_DIR/scripts/container-test-image-tag.mjs" "$ROOT_DIR")
 IMAGE_TAG=${SECPAL_CONTAINER_IMAGE:-$DEFAULT_IMAGE_TAG}
 CONTAINER_LABEL="secpal.dev/test-role=frontend-container-browser"
 RUN_ID=$(node -e 'process.stdout.write(require("node:crypto").randomUUID())')
 CONTAINER_NAME="secpal-frontend-browser-${RUN_ID}"
+CONTAINER_ID=
 PLATFORM_ARGS=()
 
 case ${SECPAL_CONTAINER_PLATFORM:-} in
@@ -27,7 +29,9 @@ case ${SECPAL_CONTAINER_PLATFORM:-} in
 esac
 
 cleanup_container() {
-  docker rm --force "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  if [ -n "$CONTAINER_ID" ]; then
+    docker rm --force "$CONTAINER_ID" >/dev/null 2>&1 || true
+  fi
 }
 
 handle_signal() {
@@ -48,8 +52,7 @@ elif ! docker image inspect "$IMAGE_TAG" >/dev/null 2>&1; then
   exit 1
 fi
 
-if ! docker run "${PLATFORM_ARGS[@]}" \
-  --detach \
+if ! CONTAINER_ID=$(docker create "${PLATFORM_ARGS[@]}" \
   --name "$CONTAINER_NAME" \
   --label "$CONTAINER_LABEL" \
   --label "secpal.dev/test-run=$RUN_ID" \
@@ -59,23 +62,29 @@ if ! docker run "${PLATFORM_ARGS[@]}" \
   --security-opt=no-new-privileges:true \
   --env SECPAL_API_URL=https://api.container.example \
   --publish 127.0.0.1::8080 \
-  "$IMAGE_TAG" >/dev/null; then
+  "$IMAGE_TAG"); then
+  printf 'ERROR: could not create frontend browser container %s\n' \
+    "$CONTAINER_NAME" >&2
+  exit 1
+fi
+
+if ! docker start "$CONTAINER_ID" >/dev/null; then
   fail_with_container_diagnostics \
-    "$CONTAINER_NAME" \
+    "$CONTAINER_ID" \
     "could not start frontend browser container"
   exit 1
 fi
 
-CONTAINER_PORT=$(wait_for_container_port "$CONTAINER_NAME" 8080)
+CONTAINER_PORT=$(wait_for_container_port "$CONTAINER_ID" 8080)
 
 SECPAL_CONTAINER_BASE_URL="http://127.0.0.1:${CONTAINER_PORT}"
 export SECPAL_CONTAINER_BASE_URL
 
-wait_for_container_live "$CONTAINER_NAME" "$CONTAINER_PORT"
+wait_for_container_live "$CONTAINER_ID" "$CONTAINER_PORT"
 
 if ! npm exec -- playwright test --config=playwright.container.config.ts; then
   fail_with_container_diagnostics \
-    "$CONTAINER_NAME" \
+    "$CONTAINER_ID" \
     "frontend container browser contract failed"
   exit 1
 fi

--- a/scripts/container-runtime.sh
+++ b/scripts/container-runtime.sh
@@ -118,7 +118,8 @@ wait_for_container_live() {
   fi
 
   for ((attempt = 1; attempt <= attempts; attempt++)); do
-    if curl --fail --silent --show-error \
+    if curl --connect-timeout 0.2 --max-time 0.5 \
+      --fail --silent --show-error \
       "http://127.0.0.1:${host_port}/health/live" >/dev/null 2>&1; then
       return 0
     fi

--- a/scripts/container-runtime.sh
+++ b/scripts/container-runtime.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+print_container_diagnostics() {
+  local container=$1
+
+  printf 'Container diagnostics for %s:\n' "$container" >&2
+
+  docker inspect \
+    --format \
+    'status={{.State.Status}} running={{.State.Running}} exit={{.State.ExitCode}} error={{json .State.Error}} ports={{json .NetworkSettings.Ports}}' \
+    "$container" >&2 ||
+    printf 'docker inspect failed for %s\n' "$container" >&2
+
+  docker logs "$container" >&2 ||
+    printf 'docker logs failed for %s\n' "$container" >&2
+}
+
+fail_with_container_diagnostics() {
+  local container=$1
+  local message=$2
+
+  printf 'ERROR: %s\n' "$message" >&2
+  print_container_diagnostics "$container"
+  return 1
+}
+
+container_allows_startup_wait() {
+  local container=$1
+  local wait_context=$2
+  local state
+
+  if ! state=$(docker inspect --format '{{.State.Status}}' "$container" 2>/dev/null); then
+    fail_with_container_diagnostics \
+      "$container" \
+      "could not inspect container state"
+    return 1
+  fi
+
+  case "$state" in
+    created | running | restarting)
+      return 0
+      ;;
+    exited | dead)
+      fail_with_container_diagnostics \
+        "$container" \
+        "container exited before ${wait_context}"
+      return 1
+      ;;
+    *)
+      fail_with_container_diagnostics \
+        "$container" \
+        "container entered unexpected state: ${state}"
+      return 1
+      ;;
+  esac
+}
+
+wait_for_container_port() {
+  local container=$1
+  local container_port=$2
+  local attempts=${3:-100}
+  local interval=${4:-0.1}
+  local attempt
+  local mapping
+
+  if ! [[ "$attempts" =~ ^[1-9][0-9]*$ ]]; then
+    fail_with_container_diagnostics \
+      "$container" \
+      "invalid container port wait attempt count: ${attempts}"
+    return 1
+  fi
+
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    mapping=$(docker port "$container" "${container_port}/tcp" 2>/dev/null || true)
+
+    if [[ "$mapping" =~ ^127\.0\.0\.1:([0-9]+)$ ]]; then
+      printf '%s\n' "${BASH_REMATCH[1]}"
+      return 0
+    fi
+
+    if [ -n "$mapping" ]; then
+      fail_with_container_diagnostics \
+        "$container" \
+        "container published an unexpected ${container_port}/tcp mapping"
+      return 1
+    fi
+
+    if ! container_allows_startup_wait \
+      "$container" \
+      "publishing ${container_port}/tcp"; then
+      return 1
+    fi
+
+    if [ "$attempt" -lt "$attempts" ]; then
+      sleep "$interval"
+    fi
+  done
+
+  fail_with_container_diagnostics \
+    "$container" \
+    "container did not publish ${container_port}/tcp before timeout"
+}
+
+wait_for_container_live() {
+  local container=$1
+  local host_port=$2
+  local attempts=${3:-100}
+  local interval=${4:-0.1}
+  local attempt
+
+  if ! [[ "$attempts" =~ ^[1-9][0-9]*$ ]]; then
+    fail_with_container_diagnostics \
+      "$container" \
+      "invalid container readiness attempt count: ${attempts}"
+    return 1
+  fi
+
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    if curl --fail --silent --show-error \
+      "http://127.0.0.1:${host_port}/health/live" >/dev/null 2>&1; then
+      return 0
+    fi
+
+    if ! container_allows_startup_wait \
+      "$container" \
+      "exposing /health/live"; then
+      return 1
+    fi
+
+    if [ "$attempt" -lt "$attempts" ]; then
+      sleep "$interval"
+    fi
+  done
+
+  fail_with_container_diagnostics \
+    "$container" \
+    "container did not expose /health/live before timeout"
+}

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -5,6 +5,8 @@
 set -euo pipefail
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
+# shellcheck source=scripts/container-runtime.sh
+source "$ROOT_DIR/scripts/container-runtime.sh"
 DEFAULT_IMAGE_TAG=$(node "$ROOT_DIR/scripts/container-test-image-tag.mjs" "$ROOT_DIR")
 IMAGE_TAG=${SECPAL_CONTAINER_IMAGE:-$DEFAULT_IMAGE_TAG}
 CONTAINER_PREFIX="secpal-frontend-contract-$$"
@@ -33,10 +35,18 @@ cleanup() {
   done
   rm -rf "$TEMP_DIR"
 }
-trap cleanup EXIT HUP INT TERM
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 fail() {
-  echo "ERROR: $*" >&2
+  local container
+
+  printf 'ERROR: %s\n' "$*" >&2
+  for container in "${CONTAINERS[@]}"; do
+    print_container_diagnostics "$container"
+  done
   exit 1
 }
 
@@ -56,7 +66,8 @@ start_container() {
   local name=$1
   local api_origin=$2
 
-  docker run "${PLATFORM_ARGS[@]}" \
+  CONTAINERS+=("$name")
+  if ! docker run "${PLATFORM_ARGS[@]}" \
     --detach \
     --name "$name" \
     --read-only \
@@ -66,28 +77,18 @@ start_container() {
     --env "SECPAL_API_URL=$api_origin" \
     --env "SECPAL_SMOKE_SENTINEL=must-not-be-serialized" \
     --publish 127.0.0.1::8080 \
-    "$IMAGE_TAG" >/dev/null
-  CONTAINERS+=("$name")
+    "$IMAGE_TAG" >/dev/null; then
+    fail_with_container_diagnostics "$name" "could not start container"
+    return 1
+  fi
 }
 
 container_port() {
-  docker inspect \
-    --format '{{(index (index .NetworkSettings.Ports "8080/tcp") 0).HostPort}}' \
-    "$1"
+  wait_for_container_port "$1" 8080
 }
 
 wait_for_live() {
-  local port=$1
-
-  for _attempt in $(seq 1 100); do
-    if curl --fail --silent --show-error \
-      "http://127.0.0.1:${port}/health/live" >/dev/null 2>&1; then
-      return
-    fi
-    sleep 0.1
-  done
-
-  fail "container did not expose /health/live"
+  wait_for_container_live "$1" "$2"
 }
 
 assert_status() {
@@ -126,8 +127,8 @@ start_container "$CONTAINER_B" "https://api.customer-b.example"
 
 PORT_A=$(container_port "$CONTAINER_A")
 PORT_B=$(container_port "$CONTAINER_B")
-wait_for_live "$PORT_A"
-wait_for_live "$PORT_B"
+wait_for_live "$CONTAINER_A" "$PORT_A"
+wait_for_live "$CONTAINER_B" "$PORT_B"
 
 [ "$(docker inspect --format '{{.Config.User}}' "$CONTAINER_A")" = "101:101" ] ||
   fail "image user is not 101:101"
@@ -135,6 +136,11 @@ wait_for_live "$PORT_B"
   fail "running process is root"
 docker exec "$CONTAINER_A" test ! -w /usr/share/nginx/html/index.html ||
   fail "static Web artifact is writable by the runtime user"
+[ "$(docker exec "$CONTAINER_A" stat -c '%a' /etc/nginx/snippets)" = "555" ] ||
+  fail "Nginx snippets directory mode is not 0555"
+docker exec "$CONTAINER_A" \
+  test -r /etc/nginx/snippets/secpal-security-headers.conf ||
+  fail "Nginx security headers are not readable by the runtime user"
 
 assert_status "$PORT_A" "/health/live" "200"
 [ "$(curl --fail --silent "http://127.0.0.1:${PORT_A}/health/live")" = '{"status":"ok"}' ] ||
@@ -181,7 +187,7 @@ cmp "$TEMP_DIR/style-${PORT_A}.css" "$TEMP_DIR/style-${PORT_B}.css" >/dev/null |
 
 docker restart "$CONTAINER_A" >/dev/null
 PORT_A=$(container_port "$CONTAINER_A")
-wait_for_live "$PORT_A"
+wait_for_live "$CONTAINER_A" "$PORT_A"
 curl --fail --silent "http://127.0.0.1:${PORT_A}/runtime-config.js" \
   >"$TEMP_DIR/runtime-a-restarted.js"
 cmp "$RUNTIME_A" "$TEMP_DIR/runtime-a-restarted.js" >/dev/null ||

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
 # shellcheck source=scripts/container-runtime.sh
+# shellcheck disable=SC1091
 source "$ROOT_DIR/scripts/container-runtime.sh"
 DEFAULT_IMAGE_TAG=$(node "$ROOT_DIR/scripts/container-test-image-tag.mjs" "$ROOT_DIR")
 IMAGE_TAG=${SECPAL_CONTAINER_IMAGE:-$DEFAULT_IMAGE_TAG}
@@ -65,10 +66,9 @@ IMAGE_ID=$(docker image inspect --format '{{.Id}}' "$IMAGE_TAG")
 start_container() {
   local name=$1
   local api_origin=$2
+  local container_id
 
-  CONTAINERS+=("$name")
-  if ! docker run "${PLATFORM_ARGS[@]}" \
-    --detach \
+  if ! container_id=$(docker create "${PLATFORM_ARGS[@]}" \
     --name "$name" \
     --read-only \
     --tmpfs /tmp:rw,noexec,nosuid,nodev,size=16m \
@@ -77,8 +77,14 @@ start_container() {
     --env "SECPAL_API_URL=$api_origin" \
     --env "SECPAL_SMOKE_SENTINEL=must-not-be-serialized" \
     --publish 127.0.0.1::8080 \
-    "$IMAGE_TAG" >/dev/null; then
-    fail_with_container_diagnostics "$name" "could not start container"
+    "$IMAGE_TAG"); then
+    printf 'ERROR: could not create container %s\n' "$name" >&2
+    return 1
+  fi
+
+  CONTAINERS+=("$container_id")
+  if ! docker start "$container_id" >/dev/null; then
+    fail_with_container_diagnostics "$container_id" "could not start container"
     return 1
   fi
 }

--- a/tests/container-browser-origin.test.ts
+++ b/tests/container-browser-origin.test.ts
@@ -5,19 +5,19 @@ import { describe, expect, it } from "vitest";
 import { hasExactOrigin } from "./e2e/container-origin";
 
 describe("container browser request origin matching", () => {
-  const expectedOrigin = "https://api.container.example";
+  const expectedOrigin = "https://api.secpal.dev";
 
   it.each([
-    "https://api.container.example/v1/me",
-    "https://api.container.example:443/health/ready",
+    "https://api.secpal.dev/v1/me",
+    "https://api.secpal.dev:443/health/ready",
   ])("accepts the configured API origin: %s", (requestUrl) => {
     expect(hasExactOrigin(requestUrl, expectedOrigin)).toBe(true);
   });
 
   it.each([
-    "https://api.container.example.evil/v1/me",
-    "https://api.container.example@evil.example/v1/me",
-    "https://evil.example/?next=https://api.container.example",
+    "https://api.secpal.dev.evil.secpal.dev/v1/me",
+    "https://api.secpal.dev@evil.secpal.dev/v1/me",
+    "https://evil.secpal.dev/?next=https://api.secpal.dev",
     "not-a-url",
   ])("rejects a non-matching URL: %s", (requestUrl) => {
     expect(hasExactOrigin(requestUrl, expectedOrigin)).toBe(false);

--- a/tests/container-contract.test.ts
+++ b/tests/container-contract.test.ts
@@ -32,7 +32,10 @@ describe("frontend container source contract", () => {
     );
     expect(dockerfile).toContain("RUN npm run build:web");
     expect(dockerfile).toMatch(
-      /RUN find \/usr\/share\/nginx\/html \/usr\/share\/licenses\/secpal-frontend[^]*-type f -exec chmod 0444[^]*&& chmod 0444[^]*&& chmod 0555 \/usr\/local\/bin\/secpal-entrypoint/u
+      /RUN find \/usr\/share\/nginx\/html \/usr\/share\/licenses\/secpal-frontend[^]*-type f -exec chmod 0444[^]*&& chmod 0444[^]*&& chmod 0555 \/etc\/nginx\/snippets \/usr\/local\/bin\/secpal-entrypoint/u
+    );
+    expect(dockerfile).toContain(
+      "chmod 0555 /etc/nginx/snippets /usr/local/bin/secpal-entrypoint"
     );
     expect(dockerfile).toContain("USER 101:101");
     expect(dockerfile).toContain("EXPOSE 8080");
@@ -129,8 +132,12 @@ describe("frontend container source contract", () => {
     expect(smokeTest).toContain("--read-only");
     expect(smokeTest).toContain("--cap-drop=ALL");
     expect(smokeTest).toContain("no-new-privileges:true");
+    expect(smokeTest).toContain("Nginx snippets directory mode is not 0555");
+    expect(smokeTest).toContain(
+      "Nginx security headers are not readable by the runtime user"
+    );
     expect(smokeTest).toMatch(
-      /docker restart "\$CONTAINER_A"[^]*PORT_A=\$\(container_port "\$CONTAINER_A"\)[^]*wait_for_live "\$PORT_A"/u
+      /docker restart "\$CONTAINER_A"[^]*PORT_A=\$\(container_port "\$CONTAINER_A"\)[^]*wait_for_live "\$CONTAINER_A" "\$PORT_A"/u
     );
     expect(smokeTest).toContain("source maps");
     expect(smokeTest).toContain("SECPAL_API_URL");

--- a/tests/container-runtime-lifecycle.test.ts
+++ b/tests/container-runtime-lifecycle.test.ts
@@ -21,6 +21,8 @@ const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   ".."
 );
+const canonicalFakeImageReference =
+  "ghcr.io/secpal/frontend@sha256:" + "0".repeat(64);
 const temporaryRoots: string[] = [];
 
 interface FakeRuntime {
@@ -305,7 +307,7 @@ describe("container runtime lifecycle", () => {
       "bash",
       ["scripts/container-smoke.sh"],
       {
-        SECPAL_CONTAINER_IMAGE: "example.invalid/frontend@sha256:fake",
+        SECPAL_CONTAINER_IMAGE: canonicalFakeImageReference,
         SECPAL_CONTAINER_SKIP_BUILD: "1",
       }
     );
@@ -336,7 +338,7 @@ describe("container runtime lifecycle", () => {
     "does not inspect or remove a container it did not create in %s",
     (script) => {
       const execution = runCommand("name-conflict", "bash", [script], {
-        SECPAL_CONTAINER_IMAGE: "example.invalid/frontend@sha256:fake",
+        SECPAL_CONTAINER_IMAGE: canonicalFakeImageReference,
         SECPAL_CONTAINER_SKIP_BUILD: "1",
       });
 
@@ -362,7 +364,7 @@ describe("container runtime lifecycle", () => {
     "diagnoses and removes only its created container when startup fails in %s",
     (script) => {
       const execution = runCommand("start-fails", "bash", [script], {
-        SECPAL_CONTAINER_IMAGE: "example.invalid/frontend@sha256:fake",
+        SECPAL_CONTAINER_IMAGE: canonicalFakeImageReference,
         SECPAL_CONTAINER_SKIP_BUILD: "1",
       });
 
@@ -452,13 +454,19 @@ describe("container runtime lifecycle", () => {
       "bash",
       ["scripts/container-browser.sh"],
       {
-        SECPAL_CONTAINER_IMAGE: "example.invalid/frontend@sha256:fake",
+        SECPAL_CONTAINER_IMAGE: canonicalFakeImageReference,
         SECPAL_CONTAINER_SKIP_BUILD: "1",
       }
     );
 
     expect(execution.result.error).toBeUndefined();
     expect(execution.result.status).toBe(0);
+    expect(execution.calls).toContainEqual(
+      expect.stringContaining(canonicalFakeImageReference)
+    );
+    expect(execution.calls).toContainEqual(
+      expect.stringContaining("--env SECPAL_API_URL=https://api.secpal.dev")
+    );
     expect(
       execution.calls.filter((call) => call.startsWith("port "))
     ).toHaveLength(3);

--- a/tests/container-runtime-lifecycle.test.ts
+++ b/tests/container-runtime-lifecycle.test.ts
@@ -477,6 +477,26 @@ describe("container runtime lifecycle", () => {
     );
   });
 
+  it("keeps the browser runtime API origin aligned with the Chromium contract", () => {
+    const browserScript = readFileSync(
+      path.join(repoRoot, "scripts/container-browser.sh"),
+      "utf8"
+    );
+    const browserSpec = readFileSync(
+      path.join(repoRoot, "tests/e2e/container.spec.ts"),
+      "utf8"
+    );
+    const runtimeOrigin = browserScript.match(
+      /--env SECPAL_API_URL=(https:\/\/[^ ]+)/u
+    )?.[1];
+    const expectedOrigin = browserSpec.match(
+      /const API_ORIGIN = "(https:\/\/[^"]+)";/u
+    )?.[1];
+
+    expect(runtimeOrigin).toBe("https://api.secpal.dev");
+    expect(expectedOrigin).toBe(runtimeOrigin);
+  });
+
   it("removes the fragile nested port template from both active scripts", () => {
     for (const script of [
       "scripts/container-smoke.sh",

--- a/tests/container-runtime-lifecycle.test.ts
+++ b/tests/container-runtime-lifecycle.test.ts
@@ -69,7 +69,31 @@ case "$command_name" in
       exit 0
     fi
     ;;
-  run | restart | exec | stop)
+  create)
+    if [ "$FAKE_DOCKER_SCENARIO" = "name-conflict" ]; then
+      printf 'docker: Error response from daemon: Conflict. The container name is already in use.\n' >&2
+      exit 125
+    fi
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = "--name" ]; then
+        printf 'fake-id-%s\n' "$2"
+        exit 0
+      fi
+      shift
+    done
+    exit 125
+    ;;
+  run)
+    exit 0
+    ;;
+  start)
+    if [ "$FAKE_DOCKER_SCENARIO" = "start-fails" ]; then
+      printf 'docker: controlled start failure\n' >&2
+      exit 125
+    fi
+    exit 0
+    ;;
+  restart | exec | stop)
     exit 0
     ;;
   port)
@@ -102,7 +126,11 @@ case "$command_name" in
         fi
         ;;
       status=*)
-        if [ "$FAKE_DOCKER_SCENARIO" = "exited" ]; then
+        if [ "$FAKE_DOCKER_SCENARIO" = "name-conflict" ]; then
+          printf 'status=running running=true exit=0 error="" ports={"foreign":true}\n'
+        elif [ "$FAKE_DOCKER_SCENARIO" = "start-fails" ]; then
+          printf 'status=created running=false exit=0 error="controlled start failure" ports={}\n'
+        elif [ "$FAKE_DOCKER_SCENARIO" = "exited" ]; then
           printf 'status=exited running=false exit=1 error="failed to create task" ports=null\n'
         else
           printf 'status=running running=true exit=0 error="" ports=null\n'
@@ -122,6 +150,10 @@ case "$command_name" in
   logs)
     if [ "$FAKE_DOCKER_SCENARIO" = "logs-fail" ]; then
       exit 125
+    fi
+    if [ "$FAKE_DOCKER_SCENARIO" = "name-conflict" ]; then
+      printf 'foreign-container-log-must-not-be-read\n'
+      exit 0
     fi
     printf 'nginx: [emerg] controlled startup error\n'
     ;;
@@ -293,12 +325,58 @@ describe("container runtime lifecycle", () => {
     expect(execution.removedContainers).toHaveLength(2);
     expect(
       execution.removedContainers.every((name) =>
-        name.startsWith("secpal-frontend-contract-")
+        name.startsWith("fake-id-secpal-frontend-contract-")
       )
     ).toBe(true);
     expect(execution.removedContainers).not.toContain("foreign-container");
     expect(readdirSync(execution.runtime.temporaryDirectory)).toEqual([]);
   });
+
+  it.each(["scripts/container-smoke.sh", "scripts/container-browser.sh"])(
+    "does not inspect or remove a container it did not create in %s",
+    (script) => {
+      const execution = runCommand("name-conflict", "bash", [script], {
+        SECPAL_CONTAINER_IMAGE: "example.invalid/frontend@sha256:fake",
+        SECPAL_CONTAINER_SKIP_BUILD: "1",
+      });
+
+      expect(execution.result.error).toBeUndefined();
+      expect(execution.result.status).toBe(1);
+      expect(execution.result.stderr).toContain(
+        "container name is already in use"
+      );
+      expect(execution.result.stderr).not.toContain(
+        "foreign-container-log-must-not-be-read"
+      );
+      expect(execution.calls).not.toContainEqual(
+        expect.stringMatching(/^inspect --format status=/u)
+      );
+      expect(execution.calls).not.toContainEqual(
+        expect.stringMatching(/^logs /u)
+      );
+      expect(execution.removedContainers).toEqual([]);
+    }
+  );
+
+  it.each(["scripts/container-smoke.sh", "scripts/container-browser.sh"])(
+    "diagnoses and removes only its created container when startup fails in %s",
+    (script) => {
+      const execution = runCommand("start-fails", "bash", [script], {
+        SECPAL_CONTAINER_IMAGE: "example.invalid/frontend@sha256:fake",
+        SECPAL_CONTAINER_SKIP_BUILD: "1",
+      });
+
+      expect(execution.result.error).toBeUndefined();
+      expect(execution.result.status).toBe(1);
+      expect(execution.result.stderr).toContain("controlled start failure");
+      expect(execution.result.stderr).toContain("could not start");
+      expect(execution.result.stderr).toContain("status=created running=false");
+      expect(execution.removedContainers).toHaveLength(1);
+      expect(execution.removedContainers[0]).toMatch(
+        /^fake-id-secpal-frontend-(?:contract|browser)-/u
+      );
+    }
+  );
 
   it("fails closed when Docker cannot inspect container state", () => {
     const execution = runHelper("inspect-fails");
@@ -387,7 +465,7 @@ describe("container runtime lifecycle", () => {
     expect(execution.result.stderr).not.toContain("template parsing error");
     expect(execution.removedContainers).toHaveLength(1);
     expect(execution.removedContainers[0]).toMatch(
-      /^secpal-frontend-browser-/u
+      /^fake-id-secpal-frontend-browser-/u
     );
   });
 

--- a/tests/container-runtime-lifecycle.test.ts
+++ b/tests/container-runtime-lifecycle.test.ts
@@ -1,0 +1,354 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  ".."
+);
+const temporaryRoots: string[] = [];
+
+interface FakeRuntime {
+  binDirectory: string;
+  stateDirectory: string;
+  temporaryDirectory: string;
+}
+
+interface RuntimeResult {
+  calls: string[];
+  removedContainers: string[];
+  result: ReturnType<typeof spawnSync>;
+  runtime: FakeRuntime;
+}
+
+function executable(filePath: string, contents: string): void {
+  writeFileSync(filePath, contents, "utf8");
+  chmodSync(filePath, 0o755);
+}
+
+function createFakeRuntime(): FakeRuntime {
+  const root = mkdtempSync(path.join(tmpdir(), "secpal-container-lifecycle-"));
+  const binDirectory = path.join(root, "bin");
+  const stateDirectory = path.join(root, "state");
+  const temporaryDirectory = path.join(root, "tmp");
+
+  temporaryRoots.push(root);
+  mkdirSync(binDirectory);
+  mkdirSync(stateDirectory);
+  mkdirSync(temporaryDirectory);
+
+  executable(
+    path.join(binDirectory, "docker"),
+    `#!/usr/bin/env bash
+set -u
+
+printf '%s\n' "$*" >>"$FAKE_DOCKER_STATE_DIR/calls"
+
+command_name=\${1:-}
+shift || true
+
+case "$command_name" in
+  image)
+    if [ "\${1:-}" = "inspect" ]; then
+      printf 'sha256:fake-image\n'
+      exit 0
+    fi
+    ;;
+  run | restart | exec | stop)
+    exit 0
+    ;;
+  port)
+    count_file="$FAKE_DOCKER_STATE_DIR/port-count"
+    count=0
+    if [ -f "$count_file" ]; then
+      count=$(<"$count_file")
+    fi
+    count=$((count + 1))
+    printf '%s\n' "$count" >"$count_file"
+
+    if [ "$FAKE_DOCKER_SCENARIO" = "delayed" ] && [ "$count" -ge 3 ]; then
+      printf '127.0.0.1:49152\n'
+      exit 0
+    fi
+    exit 1
+    ;;
+  inspect)
+    format=\${2:-}
+    if [ "$FAKE_DOCKER_SCENARIO" = "inspect-fails" ]; then
+      exit 125
+    fi
+
+    case "$format" in
+      '{{.State.Status}}')
+        if [ "$FAKE_DOCKER_SCENARIO" = "exited" ]; then
+          printf 'exited\n'
+        else
+          printf 'running\n'
+        fi
+        ;;
+      status=*)
+        if [ "$FAKE_DOCKER_SCENARIO" = "exited" ]; then
+          printf 'status=exited running=false exit=1 error="failed to create task" ports=null\n'
+        else
+          printf 'status=running running=true exit=0 error="" ports=null\n'
+        fi
+        ;;
+      '{{.Config.User}}')
+        printf '101:101\n'
+        ;;
+      '{{.State.Running}}')
+        printf 'false\n'
+        ;;
+      *)
+        exit 125
+        ;;
+    esac
+    ;;
+  logs)
+    if [ "$FAKE_DOCKER_SCENARIO" = "logs-fail" ]; then
+      exit 125
+    fi
+    printf 'nginx: [emerg] controlled startup error\n'
+    ;;
+  rm)
+    printf '%s\n' "\${*: -1}" >>"$FAKE_DOCKER_STATE_DIR/removed"
+    ;;
+esac
+`
+  );
+
+  executable(path.join(binDirectory, "curl"), "#!/bin/sh\nexit 0\n");
+  executable(path.join(binDirectory, "npm"), "#!/bin/sh\nexit 0\n");
+
+  return { binDirectory, stateDirectory, temporaryDirectory };
+}
+
+function readLines(filePath: string): string[] {
+  if (!existsSync(filePath)) {
+    return [];
+  }
+
+  return readFileSync(filePath, "utf8").trim().split("\n").filter(Boolean);
+}
+
+function runCommand(
+  scenario: string,
+  command: string,
+  args: string[],
+  extraEnvironment: NodeJS.ProcessEnv = {}
+): RuntimeResult {
+  const runtime = createFakeRuntime();
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ...extraEnvironment,
+      FAKE_DOCKER_SCENARIO: scenario,
+      FAKE_DOCKER_STATE_DIR: runtime.stateDirectory,
+      PATH: `${runtime.binDirectory}:${process.env.PATH ?? ""}`,
+      TMPDIR: runtime.temporaryDirectory,
+    },
+    timeout: 5_000,
+  });
+
+  return {
+    calls: readLines(path.join(runtime.stateDirectory, "calls")),
+    removedContainers: readLines(path.join(runtime.stateDirectory, "removed")),
+    result,
+    runtime,
+  };
+}
+
+function runHelper(scenario: string, attempts = 3): RuntimeResult {
+  const harness = `
+set -euo pipefail
+RUNTIME_TEMP_DIR=$(mktemp -d)
+cleanup() {
+  docker rm --force owned-container >/dev/null 2>&1 || true
+  rm -rf "$RUNTIME_TEMP_DIR"
+}
+trap cleanup EXIT HUP INT TERM
+source "$REPO_ROOT/scripts/container-runtime.sh"
+wait_for_container_port owned-container 8080 "$ATTEMPTS" 0
+`;
+
+  return runCommand(scenario, "bash", ["-c", harness], {
+    ATTEMPTS: String(attempts),
+    REPO_ROOT: repoRoot,
+  });
+}
+
+function expectOwnedContainerCleanup(execution: RuntimeResult): void {
+  expect(execution.removedContainers).toEqual(["owned-container"]);
+  expect(readdirSync(execution.runtime.temporaryDirectory)).toEqual([]);
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("container runtime lifecycle", () => {
+  it("waits for delayed loopback port assignment and returns the port", () => {
+    const execution = runHelper("delayed");
+
+    expect(execution.result.error).toBeUndefined();
+    expect(execution.result.status).toBe(0);
+    expect(execution.result.stdout).toBe("49152\n");
+    expect(
+      execution.calls.filter((call) => call.startsWith("port owned-container"))
+    ).toHaveLength(3);
+    expect(
+      execution.calls.filter((call) =>
+        call.includes("inspect --format {{.State.Status}} owned-container")
+      )
+    ).toHaveLength(2);
+    expectOwnedContainerCleanup(execution);
+  });
+
+  it("reports an exited smoke container and its startup logs before cleanup", () => {
+    const execution = runCommand(
+      "exited",
+      "bash",
+      ["scripts/container-smoke.sh"],
+      {
+        SECPAL_CONTAINER_IMAGE: "example.invalid/frontend@sha256:fake",
+        SECPAL_CONTAINER_SKIP_BUILD: "1",
+      }
+    );
+
+    expect(execution.result.error).toBeUndefined();
+    expect(execution.result.status).toBe(1);
+    expect(execution.result.stderr).toContain(
+      "container exited before publishing 8080/tcp"
+    );
+    expect(execution.result.stderr).toContain(
+      'status=exited running=false exit=1 error="failed to create task" ports=null'
+    );
+    expect(execution.result.stderr).toContain(
+      "nginx: [emerg] controlled startup error"
+    );
+    expect(execution.result.stderr).not.toContain("template parsing error");
+    expect(execution.removedContainers).toHaveLength(2);
+    expect(
+      execution.removedContainers.every((name) =>
+        name.startsWith("secpal-frontend-contract-")
+      )
+    ).toBe(true);
+    expect(execution.removedContainers).not.toContain("foreign-container");
+    expect(readdirSync(execution.runtime.temporaryDirectory)).toEqual([]);
+  });
+
+  it("fails closed when Docker cannot inspect container state", () => {
+    const execution = runHelper("inspect-fails");
+
+    expect(execution.result.status).toBe(1);
+    expect(execution.result.stderr).toContain(
+      "ERROR: could not inspect container state"
+    );
+    expect(execution.result.stderr).toContain(
+      "docker inspect failed for owned-container"
+    );
+    expectOwnedContainerCleanup(execution);
+  });
+
+  it("times out after bounded attempts and prints state and logs", () => {
+    const execution = runHelper("timeout", 4);
+
+    expect(execution.result.status).toBe(1);
+    expect(
+      execution.calls.filter((call) => call.startsWith("port "))
+    ).toHaveLength(4);
+    expect(execution.result.stderr).toContain(
+      "ERROR: container did not publish 8080/tcp before timeout"
+    );
+    expect(execution.result.stderr).toContain(
+      'status=running running=true exit=0 error="" ports=null'
+    );
+    expect(execution.result.stderr).toContain(
+      "nginx: [emerg] controlled startup error"
+    );
+    expectOwnedContainerCleanup(execution);
+  });
+
+  it("preserves the timeout error when container logs also fail", () => {
+    const execution = runHelper("logs-fail", 2);
+    const originalError =
+      "ERROR: container did not publish 8080/tcp before timeout";
+
+    expect(execution.result.status).toBe(1);
+    expect(execution.result.stderr).toContain(originalError);
+    expect(execution.result.stderr).toContain(
+      "docker logs failed for owned-container"
+    );
+    expect(execution.result.stderr.indexOf(originalError)).toBeLessThan(
+      execution.result.stderr.indexOf("docker logs failed for owned-container")
+    );
+    expectOwnedContainerCleanup(execution);
+  });
+
+  it("uses the same bounded lifecycle contract in the browser script", () => {
+    const execution = runCommand(
+      "delayed",
+      "bash",
+      ["scripts/container-browser.sh"],
+      {
+        SECPAL_CONTAINER_IMAGE: "example.invalid/frontend@sha256:fake",
+        SECPAL_CONTAINER_SKIP_BUILD: "1",
+      }
+    );
+
+    expect(execution.result.error).toBeUndefined();
+    expect(execution.result.status).toBe(0);
+    expect(
+      execution.calls.filter((call) => call.startsWith("port "))
+    ).toHaveLength(3);
+    expect(execution.result.stderr).not.toContain("template parsing error");
+    expect(execution.removedContainers).toHaveLength(1);
+    expect(execution.removedContainers[0]).toMatch(
+      /^secpal-frontend-browser-/u
+    );
+  });
+
+  it("removes the fragile nested port template from both active scripts", () => {
+    for (const script of [
+      "scripts/container-smoke.sh",
+      "scripts/container-browser.sh",
+    ]) {
+      const contents = readFileSync(path.join(repoRoot, script), "utf8");
+
+      expect(contents).toContain("container-runtime.sh");
+      expect(contents).not.toContain(
+        '{{(index (index .NetworkSettings.Ports "8080/tcp") 0).HostPort}}'
+      );
+    }
+  });
+
+  it("runs lifecycle regressions in pull-request and publisher validation", () => {
+    for (const workflow of [
+      ".github/workflows/frontend-container.yml",
+      ".github/workflows/publish-container.yml",
+    ]) {
+      expect(readFileSync(path.join(repoRoot, workflow), "utf8")).toContain(
+        "tests/container-runtime-lifecycle.test.ts"
+      );
+    }
+  });
+});

--- a/tests/container-runtime-lifecycle.test.ts
+++ b/tests/container-runtime-lifecycle.test.ts
@@ -132,7 +132,32 @@ esac
 `
   );
 
-  executable(path.join(binDirectory, "curl"), "#!/bin/sh\nexit 0\n");
+  executable(
+    path.join(binDirectory, "curl"),
+    `#!/usr/bin/env bash
+set -u
+
+printf 'curl %s\n' "$*" >>"$FAKE_DOCKER_STATE_DIR/calls"
+
+if [ "$FAKE_DOCKER_SCENARIO" = "hanging-health" ]; then
+  request_is_bounded=0
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "--max-time" ]; then
+      request_is_bounded=1
+      break
+    fi
+    shift
+  done
+
+  if [ "$request_is_bounded" = "0" ]; then
+    sleep 10
+  fi
+  exit 28
+fi
+
+exit 0
+`
+  );
   executable(path.join(binDirectory, "npm"), "#!/bin/sh\nexit 0\n");
 
   return { binDirectory, stateDirectory, temporaryDirectory };
@@ -186,6 +211,25 @@ cleanup() {
 trap cleanup EXIT HUP INT TERM
 source "$REPO_ROOT/scripts/container-runtime.sh"
 wait_for_container_port owned-container 8080 "$ATTEMPTS" 0
+`;
+
+  return runCommand(scenario, "bash", ["-c", harness], {
+    ATTEMPTS: String(attempts),
+    REPO_ROOT: repoRoot,
+  });
+}
+
+function runHealthHelper(scenario: string, attempts = 2): RuntimeResult {
+  const harness = `
+set -euo pipefail
+RUNTIME_TEMP_DIR=$(mktemp -d)
+cleanup() {
+  docker rm --force owned-container >/dev/null 2>&1 || true
+  rm -rf "$RUNTIME_TEMP_DIR"
+}
+trap cleanup EXIT HUP INT TERM
+source "$REPO_ROOT/scripts/container-runtime.sh"
+wait_for_container_live owned-container 49152 "$ATTEMPTS" 0
 `;
 
   return runCommand(scenario, "bash", ["-c", harness], {
@@ -300,6 +344,26 @@ describe("container runtime lifecycle", () => {
     );
     expect(execution.result.stderr.indexOf(originalError)).toBeLessThan(
       execution.result.stderr.indexOf("docker logs failed for owned-container")
+    );
+    expectOwnedContainerCleanup(execution);
+  });
+
+  it("bounds each readiness request as well as the retry count", () => {
+    const execution = runHealthHelper("hanging-health");
+    const curlCalls = execution.calls.filter((call) =>
+      call.startsWith("curl ")
+    );
+
+    expect(execution.result.error).toBeUndefined();
+    expect(execution.result.status).toBe(1);
+    expect(curlCalls).toHaveLength(2);
+    expect(
+      curlCalls.every((call) =>
+        call.includes("--connect-timeout 0.2 --max-time 0.5")
+      )
+    ).toBe(true);
+    expect(execution.result.stderr).toContain(
+      "ERROR: container did not expose /health/live before timeout"
     );
     expectOwnedContainerCleanup(execution);
   });

--- a/tests/e2e/container.spec.ts
+++ b/tests/e2e/container.spec.ts
@@ -5,7 +5,7 @@ import { expect, test } from "@playwright/test";
 import { hasExactOrigin } from "./container-origin";
 import { installStrictCspAudit } from "./strict-csp-audit";
 
-const API_ORIGIN = "https://api.container.example";
+const API_ORIGIN = "https://api.secpal.dev";
 const FRONTEND_ORIGIN = process.env.SECPAL_CONTAINER_BASE_URL;
 
 if (!FRONTEND_ORIGIN) {
@@ -140,7 +140,9 @@ test("runs the immutable frontend artifact with startup runtime configuration", 
   );
   expect(
     apiRequests.some((url) =>
-      /configured|localhost:8000|api\.secpal\.dev/u.test(url)
+      /configured\.secpal\.dev|localhost:8000|api\.container\.secpal\.dev/u.test(
+        url
+      )
     )
   ).toBe(false);
 


### PR DESCRIPTION
## Context

- Failed publisher run: `31015135852`
- Failed job: `92339237967`
- Source commit: `4fc3612aa5ab2785d05d9d3bb566f1edddc6a0df`
- Historical unverified digest: `sha256:cbe30a7bf70470903fe91f1c97032ab4be0a5b1346652c949b0c76004041a486`

The first post-merge publisher run after frontend#1593 failed while exercising the published `linux/amd64` image. Runtime verification attempted to index the first `8080/tcp` port binding before Docker exposed one, producing a secondary Go-template nil-index error. Cleanup then removed the evidence needed to distinguish delayed port assignment from an immediate container exit.

The historical digest remains unverified and is not approved for deployment.

## Reproduction and root cause

The exact digest was reproduced locally on `linux/amd64` with the published runtime hardening flags. A first immediate inspection caught the container during a short running window. The hardened lifecycle diagnostics subsequently exposed the primary failure:

```text
status=exited running=false exit=1 error="" ports={}
open() "/etc/nginx/snippets/secpal-security-headers.conf" failed (13: Permission denied)
nginx: configuration file /etc/nginx/nginx.conf test failed
```

The image had mode `0444` on `/etc/nginx/snippets` itself. Although the included file was readable, UID/GID `101:101` could not traverse its parent directory, so the entrypoint's `nginx -t` failed.

## Change

- Set `/etc/nginx/snippets` to mode `0555` and verify its mode and security-header readability as UID/GID `101:101` in the real container smoke.
- Replace the fragile nested port template with a shared lifecycle helper used by both the smoke and Chromium scripts.
- Wait for an IPv4 loopback port with bounded retries while checking container state on every unsuccessful query.
- Report status, running state, exit code, Docker `.State.Error`, port data, and startup logs before cleanup on all lifecycle failures.
- Bound every health request with a 200 ms connection timeout and a 500 ms total timeout so an accepting but unresponsive endpoint cannot defeat the finite retry count.
- Preserve read-only mode, UID/GID `101:101`, dropped capabilities, `no-new-privileges`, mandatory `amd64`/`arm64` verification, Chromium verification, and all supply-chain checks.
- Run the lifecycle regressions in both the pull-request container workflow and the publisher validation job.

## TDD evidence

- Eight lifecycle tests initially failed against the previous scripts, proving the missing bounded port wait, diagnostics, cleanup assertions, and workflow coverage.
- Two focused container invariants failed before the Nginx directory-mode correction.
- A controlled hanging health request then failed with `spawnSync bash ETIMEDOUT` before per-request curl timeouts were added; the same regression now completes fail-closed.
- Fake-Docker coverage exercises delayed port assignment, immediate exit, Docker state errors, inspect failures, log failures, bounded port and health timeouts, cleanup, and exact container ownership.

## Validation

- `npm ci --foreground-scripts`
- 73 focused lifecycle, container-contract, and publisher-workflow tests
- Registered complete local validation:
  - `npm run test:migration-boundary`
  - `npm run test:ui-csp`
  - `npm run format:check`
  - `npm run lint`
  - `npm run typecheck`
  - `npm run test:ci`
  - `npm run build:web`
  - `npm run build:android`
- 3,001 tests across 205 files in the earlier full preflight run
- `npm run test:container`
- `npm run test:e2e:container`
- Remote-Git-context build of the original fix commit followed by the complete container smoke
- Bash syntax, ShellCheck, yamllint, actionlint, REUSE, and `git diff --check`
- Signed commit and validation-receipt binding verification

The historical `linux/amd64` diagnostic now fails closed with the primary Nginx permission error instead of a nil-index exception. A local historical `linux/arm64` diagnostic could not be completed because the classic Docker image store refused to replace the already loaded platform selection for the same OCI index digest; the mandatory hosted publisher matrix remains unchanged.

## Publication safety

- The failed digest is not reused, attested, or approved for deployment.
- Historical run `31015135852` was not retried.
- No registry mutation occurs in this pull request.
- A new publisher run and a new digest can be created only from a later merge to `main`.
- Phase C remains in progress.

## Draft readiness

This pull request remains draft pending the hosted pull-request checks on the current head and a final self-review in the pull-request view. Hosted check status was not inspected during this publish step. The required post-merge publisher verification is tracked by #1591 and must produce a new digest before that issue can close.

Tracks #1591
