### PR TITLE
Emit verifiable application-surface build metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added deterministic `build-metadata.json` artifacts that expose the resolved
+  application surface and build classification for downstream native packaging
+  verification without inspecting optimized JavaScript.
 - Added push-to-`main` publication for the official
   `ghcr.io/secpal/frontend` Web/PWA image with run-specific discovery tags,
   canonical OCI index digests, exact index-byte verification, deterministic

--- a/README.md
+++ b/README.md
@@ -65,6 +65,28 @@ build modes such as `web`, `android`, and `ios` reject mock surfaces before an
 artifact is emitted. Use `android-native` for the Android WebView artifact and
 `web` for browser/PWA deployments.
 
+Every Vite build emits `build-metadata.json` at the artifact root as the stable
+downstream packaging contract. Its deterministic schema contains only the
+resolved application surface, Vite build mode, and whether the mode produces a
+production artifact. For example, `npm run build:android` emits:
+
+```json
+{
+  "schemaVersion": 1,
+  "applicationSurface": "android-native",
+  "buildMode": "android",
+  "production": true
+}
+```
+
+The application selector and this file receive the same value after
+`VITE_APP_SURFACE` has been resolved and validated once. Android and iOS
+packaging must verify `applicationSurface` in this file instead of inferring a
+surface from optimized JavaScript. `buildMode` and `production` distinguish
+preview/mock artifacts from deployable browser and native artifacts. The file
+is immutable build metadata: it contains no secrets, API credentials, runtime
+configuration, timestamps, or host-specific values.
+
 Playwright defaults local HTTP/HTTPS development and CI preview runs to the
 Android route surface so Android-specific shared UI stays covered. Select a
 surface explicitly with `PLAYWRIGHT_APP_SURFACE`:

--- a/src/platform/appSurface.test.ts
+++ b/src/platform/appSurface.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 describe("app surface", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
     vi.resetModules();
   });
 
