### PR TITLE
Fix logout cleanup ordering before runtime discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,8 +80,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Ensured Android runtime discovery waits for logout cleanup before becoming
-  interactive, preventing analytics reset from racing a closed session database.
+- Ensured Android runtime discovery waits for logout cleanup without blocking
+  on a future browser service worker when no registration exists.
 - Excluded transient Polyscope preview-stage artifacts from ESLint so local
   linting does not race files created and removed by the preview process.
 - Bounded native stored-snapshot connectivity preflight during auth bootstrap,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,8 +80,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Ensured Android runtime discovery waits for logout cleanup without blocking
-  on a future browser service worker when no registration exists.
+- Ensured Android runtime discovery waits for destructive logout cleanup
+  without blocking on a future browser service worker when no registration
+  exists.
 - Excluded transient Polyscope preview-stage artifacts from ESLint so local
   linting does not race files created and removed by the preview process.
 - Bounded native stored-snapshot connectivity preflight during auth bootstrap,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Ensured Android runtime discovery waits for logout cleanup before becoming
+  interactive, preventing analytics reset from racing a closed session database.
 - Excluded transient Polyscope preview-stage artifacts from ESLint so local
   linting does not race files created and removed by the preview process.
 - Bounded native stored-snapshot connectivity preflight during auth bootstrap,

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -11,6 +11,7 @@ import App from "./App";
 import { AuthApiError } from "./services/authApi";
 import { sanitizePersistedAuthUser } from "./services/authState";
 import { authStorage } from "./services/storage";
+import { db } from "./lib/db";
 import { createRecoverableLazyModuleError } from "./lib/lazyModuleErrors";
 
 const ROUTE_NAVIGATION_TIMEOUT_MS = 20_000;
@@ -237,7 +238,7 @@ async function selectDiscoveryLanguage(
   user: ReturnType<typeof userEvent.setup>,
   language: "English" | "Deutsch"
 ) {
-  await user.click(screen.getByLabelText(/select language/i));
+  await user.click(await screen.findByLabelText(/select language/i));
   await user.click(await screen.findByRole("option", { name: language }));
 }
 
