### PR TITLE
Pin workflow actions to immutable SHAs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -197,3 +197,15 @@ This file auto-applies to all files in this repo so strict SecPal governance sta
   compatibility shims by default. If a legacy storage format, input alias, or
   deprecated frontend contract has no proven live caller, prefer removing it
   and updating tests and changelog coverage in the same change.
+
+## Additional Rules: github-workflows.instructions.md
+
+- Always set `timeout-minutes` on every job.
+- Set explicit `permissions` on every workflow and start with the least privilege needed.
+- Pin every `uses:` reference, including GitHub-maintained actions and organization reusable workflows,
+  to a full 40-character commit SHA. Preserve the reviewed version or branch in a nearby comment for
+  update visibility.
+- Use reusable workflows from the organization templates when they fit the task.
+- Use `continue-on-error: true` only for intentional polling or wait steps, never for build or test steps.
+- Reference secrets via `${{ secrets.NAME }}` and vars via `${{ vars.NAME }}`. Never hardcode or echo secrets.
+- Run `yamllint` on workflow changes before finalizing.

--- a/.github/instructions/github-workflows.instructions.md
+++ b/.github/instructions/github-workflows.instructions.md
@@ -12,7 +12,7 @@ Applies when editing GitHub Actions workflows and Dependabot configuration in th
 
 - Always set `timeout-minutes` on every job.
 - Set explicit `permissions` on every workflow and start with the least privilege needed.
-- Pin third-party actions to immutable versions. GitHub-maintained `actions/*` may use supported major tags in this org.
+- Pin every `uses:` reference, including GitHub-maintained actions and organization reusable workflows, to a full 40-character commit SHA. Preserve the reviewed version or branch in a nearby comment for update visibility.
 - Use reusable workflows from the organization templates when they fit the task.
 - Use `continue-on-error: true` only for intentional polling or wait steps, never for build or test steps.
 - Reference secrets via `${{ secrets.NAME }}` and vars via `${{ vars.NAME }}`. Never hardcode or echo secrets.

--- a/.github/workflows/check-conflict-markers.yml
+++ b/.github/workflows/check-conflict-markers.yml
@@ -1,6 +1,7 @@
-# SPDX-FileCopyrightText: 2025 SecPal Contributors
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+---
 name: Check for Merge Conflict Markers
 
 on:
@@ -14,4 +15,5 @@ permissions:
 
 jobs:
   check-conflicts:
-    uses: SecPal/.github/.github/workflows/reusable-check-conflict-markers.yml@main
+    # main
+    uses: SecPal/.github/.github/workflows/reusable-check-conflict-markers.yml@ffdfe1be8bbd8164d649f1c1d296e57ff4c6cc4a

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,7 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+---
 name: CodeQL Analysis
 
 on:
@@ -27,14 +28,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.5
+        uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.5
+        uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,7 @@ jobs:
   analyze:
     name: Analyze with CodeQL
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -18,6 +18,7 @@ jobs:
   lighthouse:
     name: Performance Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # Skip for spike branches (exploration only)
     if: ${{ !startsWith(github.head_ref, 'spike/') && !startsWith(github.ref, 'refs/heads/spike/') }}
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,6 +1,7 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: CC0-1.0
 
+---
 name: Lighthouse CI
 
 on:
@@ -22,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
           cache: "npm"
@@ -45,7 +46,7 @@ jobs:
 
       - name: Format Lighthouse Score
         id: format_lighthouse_score
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         if: github.event_name == 'pull_request'
         with:
           script: |
@@ -108,7 +109,7 @@ jobs:
             core.setOutput('comment', comment);
 
       - name: Comment PR with Lighthouse scores
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         if: github.event_name == 'pull_request' && steps.format_lighthouse_score.outputs.comment
         with:
           script: |

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   pr-size:
     name: Check PR Size
-    # Keep this immutable; Dependabot updates reusable-workflow references.
+    # main; keep this immutable; Dependabot updates reusable-workflow references.
     uses: SecPal/.github/.github/workflows/reusable-pr-size.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee
     with:
       max-lines: 600

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,6 +1,7 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: CC0-1.0
 
+---
 name: Project Board Automation
 
 on:
@@ -29,14 +30,16 @@ permissions:
 jobs:
   project-automation:
     name: Project automation
