### PR TITLE
Fix Lighthouse report links

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -42,13 +42,23 @@ jobs:
         uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18 # v12
         with:
           configPath: ./lighthouserc.cjs
-          uploadArtifacts: true
           temporaryPublicStorage: true
+
+      - name: Upload Lighthouse report
+        id: upload_lighthouse_artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: lighthouse-report
+          path: .lighthouseci
+          if-no-files-found: error
+          include-hidden-files: true
 
       - name: Format Lighthouse Score
         id: format_lighthouse_score
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         if: github.event_name == 'pull_request'
+        env:
+          LIGHTHOUSE_ARTIFACT_URL: ${{ steps.upload_lighthouse_artifact.outputs.artifact-url }}
         with:
           script: |
             const fs = require('fs');
@@ -78,10 +88,12 @@ jobs:
 
             // We test one URL. The report itself is uploaded as a workflow artifact.
             const summary = manifest[0].summary;
-            const artifactUrl = new URL(
-              `${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}#artifacts`,
-              context.serverUrl
-            ).toString();
+            const artifactUrl = process.env.LIGHTHOUSE_ARTIFACT_URL;
+
+            if (!artifactUrl) {
+              console.log('No Lighthouse artifact URL found');
+              return;
+            }
 
             const formatScore = (score) => {
               const pct = Math.round(score * 100);

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Upload Lighthouse report
         id: upload_lighthouse_artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ always() }}
         with:
           name: lighthouse-report
           path: .lighthouseci

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -76,9 +76,12 @@ jobs:
               return;
             }
 
-            // Get the first result (we test one URL)
-            const result = manifest[0];
-            const summary = result.summary;
+            // We test one URL. The report itself is uploaded as a workflow artifact.
+            const summary = manifest[0].summary;
+            const artifactUrl = new URL(
+              `${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}#artifacts`,
+              context.serverUrl
+            ).toString();
 
             const formatScore = (score) => {
               const pct = Math.round(score * 100);
@@ -95,7 +98,7 @@ jobs:
               `| Accessibility | ${formatScore(summary.accessibility)} |`,
               `| Best Practices | ${formatScore(summary['best-practices'])} |`,
               '',
-              `[View full report](${result.htmlPath || 'See artifacts'})`,
+              `[View full report artifact](${artifactUrl})`,
               '',
               '<details>',
               '<summary>Core Web Vitals</summary>',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed Lighthouse pull-request comments to link readers to the current
   workflow run's uploaded report artifact instead of an inaccessible
-  runner-local filesystem path.
+  runner-local filesystem path, retaining the report artifact when the audit
+  fails.
 - Made local Vite config imports compatible with Vite's native config loader
   and covered the config and its dependencies with strict TypeScript checks,
   removing the future-default compatibility warning from test runs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed Lighthouse pull-request comments to link readers to the current
+  workflow run's uploaded report artifact instead of an inaccessible
+  runner-local filesystem path.
 - Changed published multi-architecture runtime verification to exercise each
   platform through its verified child manifest digest, avoiding classic Docker
   image-store conflicts while retaining the OCI index digest as the canonical

--- a/tests/lighthouse-workflow.test.ts
+++ b/tests/lighthouse-workflow.test.ts
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  ".."
+);
+
+function readWorkflow(): string {
+  return readFileSync(
+    path.join(repoRoot, ".github/workflows/lighthouse.yml"),
+    "utf8"
+  );
+}
+
+describe("Lighthouse workflow report comment", () => {
+  it("links pull-request readers to the current run's uploaded report artifact", () => {
+    const workflow = readWorkflow();
+
+    expect(workflow).toContain("uploadArtifacts: true");
+    expect(workflow).toContain(
+      "${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}#artifacts"
+    );
+    expect(workflow).toContain("context.serverUrl");
+    expect(workflow).toContain("[View full report artifact](${artifactUrl})");
+  });
+
+  it("never includes a runner-local Lighthouse report path in the comment", () => {
+    expect(readWorkflow()).not.toContain("result.htmlPath");
+  });
+});

--- a/tests/lighthouse-workflow.test.ts
+++ b/tests/lighthouse-workflow.test.ts
@@ -3,13 +3,19 @@
 
 import { readFileSync } from "node:fs";
 import path from "node:path";
+import vm from "node:vm";
 import { fileURLToPath } from "node:url";
