### PR TITLE
Bound native stored-snapshot bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Bounded native stored-snapshot connectivity preflight during auth bootstrap,
+  so a stalled native availability call now completes as offline while retaining
+  the secure local session.
 - Required current-password confirmation before passkey removal, sent the
   step-up payload required by the passkey deletion API, and retained successful
   removal state if a subsequent list refresh fails. The confirmation dialog can

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -3,7 +3,7 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, act, waitFor } from "@testing-library/react";
-import { AuthProvider } from "./AuthContext";
+import { AuthProvider, BOOTSTRAP_REVALIDATION_TIMEOUT_MS } from "./AuthContext";
 import { useAuth } from "../hooks/useAuth";
 import { getCurrentUser } from "../services/authApi";
 import { sanitizePersistedAuthUser } from "../services/authState";
@@ -236,6 +236,79 @@ describe("AuthContext", () => {
       await waitFor(() => {
         expect(screen.getByTestId("hasPermission")).toHaveTextContent("true");
       });
+    });
+  });
+
+  describe("native stored-snapshot bootstrap", () => {
+    it("finishes when native connectivity never settles without clearing the stored session", async () => {
+      const storedUser = {
+        id: "1",
+        name: "Native User",
+        email: "native.user@secpal.dev",
+        permissions: ["employees.read"],
+      };
+      await seedStoredUser(storedUser);
+
+      const authGlobal = globalThis as {
+        SecPalNativeAuthBridge?: unknown;
+      };
+      const originalNativeBridge = authGlobal.SecPalNativeAuthBridge;
+      const nativeBridge = {
+        login: vi.fn(),
+        logout: vi.fn().mockResolvedValue(undefined),
+        getCurrentUser: vi.fn(),
+        isNetworkAvailable: vi.fn().mockReturnValue(new Promise(() => {})),
+      };
+      authGlobal.SecPalNativeAuthBridge = nativeBridge;
+      const getUserSpy = vi
+        .spyOn(authStorage, "getUser")
+        .mockResolvedValue(storedUser);
+      vi.useFakeTimers();
+
+      function NativeBootstrapState() {
+        const auth = useAuth();
+
+        return (
+          <div>
+            <span data-testid="userEmail">{auth.user?.email ?? "none"}</span>
+            <span data-testid="isLoading">{String(auth.isLoading)}</span>
+          </div>
+        );
+      }
+
+      try {
+        render(
+          <AuthProvider>
+            <NativeBootstrapState />
+          </AuthProvider>
+        );
+
+        await act(async () => {
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+
+        expect(screen.getByTestId("userEmail")).toHaveTextContent(
+          storedUser.email
+        );
+        expect(screen.getByTestId("isLoading")).toHaveTextContent("true");
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(BOOTSTRAP_REVALIDATION_TIMEOUT_MS);
+        });
+
+        expect(screen.getByTestId("isLoading")).toHaveTextContent("false");
+        expect(nativeBridge.getCurrentUser).not.toHaveBeenCalled();
+        expect(authStorage.hasStoredUser()).toBe(true);
+      } finally {
+        vi.useRealTimers();
+        getUserSpy.mockRestore();
+        if (originalNativeBridge === undefined) {
+          delete authGlobal.SecPalNativeAuthBridge;
+        } else {
+          authGlobal.SecPalNativeAuthBridge = originalNativeBridge;
+        }
+      }
     });
   });
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -37,6 +37,28 @@ export const BOOTSTRAP_REVALIDATION_TIMEOUT_MS = 3500;
 const AUTH_LOGOUT_CLEANUP_WAIT_TIMEOUT_MS = 5_000;
 const AUTH_LOGIN_AFTER_LOGOUT_CLEANUP_WAIT_TIMEOUT_MS = 5_000;
 
+async function isNetworkAvailableWithinBootstrapTimeout(
+  isNetworkAvailable: () => Promise<boolean>
+): Promise<boolean> {
+  let timeoutId: ReturnType<typeof globalThis.setTimeout> | null = null;
+
+  try {
+    return await Promise.race([
+      isNetworkAvailable(),
+      new Promise<boolean>((resolve) => {
+        timeoutId = globalThis.setTimeout(
+          () => resolve(false),
+          BOOTSTRAP_REVALIDATION_TIMEOUT_MS
+        );
+      }),
+    ]);
+  } finally {
+    if (timeoutId !== null) {
+      globalThis.clearTimeout(timeoutId);
+    }
+  }
+}
+
 async function loadOfflineVaultModule() {
   return await import("../lib/offlineVault");
 }
@@ -1164,7 +1186,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         return;
       }
 
-      const networkAvailable = await authTransport.isNetworkAvailable();
+      const networkAvailable = await isNetworkAvailableWithinBootstrapTimeout(
+        () => authTransport.isNetworkAvailable()
+      );
 
       if (
         !isActive ||


### PR DESCRIPTION
## Summary

- Bound native stored-snapshot connectivity preflight during auth bootstrap.
- Preserve the secure local session when native connectivity does not settle.
- Add regression coverage for a permanently pending native availability request.

## Problem and evidence

With a stored frontend user snapshot, the native bootstrap path awaited
`isNetworkAvailable()` before starting the bounded `getCurrentUser()`
revalidation. A native availability promise that never settled therefore left
bootstrap loading indefinitely. The regression test reproduces this condition
and verifies that loading completes, no current-user request is made, and the
stored session remains available.

## Change

The stored-user native branch now races the connectivity request against the
existing 3.5-second bootstrap interval. A timeout is treated as unavailable
network, following the existing offline path without deleting the native
session. The no-snapshot native rehydration path is unchanged.

Fixes #1558

## Validation

- `npx vitest --configLoader=native run src/contexts/AuthContext.test.tsx`
- `npx eslint src/contexts/AuthContext.tsx src/contexts/AuthContext.test.tsx`
- `npm run typecheck`
- `reuse lint`
- Commit hooks: REUSE, Prettier, Markdownlint, YAML lint, shellcheck, and
  repository hygiene checks

## Draft status

No in-scope dependency or unresolved local check blocks the change. This draft
remains pending final pull-request self-review.