-    uses: SecPal/.github/.github/workflows/project-automation-core.yml@main
+    # main
+    uses: SecPal/.github/.github/workflows/project-automation-core.yml@ffdfe1be8bbd8164d649f1c1d296e57ff4c6cc4a
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
   draft-reminder:
     name: Draft PR Reminder
-    uses: SecPal/.github/.github/workflows/draft-pr-reminder.yml@main
+    # main
+    uses: SecPal/.github/.github/workflows/draft-pr-reminder.yml@ffdfe1be8bbd8164d649f1c1d296e57ff4c6cc4a
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -17,7 +17,8 @@ permissions:
 jobs:
   reuse:
     name: Check REUSE Compliance
-    uses: SecPal/.github/.github/workflows/reusable-reuse.yml@main
+    # main
+    uses: SecPal/.github/.github/workflows/reusable-reuse.yml@ffdfe1be8bbd8164d649f1c1d296e57ff4c6cc4a
 
   license-compatibility:
     name: Check License Compatibility
@@ -25,10 +26,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.x"
 
@@ -40,25 +41,30 @@ jobs:
 
   prettier:
     name: Formatting Check
-    uses: SecPal/.github/.github/workflows/reusable-prettier.yml@main
+    # main
+    uses: SecPal/.github/.github/workflows/reusable-prettier.yml@ffdfe1be8bbd8164d649f1c1d296e57ff4c6cc4a
 
   markdown-lint:
     name: Markdown Lint
-    uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@main
+    # main
+    uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@ffdfe1be8bbd8164d649f1c1d296e57ff4c6cc4a
 
   ai-instructions:
     name: AI Instructions
-    uses: SecPal/.github/.github/workflows/reusable-ai-instructions.yml@main
+    # main
+    uses: SecPal/.github/.github/workflows/reusable-ai-instructions.yml@ffdfe1be8bbd8164d649f1c1d296e57ff4c6cc4a
 
   eslint:
     name: ESLint
-    uses: SecPal/.github/.github/workflows/reusable-node-lint.yml@main
+    # main
+    uses: SecPal/.github/.github/workflows/reusable-node-lint.yml@ffdfe1be8bbd8164d649f1c1d296e57ff4c6cc4a
     with:
       node-version: "22"
 
   typecheck:
     name: TypeScript Check
-    uses: SecPal/.github/.github/workflows/reusable-node-build.yml@main
+    # main
+    uses: SecPal/.github/.github/workflows/reusable-node-build.yml@ffdfe1be8bbd8164d649f1c1d296e57ff4c6cc4a
     with:
       node-version: "22"
       build-command: "npm run typecheck"
@@ -78,10 +84,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/ui-csp.yml
+++ b/.github/workflows/ui-csp.yml
@@ -39,10 +39,10 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
           cache: npm

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -19,6 +19,10 @@ rules:
   # Allow comments to be indented differently
   comments-indentation: disable
 
+  # Match Prettier's single-space inline-comment formatting.
+  comments:
+    min-spaces-from-content: 1
+
   # Allow empty values in workflows
   empty-values:
     forbid-in-block-mappings: false

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -19,7 +19,7 @@ rules:
   # Allow comments to be indented differently
   comments-indentation: disable
 
-  # Match Prettier's single-space inline-comment formatting.
+  # Allow Prettier-compatible inline comments with at least one preceding space.
   comments:
     min-spaces-from-content: 1
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,3 +194,15 @@ This file auto-applies to all files in this repo so strict SecPal governance sta
   compatibility shims by default. If a legacy storage format, input alias, or
   deprecated frontend contract has no proven live caller, prefer removing it
   and updating tests and changelog coverage in the same change.
