### PR TITLE
fix: align governance license expressions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
@@ -61,9 +61,11 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
 
 ## Licensing, REUSE, and Branding
 
-- Use `AGPL-3.0-or-later` for SecPal-owned material intentionally covered by
-  the AGPL. Never add or restore `LicenseRef-SecPal-Attribution` after the
-  licensing rollout.
+- Use `AGPL-3.0-or-later` for SecPal-owned agent-governance material migrated
+  by this licensing rollout. Never add or restore
+  `LicenseRef-SecPal-Attribution` to that material.
+- Application code and tests retain `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`
+  wherever it is declared by `REUSE.toml` or file-level SPDX metadata.
 - Preserve deliberately different licenses, including `CC0-1.0`, `MIT`,
   `Apache-2.0`, third-party and generated-file licenses, and unrelated custom
   license references. Do not rewrite third-party copyright or license metadata.
@@ -193,10 +195,12 @@ This file auto-applies to all files in this repo so strict SecPal governance sta
 - Keep changes repo-local, minimal, and consistent with React, strict TypeScript, and generated API type conventions.
 - Apply the SecPal domain policy and immediate warning and issue triage rules from the repo baseline.
 - Apply the baseline licensing and REUSE rules: plain `AGPL-3.0-or-later` for
-  SecPal-owned AGPL material, deliberately different licenses and third-party
-  metadata preserved, `SecPal Contributors` where the project convention
-  applies, first-publication years retained and extended when required, and
-  relevant license validation after metadata changes.
+  SecPal-owned agent-governance material migrated by this rollout; the declared
+  attribution expression preserved for application code and tests; deliberately
+  different licenses and third-party metadata preserved; `SecPal Contributors`
+  used where the project convention applies; first-publication years retained
+  and extended when required; and relevant license validation run after
+  metadata changes.
 - Preserve `Powered by SecPal – A guard's best friend` on official user-facing
   SecPal surfaces where intentionally present. Licensing work must not weaken
   or make this branding optional, add `Based on SecPal` guidance, or introduce

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2026 SecPal Contributors
-SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
 # SecPal/frontend Copilot Instructions
@@ -58,6 +58,27 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
   branch, prune remotes, refresh Node dependencies with `npm ci` where
   applicable, run `npm run build` when available, and confirm the working tree
   is clean.
+
+## Licensing, REUSE, and Branding
+
+- Use `AGPL-3.0-or-later` for SecPal-owned material intentionally covered by
+  the AGPL. Never add or restore `LicenseRef-SecPal-Attribution` after the
+  licensing rollout.
+- Preserve deliberately different licenses, including `CC0-1.0`, `MIT`,
+  `Apache-2.0`, third-party and generated-file licenses, and unrelated custom
+  license references. Do not rewrite third-party copyright or license metadata.
+- Use `SecPal Contributors` where the project copyright convention applies.
+  Preserve each file's first-publication year and extend its year range through
+  the current year when an edited file requires a copyright-year update.
+- Run the relevant REUSE or license validation after changing copyright or
+  license metadata.
+- On user-facing official SecPal product surfaces, preserve
+  `Powered by SecPal – A guard's best friend` where it is intentionally present.
+  A licensing change must not remove, weaken, parameterize, genericize, or make
+  that SecPal branding optional.
+- Do not add fork-oriented `Based on SecPal` guidance to AI instructions, and
+  do not introduce white-label or fork-branding configuration as part of a
+  licensing change.
 
 ## Design Principles
 
@@ -171,6 +192,15 @@ This file auto-applies to all files in this repo so strict SecPal governance sta
   attribution unless the task explicitly requires documenting AI tooling.
 - Keep changes repo-local, minimal, and consistent with React, strict TypeScript, and generated API type conventions.
 - Apply the SecPal domain policy and immediate warning and issue triage rules from the repo baseline.
+- Apply the baseline licensing and REUSE rules: plain `AGPL-3.0-or-later` for
+  SecPal-owned AGPL material, deliberately different licenses and third-party
+  metadata preserved, `SecPal Contributors` where the project convention
+  applies, first-publication years retained and extended when required, and
+  relevant license validation after metadata changes.
+- Preserve `Powered by SecPal – A guard's best friend` on official user-facing
+  SecPal surfaces where intentionally present. Licensing work must not weaken
+  or make this branding optional, add `Based on SecPal` guidance, or introduce
+  white-label or fork-branding configuration.
 
 ## Additional Rules: react-typescript.instructions.md
 

--- a/.github/instructions/github-workflows.instructions.md
+++ b/.github/instructions/github-workflows.instructions.md
@@ -1,6 +1,6 @@
 ---
 # SPDX-FileCopyrightText: 2026 SecPal Contributors
-# SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+# SPDX-License-Identifier: AGPL-3.0-or-later
 name: GitHub Workflow Rules
 description: Applies workflow and Dependabot rules to GitHub automation files in this repo.
 applyTo: ".github/workflows/**/*.yml,.github/workflows/**/*.yaml,.github/dependabot.yml,.github/dependabot.yaml"

--- a/.github/instructions/org-shared.instructions.md
+++ b/.github/instructions/org-shared.instructions.md
@@ -24,10 +24,12 @@ This file auto-applies to all files in this repo so strict SecPal governance sta
 - Keep changes repo-local, minimal, and consistent with React, strict TypeScript, and generated API type conventions.
 - Apply the SecPal domain policy and immediate warning and issue triage rules from the repo baseline.
 - Apply the baseline licensing and REUSE rules: plain `AGPL-3.0-or-later` for
-  SecPal-owned AGPL material, deliberately different licenses and third-party
-  metadata preserved, `SecPal Contributors` where the project convention
-  applies, first-publication years retained and extended when required, and
-  relevant license validation after metadata changes.
+  SecPal-owned agent-governance material migrated by this rollout. Application
+  code and tests retain `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`
+  where declared. Preserve deliberately different licenses and third-party
+  metadata, use `SecPal Contributors` where the project convention applies,
+  retain and extend first-publication years when required, and run relevant
+  license validation after metadata changes.
 - Preserve `Powered by SecPal – A guard's best friend` on official user-facing
   SecPal surfaces where intentionally present. Licensing work must not weaken
   or make this branding optional, add `Based on SecPal` guidance, or introduce

--- a/.github/instructions/org-shared.instructions.md
+++ b/.github/instructions/org-shared.instructions.md
@@ -1,6 +1,6 @@
 ---
 # SPDX-FileCopyrightText: 2026 SecPal Contributors
-# SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+# SPDX-License-Identifier: AGPL-3.0-or-later
 name: Frontend Runtime Overlay
 description: Reinforces strict SecPal governance for all files in this repo.
 applyTo: "**"
@@ -23,3 +23,12 @@ This file auto-applies to all files in this repo so strict SecPal governance sta
   attribution unless the task explicitly requires documenting AI tooling.
 - Keep changes repo-local, minimal, and consistent with React, strict TypeScript, and generated API type conventions.
 - Apply the SecPal domain policy and immediate warning and issue triage rules from the repo baseline.
+- Apply the baseline licensing and REUSE rules: plain `AGPL-3.0-or-later` for
+  SecPal-owned AGPL material, deliberately different licenses and third-party
+  metadata preserved, `SecPal Contributors` where the project convention
+  applies, first-publication years retained and extended when required, and
+  relevant license validation after metadata changes.
+- Preserve `Powered by SecPal – A guard's best friend` on official user-facing
+  SecPal surfaces where intentionally present. Licensing work must not weaken
+  or make this branding optional, add `Based on SecPal` guidance, or introduce
+  white-label or fork-branding configuration.

--- a/.github/instructions/react-typescript.instructions.md
+++ b/.github/instructions/react-typescript.instructions.md
@@ -1,6 +1,6 @@
 ---
 # SPDX-FileCopyrightText: 2026 SecPal Contributors
-# SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+# SPDX-License-Identifier: AGPL-3.0-or-later
 name: React TypeScript Rules
 description: Applies React and strict TypeScript rules to frontend source files.
 applyTo: "src/**/*.ts,src/**/*.tsx,tests/**/*.ts,tests/**/*.tsx,vite.config.ts"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2026 SecPal Contributors
-SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
 # SecPal/frontend Agent Instructions
@@ -55,6 +55,27 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
   branch, prune remotes, refresh Node dependencies with `npm ci` where
   applicable, run `npm run build` when available, and confirm the working tree
   is clean.
+
+## Licensing, REUSE, and Branding
+
+- Use `AGPL-3.0-or-later` for SecPal-owned material intentionally covered by
+  the AGPL. Never add or restore `LicenseRef-SecPal-Attribution` after the
+  licensing rollout.
+- Preserve deliberately different licenses, including `CC0-1.0`, `MIT`,
+  `Apache-2.0`, third-party and generated-file licenses, and unrelated custom
+  license references. Do not rewrite third-party copyright or license metadata.
+- Use `SecPal Contributors` where the project copyright convention applies.
+  Preserve each file's first-publication year and extend its year range through
+  the current year when an edited file requires a copyright-year update.
+- Run the relevant REUSE or license validation after changing copyright or
+  license metadata.
+- On user-facing official SecPal product surfaces, preserve
+  `Powered by SecPal – A guard's best friend` where it is intentionally present.
+  A licensing change must not remove, weaken, parameterize, genericize, or make
+  that SecPal branding optional.
+- Do not add fork-oriented `Based on SecPal` guidance to AI instructions, and
+  do not introduce white-label or fork-branding configuration as part of a
+  licensing change.
 
 ## Design Principles
 