@@ -23,6 +24,17 @@ describe("app surface", () => {
     expect(surface.isIosNativeSurface).toBe(false);
     expect(surface.isIosSurface).toBe(false);
     expect(surface.isNativeSurface).toBe(false);
+  });
+
+  it("uses the build-resolved surface instead of parsing a decoy runtime value", async () => {
+    vi.stubEnv("VITE_APP_SURFACE", "web");
+    vi.stubGlobal("__SECPAL_RESOLVED_APP_SURFACE__", "android-native");
+
+    const surface = await import("./appSurface");
+
+    expect(surface.appSurface).toBe("android-native");
+    expect(surface.isAndroidNativeSurface).toBe(true);
+    expect(surface.isWebSurface).toBe(false);
   });
 
   it.each([

--- a/src/platform/appSurface.ts
+++ b/src/platform/appSurface.ts
@@ -7,6 +7,10 @@ import {
 } from "./appSurfaceContract";
 
 const resolveRuntimeAppSurface = (): AppSurface => {
+  if (typeof __SECPAL_RESOLVED_APP_SURFACE__ !== "undefined") {
+    return __SECPAL_RESOLVED_APP_SURFACE__;
+  }
+
   const isProductionArtifact =
     import.meta.env.PROD && import.meta.env.MODE !== "preview";
 

--- a/src/platform/appSurfaceContract.test.ts
+++ b/src/platform/appSurfaceContract.test.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 import { describe, expect, it } from "vitest";
-import { getAppSurfaceMode, resolveAppSurface } from "./appSurfaceContract";
+import {
+  createAppSurfaceBuildMetadata,
+  getAppSurfaceMode,
+  resolveAppSurface,
+  serializeAppSurfaceBuildMetadata,
+} from "./appSurfaceContract";
 
 describe("appSurfaceContract", () => {
   it.each([
@@ -46,4 +51,31 @@ describe("appSurfaceContract", () => {
   ] as const)("maps %s to the %s Vite mode family", (surface, expectedMode) => {
     expect(getAppSurfaceMode(surface)).toBe(expectedMode);
   });
+
+  it.each([
+    ["web", "web", true],
+    ["android-native", "android", true],
+    ["ios-native", "ios", true],
+    ["android-mock", "preview", false],
+    ["ios-mock", "preview", false],
+  ] as const)(
+    "creates deterministic metadata for the %s surface in %s mode",
+    (surface, buildMode, production) => {
+      const metadata = createAppSurfaceBuildMetadata(
+        surface,
+        buildMode,
+        production
+      );
+
+      expect(metadata).toEqual({
+        schemaVersion: 1,
+        applicationSurface: surface,
+        buildMode,
+        production,
+      });
+      expect(serializeAppSurfaceBuildMetadata(metadata)).toBe(
+        `{\n  "schemaVersion": 1,\n  "applicationSurface": "${surface}",\n  "buildMode": "${buildMode}",\n  "production": ${production}\n}\n`
+      );
+    }
+  );
 });

--- a/src/platform/appSurfaceContract.ts
+++ b/src/platform/appSurfaceContract.ts
@@ -12,6 +12,13 @@ export const appSurfaces = [
 export type AppSurface = (typeof appSurfaces)[number];
 export type AppSurfaceMode = "web" | "android" | "ios";
 
+export interface AppSurfaceBuildMetadata {
+  readonly schemaVersion: 1;
+  readonly applicationSurface: AppSurface;
+  readonly buildMode: string;
+  readonly production: boolean;
+}
+
 export const isAppSurface = (value: string): value is AppSurface =>
   appSurfaces.includes(value as AppSurface);
 
@@ -46,4 +53,23 @@ export function getAppSurfaceMode(surface: AppSurface): AppSurfaceMode {
   }
 
   return "ios";
+}
+
+export function createAppSurfaceBuildMetadata(
+  applicationSurface: AppSurface,
+  buildMode: string,
+  production: boolean
+): AppSurfaceBuildMetadata {
+  return {
+    schemaVersion: 1,
+    applicationSurface,
+    buildMode,
+    production,
+  };
+}
+
+export function serializeAppSurfaceBuildMetadata(
+  metadata: AppSurfaceBuildMetadata
+): string {
+  return `${JSON.stringify(metadata, null, 2)}\n`;
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,6 +4,8 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-pwa/client" />
 
+declare const __SECPAL_RESOLVED_APP_SURFACE__: import("./platform/appSurfaceContract").AppSurface;
+
 interface ImportMetaEnv {
   readonly VITEST?: boolean;
   readonly VITE_API_URL?: string;

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -347,7 +347,7 @@ describe("Build Configuration and Source Verification", () => {
     });
   });
 
-  it("forwards custom Vite output directories to the build artifact and SBOM", () => {
+  it("forwards custom Vite output directories to the web artifact and SBOM", () => {
     const distRoot = mkdtempSync(path.join(tmpdir(), "secpal-build-output-"));
     const safeEnv = { ...process.env, VITE_APP_SURFACE: "web" };
     delete safeEnv.NODE_V8_COVERAGE;
@@ -355,7 +355,7 @@ describe("Build Configuration and Source Verification", () => {
     try {
       execFileSync(
         "npm",
-        ["run", "build", "--", "--outDir", distRoot, "--base", "/custom/"],
+        ["run", "build:web", "--", "--outDir", distRoot, "--base", "/custom/"],
         {
           cwd: repoRoot,
           stdio: "pipe",
@@ -395,6 +395,16 @@ describe("Build Configuration and Source Verification", () => {
         true
       );
       expect(existsSync(path.join(distRoot, "LICENSES/MIT.txt"))).toBe(true);
+      expect(
+        JSON.parse(
+          readFileSync(path.join(distRoot, "build-metadata.json"), "utf8")
+        )
+      ).toEqual({
+        schemaVersion: 1,
+        applicationSurface: "web",
+        buildMode: "web",
+        production: true,
+      });
       expect(readFileSync(path.join(distRoot, "index.html"), "utf8")).toContain(
         'src="/custom/'
       );
@@ -530,6 +540,16 @@ describe("Build Configuration and Source Verification", () => {
       expect(existsSync(path.join(distRoot, "THIRD-PARTY-NOTICES.md"))).toBe(
         true
       );
+      expect(
+        JSON.parse(
+          readFileSync(path.join(distRoot, "build-metadata.json"), "utf8")
+        )
+      ).toEqual({
+        schemaVersion: 1,
+        applicationSurface: "android-native",
+        buildMode: "android",
+        production: true,
+      });
     } finally {
       rmSync(distRoot, { recursive: true, force: true });
     }
@@ -784,6 +804,9 @@ jobs:
     expect(readme).toContain("npm run build:android:mock");
     expect(readme).toContain("PLAYWRIGHT_APP_SURFACE=android-mock");
     expect(readme).toContain("workspace previews keep the deployed bundle");
+    expect(readme).toContain("build-metadata.json");
+    expect(readme).toContain('"applicationSurface": "android-native"');
+    expect(readme).toContain("downstream packaging");
 
     expect(envExample).toContain("VITE_APP_SURFACE=web");
     expect(envExample).toContain(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,11 +11,11 @@ import { viteStaticCopy } from "vite-plugin-static-copy";
 import { visualizer } from "rollup-plugin-visualizer";
 import path from "path";
 import { fileURLToPath } from "url";
-import type { ProxyOptions } from "vite";
+import type { Plugin, ProxyOptions } from "vite";
 import { resolveLinguiVitePluginExports } from "./linguiVitePluginInterop.ts";
 import { applyInjectManifestCodeSplittingFix } from "./src/lib/pwaInjectManifestBuildConfig.ts";
 import { buildPwaRuntimeCaching } from "./src/lib/pwaRuntimeCaching.ts";
-import { resolveAppSurface } from "./src/platform/appSurfaceContract.ts";
+import * as appSurfaceContract from "./src/platform/appSurfaceContract.ts";
 import { thirdPartyDependencyNotices } from "./thirdPartyDependencyNotices.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -37,6 +37,20 @@ const defaultDevProxyTarget = "http://localhost:8000";
 const metaElementPattern = /[ \t]*<meta\b[^>]*\/?>[ \t]*(?:\r?\n)?/giu;
 const cspHttpEquivAttributePattern =
   /\bhttp-equiv\s*=\s*(?:(["'])Content-Security-Policy\1|Content-Security-Policy(?=[\s/>]))/iu;
+
+function appSurfaceBuildMetadataPlugin(metadataSource: string): Plugin {
+  return {
+    name: "app-surface-build-metadata",
+    apply: "build",
+    generateBundle() {
+      this.emitFile({
+        type: "asset",
+        fileName: "build-metadata.json",
+        source: metadataSource,
+      });
+    },
+  };
+}
 
 export function stripStaticCspForViteDev(html: string): string {
   const staticCspMetaElements = (html.match(metaElementPattern) ?? []).filter(
@@ -142,22 +156,41 @@ function getManualChunk(moduleId: string): string | undefined {
 export default defineConfig(({ mode, command }) => {
   // Load env file based on `mode` in the current working directory.
   const env = loadEnv(mode, process.cwd(), "");
-  resolveAppSurface(
+  const isProductionArtifact = command === "build" && mode !== "preview";
+  const resolvedAppSurface = appSurfaceContract.resolveAppSurface(
     env.VITE_APP_SURFACE,
-    command === "build" && mode !== "preview"
+    isProductionArtifact
   );
+  const appSurfaceBuildMetadata =
+    appSurfaceContract.createAppSurfaceBuildMetadata(
+      resolvedAppSurface,
+      mode,
+      isProductionArtifact
+    );
   const isCi = Boolean(process.env.CI);
   const devServerProxyConfig =
     command === "serve" ? buildDevServerProxyConfig(env.VITE_API_URL) : null;
   return {
-    define: devServerProxyConfig
-      ? {
-          "import.meta.env.VITE_API_URL": JSON.stringify(
-            devServerProxyConfig.clientApiBaseUrl
-          ),
-        }
-      : undefined,
+    define: {
+      ...(command === "build"
+        ? {
+            __SECPAL_RESOLVED_APP_SURFACE__: JSON.stringify(resolvedAppSurface),
+          }
+        : {}),
+      ...(devServerProxyConfig
+        ? {
+            "import.meta.env.VITE_API_URL": JSON.stringify(
+              devServerProxyConfig.clientApiBaseUrl
+            ),
+          }
+        : {}),
+    },
     plugins: [
+      appSurfaceBuildMetadataPlugin(
+        appSurfaceContract.serializeAppSurfaceBuildMetadata(
+          appSurfaceBuildMetadata
+        )
+      ),
       {
         name: "vite-dev-csp-compatibility",
         apply: "serve",


### PR DESCRIPTION
## Problem and evidence

The Android packaging verifier currently infers the active frontend application surface from optimized JavaScript. That approach can accept an unused `android-native` resolver call even when the active application selector still resolves to the Web surface. The existing `VITE_APP_SURFACE` source contract did not expose a deterministic artifact-level value that downstream packaging could verify directly.

Closes #1656.

## Change

- Resolve `VITE_APP_SURFACE` once in the Vite build configuration.
- Inject that resolved value into the active application selector.
- Emit deterministic `build-metadata.json` at the artifact root with the schema version, resolved application surface, build mode, and production classification.
- Keep Web, Android, iOS, mock, and preview artifacts distinguishable without including timestamps, credentials, API configuration, or other mutable runtime values.
- Document the metadata as the downstream native-packaging contract and update the changelog.
- Add focused regression coverage for exact metadata serialization, Web and Android build artifacts, and a decoy runtime surface value.

## Validation

- `npm run test:run -- tests/build.test.ts src/platform/appSurface.test.ts src/platform/appSurfaceContract.test.ts` — 85 tests passed
- `npm run test:run -- tests/vite.config.test.ts` — passed
- `npm run typecheck` — passed
- `npm run lint` — passed
- `npm run format:check` — passed
- `reuse lint` — passed
- `npm run build:web` — passed and emitted `applicationSurface: web`
- `npm run build:android` — passed and emitted `applicationSurface: android-native`
- Commit hooks, including REUSE, Prettier, Markdownlint, and repository hygiene checks — passed

## Dependencies and readiness

This frontend contract must merge before `SecPal/android#508` can replace its optimized-bundle inference with metadata verification. The Android consumer remains intentionally outside this repository and PR.

No in-scope implementation issue or untracked follow-up was found during the local four-pass review. The final self-review in the PR view also found no issue. This PR remains a draft as requested. GitHub-hosted checks have not been evaluated as part of this local publication step.
