### PR TITLE
fix: clarify post-rollout license policy

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -61,11 +61,9 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
 
 ## Licensing, REUSE, and Branding
 
-- Use `AGPL-3.0-or-later` for SecPal-owned agent-governance material migrated
-  by this licensing rollout. Never add or restore
-  `LicenseRef-SecPal-Attribution` to that material.
-- Application code and tests retain `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`
-  wherever it is declared by `REUSE.toml` or file-level SPDX metadata.
+- Use `AGPL-3.0-or-later` for SecPal-owned material intentionally covered by
+  the AGPL. Never add or restore `LicenseRef-SecPal-Attribution` after the
+  licensing rollout.
 - Preserve deliberately different licenses, including `CC0-1.0`, `MIT`,
   `Apache-2.0`, third-party and generated-file licenses, and unrelated custom
   license references. Do not rewrite third-party copyright or license metadata.
@@ -194,13 +192,13 @@ This file auto-applies to all files in this repo so strict SecPal governance sta
   attribution unless the task explicitly requires documenting AI tooling.
 - Keep changes repo-local, minimal, and consistent with React, strict TypeScript, and generated API type conventions.
 - Apply the SecPal domain policy and immediate warning and issue triage rules from the repo baseline.
-- Apply the baseline licensing and REUSE rules: plain `AGPL-3.0-or-later` for
-  SecPal-owned agent-governance material migrated by this rollout; the declared
-  attribution expression preserved for application code and tests; deliberately
-  different licenses and third-party metadata preserved; `SecPal Contributors`
-  used where the project convention applies; first-publication years retained
-  and extended when required; and relevant license validation run after
-  metadata changes.
+- Apply the baseline licensing and REUSE rules. Use `AGPL-3.0-or-later` for
+  SecPal-owned material intentionally covered by the AGPL. Never add or restore
+  `LicenseRef-SecPal-Attribution` after the licensing rollout. Preserve
+  deliberately different licenses and third-party metadata, use
+  `SecPal Contributors` where the project convention applies, retain and extend
+  first-publication years when required, and run relevant license validation
+  after metadata changes.
 - Preserve `Powered by SecPal – A guard's best friend` on official user-facing
   SecPal surfaces where intentionally present. Licensing work must not weaken
   or make this branding optional, add `Based on SecPal` guidance, or introduce

--- a/.github/instructions/org-shared.instructions.md
+++ b/.github/instructions/org-shared.instructions.md
@@ -23,13 +23,13 @@ This file auto-applies to all files in this repo so strict SecPal governance sta
   attribution unless the task explicitly requires documenting AI tooling.
 - Keep changes repo-local, minimal, and consistent with React, strict TypeScript, and generated API type conventions.
 - Apply the SecPal domain policy and immediate warning and issue triage rules from the repo baseline.
-- Apply the baseline licensing and REUSE rules: plain `AGPL-3.0-or-later` for
-  SecPal-owned agent-governance material migrated by this rollout. Application
-  code and tests retain `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`
-  where declared. Preserve deliberately different licenses and third-party
-  metadata, use `SecPal Contributors` where the project convention applies,
-  retain and extend first-publication years when required, and run relevant
-  license validation after metadata changes.
+- Apply the baseline licensing and REUSE rules. Use `AGPL-3.0-or-later` for
+  SecPal-owned material intentionally covered by the AGPL. Never add or restore
+  `LicenseRef-SecPal-Attribution` after the licensing rollout. Preserve
+  deliberately different licenses and third-party metadata, use
+  `SecPal Contributors` where the project convention applies, retain and extend
+  first-publication years when required, and run relevant license validation
+  after metadata changes.
 - Preserve `Powered by SecPal – A guard's best friend` on official user-facing
   SecPal surfaces where intentionally present. Licensing work must not weaken
   or make this branding optional, add `Based on SecPal` guidance, or introduce

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,11 +58,9 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
 
 ## Licensing, REUSE, and Branding
 