@@ -168,6 +189,15 @@ This file auto-applies to all files in this repo so strict SecPal governance sta
   attribution unless the task explicitly requires documenting AI tooling.
 - Keep changes repo-local, minimal, and consistent with React, strict TypeScript, and generated API type conventions.
 - Apply the SecPal domain policy and immediate warning and issue triage rules from the repo baseline.
+- Apply the baseline licensing and REUSE rules: plain `AGPL-3.0-or-later` for
+  SecPal-owned AGPL material, deliberately different licenses and third-party
+  metadata preserved, `SecPal Contributors` where the project convention
+  applies, first-publication years retained and extended when required, and
+  relevant license validation after metadata changes.
+- Preserve `Powered by SecPal – A guard's best friend` on official user-facing
+  SecPal surfaces where intentionally present. Licensing work must not weaken
+  or make this branding optional, add `Based on SecPal` guidance, or introduce
+  white-label or fork-branding configuration.
 
 ## Additional Rules: react-typescript.instructions.md
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,9 +58,11 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
 
 ## Licensing, REUSE, and Branding
 
-- Use `AGPL-3.0-or-later` for SecPal-owned material intentionally covered by
-  the AGPL. Never add or restore `LicenseRef-SecPal-Attribution` after the
-  licensing rollout.
+- Use `AGPL-3.0-or-later` for SecPal-owned agent-governance material migrated
+  by this licensing rollout. Never add or restore
+  `LicenseRef-SecPal-Attribution` to that material.
+- Application code and tests retain `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`
+  wherever it is declared by `REUSE.toml` or file-level SPDX metadata.
 - Preserve deliberately different licenses, including `CC0-1.0`, `MIT`,
   `Apache-2.0`, third-party and generated-file licenses, and unrelated custom
   license references. Do not rewrite third-party copyright or license metadata.
@@ -190,10 +192,12 @@ This file auto-applies to all files in this repo so strict SecPal governance sta
 - Keep changes repo-local, minimal, and consistent with React, strict TypeScript, and generated API type conventions.
 - Apply the SecPal domain policy and immediate warning and issue triage rules from the repo baseline.
 - Apply the baseline licensing and REUSE rules: plain `AGPL-3.0-or-later` for
-  SecPal-owned AGPL material, deliberately different licenses and third-party
-  metadata preserved, `SecPal Contributors` where the project convention
-  applies, first-publication years retained and extended when required, and
-  relevant license validation after metadata changes.
+  SecPal-owned agent-governance material migrated by this rollout; the declared
+  attribution expression preserved for application code and tests; deliberately
+  different licenses and third-party metadata preserved; `SecPal Contributors`
+  used where the project convention applies; first-publication years retained
+  and extended when required; and relevant license validation run after
+  metadata changes.
 - Preserve `Powered by SecPal – A guard's best friend` on official user-facing
   SecPal surfaces where intentionally present. Licensing work must not weaken
   or make this branding optional, add `Based on SecPal` guidance, or introduce

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 SPDX-License-Identifier: CC0-1.0
 -->
 
@@ -89,8 +89,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Corrected the SPDX expressions for frontend agent-governance files to use
-  plain AGPL-3.0-or-later, while retaining the attribution expression for the
-  repository configurations that intentionally require it.
+  plain AGPL-3.0-or-later, while retaining the attribution expression where
+  repository policy declares it for application code, tests, and selected
+  configurations; the guardrail now also preserves first-publication years.
 
 - Bound employee establishment-name lookup fan-out so Android pages remain
   within the native authenticated-request admission limit, surface lookup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Corrected the SPDX expressions for frontend agent-governance files to use
+  plain AGPL-3.0-or-later, while retaining the attribution expression for the
+  repository configurations that intentionally require it.
+
 - Bound employee establishment-name lookup fan-out so Android pages remain
   within the native authenticated-request admission limit, surface lookup
   failures without exposing raw domain identifiers, and attach a stable

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -828,10 +828,20 @@ jobs:
     expect(deploymentDoc).not.toContain("customer.example");
   });
 
