### PR TITLE
chore(deps): refresh Browserslist data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "@vitejs/plugin-react": "^6.0.5",
         "@vitest/coverage-v8": "^4.1.10",
         "@vitest/ui": "^4.1.10",
-        "caniuse-lite": "^1.0.30001806",
+        "caniuse-lite": "^1.0.30001809",
         "chai": "^6.2.2",
         "cross-env": "^10.1.0",
         "eslint": "^10.8.0",
@@ -5516,9 +5516,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5704,9 +5704,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001806",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
-      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "@vitejs/plugin-react": "^6.0.5",
     "@vitest/coverage-v8": "^4.1.10",
     "@vitest/ui": "^4.1.10",
-    "caniuse-lite": "^1.0.30001806",
+    "caniuse-lite": "^1.0.30001809",
     "chai": "^6.2.2",
     "cross-env": "^10.1.0",
     "eslint": "^10.8.0",


### PR DESCRIPTION
## Problem and evidence

Issue #1555 reports that the focused onboarding Vitest suite emits a warning because the installed Browserslist compatibility data is six months old. The lockfile contained `caniuse-lite` 1.0.30001806 and `baseline-browser-mapping` 2.10.0. A local pre-update run of the focused suite passed without reproducing the warning, but the locked browser-data packages were behind the current available versions.

## Change

- Update `caniuse-lite` to 1.0.30001809.
- Update `baseline-browser-mapping` to 2.11.12 through the supported Browserslist database refresh.
- Keep `caniuse-lite` as a direct development dependency so the existing daily npm Dependabot configuration continues to propose future version updates.

## Validation

- `npm exec vitest -- --configLoader=native run src/ui/onboarding.test.tsx` — 33 tests passed without the stale-data warning.
- `npm run build` — passed, including the TypeScript compilation and production PWA build.
- `npm exec prettier -- --check package.json package-lock.json` — passed.
- `reuse lint` — passed.
- Commit hooks — passed without bypasses.

## Readiness

No known in-scope dependency or failed local check blocks readiness. This pull request remains draft for the required final self-review in the PR view.

Closes #1555