-- Use `AGPL-3.0-or-later` for SecPal-owned agent-governance material migrated
-  by this licensing rollout. Never add or restore
-  `LicenseRef-SecPal-Attribution` to that material.
-- Application code and tests retain `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`
-  wherever it is declared by `REUSE.toml` or file-level SPDX metadata.
+- Use `AGPL-3.0-or-later` for SecPal-owned material intentionally covered by
+  the AGPL. Never add or restore `LicenseRef-SecPal-Attribution` after the
+  licensing rollout.
 - Preserve deliberately different licenses, including `CC0-1.0`, `MIT`,
   `Apache-2.0`, third-party and generated-file licenses, and unrelated custom
   license references. Do not rewrite third-party copyright or license metadata.
@@ -191,13 +189,13 @@ This file auto-applies to all files in this repo so strict SecPal governance sta
   attribution unless the task explicitly requires documenting AI tooling.
 - Keep changes repo-local, minimal, and consistent with React, strict TypeScript, and generated API type conventions.
 - Apply the SecPal domain policy and immediate warning and issue triage rules from the repo baseline.
-- Apply the baseline licensing and REUSE rules: plain `AGPL-3.0-or-later` for
-  SecPal-owned agent-governance material migrated by this rollout; the declared
-  attribution expression preserved for application code and tests; deliberately
-  different licenses and third-party metadata preserved; `SecPal Contributors`
-  used where the project convention applies; first-publication years retained
-  and extended when required; and relevant license validation run after
-  metadata changes.
+- Apply the baseline licensing and REUSE rules. Use `AGPL-3.0-or-later` for
+  SecPal-owned material intentionally covered by the AGPL. Never add or restore
+  `LicenseRef-SecPal-Attribution` after the licensing rollout. Preserve
+  deliberately different licenses and third-party metadata, use
+  `SecPal Contributors` where the project convention applies, retain and extend
+  first-publication years when required, and run relevant license validation
+  after metadata changes.
 - Preserve `Powered by SecPal – A guard's best friend` on official user-facing
   SecPal surfaces where intentionally present. Licensing work must not weaken
   or make this branding optional, add `Based on SecPal` guidance, or introduce

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,9 +90,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Corrected the SPDX expressions for frontend agent-governance files to use
   plain AGPL-3.0-or-later, made the project-wide prohibition against adding or
-  restoring the obsolete SecPal attribution expression explicit, and preserved
-  first-publication-year and branding safeguards without migrating product or
-  source-file metadata.
+  restoring the obsolete SecPal attribution expression explicit, aligned REUSE
+  defaults for future SecPal-owned source, public, and test files, and preserved
+  existing declarations plus first-publication-year and branding safeguards.
 
 - Bound employee establishment-name lookup fan-out so Android pages remain
   within the native authenticated-request admission limit, surface lookup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,9 +89,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Corrected the SPDX expressions for frontend agent-governance files to use
-  plain AGPL-3.0-or-later, while retaining the attribution expression where
-  repository policy declares it for application code, tests, and selected
-  configurations; the guardrail now also preserves first-publication years.
+  plain AGPL-3.0-or-later, made the project-wide prohibition against adding or
+  restoring the obsolete SecPal attribution expression explicit, and preserved
+  first-publication-year and branding safeguards without migrating product or
+  source-file metadata.
 
 - Bound employee establishment-name lookup fan-out so Android pages remain
   within the native authenticated-request admission limit, surface lookup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   plain AGPL-3.0-or-later, made the project-wide prohibition against adding or
   restoring the obsolete SecPal attribution expression explicit, aligned REUSE
   defaults for future SecPal-owned source, public, and test files, and preserved
-  existing declarations plus first-publication-year and branding safeguards.
+  existing asset declarations with explicit override precedence plus
+  first-publication-year and branding safeguards.
 
 - Bound employee establishment-name lookup fan-out so Android pages remain
   within the native authenticated-request admission limit, surface lookup

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -395,56 +395,54 @@ All files must include SPDX license headers. **SecPal uses different licenses de
 
 ### License Selection Guide
 