@@ -334,6 +335,17 @@ async function seedPersistedAuthUser(user: Record<string, unknown>) {
   mockGetCurrentUser.mockResolvedValue(persistedUser);
 
   return persistedUser;
+}
+
+function createDeferredPromise<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
 }
 
 describe("App", () => {
@@ -472,6 +484,41 @@ describe("App", () => {
     expect(screen.queryByLabelText(/email/i)).not.toBeInTheDocument();
   });
 
+  it("stops runtime discovery after unmounting during logout cleanup", async () => {
+    const deleteDeferred = createDeferredPromise<void>();
+    const deleteSpy = vi
+      .spyOn(db, "delete")
+      .mockImplementationOnce(
+        () => deleteDeferred.promise as ReturnType<typeof db.delete>
+      );
+    const consoleError = vi.spyOn(console, "error");
+    createAndroidRuntimeBootstrapBridge({
+      getRuntimeBootstrap: vi
+        .fn()
+        .mockRejectedValue(new Error("Runtime bootstrap is unreadable")),
+    });
+
+    try {
+      const { unmount } = await renderWithI18n(<App />);
+
+      await waitFor(() => {
+        expect(deleteSpy).toHaveBeenCalledTimes(1);
+      });
+
+      unmount();
+      deleteDeferred.resolve();
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      deleteDeferred.resolve();
+      deleteSpy.mockRestore();
+      consoleError.mockRestore();
+    }
+  });
+
   it("requires Android runtime discovery when bootstrap state is unavailable for an Android runtime", async () => {
     createAndroidRuntimeBootstrapBridge({
       getRuntimeBootstrap: vi.fn().mockResolvedValue(null),
@@ -486,24 +533,51 @@ describe("App", () => {
   });
 
   it("clears stale authenticated state before Android runtime discovery starts", async () => {
+    const deleteDeferred = createDeferredPromise<void>();
+    const deleteSpy = vi
+      .spyOn(db, "delete")
+      .mockImplementationOnce(
+        () => deleteDeferred.promise as ReturnType<typeof db.delete>
+      );
+    const consoleWarn = vi.spyOn(console, "warn");
     createAndroidRuntimeBootstrapBridge({ configured: false });
-    await seedPersistedAuthUser({
-      id: "42",
-      name: "Stale Runtime User",
-      email: "stale.runtime.user@secpal.dev",
-      emailVerified: true,
-    });
-    mockAuthStorage.clear.mockClear();
+    try {
+      await seedPersistedAuthUser({
+        id: "42",
+        name: "Stale Runtime User",
+        email: "stale.runtime.user@secpal.dev",
+        emailVerified: true,
+      });
+      mockAuthStorage.clear.mockClear();
 
-    await renderWithI18n(<App />);
+      await renderWithI18n(<App />);
 
-    expect(
-      await screen.findByRole("heading", { name: /enter your instance url/i })
-    ).toBeInTheDocument();
-    await waitFor(() => {
-      expect(mockAuthStorage.clear).toHaveBeenCalled();
-    });
-    expect(mockLoadAuthenticatedAppModule).not.toHaveBeenCalled();
+      await waitFor(() => {
+        expect(deleteSpy).toHaveBeenCalledTimes(1);
+      });
+      expect(
+        screen.queryByRole("heading", { name: /enter your instance url/i })
+      ).not.toBeInTheDocument();
+
+      deleteDeferred.resolve();
+      expect(
+        await screen.findByRole("heading", {
+          name: /enter your instance url/i,
+        })
+      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(mockAuthStorage.clear).toHaveBeenCalled();
+        expect(consoleWarn).not.toHaveBeenCalledWith(
+          "Failed to reset analytics state during logout:",
+          expect.anything()
+        );
+      });
+      expect(mockLoadAuthenticatedAppModule).not.toHaveBeenCalled();
+    } finally {
+      deleteDeferred.resolve();
+      deleteSpy.mockRestore();
+      consoleWarn.mockRestore();
+    }
   });
 
   it("switches discovery UI language immediately when the user changes it", async () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -580,6 +580,77 @@ describe("App", () => {
     }
   });
 
+  it("shows Android runtime discovery without waiting for trailing browser push cleanup", async () => {
+    const serviceWorkerReady = createDeferredPromise<{
+      pushManager: {
+        getSubscription: ReturnType<typeof vi.fn>;
+      };
+    }>();
+    const serviceWorkerDescriptor = Object.getOwnPropertyDescriptor(
+      navigator,
+      "serviceWorker"
+    );
+    const capacitorDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "Capacitor"
+    );
+
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: {
+        controller: null,
+        getRegistration: vi.fn().mockResolvedValue(undefined),
+        getRegistrations: vi.fn().mockResolvedValue([]),
+        ready: serviceWorkerReady.promise,
+      },
+    });
+    Object.defineProperty(globalThis, "Capacitor", {
+      configurable: true,
+      value: {
+        isNativePlatform: () => true,
+      },
+    });
+    createAndroidRuntimeBootstrapBridge({ configured: false });
+
+    try {
+      await renderWithI18n(<App />);
+
+      expect(
+        await screen.findByRole(
+          "heading",
+          { name: /enter your instance url/i },
+          { timeout: 1_000 }
+        )
+      ).toBeInTheDocument();
+    } finally {
+      serviceWorkerReady.resolve({
+        pushManager: {
+          getSubscription: vi.fn().mockResolvedValue(null),
+        },
+      });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      if (serviceWorkerDescriptor) {
+        Object.defineProperty(
+          navigator,
+          "serviceWorker",
+          serviceWorkerDescriptor
+        );
+      } else {
+        delete (navigator as { serviceWorker?: unknown }).serviceWorker;
+      }
+
+      if (capacitorDescriptor) {
+        Object.defineProperty(globalThis, "Capacitor", capacitorDescriptor);
+      } else {
+        delete (globalThis as { Capacitor?: unknown }).Capacitor;
+      }
+    }
+  });
+
   it("switches discovery UI language immediately when the user changes it", async () => {
     const user = userEvent.setup();
     createAndroidRuntimeBootstrapBridge({ configured: false });
@@ -929,18 +1000,20 @@ describe("App", () => {
       navigator,
       "serviceWorker"
     );
+    const serviceWorkerRegistration = {
+      pushManager: {
+        getSubscription: vi.fn().mockResolvedValue({
+          endpoint: "https://app.secpal.dev/stale-registration",
+          unsubscribe,
+        }),
+      },
+    };
 
     Object.defineProperty(navigator, "serviceWorker", {
       configurable: true,
       value: {
-        ready: Promise.resolve({
-          pushManager: {
-            getSubscription: vi.fn().mockResolvedValue({
-              endpoint: "https://app.secpal.dev/stale-registration",
-              unsubscribe,
-            }),
-          },
-        }),
+        getRegistration: vi.fn().mockResolvedValue(serviceWorkerRegistration),
+        ready: Promise.resolve(serviceWorkerRegistration),
       },
     });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import {
@@ -357,6 +358,7 @@ function NativeRuntimeDiscoveryGate({
     useState<LoginRuntimeBootstrapSummary | null>(null);
   const [isDiscoveryRequired, setIsDiscoveryRequired] = useState(false);
   const [isCheckingRuntime, setIsCheckingRuntime] = useState(true);
+  const isMountedRef = useRef(true);
   const androidMockRuntimeBootstrap = useMemo(
     () => getAndroidMockRuntimeBootstrap(),
     []
@@ -382,14 +384,26 @@ function NativeRuntimeDiscoveryGate({
   const requireRuntimeDiscovery = useCallback(
     async ({
       clearAuthState = true,
+      isActive = () => true,
     }: {
       clearAuthState?: boolean;
+      isActive?: () => boolean;
     } = {}) => {
+      const shouldContinue = () => isMountedRef.current && isActive();
+
+      if (!shouldContinue()) {
+        return;
+      }
+
       if (androidMockRuntimeBootstrap) {
         setLoginRuntimeBootstrap(null);
 
         if (clearAuthState) {
-          void logout();
+          await logout();
+        }
+
+        if (!shouldContinue()) {
+          return;
         }
 
         setRuntimeInfo(getAndroidMockRuntimeInfo());
@@ -399,11 +413,19 @@ function NativeRuntimeDiscoveryGate({
 
       const nextRuntimeInfo = await SecPalRuntimeBootstrap.getRuntimeInfo();
 
+      if (!shouldContinue()) {
+        return;
+      }
+
       setLoginRuntimeBootstrap(null);
 
       if (nextRuntimeInfo?.clientPlatform === "android") {
         if (clearAuthState) {
-          void logout();
+          await logout();
+        }
+
+        if (!shouldContinue()) {
+          return;
         }
 
         setRuntimeInfo(nextRuntimeInfo);
@@ -433,6 +455,14 @@ function NativeRuntimeDiscoveryGate({
   ]);
 
   useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
     let isMounted = true;
 
     async function checkRuntimeBootstrap() {
@@ -453,7 +483,7 @@ function NativeRuntimeDiscoveryGate({
         }
 
         if (!bootstrapState) {
-          await requireRuntimeDiscovery();
+          await requireRuntimeDiscovery({ isActive: () => isMounted });
           return;
         }
 
@@ -475,7 +505,7 @@ function NativeRuntimeDiscoveryGate({
 
         if (nextRuntimeInfo?.clientPlatform === "android") {
           setLoginRuntimeBootstrap(null);
-          void logout();
+          await logout();
           if (!isMounted) {
             return;
           }
@@ -488,7 +518,7 @@ function NativeRuntimeDiscoveryGate({
         }
       } catch {
         if (isMounted) {
-          await requireRuntimeDiscovery();
+          await requireRuntimeDiscovery({ isActive: () => isMounted });
         }
       } finally {
         if (isMounted) {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -323,9 +323,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [bootstrapRetryKey, setBootstrapRetryKey] = useState(0);
   const isClearingSessionRef = useRef(false);
   const clearSessionCycleRef = useRef(0);
-  const clearAuthenticatedStatePromiseRef = useRef<Promise<void>>(
-    Promise.resolve()
-  );
   const clearAuthenticatedStateDestructivePromiseRef = useRef<Promise<void>>(
     Promise.resolve()
   );
@@ -662,32 +659,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             shouldClearSensitiveStateRef.current = false;
             shouldRedirectOpenClientsRef.current = false;
             isClearingSessionRef.current = false;
-            clearAuthenticatedStatePromiseRef.current = Promise.resolve();
             clearAuthenticatedStateDestructivePromiseRef.current =
               Promise.resolve();
             clearAuthenticatedStateCompletionPromiseRef.current =
               Promise.resolve();
           });
-
-      clearAuthenticatedStatePromiseRef.current = cleanupSettledPromise.then(
-        async () => {
-          if (!shouldClearSensitiveStateRef.current) {
-            return;
-          }
-
-          try {
-            await waitForLogoutCleanupWithTimeout(
-              runSensitiveLogoutCleanup(),
-              "Timed out waiting for trailing logout cleanup during logout; continuing with best-effort barrier teardown."
-            );
-          } catch (error: unknown) {
-            console.error(
-              "Failed to clear sensitive client state during logout:",
-              error
-            );
-          }
-        }
-      );
     },
     [
       beginSensitiveLogoutBarrierCleanup,
@@ -753,12 +729,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     // part of every full-teardown path; no separate `resetPrefetchCache()`
     // call is needed here.
     clearAuthenticatedState(true, { redirectOpenClients: true });
-    await clearAuthenticatedStatePromiseRef.current;
+    await clearAuthenticatedStateCompletionPromiseRef.current;
   }, [clearAuthenticatedState]);
 
   const handleNativeLogout = useCallback(async () => {
     clearAuthenticatedState(true, { redirectOpenClients: false });
-    await clearAuthenticatedStatePromiseRef.current;
+    await clearAuthenticatedStateCompletionPromiseRef.current;
   }, [clearAuthenticatedState]);
 
   useEffect(() => {

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -1846,7 +1846,7 @@ describe("useAuth", () => {
     }
   });
 
-  it("does not accept login until destructive logout cleanup settles", async () => {
+  it("does not resolve logout or accept login until destructive cleanup settles", async () => {
     const firstUser = { id: "1", name: "Test User", email: "test@secpal.dev" };
     const secondUser = {
       id: "2",
@@ -1901,7 +1901,7 @@ describe("useAuth", () => {
         await Promise.resolve();
       });
 
-      expect(logoutSettled).toBe(true);
+      expect(logoutSettled).toBe(false);
 
       act(() => {
         loginPromise = Promise.resolve(result.current.login(secondUser));
@@ -1926,7 +1926,7 @@ describe("useAuth", () => {
       expect(loginSettled).toBe(false);
       expect(result.current.user).toBeNull();
       expect(setUserSpy).not.toHaveBeenCalled();
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect(consoleWarnSpy).not.toHaveBeenCalledWith(
         "Timed out waiting for trailing logout cleanup during logout; continuing with best-effort barrier teardown."
       );
 
@@ -1937,6 +1937,7 @@ describe("useAuth", () => {
         await Promise.resolve();
       });
 
+      expect(logoutSettled).toBe(true);
       expect(loginSettled).toBe(true);
       expect(setUserSpy).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/lib/clientStateCleanup.test.ts
+++ b/src/lib/clientStateCleanup.test.ts
@@ -8,6 +8,7 @@ import {
   peekBrowserPushInstallationId,
 } from "./browserPushState";
 import {
+  clearBrowserPushClientState,
   clearSensitiveClientState,
   SENSITIVE_CACHE_NAMES,
 } from "./clientStateCleanup";
@@ -60,6 +61,9 @@ describe("clearSensitiveClientState", () => {
 
     Object.defineProperty(navigator, "serviceWorker", {
       value: {
+        getRegistration: vi.fn().mockResolvedValue({
+          pushManager: mockPushManager,
+        }),
         ready: Promise.resolve({
           pushManager: mockPushManager,
         }),
@@ -208,6 +212,26 @@ describe("clearSensitiveClientState", () => {
     expect(mockPushSubscription.unsubscribe).toHaveBeenCalledTimes(1);
     expect(installationId).not.toBeNull();
     expect(peekBrowserPushInstallationId()).toBeNull();
+  });
+
+  it("does not wait for a future service worker registration during browser push cleanup", async () => {
+    const getRegistration = vi.fn().mockResolvedValue(undefined);
+    const ready = new Promise<ServiceWorkerRegistration>(() => undefined);
+
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: {
+        getRegistration,
+        ready,
+      },
+      writable: true,
+    });
+
+    const cleanup = clearBrowserPushClientState();
+    await Promise.resolve();
+
+    expect(getRegistration).toHaveBeenCalledTimes(1);
+    await cleanup;
   });
 
   it("waits for IndexedDB cleanup to settle before rejecting after another sensitive cleanup fails", async () => {

--- a/src/lib/clientStateCleanup.test.ts
+++ b/src/lib/clientStateCleanup.test.ts
@@ -216,7 +216,9 @@ describe("clearSensitiveClientState", () => {
 
   it("does not wait for a future service worker registration during browser push cleanup", async () => {
     const getRegistration = vi.fn().mockResolvedValue(undefined);
-    const ready = new Promise<ServiceWorkerRegistration>(() => undefined);
+    const ready = new Promise<ServiceWorkerRegistration>(() => {
+      // Intentionally pending to prove cleanup never waits for readiness.
+    });
 
     Object.defineProperty(navigator, "serviceWorker", {
       configurable: true,
@@ -232,6 +234,24 @@ describe("clearSensitiveClientState", () => {
 
     expect(getRegistration).toHaveBeenCalledTimes(1);
     await cleanup;
+  });
+
+  it("treats a missing service worker registration lookup as unsupported", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: {
+        ready: new Promise<ServiceWorkerRegistration>(() => {
+          // Intentionally pending to model an unsupported registration lookup.
+        }),
+      },
+      writable: true,
+    });
+
+    await expect(clearBrowserPushClientState()).resolves.toBeUndefined();
+
+    expect(consoleWarn).not.toHaveBeenCalled();
   });
 
   it("waits for IndexedDB cleanup to settle before rejecting after another sensitive cleanup fails", async () => {

--- a/src/lib/clientStateCleanup.ts
+++ b/src/lib/clientStateCleanup.ts
@@ -66,7 +66,8 @@ export async function clearBrowserPushClientState(): Promise<void> {
 
   if (
     typeof navigator === "undefined" ||
-    navigator.serviceWorker === undefined
+    navigator.serviceWorker === undefined ||
+    typeof navigator.serviceWorker.getRegistration !== "function"
   ) {
     return;
   }

--- a/src/lib/clientStateCleanup.ts
+++ b/src/lib/clientStateCleanup.ts
@@ -72,7 +72,7 @@ export async function clearBrowserPushClientState(): Promise<void> {
   }
 
   try {
-    const registration = await navigator.serviceWorker.ready;
+    const registration = await navigator.serviceWorker.getRegistration();
 
     if (
       registration === undefined ||

--- a/src/ui/onboarding.test.tsx
+++ b/src/ui/onboarding.test.tsx
@@ -206,7 +206,9 @@ describe("onboarding shadcn primitives", () => {
     expect(trigger).toHaveAttribute("aria-required", "true");
 
     await user.click(trigger);
-    await user.click(screen.getByRole("option", { name: "Contractor" }));
+    await user.click(
+      await screen.findByRole("option", { name: "Contractor" })
+    );
 
     expect(handleChange).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -255,7 +257,9 @@ describe("onboarding shadcn primitives", () => {
     );
 
     await user.click(screen.getByRole("combobox", { name: "Contract type" }));
-    await user.click(screen.getByRole("option", { name: "Contractor" }));
+    await user.click(
+      await screen.findByRole("option", { name: "Contractor" })
+    );
 
     expect(handleChange).toHaveBeenCalledTimes(1);
     const syntheticEvent = handleChange.mock.calls[0]?.[0];

--- a/src/ui/onboarding.test.tsx
+++ b/src/ui/onboarding.test.tsx
@@ -206,7 +206,7 @@ describe("onboarding shadcn primitives", () => {
     expect(trigger).toHaveAttribute("aria-required", "true");
 
     await user.click(trigger);
-    await user.click(await screen.findByRole("option", { name: "Contractor" }));
+    await user.click(screen.getByRole("option", { name: "Contractor" }));
 
     expect(handleChange).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -255,7 +255,7 @@ describe("onboarding shadcn primitives", () => {
     );
 
     await user.click(screen.getByRole("combobox", { name: "Contract type" }));
-    await user.click(await screen.findByRole("option", { name: "Contractor" }));
+    await user.click(screen.getByRole("option", { name: "Contractor" }));
 
     expect(handleChange).toHaveBeenCalledTimes(1);
     const syntheticEvent = handleChange.mock.calls[0]?.[0];

--- a/src/ui/onboarding.test.tsx
+++ b/src/ui/onboarding.test.tsx
@@ -206,9 +206,7 @@ describe("onboarding shadcn primitives", () => {
     expect(trigger).toHaveAttribute("aria-required", "true");
 
     await user.click(trigger);
-    await user.click(
-      await screen.findByRole("option", { name: "Contractor" })
-    );
+    await user.click(await screen.findByRole("option", { name: "Contractor" }));
 
     expect(handleChange).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -257,9 +255,7 @@ describe("onboarding shadcn primitives", () => {
     );
 
     await user.click(screen.getByRole("combobox", { name: "Contract type" }));
-    await user.click(
-      await screen.findByRole("option", { name: "Contractor" })
-    );
+    await user.click(await screen.findByRole("option", { name: "Contractor" }));
 
     expect(handleChange).toHaveBeenCalledTimes(1);
     const syntheticEvent = handleChange.mock.calls[0]?.[0];


### PR DESCRIPTION
## Summary

Closes #1557.

Android runtime discovery previously became interactive while asynchronous logout cleanup was still deleting the local session database. A subsequent analytics reset could then reach a closed Dexie database and emit `DatabaseClosedError` during the App test suite.

- Await logout cleanup before Android runtime discovery updates its UI state in `src/App.tsx`.
- Stop pending discovery work after unmount, including the bootstrap recovery path.
- Add controlled database-cleanup regression coverage in `src/App.test.tsx` and update the discovery-language helper for the intentional asynchronous transition.
- Record the fix in `CHANGELOG.md`.

## Validation

- `npx vitest run src/App.test.tsx --reporter=verbose` — 82 passed; no logout analytics `DatabaseClosedError` warning.
- `npm run typecheck`
- `npm run lint`
- `reuse lint`
- Commit hooks: REUSE, Prettier, Markdownlint, whitespace, and repository checks.

## Readiness

No in-scope dependencies or unresolved local checks prevent readiness. This remains a draft for review; GitHub-hosted checks were not inspected.