### PR TITLE
Stabilize onboarding select option tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Stabilized the onboarding Select interaction tests by waiting for Base UI's
+  asynchronously exposed popup options before clicking them. Closes #1622.
 - Excluded transient Polyscope preview-stage artifacts from ESLint so local
   linting does not race files created and removed by the preview process.
 - Bounded native stored-snapshot connectivity preflight during auth bootstrap,

--- a/src/ui/onboarding.test.tsx
+++ b/src/ui/onboarding.test.tsx
@@ -206,7 +206,9 @@ describe("onboarding shadcn primitives", () => {
     expect(trigger).toHaveAttribute("aria-required", "true");
 
     await user.click(trigger);
-    await user.click(screen.getByRole("option", { name: "Contractor" }));
+    await user.click(
+      await screen.findByRole("option", { name: "Contractor" })
+    );
 
     expect(handleChange).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -255,7 +257,9 @@ describe("onboarding shadcn primitives", () => {
     );
 
     await user.click(screen.getByRole("combobox", { name: "Contract type" }));
-    await user.click(screen.getByRole("option", { name: "Contractor" }));
+    await user.click(
+      await screen.findByRole("option", { name: "Contractor" })
+    );
 
     expect(handleChange).toHaveBeenCalledTimes(1);
     const syntheticEvent = handleChange.mock.calls[0]?.[0];

--- a/src/ui/onboarding.test.tsx
+++ b/src/ui/onboarding.test.tsx
@@ -206,9 +206,7 @@ describe("onboarding shadcn primitives", () => {
     expect(trigger).toHaveAttribute("aria-required", "true");
 
     await user.click(trigger);
-    await user.click(
-      await screen.findByRole("option", { name: "Contractor" })
-    );
+    await user.click(await screen.findByRole("option", { name: "Contractor" }));
 
     expect(handleChange).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -257,9 +255,7 @@ describe("onboarding shadcn primitives", () => {
     );
 
     await user.click(screen.getByRole("combobox", { name: "Contract type" }));
-    await user.click(
-      await screen.findByRole("option", { name: "Contractor" })
-    );
+    await user.click(await screen.findByRole("option", { name: "Contractor" }));
 
     expect(handleChange).toHaveBeenCalledTimes(1);
     const syntheticEvent = handleChange.mock.calls[0]?.[0];


### PR DESCRIPTION
## Problem

Two onboarding Select interaction tests queried the Base UI popup option synchronously immediately after opening the Select. The focused file usually passed, but under six-process contention the original query failed in 3 of 24 runs because the portal was still closed and hidden when `getByRole()` executed.

This confirms a scheduling-dependent test synchronization problem rather than a deterministic Select component defect.

## Change

- Wait for the accessible `Contractor` option with `findByRole()` in both affected onboarding Select tests before clicking it.
- Document the stabilization in the changelog.
- Leave the production Select implementation unchanged.

Closes #1622.

## Validation

- `npx vitest run src/ui/onboarding.test.tsx --reporter=verbose` — 33 tests passed.
- Post-fix contention reproduction — 24 runs and 48 affected test executions passed.
- `npx eslint src/ui/onboarding.test.tsx --report-unused-disable-directives --max-warnings 0`
- `npm run typecheck`
- `reuse lint`
- `git diff --check`
- Commit hooks: REUSE, Prettier, Markdownlint, and repository hygiene checks passed.

## Readiness

No in-scope dependency or implementation check is unresolved. The pull request remains a draft pending the required final self-review in the pull request view.