-  it("keeps SecPal-owned governance files on the attribution license expression", () => {
+  it("keeps SecPal-owned governance files on their intended license expressions", () => {
+    for (const relativePath of [".pre-commit-config.yaml", ".yamllint.yml"]) {
+      const fileContents = readRepoFile(relativePath);
+
+      expect(fileContents).toContain("SecPal Contributors");
+      expect(fileContents).toContain(
+        [
+          "SPDX-License-Identifier",
+          "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution",
+        ].join(": ")
+      );
+    }
+
     for (const relativePath of [
-      ".pre-commit-config.yaml",
-      ".yamllint.yml",
       ".github/copilot-instructions.md",
       ".github/instructions/org-shared.instructions.md",
       ".github/instructions/react-typescript.instructions.md",
@@ -841,6 +851,9 @@ jobs:
 
       expect(fileContents).toContain("SecPal Contributors");
       expect(fileContents).toContain(
+        ["SPDX-License-Identifier", "AGPL-3.0-or-later"].join(": ")
+      );
+      expect(fileContents).not.toContain(
         [
           "SPDX-License-Identifier",
           "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution",

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -829,10 +829,21 @@ jobs:
   });
 
   it("keeps SecPal-owned governance files on their intended license expressions", () => {
+    const changelog = readRepoFile("CHANGELOG.md");
+
+    expect(changelog).toContain(
+      "SPDX-FileCopyrightText: 2025-2026 SecPal Contributors"
+    );
+    expect(changelog).toContain(
+      ["SPDX-License-Identifier", "CC0-1.0"].join(": ")
+    );
+
     for (const relativePath of [".pre-commit-config.yaml", ".yamllint.yml"]) {
       const fileContents = readRepoFile(relativePath);
 
-      expect(fileContents).toContain("SecPal Contributors");
+      expect(fileContents).toContain(
+        "SPDX-FileCopyrightText: 2025-2026 SecPal Contributors"
+      );
       expect(fileContents).toContain(
         [
           "SPDX-License-Identifier",
@@ -841,15 +852,18 @@ jobs:
       );
     }
 
-    for (const relativePath of [
-      ".github/copilot-instructions.md",
-      ".github/instructions/org-shared.instructions.md",
-      ".github/instructions/react-typescript.instructions.md",
-      ".github/instructions/github-workflows.instructions.md",
-    ]) {
+    for (const [relativePath, copyrightYears] of [
+      ["AGENTS.md", "2026"],
+      [".github/copilot-instructions.md", "2025-2026"],
+      [".github/instructions/org-shared.instructions.md", "2026"],
+      [".github/instructions/react-typescript.instructions.md", "2026"],
+      [".github/instructions/github-workflows.instructions.md", "2026"],
+    ] as const) {
       const fileContents = readRepoFile(relativePath);
 
-      expect(fileContents).toContain("SecPal Contributors");
+      expect(fileContents).toContain(
+        `SPDX-FileCopyrightText: ${copyrightYears} SecPal Contributors`
+      );
       expect(fileContents).toContain(
         ["SPDX-License-Identifier", "AGPL-3.0-or-later"].join(": ")
       );
@@ -858,6 +872,19 @@ jobs:
           "SPDX-License-Identifier",
           "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution",
         ].join(": ")
+      );
+    }
+
+    for (const relativePath of [
+      "AGENTS.md",
+      ".github/copilot-instructions.md",
+      ".github/instructions/org-shared.instructions.md",
+    ]) {
+      const fileContents = readRepoFile(relativePath);
+
+      expect(fileContents).toContain("SecPal-owned agent-governance material");
+      expect(fileContents).toMatch(
+        /Application\s+code and tests retain `AGPL-3\.0-or-later AND LicenseRef-SecPal-Attribution`/
       );
     }
   });


### PR DESCRIPTION
## Problem and evidence

Frontend governance files used the retired attribution SPDX expression even though the repository policy requires plain AGPL-3.0-or-later for those files. The focused regression test grouped those files with configuration files that intentionally retain the attribution expression, so it could not enforce the required distinction.

## Change

- Use plain AGPL-3.0-or-later for frontend governance files and their mirrored instruction content.
- Preserve the attribution expression in the repository configurations that intentionally require it.
- Split the regression coverage by intended license expression.
- Record the correction in the changelog.

## Validation

- `npm test -- tests/build.test.ts`
- `npm run lint`
- `npm run typecheck`
- `reuse lint`
- `npm run format:check`
- `git diff --check`
- Local pre-commit hooks

## Readiness

No in-scope dependency or unresolved local check prevents review. This remains a draft PR as required by repository process; the final PR-view self-review is still required before it can be marked ready.