### PR TITLE
fix(deps): resolve nanoid security advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Updated the transitive `nanoid` dependency to 3.3.18, resolving
+  GHSA-2v37-7h3g-55p8.
 - Stabilized the onboarding Select interaction tests by waiting for Base UI's
   asynchronously exposed popup options before clicking them. Closes #1622.
 - Ensured Android runtime discovery waits for destructive logout cleanup

--- a/package-lock.json
+++ b/package-lock.json
@@ -10136,9 +10136,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- Resolves the transitive `nanoid` security advisory in the frontend lockfile.

## Problem and evidence

- `npm audit --json` reported one high-severity vulnerability: GHSA-2v37-7h3g-55p8, affecting `nanoid` versions below 3.3.17.
- The dependency path was `vite` → `postcss` → `nanoid@3.3.16`.

## Change

- Updated the locked `nanoid` package to 3.3.18 within PostCSS's existing version range.
- Documented the remediation in `CHANGELOG.md`.

## Validation

- `npm ci`
- `npm audit --json` — zero vulnerabilities
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `reuse lint`

## Readiness

- No unresolved in-scope dependency changes or checks remain.

Closes #1624
