### PR TITLE
docs: record verified frontend publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   canonical image
   `ghcr.io/secpal/frontend@sha256:cdccded2eade53d9300aafff3a2663a779d3d158cfa74f1e9c182e5786285077`,
   including the public package linkage, anonymous digest pull, final discovery
-  snapshot, and independent artifact-attestation verification. Digest
-  consumption remains pending in `SecPal/deployment#3`, and Phase C remains in
-  progress.
+  snapshot, and independent artifact-attestation verification.
+  `SecPal/deployment#6` consumed the verified digest and closed
+  `SecPal/deployment#3`, completing Phase C.
 - Added a production-ready unprivileged frontend container image that serves
   the existing Web/PWA artifact through static Nginx on port 8080, configures
   the API origin at startup through strict `SECPAL_API_URL` validation, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   OCI metadata, `linux/amd64` and `linux/arm64` runtime and Chromium checks,
   per-platform BuildKit SPDX SBOM and SLSA v1 `mode=max` provenance
   verification, and digest-bound GitHub Artifact Attestations. Pull-request CI
-  remains registry read-only, deployment consumption remains pending, and
-  Phase C remains in progress. Frontend image publication is implemented but
-  not yet operationally verified.
+  remains registry read-only. Post-merge publisher run `31247196734` for source
+  commit `b755ca0d0ee5a85eca5ad5688d457241f070b1b4` operationally verified the
+  canonical image
+  `ghcr.io/secpal/frontend@sha256:cdccded2eade53d9300aafff3a2663a779d3d158cfa74f1e9c182e5786285077`,
+  including the public package linkage, anonymous digest pull, final discovery
+  snapshot, and independent artifact-attestation verification. Digest
+  consumption remains pending in `SecPal/deployment#3`, and Phase C remains in
+  progress.
 - Added a production-ready unprivileged frontend container image that serves
   the existing Web/PWA artifact through static Nginx on port 8080, configures
   the API origin at startup through strict `SECPAL_API_URL` validation, and

--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ Frontend image publication is operationally verified. Publisher run
 `b755ca0d0ee5a85eca5ad5688d457241f070b1b4` and verified the canonical image
 `ghcr.io/secpal/frontend@sha256:cdccded2eade53d9300aafff3a2663a779d3d158cfa74f1e9c182e5786285077`.
 The linked public package passed an anonymous digest pull and independent final
-artifact-attestation verification. Digest consumption remains pending in
-`SecPal/deployment#3`, so Phase C remains in progress.
+artifact-attestation verification. `SecPal/deployment#6` consumed the verified
+digest and closed `SecPal/deployment#3`, so Phase C is complete.
 
 ### Customer-Owned Browser Web Push Rollout
 

--- a/README.md
+++ b/README.md
@@ -137,9 +137,13 @@ a static, unprivileged `101:101` reference server without Node.js;
 `SECPAL_API_URL` is supplied only at startup. It does not publish Android or
 iOS artifacts and does not provide TLS or public-edge behavior.
 
-Frontend image publication is implemented but not yet operationally verified.
-Digest consumption in `SecPal/deployment` remains pending in a separate change,
-so Phase C remains in progress.
+Frontend image publication is operationally verified. Publisher run
+`31247196734` built source commit
+`b755ca0d0ee5a85eca5ad5688d457241f070b1b4` and verified the canonical image
+`ghcr.io/secpal/frontend@sha256:cdccded2eade53d9300aafff3a2663a779d3d158cfa74f1e9c182e5786285077`.
+The linked public package passed an anonymous digest pull and independent final
+artifact-attestation verification. Digest consumption remains pending in
+`SecPal/deployment#3`, so Phase C remains in progress.
 
 ### Customer-Owned Browser Web Push Rollout
 

--- a/docs/deployment/frontend-container.md
+++ b/docs/deployment/frontend-container.md
@@ -76,12 +76,26 @@ static reference server without Node.js; deployments supply `SECPAL_API_URL`
 only when the container starts. TLS termination and public-edge controls remain
 deployment responsibilities.
 
-Frontend image publication is implemented but not yet operationally verified.
-After merge, operators must record the successful publisher run and complete
-the package linkage, public-visibility, anonymous digest-pull, final discovery
-snapshot, and final attestation checks. Digest consumption in
-`SecPal/deployment` remains a separate follow-up, so Phase C remains in
-progress.
+Frontend image publication is operationally verified. Post-merge publisher run
+`31247196734` (attempt `1`) built source commit
+`b755ca0d0ee5a85eca5ad5688d457241f070b1b4` and verified this canonical
+artifact:
+
+```text
+ghcr.io/secpal/frontend@sha256:cdccded2eade53d9300aafff3a2663a779d3d158cfa74f1e9c182e5786285077
+```
+
+The run verified the exact OCI index bytes and registry digest header, both
+runtime platforms, per-platform SBOM and provenance, both container and
+Chromium contracts, GitHub Artifact Attestation `39567451`, and the final
+discovery snapshot. The GHCR package is linked to `SecPal/frontend`, is public,
+and accepted a digest-only pull with an empty anonymous Docker configuration.
+An independent final attestation check with the pinned GitHub CLI `2.97.0`
+verified the same subject, digest, repository, workflow, source and signer
+commit, `refs/heads/main`, and GitHub-hosted runner binding.
+
+Digest consumption remains pending in `SecPal/deployment#3`; Phase C remains
+in progress.
 
 ## Run
 