+import { load } from "js-yaml";
 import { describe, expect, it } from "vitest";
 
 const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   ".."
 );
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
 function readWorkflow(): string {
   return readFileSync(
@@ -18,19 +24,99 @@ function readWorkflow(): string {
   );
 }
 
+function getWorkflowStep(name: string): Record<string, unknown> {
+  const workflow = load(readWorkflow());
+
+  if (!isRecord(workflow) || !isRecord(workflow.jobs)) {
+    throw new Error("Lighthouse workflow must define jobs");
+  }
+
+  const lighthouseJob = workflow.jobs.lighthouse;
+  if (!isRecord(lighthouseJob) || !Array.isArray(lighthouseJob.steps)) {
+    throw new Error("Lighthouse workflow must define lighthouse steps");
+  }
+
+  const step = lighthouseJob.steps.find(
+    (candidate) => isRecord(candidate) && candidate.name === name
+  );
+  if (!isRecord(step)) {
+    throw new Error(`Lighthouse workflow step not found: ${name}`);
+  }
+
+  return step;
+}
+
 describe("Lighthouse workflow report comment", () => {
-  it("links pull-request readers to the current run's uploaded report artifact", () => {
-    const workflow = readWorkflow();
-
-    expect(workflow).toContain("uploadArtifacts: true");
-    expect(workflow).toContain(
-      "${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}#artifacts"
+  it("links pull-request readers directly to the uploaded report artifact", async () => {
+    const uploadStep = getWorkflowStep("Upload Lighthouse report");
+    expect(uploadStep.id).toBe("upload_lighthouse_artifact");
+    expect(uploadStep.uses).toBe(
+      "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
     );
-    expect(workflow).toContain("context.serverUrl");
-    expect(workflow).toContain("[View full report artifact](${artifactUrl})");
-  });
+    expect(uploadStep.with).toMatchObject({
+      "if-no-files-found": "error",
+      "include-hidden-files": true,
+      name: "lighthouse-report",
+      path: ".lighthouseci",
+    });
 
-  it("never includes a runner-local Lighthouse report path in the comment", () => {
-    expect(readWorkflow()).not.toContain("result.htmlPath");
+    const formatStep = getWorkflowStep("Format Lighthouse Score");
+    expect(formatStep.env).toMatchObject({
+      LIGHTHOUSE_ARTIFACT_URL:
+        "${{ steps.upload_lighthouse_artifact.outputs.artifact-url }}",
+    });
+
+    if (
+      !isRecord(formatStep.with) ||
+      typeof formatStep.with.script !== "string"
+    ) {
+      throw new Error("Format Lighthouse Score must define a script");
+    }
+
+    const artifactUrl =
+      "https://github.com/SecPal/frontend/actions/runs/123/artifacts/456";
+    const outputs = new Map<string, string>();
+    const manifest = JSON.stringify([
+      {
+        htmlPath: "/home/runner/work/frontend/.lighthouseci/report.html",
+        summary: {
+          accessibility: 0.98,
+          "best-practices": 0.97,
+          performance: 0.96,
+        },
+      },
+    ]);
+    const requireModule = (moduleName: string): unknown => {
+      if (moduleName === "fs") {
+        return {
+          existsSync: () => true,
+          readFileSync: () => manifest,
+          readdirSync: () => ["manifest.json"],
+        };
+      }
+      if (moduleName === "path") {
+        return path;
+      }
+
+      throw new Error(`Unexpected module request: ${moduleName}`);
+    };
+    const script = new vm.Script(
+      `(async () => {\n${formatStep.with.script}\n})()`
+    );
+
+    await script.runInNewContext({
+      URL,
+      console,
+      core: {
+        setOutput: (name: string, value: string) => outputs.set(name, value),
+      },
+      process: { env: { LIGHTHOUSE_ARTIFACT_URL: artifactUrl } },
+      require: requireModule,
+    });
+
+    const comment = outputs.get("comment");
+    expect(comment).toContain(`[View full report artifact](${artifactUrl})`);
+    expect(comment).not.toContain("/home/runner/");
+    expect(comment).not.toContain("#artifacts");
   });
 });

--- a/tests/lighthouse-workflow.test.ts
+++ b/tests/lighthouse-workflow.test.ts
@@ -53,6 +53,7 @@ describe("Lighthouse workflow report comment", () => {
     expect(uploadStep.uses).toBe(
       "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
     );
+    expect(uploadStep.if).toBe("${{ always() }}");
     expect(uploadStep.with).toMatchObject({
       "if-no-files-found": "error",
       "include-hidden-files": true,
@@ -117,6 +118,7 @@ describe("Lighthouse workflow report comment", () => {
     const comment = outputs.get("comment");
     expect(comment).toContain(`[View full report artifact](${artifactUrl})`);
     expect(comment).not.toContain("/home/runner/");
+    expect(comment).not.toContain(".lighthouseci/");
     expect(comment).not.toContain("#artifacts");
   });
 });


### PR DESCRIPTION
## Summary

Closes #1594.

Lighthouse pull-request comments used the manifest's `htmlPath`, which points
to the GitHub Actions runner filesystem. The comment now directs readers to
the uploaded report artifact in the corresponding workflow run.

## Changes

- Build the report link from the current repository and workflow run context.
- Remove the runner-local manifest path from the comment construction.
- Add focused workflow-policy coverage for the artifact link and the absence
  of `result.htmlPath`.
- Record the correction in `CHANGELOG.md`.

## Validation

- `npx vitest run tests/lighthouse-workflow.test.ts`
- `npm run typecheck`
- `npx eslint tests/lighthouse-workflow.test.ts`
- `npx prettier --check .github/workflows/lighthouse.yml tests/lighthouse-workflow.test.ts CHANGELOG.md`
- `yamllint .github/workflows/lighthouse.yml`
- `reuse lint`
- `git diff --check`

## Readiness

No in-scope dependency or unresolved check prevents review. The Vite native
config-loader warning emitted during Vitest is outside this change and already
tracked in #1582 (with #1583 covering the same warning).