+
+## Additional Rules: github-workflows.instructions.md
+
+- Always set `timeout-minutes` on every job.
+- Set explicit `permissions` on every workflow and start with the least privilege needed.
+- Pin every `uses:` reference, including GitHub-maintained actions and organization reusable workflows,
+  to a full 40-character commit SHA. Preserve the reviewed version or branch in a nearby comment for
+  update visibility.
+- Use reusable workflows from the organization templates when they fit the task.
+- Use `continue-on-error: true` only for intentional polling or wait steps, never for build or test steps.
+- Reference secrets via `${{ secrets.NAME }}` and vars via `${{ vars.NAME }}`. Never hardcode or echo secrets.
+- Run `yamllint` on workflow changes before finalizing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Pinned every GitHub Actions and organization reusable-workflow reference to
+  reviewed immutable commit SHAs, with version or branch comments and
+  regression coverage that rejects moving refs.
 - Fixed published frontend startup by explicitly setting the Nginx snippets
   directory to mode `0555`, and hardened runtime verification with
   ownership-safe container creation plus bounded loopback port and readiness

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pinned every GitHub Actions and organization reusable-workflow reference to
   reviewed immutable commit SHAs, with version or branch comments and
-  regression coverage that rejects moving refs.
+  regression coverage that rejects moving refs in named and unnamed steps and
+  enforces the review-comment convention.
 - Fixed published frontend startup by explicitly setting the Nginx snippets
   directory to mode `0555`, and hardened runtime verification with
   ownership-safe container creation plus bounded loopback port and readiness

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pinned every GitHub Actions and organization reusable-workflow reference to
   reviewed immutable commit SHAs, with version or branch comments and
   regression coverage that rejects moving refs in named and unnamed steps and
-  enforces the review-comment convention.
+  enforces the review-comment convention. Added explicit timeouts to the
+  remaining runnable CodeQL and Lighthouse jobs and repository-wide regression
+  coverage for the timeout policy.
 - Fixed published frontend startup by explicitly setting the Nginx snippets
   directory to mode `0555`, and hardened runtime verification with
   ownership-safe container creation plus bounded loopback port and readiness

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "eslint-plugin-react-refresh": "^0.5.3",
         "fake-indexeddb": "^6.2.5",
         "globals": "^17.9.0",
+        "js-yaml": ">=5.2.2",
         "jsdom": "^30.0.1",
         "jsdom-testing-mocks": "^1.16.0",
         "lighthouse": "^13.4.1",

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "eslint-plugin-react-refresh": "^0.5.3",
     "fake-indexeddb": "^6.2.5",
     "globals": "^17.9.0",
+    "js-yaml": ">=5.2.2",
     "jsdom": "^30.0.1",
     "jsdom-testing-mocks": "^1.16.0",
     "lighthouse": "^13.4.1",

