### PR TITLE
test: await AuthContext bootstrap state

### DIFF
--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -82,6 +82,7 @@ function PermissionTestComponent({ permission }: { permission?: string }) {
       <span data-testid="hasOrgAccess">
         {auth.hasOrganizationalAccess() ? "true" : "false"}
       </span>
+      <span data-testid="isLoading">{String(auth.isLoading)}</span>
     </div>
   );
 }
@@ -156,6 +157,7 @@ describe("AuthContext", () => {
 
       await waitFor(() => {
         expect(screen.getByTestId("hasPermission")).toHaveTextContent("false");
+        expect(screen.getByTestId("isLoading")).toHaveTextContent("false");
       });
     });
 
@@ -194,6 +196,7 @@ describe("AuthContext", () => {
 
       await waitFor(() => {
         expect(screen.getByTestId("hasPermission")).toHaveTextContent("false");
+        expect(screen.getByTestId("isLoading")).toHaveTextContent("false");
       });
     });
 
@@ -212,6 +215,7 @@ describe("AuthContext", () => {
 
       await waitFor(() => {
         expect(screen.getByTestId("hasPermission")).toHaveTextContent("false");
+        expect(screen.getByTestId("isLoading")).toHaveTextContent("false");
       });
     });
 
@@ -354,6 +358,7 @@ describe("AuthContext", () => {
 
       await waitFor(() => {
         expect(screen.getByTestId("hasOrgAccess")).toHaveTextContent("false");
+        expect(screen.getByTestId("isLoading")).toHaveTextContent("false");
       });
     });
 
@@ -372,6 +377,7 @@ describe("AuthContext", () => {
 
       await waitFor(() => {
         expect(screen.getByTestId("hasOrgAccess")).toHaveTextContent("false");
+        expect(screen.getByTestId("isLoading")).toHaveTextContent("false");
       });
     });
 


### PR DESCRIPTION
## Summary

Closes #1630.

## Problem and evidence

Negative permission and organizational-access assertions could pass before the asynchronous `AuthProvider` restore completed. The verbose `AuthContext` test run emitted React `act(...)` warnings in those cases.

## Change

Expose the provider loading state in the test helper and require each affected negative case to wait for bootstrap completion before checking its expected denial.

## Validation

- `npx vitest run src/contexts/AuthContext.test.tsx --reporter=verbose`
- `npm run typecheck`
- `npm run lint`
- Commit hooks: `reuse lint`, formatting, and repository checks

## Readiness

No in-scope dependency or unresolved check prevents readiness. This PR remains a draft because its initial state must be draft.