--- a/docs/deployment/frontend-container.md
+++ b/docs/deployment/frontend-container.md
@@ -94,8 +94,9 @@ An independent final attestation check with the pinned GitHub CLI `2.97.0`
 verified the same subject, digest, repository, workflow, source and signer
 commit, `refs/heads/main`, and GitHub-hosted runner binding.
 
-Digest consumption remains pending in `SecPal/deployment#3`; Phase C remains
-in progress.
+`SecPal/deployment#6` consumed the verified digest at merge commit
+`4fc2796409b7c37a541f515ccf29236f143fc132`, closing `SecPal/deployment#3`.
+Phase C is complete.
 
 ## Run
 

--- a/tests/container-publishing-workflow.test.ts
+++ b/tests/container-publishing-workflow.test.ts
@@ -931,7 +931,7 @@ describe("frontend container publishing workflow", () => {
     expect(pullRequestWorkflow).toContain("npm run test:e2e:container");
   });
 
-  it("documents verified digest-only publication without claiming Phase C completion", () => {
+  it("documents verified digest-only publication and completed Phase C rollout", () => {
     const documentation = `${readme}\n${containerGuide}\n${changelog}`;
 
     expect(documentation).toContain("ghcr.io/secpal/frontend");
@@ -959,16 +959,19 @@ describe("frontend container publishing workflow", () => {
       "anonymous digest pull",
       "independent final",
       "SecPal/deployment#3",
+      "SecPal/deployment#6",
     ]) {
       expect(documentation).toContain(evidence);
     }
-    expect(documentation).toContain("Phase C remains in progress");
+    expect(documentation).toContain("Phase C is complete");
+    expect(documentation).not.toContain("Digest consumption remains pending");
+    expect(documentation).not.toContain("Phase C remains in progress");
     expect(containerGuide).toMatch(
       /Platform child manifest digests are runtime\s+verification evidence only/u
     );
     expect(containerGuide).not.toMatch(/\bruntime-\s+verification\b/u);
     expect(documentation).not.toMatch(
-      /Phase C is complete|The frontend is deployed|SecPal is production-ready|Phase D is complete/u
+      /The frontend is deployed|SecPal is production-ready|Phase D is complete/u
     );
   });
 

--- a/tests/container-publishing-workflow.test.ts
+++ b/tests/container-publishing-workflow.test.ts
@@ -931,7 +931,7 @@ describe("frontend container publishing workflow", () => {
     expect(pullRequestWorkflow).toContain("npm run test:e2e:container");
   });
 
-  it("documents digest-only trust without claiming Phase C completion", () => {
+  it("documents verified digest-only publication without claiming Phase C completion", () => {
     const documentation = `${readme}\n${containerGuide}\n${changelog}`;
 
     expect(documentation).toContain("ghcr.io/secpal/frontend");
@@ -947,8 +947,21 @@ describe("frontend container publishing workflow", () => {
       );
     }
     expect(documentation).toContain(
+      "Frontend image publication is operationally verified."
+    );
+    expect(documentation).not.toContain(
       "Frontend image publication is implemented but not yet operationally verified."
     );
+    for (const evidence of [
+      "31247196734",
+      "b755ca0d0ee5a85eca5ad5688d457241f070b1b4",
+      "ghcr.io/secpal/frontend@sha256:cdccded2eade53d9300aafff3a2663a779d3d158cfa74f1e9c182e5786285077",
+      "anonymous digest pull",
+      "independent final",
+      "SecPal/deployment#3",
+    ]) {
+      expect(documentation).toContain(evidence);
+    }
     expect(documentation).toContain("Phase C remains in progress");
     expect(containerGuide).toMatch(
       /Platform child manifest digests are runtime\s+verification evidence only/u


### PR DESCRIPTION
## Summary

- record the completed Phase C.3 post-merge frontend publication audit
- replace the obsolete operational-verification blocker in the container guide, README, and changelog
- record that `SecPal/deployment#6` consumed the verified digest and closed `SecPal/deployment#3`, completing Phase C

## Verified publication

- Publisher run: `31247196734` (attempt `1`)
- Source commit: `b755ca0d0ee5a85eca5ad5688d457241f070b1b4`
- Canonical OCI index digest: `sha256:cdccded2eade53d9300aafff3a2663a779d3d158cfa74f1e9c182e5786285077`
- Canonical image: `ghcr.io/secpal/frontend@sha256:cdccded2eade53d9300aafff3a2663a779d3d158cfa74f1e9c182e5786285077`
- Package linkage/public visibility, anonymous digest pull, final discovery snapshot, and independent artifact attestation: verified

The OCI index digest remains the only trust, deployment, update, and rollback identity. Platform manifest digests remain verification evidence only.

## Validation

- `npm exec -- vitest --configLoader=native run tests/container-publishing-workflow.test.ts` (`72` tests passed)
- `npm run format:check`
- `npm exec -- markdownlint --config .markdownlint.json README.md CHANGELOG.md docs/deployment/frontend-container.md`
- `npm run typecheck`
- `npm run lint`
- `reuse lint`
- `git diff --check`

## Tracking

- Records completion evidence for SecPal/frontend#1591
- Updates SecPal/frontend#1590 while leaving the epic open
- Records `SecPal/deployment#6` consuming the verified digest and closing `SecPal/deployment#3`