-| File Type            | License                                               | Use For                                         |
-| -------------------- | ----------------------------------------------------- | ----------------------------------------------- |
-| **Application Code** | `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution` | PHP, TypeScript, JavaScript, React components   |
-| **Configuration**    | `CC0-1.0`                                             | YAML, JSON, TOML, `.gitignore`, `.editorconfig` |
-| **Helper Scripts**   | `MIT`                                                 | Standalone bash/shell scripts, build utilities  |
-| **Documentation**    | `CC0-1.0`                                             | Markdown files (except LICENSE itself)          |
+| File Type            | License             | Use For                                         |
+| -------------------- | ------------------- | ----------------------------------------------- |
+| **Application Code** | `AGPL-3.0-or-later` | PHP, TypeScript, JavaScript, React components   |
+| **Configuration**    | `CC0-1.0`           | YAML, JSON, TOML, `.gitignore`, `.editorconfig` |
+| **Helper Scripts**   | `MIT`               | Standalone bash/shell scripts, build utilities  |
+| **Documentation**    | `CC0-1.0`           | Markdown files (except LICENSE itself)          |
 
 ### SPDX Header Examples
 
-**For application code (AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution):**
+<!-- REUSE-IgnoreStart -->
+
+**For application code (AGPL-3.0-or-later):**
 
 ```php
 <?php
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
 ```
 
 ```javascript
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
 ```
 
 ```typescript
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
 ```
 
 **For configuration files (CC0-1.0):**
 
 ```yaml
-# SPDX-FileCopyrightText: 2025 SecPal Contributors
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
 # SPDX-License-Identifier: CC0-1.0
 ```
 
-<!-- REUSE-IgnoreStart -->
-
 ```json
 {
-  "_comment": "SPDX-FileCopyrightText: 2025 SecPal Contributors",
+  "_comment": "SPDX-FileCopyrightText: 2026 SecPal Contributors",
   "_license": "SPDX-License-Identifier: CC0-1.0"
 }
 ```
-
-<!-- REUSE-IgnoreEnd -->
 
 **For helper scripts (MIT):**
 
 ```bash
 #!/bin/bash
-# SPDX-FileCopyrightText: 2025 SecPal Contributors
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
 # SPDX-License-Identifier: MIT
 ```
 
@@ -452,10 +450,12 @@ All files must include SPDX license headers. **SecPal uses different licenses de
 
 ```markdown
 <!--
-SPDX-FileCopyrightText: 2025 SecPal Contributors
+SPDX-FileCopyrightText: 2026 SecPal Contributors
 SPDX-License-Identifier: CC0-1.0
 -->
 ```
+
+<!-- REUSE-IgnoreEnd -->
 
 ### Verification
 
@@ -466,7 +466,7 @@ Run `reuse lint` before committing to verify compliance:
 reuse lint
 
 # Add headers to new files automatically
