### PR TITLE
fix(hooks): format TSX before commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         name: prettier
         entry: ./node_modules/.bin/prettier --write
         language: system
-        types_or: [markdown, yaml, json]
+        files: \.(?:md|yml|yaml|json|ts|tsx|js|jsx)$
         exclude: 'package-lock\.json|composer\.lock|yarn\.lock|pnpm-lock\.yaml'
 
   # Markdown linting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Aligned the local Prettier pre-commit matcher with the TypeScript, TSX,
+  JavaScript, JSX, Markdown, YAML, and JSON extensions checked by CI, so
+  unformatted TSX changes are rejected before commit. Closes #1625.
 - Updated the transitive `nanoid` dependency to 3.3.18, resolving
   GHSA-2v37-7h3g-55p8.
 - Stabilized the onboarding Select interaction tests by waiting for Base UI's

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -825,6 +825,33 @@ jobs:
     expect(preCommitConfig).not.toContain("npx --no-install prettier");
   });
 
+  it("formats every source extension checked by the CI Prettier command", () => {
+    const preCommitConfig = readRepoFile(".pre-commit-config.yaml");
+    const packageManifest = JSON.parse(readRepoFile("package.json")) as {
+      scripts: Record<string, string>;
+    };
+    const formatCheckGlob = packageManifest.scripts["format:check"].match(
+      /'\*\*\/\*\.\{(?<extensions>[^}]+)\}'/u
+    );
+    const prettierHook = preCommitConfig.match(
+      /- id: prettier[\s\S]*?^\s{8}files: (.+)$/mu
+    );
+
+    expect(formatCheckGlob?.groups?.extensions).toBeDefined();
+    expect(prettierHook).not.toBeNull();
+
+    const extensions = formatCheckGlob?.groups?.extensions?.split(",") ?? [];
+    const expectedMatcher = String.raw`\.(?:${extensions.join("|")})$`;
+
+    expect(prettierHook?.[1]).toBe(expectedMatcher);
+
+    const matcher = new RegExp(prettierHook?.[1] ?? "");
+
+    for (const extension of extensions) {
+      expect(matcher.test(`src/fixture.${extension}`)).toBe(true);
+    }
+  });
+
   it("installs Node dependencies before verifying local pre-commit hooks", () => {
     const setupPreCommit = readRepoFile("scripts/setup-pre-commit.sh");
 

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -23,6 +23,19 @@ function readRepoFile(relativePath: string): string {
   return readFileSync(path.join(repoRoot, relativePath), "utf8");
 }
 
+function getPrettierFormatExtensions(formatCheck: string): string[] {
+  const formatCheckGlob = formatCheck.match(
+    /(?<quote>['"])\*\*\/\*\.\{(?<extensions>[^}]+)\}\k<quote>/u
+  );
+
+  return (
+    formatCheckGlob?.groups?.extensions
+      ?.split(",")
+      .map((extension) => extension.trim())
+      .filter(Boolean) ?? []
+  );
+}
+
 interface WorkflowUsesReference {
   reference: string;
   reviewComment: string | undefined;
@@ -830,22 +843,35 @@ jobs:
     const packageManifest = JSON.parse(readRepoFile("package.json")) as {
       scripts: Record<string, string>;
     };
-    const formatCheckGlob = packageManifest.scripts["format:check"].match(
-      /'\*\*\/\*\.\{(?<extensions>[^}]+)\}'/u
-    );
-    const prettierHook = preCommitConfig.match(
-      /- id: prettier[\s\S]*?^\s{8}files: (.+)$/mu
-    );
+    const formatCheck = packageManifest.scripts["format:check"];
+    const extensions = getPrettierFormatExtensions(formatCheck);
+    const preCommitDocument = load(preCommitConfig);
+    const repositories =
+      isRecord(preCommitDocument) && Array.isArray(preCommitDocument.repos)
+        ? preCommitDocument.repos.filter(isRecord)
+        : [];
+    const prettierHook = repositories
+      .flatMap((repository) =>
+        Array.isArray(repository.hooks) ? repository.hooks.filter(isRecord) : []
+      )
+      .find((hook) => hook.id === "prettier");
 
-    expect(formatCheckGlob?.groups?.extensions).toBeDefined();
-    expect(prettierHook).not.toBeNull();
+    expect(extensions).not.toHaveLength(0);
+    expect(
+      getPrettierFormatExtensions(formatCheck.replaceAll(",", ", "))
+    ).toEqual(extensions);
+    expect(
+      getPrettierFormatExtensions(formatCheck.replaceAll("'", '"'))
+    ).toEqual(extensions);
+    expect(prettierHook).toBeDefined();
 
-    const extensions = formatCheckGlob?.groups?.extensions?.split(",") ?? [];
     const expectedMatcher = String.raw`\.(?:${extensions.join("|")})$`;
+    const hookMatcher =
+      typeof prettierHook?.files === "string" ? prettierHook.files : "";
 
-    expect(prettierHook?.[1]).toBe(expectedMatcher);
+    expect(hookMatcher).toBe(expectedMatcher);
 
-    const matcher = new RegExp(prettierHook?.[1] ?? "");
+    const matcher = new RegExp(hookMatcher);
 
     for (const extension of extensions) {
       expect(matcher.test(`src/fixture.${extension}`)).toBe(true);


### PR DESCRIPTION
## Summary

- Align the local Prettier pre-commit matcher with the extensions checked by CI.
- Add a regression test that derives the expected matcher from `format:check`.

## Problem and evidence

The local Prettier hook only selected Markdown, YAML, and JSON files, while
`npm run format:check` also checks TypeScript, TSX, JavaScript, and JSX files.
As a result, an unformatted TSX change could pass a local commit and fail the
hosted formatting check. A staged, deliberately unformatted TSX fixture now
causes the local hook to fail because it modifies the file.

## Change

The hook in `.pre-commit-config.yaml` now uses an explicit filename matcher
for the same extensions as `format:check`. The regression test in
`tests/build.test.ts` derives the expected extension list from the CI command,
preventing future drift between the local hook and CI.

## Validation

- `vitest --configLoader=native run tests/build.test.ts --maxWorkers=1 --no-file-parallelism`
- `npm run format:check`
- `pre-commit run prettier --all-files`
- `npm run lint`
- `npm run typecheck`
- `pre-commit run reuse --files .pre-commit-config.yaml CHANGELOG.md tests/build.test.ts`
- Deliberately unformatted staged TSX fixture rejected by `pre-commit run prettier --files`

## Readiness

No in-scope dependencies or unresolved local checks prevent review readiness.

Closes #1625.
