### PR TITLE
fix(lint): ignore Polyscope preview artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Excluded transient Polyscope preview-stage artifacts from ESLint so local
+  linting does not race files created and removed by the preview process.
 - Required current-password confirmation before passkey removal, sent the
   step-up payload required by the passkey deletion API, and retained successful
   removal state if a subsequent list refresh fails. The confirmation dialog can

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,7 @@ export default tseslint.config(
     ignores: [
       "dist",
       "coverage",
+      ".polyscope-preview-stage",
       "src/locales/**/*.js",
       "src/locales/**/*.mjs",
     ],

--- a/tests/unit/lint/issue1559-polyscope-preview-stage.test.ts
+++ b/tests/unit/lint/issue1559-polyscope-preview-stage.test.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+import { describe, expect, it } from "vitest";
+import { ESLint } from "eslint";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../.."
+);
+
+describe("Issue 1559 Polyscope preview staging regression", () => {
+  it("ignores transient preview assets", async () => {
+    const eslint = new ESLint({ cwd: repoRoot });
+    const previewAsset = path.join(
+      repoRoot,
+      ".polyscope-preview-stage",
+      "workspace",
+      "assets",
+      "ActivityLogList-DZcvh31E.js"
+    );
+
+    await expect(eslint.isPathIgnored(previewAsset)).resolves.toBe(true);
+  });
+});

--- a/tests/unit/lint/issue1559-polyscope-preview-stage.test.ts
+++ b/tests/unit/lint/issue1559-polyscope-preview-stage.test.ts
@@ -12,7 +12,7 @@ const repoRoot = path.resolve(
 );
 
 describe("Issue 1559 Polyscope preview staging regression", () => {
-  it("ignores transient preview assets", async () => {
+  it("ignores transient preview assets without ignoring tracked JavaScript", async () => {
     const eslint = new ESLint({ cwd: repoRoot });
     const previewAsset = path.join(
       repoRoot,
@@ -21,7 +21,15 @@ describe("Issue 1559 Polyscope preview staging regression", () => {
       "assets",
       "ActivityLogList-DZcvh31E.js"
     );
+    const trackedJavaScriptFile = path.join(
+      repoRoot,
+      "public",
+      "runtime-config.js"
+    );
 
     await expect(eslint.isPathIgnored(previewAsset)).resolves.toBe(true);
+    await expect(eslint.isPathIgnored(trackedJavaScriptFile)).resolves.toBe(
+      false
+    );
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1559.

- Exclude transient Polyscope preview staging artifacts from ESLint.
- Add a regression test against ESLint's configured ignore behavior.

## Problem and evidence

`npm run lint` traversed `.polyscope-preview-stage` while preview staging was
active. A generated asset could be removed before ESLint opened it, producing
an `ENOENT` failure for a path below that directory.

## Change

Added `.polyscope-preview-stage` to the flat-config global ignores and covered
an asset path beneath it with the ESLint API.

## Validation

- Focused Vitest regression test
- `npm run lint`
- `npm run typecheck`
- Prettier format check
- `reuse lint`
- `git diff --check`
- Local pre-commit hooks

## Draft status

No in-scope dependency or unresolved implementation check remains. The PR stays
draft pending the required final self-review in the PR view before it is marked
ready for review.