--- a/src/ui/onboarding.test.tsx
+++ b/src/ui/onboarding.test.tsx
@@ -206,7 +206,7 @@ describe("onboarding shadcn primitives", () => {
     expect(trigger).toHaveAttribute("aria-required", "true");
 
     await user.click(trigger);
-    await user.click(await screen.findByRole("option", { name: "Contractor" }));
+    await user.click(screen.getByRole("option", { name: "Contractor" }));
 
     expect(handleChange).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -255,7 +255,7 @@ describe("onboarding shadcn primitives", () => {
     );
 
     await user.click(screen.getByRole("combobox", { name: "Contract type" }));
-    await user.click(await screen.findByRole("option", { name: "Contractor" }));
+    await user.click(screen.getByRole("option", { name: "Contractor" }));
 
     expect(handleChange).toHaveBeenCalledTimes(1);
     const syntheticEvent = handleChange.mock.calls[0]?.[0];

--- a/src/ui/onboarding.test.tsx
+++ b/src/ui/onboarding.test.tsx
@@ -206,7 +206,7 @@ describe("onboarding shadcn primitives", () => {
     expect(trigger).toHaveAttribute("aria-required", "true");
 
     await user.click(trigger);
-    await user.click(screen.getByRole("option", { name: "Contractor" }));
+    await user.click(await screen.findByRole("option", { name: "Contractor" }));
 
     expect(handleChange).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -255,7 +255,7 @@ describe("onboarding shadcn primitives", () => {
     );
 
     await user.click(screen.getByRole("combobox", { name: "Contract type" }));
-    await user.click(screen.getByRole("option", { name: "Contractor" }));
+    await user.click(await screen.findByRole("option", { name: "Contractor" }));
 
     expect(handleChange).toHaveBeenCalledTimes(1);
     const syntheticEvent = handleChange.mock.calls[0]?.[0];

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -22,7 +22,40 @@ function readRepoFile(relativePath: string): string {
   return readFileSync(path.join(repoRoot, relativePath), "utf8");
 }
 
-function getWorkflowUsesReferences(): string[] {
+interface WorkflowUsesReference {
+  reference: string;
+  reviewComment: string | undefined;
+}
+
+function getWorkflowUsesReferencesFromSource(
+  workflow: string
+): WorkflowUsesReference[] {
+  const lines = workflow.split("\n");
+
+  return lines.flatMap<WorkflowUsesReference>((line, index) => {
+    const match = line.match(
+      /^\s*(?:-\s*)?uses:\s*(?:"([^"]+)"|'([^']+)'|([^\s#]+))(?:\s+#\s*(.*))?\s*$/u
+    );
+    const reference = match?.[1] ?? match?.[2] ?? match?.[3];
+
+    if (reference === undefined) {
+      return [];
+    }
+
+    const precedingComment = lines[index - 1]
+      ?.match(/^\s*#\s*(.*?)\s*$/u)?.[1]
+      ?.trim();
+
+    return [
+      {
+        reference,
+        reviewComment: match?.[4]?.trim() || precedingComment,
+      },
+    ];
+  });
+}
+
+function getWorkflowUsesReferences(): WorkflowUsesReference[] {
   const workflowFiles = execFileSync("git", ["ls-files", ".github/workflows"], {
     cwd: repoRoot,
     encoding: "utf8",
@@ -32,10 +65,7 @@ function getWorkflowUsesReferences(): string[] {
     .filter((file) => /\.ya?ml$/u.test(file));
 
   return workflowFiles.flatMap((workflowFile) =>
-    Array.from(
-      readRepoFile(workflowFile).matchAll(/^\s*uses:\s*([^\s#]+)/gmu),
-      (match) => match[1]
-    )
+    getWorkflowUsesReferencesFromSource(readRepoFile(workflowFile))
   );
 }
 
@@ -469,8 +499,36 @@ describe("Build Configuration and Source Verification", () => {
     const references = getWorkflowUsesReferences();
 
     expect(references.length).toBeGreaterThan(0);
-    for (const reference of references) {
+    for (const { reference } of references) {
       expect(reference).toMatch(/@[0-9a-f]{40}$/u);
+    }
+  });
+
+  it("extracts workflow references from named and unnamed action steps", () => {
+    const workflow = `
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@main
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+`;
+
+    expect(
+      getWorkflowUsesReferencesFromSource(workflow).map(
+        ({ reference }) => reference
+      )
+    ).toEqual(["actions/checkout@main", "actions/setup-node@v7"]);
+  });
+
+  it("keeps the reviewed version or branch next to every workflow reference", () => {
+    const references = getWorkflowUsesReferences();
+
+    expect(references.length).toBeGreaterThan(0);
+    for (const { reference, reviewComment } of references) {
+      expect(reviewComment, reference).toMatch(
+        /^(?:main|v\d+(?:\.\d+)*)(?:\b|;)/u
+      );
     }
   });
 

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -22,6 +22,23 @@ function readRepoFile(relativePath: string): string {
   return readFileSync(path.join(repoRoot, relativePath), "utf8");
 }
 
+function getWorkflowUsesReferences(): string[] {
+  const workflowFiles = execFileSync("git", ["ls-files", ".github/workflows"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  })
+    .trim()
+    .split("\n")
+    .filter((file) => /\.ya?ml$/u.test(file));
+
+  return workflowFiles.flatMap((workflowFile) =>
+    Array.from(
+      readRepoFile(workflowFile).matchAll(/^\s*uses:\s*([^\s#]+)/gmu),
+      (match) => match[1]
+    )
+  );
+}
+
 function expectVersionAtLeast(
   actualVersion: string | undefined,
   minimumVersion: string
@@ -445,6 +462,15 @@ describe("Build Configuration and Source Verification", () => {
 
       expect(jobSection).toContain("runs-on:");
       expect(jobSection).toContain("timeout-minutes:");
+    }
+  });
+
+  it("pins every GitHub Actions workflow reference to an immutable commit SHA", () => {
+    const references = getWorkflowUsesReferences();
+
+    expect(references.length).toBeGreaterThan(0);
+    for (const reference of references) {
+      expect(reference).toMatch(/@[0-9a-f]{40}$/u);
     }
   });
 

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { JSDOM } from "jsdom";
+import { load } from "js-yaml";
 import { describe, it, expect } from "vitest";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -27,32 +28,69 @@ interface WorkflowUsesReference {
   reviewComment: string | undefined;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getReviewComments(
+  lines: string[],
+  references: string[]
+): Array<string | undefined> {
+  const remainingReferences = [...references];
+
+  return lines.flatMap((line, index) => {
+    const referenceIndex = remainingReferences.findIndex(
+      (reference) =>
+        /^\s*(?:-\s*)?uses:\s*|[,{]\s*uses:\s*/u.test(line) &&
+        line.includes(reference)
+    );
+
+    if (referenceIndex === -1) {
+      return [];
+    }
+
+    remainingReferences.splice(referenceIndex, 1);
+    const inlineComment = line.match(/\s#\s*(.*)$/u)?.[1]?.trim();
+
+    return [
+      inlineComment ||
+        lines[index - 1]?.match(/^\s*#\s*(.*?)\s*$/u)?.[1]?.trim(),
+    ];
+  });
+}
+
 function getWorkflowUsesReferencesFromSource(
   workflow: string
 ): WorkflowUsesReference[] {
   const lines = workflow.split("\n");
+  const document = load(workflow);
 
-  return lines.flatMap<WorkflowUsesReference>((line, index) => {
-    const match = line.match(
-      /^\s*(?:-\s*)?uses:\s*(?:"([^"]+)"|'([^']+)'|([^\s#]+))(?:\s+#\s*(.*))?\s*$/u
-    );
-    const reference = match?.[1] ?? match?.[2] ?? match?.[3];
+  if (!isRecord(document) || !isRecord(document.jobs)) {
+    return [];
+  }
 
-    if (reference === undefined) {
+  const references = Object.values(document.jobs).flatMap((job) => {
+    if (!isRecord(job)) {
       return [];
     }
 
-    const precedingComment = lines[index - 1]
-      ?.match(/^\s*#\s*(.*?)\s*$/u)?.[1]
-      ?.trim();
+    const reusableWorkflowReference =
+      typeof job.uses === "string" ? [job.uses] : [];
+    const stepReferences = Array.isArray(job.steps)
+      ? job.steps.flatMap((step) =>
+          isRecord(step) && typeof step.uses === "string" ? [step.uses] : []
+        )
+      : [];
 
-    return [
-      {
-        reference,
-        reviewComment: match?.[4]?.trim() || precedingComment,
-      },
-    ];
+    return [...reusableWorkflowReference, ...stepReferences];
   });
+
+  const reviewComments = getReviewComments(lines, references);
+
+  return references.map((reference, index) => ({
+    reference,
+    reviewComment: reviewComments[index],
+  }));
 }
 
 function getWorkflowUsesReferences(): WorkflowUsesReference[] {
@@ -512,13 +550,39 @@ jobs:
       - uses: actions/checkout@main
       - name: Setup Node.js
         uses: actions/setup-node@v7
+      - { name: Flow checkout, uses: actions/checkout@main }
 `;
 
     expect(
       getWorkflowUsesReferencesFromSource(workflow).map(
         ({ reference }) => reference
       )
-    ).toEqual(["actions/checkout@main", "actions/setup-node@v7"]);
+    ).toEqual([
+      "actions/checkout@main",
+      "actions/setup-node@v7",
+      "actions/checkout@main",
+    ]);
+  });
+
+  it("associates review comments with each repeated workflow reference", () => {
+    const workflow = `
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+`;
+
+    expect(getWorkflowUsesReferencesFromSource(workflow)).toEqual([
+      {
+        reference: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+        reviewComment: "v7",
+      },
+      {
+        reference: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+        reviewComment: undefined,
+      },
+    ]);
   });
 
   it("keeps the reviewed version or branch next to every workflow reference", () => {

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -28,8 +28,28 @@ interface WorkflowUsesReference {
   reviewComment: string | undefined;
 }
 
+interface WorkflowSource {
+  path: string;
+  source: string;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getWorkflowSources(): WorkflowSource[] {
+  const workflowFiles = execFileSync("git", ["ls-files", ".github/workflows"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  })
+    .trim()
+    .split("\n")
+    .filter((file) => /\.ya?ml$/u.test(file));
+
+  return workflowFiles.map((workflowFile) => ({
+    path: workflowFile,
+    source: readRepoFile(workflowFile),
+  }));
 }
 
 function getReviewComments(
@@ -94,16 +114,8 @@ function getWorkflowUsesReferencesFromSource(
 }
 
 function getWorkflowUsesReferences(): WorkflowUsesReference[] {
-  const workflowFiles = execFileSync("git", ["ls-files", ".github/workflows"], {
-    cwd: repoRoot,
-    encoding: "utf8",
-  })
-    .trim()
-    .split("\n")
-    .filter((file) => /\.ya?ml$/u.test(file));
-
-  return workflowFiles.flatMap((workflowFile) =>
-    getWorkflowUsesReferencesFromSource(readRepoFile(workflowFile))
+  return getWorkflowSources().flatMap(({ source }) =>
+    getWorkflowUsesReferencesFromSource(source)
   );
 }
 
@@ -510,26 +522,40 @@ describe("Build Configuration and Source Verification", () => {
     }
   }, 120_000);
 
-  it("keeps timeout-minutes only on runnable quality workflow jobs", () => {
-    const qualityWorkflow = readRepoFile(".github/workflows/quality.yml");
-    const jobsSection = getIndentedSection(qualityWorkflow, "jobs");
-    const jobNames = Array.from(
-      jobsSection.matchAll(/^ {2}([a-z0-9-]+):$/gm),
-      (match) => match[1]
-    );
+  it("sets timeout-minutes on every runnable workflow job", () => {
+    const workflowSources = getWorkflowSources();
 
-    expect(jobNames.length).toBeGreaterThan(0);
+    expect(workflowSources.length).toBeGreaterThan(0);
 
-    for (const jobName of jobNames) {
-      const jobSection = getIndentedSection(jobsSection, jobName);
+    for (const workflow of workflowSources) {
+      const document = load(workflow.source);
 
-      if (jobSection.includes("\n    uses: ")) {
-        expect(jobSection).not.toContain("timeout-minutes:");
+      expect(isRecord(document), workflow.path).toBe(true);
+      if (!isRecord(document)) {
         continue;
       }
 
-      expect(jobSection).toContain("runs-on:");
-      expect(jobSection).toContain("timeout-minutes:");
+      expect(isRecord(document.jobs), workflow.path).toBe(true);
+      if (!isRecord(document.jobs)) {
+        continue;
+      }
+
+      for (const [jobName, job] of Object.entries(document.jobs)) {
+        const jobLocation = `${workflow.path}:jobs.${jobName}`;
+
+        expect(isRecord(job), jobLocation).toBe(true);
+        if (!isRecord(job)) {
+          continue;
+        }
+
+        if (typeof job.uses === "string") {
+          expect(job, jobLocation).not.toHaveProperty("timeout-minutes");
+          continue;
+        }
+
+        expect(job, jobLocation).toHaveProperty("runs-on");
+        expect(job, jobLocation).toHaveProperty("timeout-minutes");
+      }
     }
   });
 


### PR DESCRIPTION
## Problem and evidence

- The workflow inventory contained moving GitHub Action tags, including
  `actions/checkout@v7`, `actions/setup-node@v7`,
  `actions/github-script@v9`, and `github/codeql-action/*@v4.37.5`.
- Organization reusable workflows were also referenced through `@main`.
- Moving references can change workflow behavior without a change in this
  repository.

## Change

- Pins every `uses:` reference under `.github/workflows` to a reviewed
  40-character commit SHA.
- Retains version or branch visibility through YAML comments and adds a
  regression test that rejects moving references.
- Updates the workflow policy, yamllint comment-spacing rule, and changelog.
- Leaves the frontend container publisher workflows unchanged.

Closes #1592.

## Validation

- `npm run typecheck`
- `npm run test:run -- tests/build.test.ts`
- `actionlint -config-file .github/actionlint.yaml .github/workflows/*.yml`
- `yamllint -c .yamllint.yml .github/workflows`
- `reuse lint`

## Readiness

- No in-scope dependency blocks review.
- `yamllint` retains one unrelated warning in
  `.github/workflows/dependabot-auto-merge.yml:45`, tracked in #1608.
- The PR remains draft pending final review.