-reuse annotate --license "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution" --copyright "SecPal Contributors" path/to/file.php
+reuse annotate --license "AGPL-3.0-or-later" --copyright "SecPal Contributors" path/to/file.php
 ```
 
 ### Bulk Licensing with REUSE.toml
@@ -484,7 +484,7 @@ version = 1
 [[annotations]]
 path = "assets/images/**"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2025 SecPal Contributors"
+SPDX-FileCopyrightText = "2026 SecPal Contributors"
 SPDX-License-Identifier = "CC0-1.0"
 
 # Example: Override licensing for vendor/third-party code
@@ -511,7 +511,7 @@ SPDX-License-Identifier = "SEE-LICENSE-IN-PACKAGE"
 - Use **"SecPal"** for organizational documentation (e.g., `README.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`), workflow files (e.g., `.github/workflows/*.yml`), and configuration files in the root directory (e.g., `.eslintrc.yml`, `.prettierrc`, `package.json`, `composer.json`, etc.).
 - If a configuration file is specific to a code module or contains logic contributed by individuals, use **"SecPal Contributors"**.
 - For ambiguous cases, prefer **"SecPal Contributors"** if the file is likely to be edited by multiple people over time.
-- Use the **current year** in the copyright date (e.g., 2025 for files created in 2025).
+- Use the **current year** in the copyright date (e.g., 2026 for files created in 2026).
 
 Run `reuse lint` to check compliance.
 
@@ -574,6 +574,6 @@ If you have questions or need help:
 
 ## License
 
-By contributing to SecPal, you agree that your contributions will be licensed under [AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution](https://spdx.org/licenses/AGPL-3.0-or-later.html), including the additional SecPal attribution terms in [LICENSES/LicenseRef-SecPal-Attribution.txt](LICENSES/LicenseRef-SecPal-Attribution.txt).
+By contributing to SecPal, you agree that your contributions will be licensed under [AGPL-3.0-or-later](https://spdx.org/licenses/AGPL-3.0-or-later.html).
 
 Thank you for contributing to SecPal! 🎉

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -6,14 +6,42 @@ SPDX-FileCopyrightText = "SecPal Contributors"
 
 [[annotations]]
 path = "src/**"
-SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
+SPDX-License-Identifier = "AGPL-3.0-or-later"
 
 [[annotations]]
 path = "public/**"
-SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
+SPDX-License-Identifier = "AGPL-3.0-or-later"
 
 [[annotations]]
-path = ["public/logo-*.png", "public/logo-*.svg", "public/favicon-*.png", "public/favicon-*.ico", "public/pwa-*.png", "public/apple-touch-icon*.png", "public/mask-icon.svg"]
+path = [
+  "public/apple-touch-icon.png",
+  "public/favicon-16x16.png",
+  "public/favicon-32x32.png",
+  "public/favicon-dark.ico",
+  "public/favicon-light.ico",
+  "public/logo-dark-128.png",
+  "public/logo-dark-16.png",
+  "public/logo-dark-256.png",
+  "public/logo-dark-32.png",
+  "public/logo-dark-48.png",
+  "public/logo-dark-512.png",
+  "public/logo-dark-64.png",
+  "public/logo-dark.svg",
+  "public/logo-light-128.png",
+  "public/logo-light-16.png",
+  "public/logo-light-256.png",
+  "public/logo-light-32.png",
+  "public/logo-light-48.png",
+  "public/logo-light-512.png",
+  "public/logo-light-64.png",
+  "public/logo-light.svg",
+  "public/logo-source.png",
+  "public/mask-icon.svg",
+  "public/pwa-192x192-maskable.png",
+  "public/pwa-192x192.png",
+  "public/pwa-512x512-maskable.png",
+  "public/pwa-512x512.png",
+]
 SPDX-FileCopyrightText = "2025-2026 SecPal Contributors"
 SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
 
@@ -78,7 +106,7 @@ SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
 path = "tests/**"
-SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
+SPDX-License-Identifier = "AGPL-3.0-or-later"
 
 [[annotations]]
 path = [

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -42,6 +42,7 @@ path = [
   "public/pwa-512x512-maskable.png",
   "public/pwa-512x512.png",
 ]
+precedence = "override"
 SPDX-FileCopyrightText = "2025-2026 SecPal Contributors"
 SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
 

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -889,10 +889,59 @@ jobs:
       expect(normalizedFileContents).toContain(
         "Never add or restore `LicenseRef-SecPal-Attribution` after the licensing rollout."
       );
-      expect(fileContents).not.toContain(
+      expect(normalizedFileContents).not.toContain(
         "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
       );
     }
+
+    const reuseConfig = readRepoFile("REUSE.toml");
+    const reuseAnnotations = reuseConfig.split("[[annotations]]").slice(1);
+
+    for (const pathPattern of ["src/**", "public/**", "tests/**"]) {
+      expect(reuseConfig).toContain(
+        [
+          `path = "${pathPattern}"`,
+          'SPDX-License-Identifier = "AGPL-3.0-or-later"',
+        ].join("\n")
+      );
+    }
+
+    expect(
+      reuseAnnotations.filter(
+        (annotation) =>
+          annotation.includes("LicenseRef-SecPal-Attribution") &&
+          annotation.includes("*")
+      )
+    ).toEqual([]);
+
+    const contributingGuide = readRepoFile("CONTRIBUTING.md");
+
+    expect(contributingGuide).toContain(
+      "| **Application Code** | `AGPL-3.0-or-later`"
+    );
+    expect(contributingGuide).toContain(
+      'reuse annotate --license "AGPL-3.0-or-later"'
+    );
+    expect(contributingGuide).not.toContain(
+      'reuse annotate --license "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"'
+    );
+    expect(contributingGuide).not.toContain(
+      "your contributions will be licensed under [AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution]"
+    );
+
+    const spdxExamples = contributingGuide.slice(
+      contributingGuide.indexOf("### SPDX Header Examples"),
+      contributingGuide.indexOf("### Verification")
+    );
+
+    expect(spdxExamples.match(/REUSE-IgnoreStart/gu)).toHaveLength(1);
+    expect(spdxExamples.match(/REUSE-IgnoreEnd/gu)).toHaveLength(1);
+    expect(spdxExamples.indexOf("REUSE-IgnoreStart")).toBeLessThan(
+      spdxExamples.indexOf("SPDX-License-Identifier")
+    );
+    expect(spdxExamples.indexOf("REUSE-IgnoreEnd")).toBeGreaterThan(
+      spdxExamples.lastIndexOf("SPDX-License-Identifier")
+    );
   });
 
   it("runs Prettier as a local system hook compatible with npm 12", () => {

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -914,6 +914,14 @@ jobs:
       )
     ).toEqual([]);
 
+    const preservedAssetAnnotation = reuseAnnotations.find(
+      (annotation) =>
+        annotation.includes('"public/apple-touch-icon.png"') &&
+        annotation.includes("LicenseRef-SecPal-Attribution")
+    );
+
+    expect(preservedAssetAnnotation).toContain('precedence = "override"');
+
     const contributingGuide = readRepoFile("CONTRIBUTING.md");
 
     expect(contributingGuide).toContain(

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -881,10 +881,16 @@ jobs:
       ".github/instructions/org-shared.instructions.md",
     ]) {
       const fileContents = readRepoFile(relativePath);
+      const normalizedFileContents = fileContents.replace(/\s+/g, " ");
 
-      expect(fileContents).toContain("SecPal-owned agent-governance material");
-      expect(fileContents).toMatch(
-        /Application\s+code and tests retain `AGPL-3\.0-or-later AND LicenseRef-SecPal-Attribution`/
+      expect(normalizedFileContents).toContain(
+        "Use `AGPL-3.0-or-later` for SecPal-owned material intentionally covered by the AGPL."
+      );
+      expect(normalizedFileContents).toContain(
+        "Never add or restore `LicenseRef-SecPal-Attribution` after the licensing rollout."
+      );
+      expect(fileContents).not.toContain(
+        "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
       );
     }
   });


### PR DESCRIPTION
## Problem and evidence

After #1682 merged, the repository guidance still described the plain AGPL-3.0-or-later rule as limited to migrated agent-governance material and explicitly retained the retired attribution expression for application code and tests. That wording conflicts with the current post-rollout policy, which prohibits adding or restoring the obsolete expression while preserving deliberately different licenses and existing metadata that is outside this instruction-only follow-up.

## Change

- Align the authoritative agent instructions, compatibility mirror, and repository-wide overlay with the current post-rollout rule.
- Keep branding, third-party metadata, and first-publication-year safeguards explicit.
- Update the focused regression to enforce the two policy sentences and reject the obsolete compound expression in governance instructions.
- Clarify the changelog without migrating product or source-file metadata.

## Validation

- `npm test -- tests/build.test.ts -t "keeps SecPal-owned governance files on their intended license expressions" --bail=1`
- `npm run lint`
- `npm run typecheck`
- `reuse lint`
- `npm run format:check`
- `git diff --check`
- Local pre-commit hooks

## Readiness

No in-scope dependency or unresolved local check prevents review. This remains a draft PR as required by repository process; the final PR-view self-review is still required before it can be marked ready.