### PR TITLE
Isolate AuthContext vault seeding in filtered tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Isolated AuthContext tests from shared offline-vault state and awaited the
+  complete login handoff before teardown, so filtered runs no longer leave a
+  rejected vault persistence task. Closes #1629.
 - Aligned the local Prettier pre-commit matcher with the TypeScript, TSX,
   JavaScript, JSX, Markdown, YAML, and JSON extensions checked by CI, so
   unformatted TSX changes are rejected before commit. Closes #1625.

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, act, waitFor } from "@testing-library/react";
 import { AuthProvider, BOOTSTRAP_REVALIDATION_TIMEOUT_MS } from "./AuthContext";
 import { useAuth } from "../hooks/useAuth";
@@ -11,6 +11,8 @@ import { isOnline } from "../services/sessionEvents";
 import {
   AUTH_VAULT_STORAGE_KEY,
   clearOfflineVaultSession,
+  clearOfflineVaultTables,
+  clearRecentAuthVaultKeyMaterials,
 } from "../lib/offlineVault";
 import {
   clearBrowserPushClientState,
@@ -98,9 +100,11 @@ async function seedStoredUser(user: Record<string, unknown>) {
 }
 
 describe("AuthContext", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     localStorage.clear();
     clearOfflineVaultSession();
+    clearRecentAuthVaultKeyMaterials();
+    await clearOfflineVaultTables();
     document.cookie = `XSRF-TOKEN=;expires=${new Date(0).toUTCString()};path=/`;
     document.cookie = "XSRF-TOKEN=test-csrf-token;path=/";
     sessionEventHandlers.clear();
@@ -110,8 +114,10 @@ describe("AuthContext", () => {
     vi.mocked(syncOfflineSessionAccess).mockClear();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await clearOfflineVaultTables();
     clearOfflineVaultSession();
+    clearRecentAuthVaultKeyMaterials();
   });
 
   describe("hasPermission", () => {
@@ -508,6 +514,13 @@ describe("AuthContext", () => {
 
         expect(clearSensitiveClientState).toHaveBeenCalledTimes(1);
         expect(cleanupCallOrder).toBeLessThan(setUserCallOrder);
+
+        vi.useRealTimers();
+        await waitFor(() => {
+          expect(screen.getByTestId("userEmail")).toHaveTextContent(
+            "next@secpal.dev"
+          );
+        });
       } finally {
         vi.useRealTimers();
         setUserSpy.mockRestore();


### PR DESCRIPTION
## Summary

- reset the IndexedDB-backed offline-vault tables, active vault session, and recent key material for every `AuthContext` test
- wait for the login handoff to finish persisting the next user before the filtered test can enter teardown
- document the test-isolation fix in `CHANGELOG.md`

Closes #1629.

## Problem and evidence

The filtered login-handoff test completed its ordering assertions while the secure-vault write was still running. Test teardown could then clear the CSRF cookie before persistence settled, leaving a post-test persistence failure. Running the complete file masked the race because later tests restored the shared browser state.

Before this change, the issue's filtered command passed its selected assertion but emitted `Failed to persist stored user data` after the test with a missing CSRF/session-context error. The complete 22-test file passed, matching the reported order-dependent behavior.

## Change

`src/contexts/AuthContext.test.tsx` now owns the persistent and in-memory offline-vault state in asynchronous `beforeEach` and `afterEach` hooks. The login-handoff regression also waits for the next user's visible authenticated state after restoring real timers. `AuthContext` only publishes that state after `persistAuthenticatedUser()` settles, so teardown cannot overtake the vault write.

No production behavior or public contract changes.

## Validation

- exact filtered reproduction: 1 passed, 21 skipped, with no post-test vault persistence failure
- complete `src/contexts/AuthContext.test.tsx`: 22 passed
- `npm run typecheck`
- focused ESLint for `src/contexts/AuthContext.test.tsx`
- Prettier check for the changed files
- `git diff --check`
- commit hooks, including REUSE lint, Prettier, Markdown lint, and repository integrity checks
- signed commit verified locally

The timeout warnings emitted by the login-handoff test are intentional because the test exercises those timeout paths. Pre-existing React `act(...)` warnings are tracked separately in #1630 and do not block this isolated fix.

## Readiness

There is no in-scope dependency or unresolved local validation failure. The final self-review in the PR view found zero issues. This PR remains draft as requested. GitHub-hosted checks have not been used as readiness evidence.
